### PR TITLE
Replace all narrative text with minimal text placeholder

### DIFF
--- a/conformance/fhir-ig-us-core/CHANGELOG
+++ b/conformance/fhir-ig-us-core/CHANGELOG
@@ -3,8 +3,7 @@ Source - http://hl7.org/fhir/us/core/STU3.1.1/
 - Removed 3.1.0 Artifacts
 - Updated to 3.1.1 Artifacts STU3.1.1
 - Examples are under src/test/resources/JSON/311
-- Changed the text-generated for the CapabilityStatements CapabilityStatement-us-core-client.json and CapabilityStatement-us-core-server.json
-    as the xhtml was invalid
+- Replace all narrative text with minimal placeholder for space efficiency
 - Per https://github.com/IBM/FHIR/issues/1460 Relaxed required to extensible
     - https://jira.hl7.org/browse/FHIR-27911 Change binding to UCUM from required to extensible + max binding UCUM
     - Per https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/US.20Core.20QA.20Issue.20.233-.20nasty.20profiling.20error
@@ -24,6 +23,5 @@ Source - http://hl7.org/fhir/us/core/STU3.1.1/
 # US Core 4.0.0 - STU4
 Source - https://www.hl7.org/fhir/us/core/stu4/
 - Examples are under src/test/resources/JSON/400
-- Changed the text-generated for the CapabilityStatements CapabilityStatement-us-core-client.json and CapabilityStatement-us-core-server.json
-    as the xhtml was invalid
+- Replace all narrative text with minimal placeholder for space efficiency
 - Revised Endpoint in the Practitioner endpoint so it points to relative path, not absolute path

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/CapabilityStatement-us-core-client.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/CapabilityStatement-us-core-client.json
@@ -1,3746 +1,3746 @@
 {
-	"resourceType": "CapabilityStatement",
-	"id": "us-core-client",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2 id=\"title\">US Core Client CapabilityStatement</h2></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/CapabilityStatement/us-core-client",
-	"version": "3.1.1",
-	"name": "UsCoreClientCapabilityStatement",
-	"title": "US Core Client CapabilityStatement",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-28",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "​The Section describes the expected capabilities of the US Core Client which is responsible for creating and initiating the queries for information about an individual patient. The complete list of FHIR profiles, RESTful operations, and search parameters supported by US Core Servers are defined in the [Conformance Requirements for Server](CapabilityStatement-us-core-server.html). US Core Clients have the option of choosing from this list to access necessary data based on their local use cases and other contextual requirements.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"kind": "requirements",
-	"fhirVersion": "4.0.1",
-	"format": [
-		"xml",
-		"json"
-	],
-	"patchFormat": [
-		"application/json-patch+json"
-	],
-	"implementationGuide": [
-		"http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core|3.1.1"
-	],
-	"rest": [
-		{
-			"mode": "client",
-			"documentation": "The US Core Client **SHALL**:\n\n1. Support fetching and querying of one or more US Core profile(s), using the supported RESTful interactions and search parameters declared in the US Core Server CapabilityStatement.\n",
-			"security": {
-				"description": "1. See the [General Security Considerations] section for requirements and recommendations."
-			},
-			"resource": [
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "clinical-status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "AllergyIntolerance",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance|3.1.1"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "clinical-status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-clinical-status|3.1.1",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-patient|3.1.1",
-							"type": "reference"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "CarePlan",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan|3.1.1"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "category",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-category|3.1.1",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-date|3.1.1",
-							"type": "date"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-patient|3.1.1",
-							"type": "reference"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-status|3.1.1",
-							"type": "token"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "CareTeam",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam|3.1.1"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-patient|3.1.1",
-							"type": "reference"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-status|3.1.1",
-							"type": "token"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "onset-date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "clinical-status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "code"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Condition",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition|3.1.1"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "category",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-category|3.1.1",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "clinical-status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-clinical-status|3.1.1",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-patient|3.1.1",
-							"type": "reference"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "onset-date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-onset-date|3.1.1",
-							"type": "date"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "code",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-code",
-							"type": "token"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "type"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Device",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-patient",
-							"type": "reference"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "type",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-type",
-							"type": "token"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "code"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "code"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "DiagnosticReport",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note",
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "create",
-							"documentation": "This conformance expectation applies **only**  to the *US Core DiagnosticReport Profile for Report and Note exchange* profile.  The conformance expectation for the *US Core DiagnosticReport Profile for Laboratory Results Reporting* is  **MAY**."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-status",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient",
-							"type": "reference"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "category",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-category",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "code",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-code",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-date",
-							"type": "date"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "type"
-								},
-								{
-									"url": "required",
-									"valueString": "period"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "type"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "DocumentReference",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference"
-					],
-					"documentation": "The DocumentReference.type binding SHALL support at a minimum the [5 Common Clinical Notes](ValueSet-us-core-clinical-note-type.html) and may extend to the full US Core DocumentReference Type Value Set",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "_id",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-id",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-status",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient",
-							"type": "reference"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "category",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-category",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "type",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-type",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-date",
-							"type": "date"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "period",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-period",
-							"type": "date"
-						}
-					],
-					"operation": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "docref",
-							"definition": "http://hl7.org/fhir/us/core/OperationDefinition/docref",
-							"documentation": "A client **SHOULD** be capable of transacting a $docref operation and capable of receiving at least a reference to a generated CCD document, and  **MAY** be able to receive other document types, if available.   **SHOULD**  be capable of receiving documents as included resources in response to the operation.\n\n`GET [base]/DocumentReference/$docref?patient=[id]`"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "class"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "type"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Encounter",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "_id",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-id",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "class",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-class",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-date",
-							"type": "date"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "identifier",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-identifier",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-patient",
-							"type": "reference"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-status",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "type",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-type",
-							"type": "token"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "lifecycle-status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "target-date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Goal",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "lifecycle-status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-lifecycle-status",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-patient",
-							"type": "reference"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "target-date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-target-date",
-							"type": "date"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Immunization",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-patient",
-							"type": "reference"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-status",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-date",
-							"type": "date"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						}
-					],
-					"type": "Location",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-location"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "name",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-name",
-							"type": "string"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "address",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address",
-							"type": "string"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "address-city",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-city",
-							"type": "string"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "address-state",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-state",
-							"type": "string"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "address-postalcode",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-postalcode",
-							"type": "string"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						}
-					],
-					"type": "Medication",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication"
-					],
-					"documentation": "The MedicationRequest resource can represent a medication, using an external reference to a Medication resource. If an external Medication Resource is used in a MedicationRequest, then the READ **SHALL**  be supported.",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "intent"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "intent"
-								},
-								{
-									"url": "required",
-									"valueString": "encounter"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "intent"
-								},
-								{
-									"url": "required",
-									"valueString": "authoredon"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "intent"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "MedicationRequest",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest"
-					],
-					"documentation": "The MedicationRequest resources can represent a medication using either a code or refer to the Medication resource. When referencing Medication, the resource may be [contained](http://hl7.org/fhir/R4/references.html#contained) or an external resource. The server application **MAY** choose any one way or more than one method, but if an external reference to Medication is used, the server **SHALL** support the _include` parameter for searching this element. The client application must support all methods.\n\n For example, A server **SHALL** be capable of returning all medications for a patient using one of or both:\n\n `GET /MedicationRequest?patient=[id]`\n\n `GET /MedicationRequest?patient=[id]&_include=MedicationRequest:medication`",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchInclude": [
-						"MedicationRequest:medication"
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-status",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "intent",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-intent",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-patient",
-							"type": "reference"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "encounter",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-encounter",
-							"type": "reference"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "authoredon",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-authoredon",
-							"type": "date"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "code"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "code"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Observation",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus",
-						"http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height",
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab",
-						"http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age",
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry",
-						"http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-status",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "category",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-category",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "code",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-code",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-date",
-							"type": "date"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient",
-							"type": "reference"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						}
-					],
-					"type": "Organization",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "name",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-name",
-							"type": "string"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "address",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-address",
-							"type": "string"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "birthdate"
-								},
-								{
-									"url": "required",
-									"valueString": "family"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "family"
-								},
-								{
-									"url": "required",
-									"valueString": "gender"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "birthdate"
-								},
-								{
-									"url": "required",
-									"valueString": "name"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "gender"
-								},
-								{
-									"url": "required",
-									"valueString": "name"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Patient",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "_id",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-id",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "birthdate",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-birthdate",
-							"type": "date"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "family",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-family",
-							"type": "string"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "gender",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-gender",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "given",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-given",
-							"type": "string"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "identifier",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-identifier",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "name",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-name",
-							"type": "string"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						}
-					],
-					"type": "Practitioner",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "name",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-name",
-							"type": "string"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "identifier",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-identifier",
-							"type": "token"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						}
-					],
-					"type": "PractitionerRole",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchInclude": [
-						"PractitionerRole:endpoint",
-						"PractitionerRole:practitioner"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "specialty",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-specialty",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "practitioner",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-practitioner",
-							"type": "reference"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "code"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Procedure",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-status",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-patient",
-							"type": "reference"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-date",
-							"type": "date"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "code",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-code",
-							"type": "token"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						}
-					],
-					"type": "Provenance",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						}
-					],
-					"type": "ValueSet",
-					"operation": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "expand",
-							"definition": "http://hl7.org/fhir/OperationDefinition/ValueSet-expand",
-							"documentation": "A  client can determine the note and report types support by a server by invoking the standard FHIR Value Set Expansion ($expand) operation defined in the FHIR R4 specification. Because servers may support different read and write formats, it also is used to determine the formats (for example, text, pdf) the server supports read and write transactions."
-						}
-					]
-				}
-			],
-			"interaction": [
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "MAY"
-						}
-					],
-					"code": "transaction"
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "MAY"
-						}
-					],
-					"code": "batch"
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "MAY"
-						}
-					],
-					"code": "search-system"
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "MAY"
-						}
-					],
-					"code": "history-system"
-				}
-			]
-		}
-	]
+    "resourceType": "CapabilityStatement",
+    "id": "us-core-client",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/CapabilityStatement/us-core-client",
+    "version": "3.1.1",
+    "name": "UsCoreClientCapabilityStatement",
+    "title": "US Core Client CapabilityStatement",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-28",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "​The Section describes the expected capabilities of the US Core Client which is responsible for creating and initiating the queries for information about an individual patient. The complete list of FHIR profiles, RESTful operations, and search parameters supported by US Core Servers are defined in the [Conformance Requirements for Server](CapabilityStatement-us-core-server.html). US Core Clients have the option of choosing from this list to access necessary data based on their local use cases and other contextual requirements.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "kind": "requirements",
+    "fhirVersion": "4.0.1",
+    "format": [
+        "xml",
+        "json"
+    ],
+    "patchFormat": [
+        "application/json-patch+json"
+    ],
+    "implementationGuide": [
+        "http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core|3.1.1"
+    ],
+    "rest": [
+        {
+            "mode": "client",
+            "documentation": "The US Core Client **SHALL**:\n\n1. Support fetching and querying of one or more US Core profile(s), using the supported RESTful interactions and search parameters declared in the US Core Server CapabilityStatement.\n",
+            "security": {
+                "description": "1. See the [General Security Considerations] section for requirements and recommendations."
+            },
+            "resource": [
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "clinical-status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "AllergyIntolerance",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance|3.1.1"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "clinical-status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-clinical-status|3.1.1",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-patient|3.1.1",
+                            "type": "reference"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "CarePlan",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan|3.1.1"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "category",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-category|3.1.1",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-date|3.1.1",
+                            "type": "date"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-patient|3.1.1",
+                            "type": "reference"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-status|3.1.1",
+                            "type": "token"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "CareTeam",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam|3.1.1"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-patient|3.1.1",
+                            "type": "reference"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-status|3.1.1",
+                            "type": "token"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "onset-date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "clinical-status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "code"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Condition",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition|3.1.1"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "category",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-category|3.1.1",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "clinical-status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-clinical-status|3.1.1",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-patient|3.1.1",
+                            "type": "reference"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "onset-date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-onset-date|3.1.1",
+                            "type": "date"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "code",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-code",
+                            "type": "token"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "type"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Device",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-patient",
+                            "type": "reference"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "type",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-type",
+                            "type": "token"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "code"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "code"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "DiagnosticReport",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "create",
+                            "documentation": "This conformance expectation applies **only**  to the *US Core DiagnosticReport Profile for Report and Note exchange* profile.  The conformance expectation for the *US Core DiagnosticReport Profile for Laboratory Results Reporting* is  **MAY**."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-status",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient",
+                            "type": "reference"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "category",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-category",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "code",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-code",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-date",
+                            "type": "date"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "type"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "period"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "type"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "DocumentReference",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference"
+                    ],
+                    "documentation": "The DocumentReference.type binding SHALL support at a minimum the [5 Common Clinical Notes](ValueSet-us-core-clinical-note-type.html) and may extend to the full US Core DocumentReference Type Value Set",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "_id",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-id",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-status",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient",
+                            "type": "reference"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "category",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-category",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "type",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-type",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-date",
+                            "type": "date"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "period",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-period",
+                            "type": "date"
+                        }
+                    ],
+                    "operation": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "docref",
+                            "definition": "http://hl7.org/fhir/us/core/OperationDefinition/docref",
+                            "documentation": "A client **SHOULD** be capable of transacting a $docref operation and capable of receiving at least a reference to a generated CCD document, and  **MAY** be able to receive other document types, if available.   **SHOULD**  be capable of receiving documents as included resources in response to the operation.\n\n`GET [base]/DocumentReference/$docref?patient=[id]`"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "class"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "type"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Encounter",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "_id",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-id",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "class",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-class",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-date",
+                            "type": "date"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "identifier",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-identifier",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-patient",
+                            "type": "reference"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-status",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "type",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-type",
+                            "type": "token"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "lifecycle-status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "target-date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Goal",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "lifecycle-status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-lifecycle-status",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-patient",
+                            "type": "reference"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "target-date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-target-date",
+                            "type": "date"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Immunization",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-patient",
+                            "type": "reference"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-status",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-date",
+                            "type": "date"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        }
+                    ],
+                    "type": "Location",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-location"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "name",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-name",
+                            "type": "string"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "address",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address",
+                            "type": "string"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "address-city",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-city",
+                            "type": "string"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "address-state",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-state",
+                            "type": "string"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "address-postalcode",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-postalcode",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        }
+                    ],
+                    "type": "Medication",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication"
+                    ],
+                    "documentation": "The MedicationRequest resource can represent a medication, using an external reference to a Medication resource. If an external Medication Resource is used in a MedicationRequest, then the READ **SHALL**  be supported.",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "intent"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "intent"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "encounter"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "intent"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "authoredon"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "intent"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "MedicationRequest",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest"
+                    ],
+                    "documentation": "The MedicationRequest resources can represent a medication using either a code or refer to the Medication resource. When referencing Medication, the resource may be [contained](http://hl7.org/fhir/R4/references.html#contained) or an external resource. The server application **MAY** choose any one way or more than one method, but if an external reference to Medication is used, the server **SHALL** support the _include` parameter for searching this element. The client application must support all methods.\n\n For example, A server **SHALL** be capable of returning all medications for a patient using one of or both:\n\n `GET /MedicationRequest?patient=[id]`\n\n `GET /MedicationRequest?patient=[id]&_include=MedicationRequest:medication`",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchInclude": [
+                        "MedicationRequest:medication"
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-status",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "intent",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-intent",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-patient",
+                            "type": "reference"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "encounter",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-encounter",
+                            "type": "reference"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "authoredon",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-authoredon",
+                            "type": "date"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "code"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "code"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Observation",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-status",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "category",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-category",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "code",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-code",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-date",
+                            "type": "date"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient",
+                            "type": "reference"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        }
+                    ],
+                    "type": "Organization",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "name",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-name",
+                            "type": "string"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "address",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-address",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "birthdate"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "family"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "family"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "gender"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "birthdate"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "name"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "gender"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "name"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Patient",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "_id",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-id",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "birthdate",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-birthdate",
+                            "type": "date"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "family",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-family",
+                            "type": "string"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "gender",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-gender",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "given",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-given",
+                            "type": "string"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "identifier",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-identifier",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "name",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-name",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        }
+                    ],
+                    "type": "Practitioner",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "name",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-name",
+                            "type": "string"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "identifier",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-identifier",
+                            "type": "token"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        }
+                    ],
+                    "type": "PractitionerRole",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchInclude": [
+                        "PractitionerRole:endpoint",
+                        "PractitionerRole:practitioner"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "specialty",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-specialty",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "practitioner",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-practitioner",
+                            "type": "reference"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "code"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Procedure",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-status",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-patient",
+                            "type": "reference"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-date",
+                            "type": "date"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "code",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-code",
+                            "type": "token"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        }
+                    ],
+                    "type": "Provenance",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        }
+                    ],
+                    "type": "ValueSet",
+                    "operation": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "expand",
+                            "definition": "http://hl7.org/fhir/OperationDefinition/ValueSet-expand",
+                            "documentation": "A  client can determine the note and report types support by a server by invoking the standard FHIR Value Set Expansion ($expand) operation defined in the FHIR R4 specification. Because servers may support different read and write formats, it also is used to determine the formats (for example, text, pdf) the server supports read and write transactions."
+                        }
+                    ]
+                }
+            ],
+            "interaction": [
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ],
+                    "code": "transaction"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ],
+                    "code": "batch"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ],
+                    "code": "search-system"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ],
+                    "code": "history-system"
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/CapabilityStatement-us-core-server.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/CapabilityStatement-us-core-server.json
@@ -1,3807 +1,3807 @@
 {
-	"resourceType": "CapabilityStatement",
-	"id": "us-core-server",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2 id=\"title\">US Core Server CapabilityStatement</h2></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/CapabilityStatement/us-core-server",
-	"version": "3.1.1",
-	"name": "UsCoreServerCapabilityStatement",
-	"title": "US Core Server CapabilityStatement",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-28",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "This Section describes the expected capabilities of the US Core Server actor which is responsible for providing responses to the queries submitted by the US Core Requestors. The complete list of FHIR profiles, RESTful operations, and search parameters supported by US Core Servers are defined. Systems implementing this capability statement should meet the ONC 2015 Common Clinical Data Set (CCDS) access requirement for Patient Selection 170.315(g)(7) and Application Access - Data Category Request 170.315(g)(8) and and the ONC [U.S. Core Data for Interoperability (USCDI)](https://www.healthit.gov/isa/sites/isa/files/2020-03/USCDI-Version1-2020-Final-Standard.pdf).  US Core Clients have the option of choosing from this list to access necessary data based on their local use cases and other contextual requirements.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"kind": "requirements",
-	"fhirVersion": "4.0.1",
-	"format": [
-		"xml",
-		"json"
-	],
-	"patchFormat": [
-		"application/json-patch+json"
-	],
-	"implementationGuide": [
-		"http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core|3.1.1"
-	],
-	"rest": [
-		{
-			"mode": "server",
-			"documentation": "The US Core Server **SHALL**:\n\n1. Support the US Core Patient resource profile.\n1. Support at least one additional resource profile from the list of US Core Profiles.\n1. Implement the RESTful behavior according to the FHIR specification.\n1. Return the following response classes:\n   - (Status 400): invalid parameter\n   - (Status 401/4xx): unauthorized request\n   - (Status 403): insufficient scope\n   - (Status 404): unknown resource\n   - (Status 410): deleted resource.\n1. Support json source formats for all US Core interactions.\n\nThe US Core Server **SHOULD**:\n\n1. Support xml source formats for all US Core interactions.\n1. Identify the US Core profiles supported as part of the FHIR `meta.profile` attribute for each instance.\n1. Support xml resource formats for all Argonaut questionnaire interactions.",
-			"security": {
-				"description": "1. See the [General Security Considerations](security.html) section for requirements and recommendations.\n1. A server **SHALL** reject any unauthorized requests by returning an `HTTP 401` unauthorized response code."
-			},
-			"resource": [
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "clinical-status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "AllergyIntolerance",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "clinical-status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-clinical-status",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-patient",
-							"type": "reference"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "CarePlan",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "category",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-category",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-date",
-							"type": "date"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-patient",
-							"type": "reference"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-status",
-							"type": "token"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "CareTeam",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-patient",
-							"type": "reference"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-status",
-							"type": "token"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "onset-date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "clinical-status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "code"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Condition",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "category",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-category",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "clinical-status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-clinical-status",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-patient",
-							"type": "reference"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "onset-date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-onset-date",
-							"type": "date"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "code",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-code",
-							"type": "token"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "type"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Device",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-patient",
-							"type": "reference"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "type",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-type",
-							"type": "token"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "code"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "code"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "DiagnosticReport",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note",
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "create",
-							"documentation": "This conformance expectation applies **only**  to the *US Core DiagnosticReport Profile for Report and Note exchange* profile.  The conformance expectation for the *US Core DiagnosticReport Profile for Laboratory Results Reporting* is  **MAY**."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-status",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient",
-							"type": "reference"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "category",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-category",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "code",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-code",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-date",
-							"type": "date"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "type"
-								},
-								{
-									"url": "required",
-									"valueString": "period"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "type"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "DocumentReference",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference"
-					],
-					"documentation": "The DocumentReference.type binding SHALL support at a minimum the [5 Common Clinical Notes](ValueSet-us-core-clinical-note-type.html) and may extend to the full US Core DocumentReference Type Value Set",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "_id",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-id",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-status",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient",
-							"type": "reference"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "category",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-category",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "type",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-type",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-date",
-							"type": "date"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "period",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-period",
-							"type": "date"
-						}
-					],
-					"operation": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "docref",
-							"definition": "http://hl7.org/fhir/us/core/OperationDefinition/docref",
-							"documentation": "A server **SHALL** be capable of responding to a $docref operation and  capable of returning at least a reference to a generated CCD document, if available. **MAY** provide references to other 'on-demand' and 'stable' documents (or 'delayed/deferred assembly') that meet the query parameters as well. If a context date range is supplied the server ** SHOULD**  provide references to any document that falls within the date range If no date range is supplied, then the server **SHALL** provide references to last or current encounter.  **SHOULD** document what resources, if any, are returned as included resources\n\n`GET [base]/DocumentReference/$docref?patient=[id]`"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "class"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "type"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Encounter",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "_id",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-id",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "class",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-class",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-date",
-							"type": "date"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "identifier",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-identifier",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-patient",
-							"type": "reference"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-status",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "type",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-type",
-							"type": "token"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "lifecycle-status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "target-date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Goal",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "lifecycle-status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-lifecycle-status",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-patient",
-							"type": "reference"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "target-date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-target-date",
-							"type": "date"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Immunization",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-patient",
-							"type": "reference"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-status",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-date",
-							"type": "date"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						}
-					],
-					"type": "Location",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-location"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "name",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-name",
-							"type": "string"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "address",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address",
-							"type": "string"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "address-city",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-city",
-							"type": "string"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "address-state",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-state",
-							"type": "string"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "address-postalcode",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-postalcode",
-							"type": "string"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						}
-					],
-					"type": "Medication",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication"
-					],
-					"documentation": "The  MedicationRequest resource can represent a medication, using an external reference to a Medication resource. If an external Medication Resourcse is used in a MedicationRequest, then the READ  **SHALL**  be supported.",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "intent"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "intent"
-								},
-								{
-									"url": "required",
-									"valueString": "encounter"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "intent"
-								},
-								{
-									"url": "required",
-									"valueString": "authoredon"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "intent"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "MedicationRequest",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest"
-					],
-					"documentation": "The MedicationRequest resources can represent a medication using either a code or refer to the Medication resource. When referencing Medication, the resource may be [contained](http://hl7.org/fhir/R4/references.html#contained) or an external resource. The server application **MAY** choose any one way or more than one method, but if an external reference to Medication is used, the server **SHALL** support the _include` parameter for searching this element. The client application must support all methods.\n\n For example, A server **SHALL** be capable of returning all medications for a patient using one of or both:\n\n `GET /MedicationRequest?patient=[id]`\n\n `GET /MedicationRequest?patient=[id]&_include=MedicationRequest:medication`",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchInclude": [
-						"MedicationRequest:medication"
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-status",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "intent",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-intent",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-patient",
-							"type": "reference"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "encounter",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-encounter",
-							"type": "reference"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "authoredon",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-authoredon",
-							"type": "date"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "code"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "code"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Observation",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus",
-						"http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height",
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab",
-						"http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age",
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry",
-						"http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-status",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "category",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-category",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "code",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-code",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-date",
-							"type": "date"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient",
-							"type": "reference"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						}
-					],
-					"type": "Organization",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "name",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-name",
-							"type": "string"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "address",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-address",
-							"type": "string"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "birthdate"
-								},
-								{
-									"url": "required",
-									"valueString": "family"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "family"
-								},
-								{
-									"url": "required",
-									"valueString": "gender"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "birthdate"
-								},
-								{
-									"url": "required",
-									"valueString": "name"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "gender"
-								},
-								{
-									"url": "required",
-									"valueString": "name"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Patient",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "_id",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-id",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "birthdate",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-birthdate",
-							"type": "date"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "family",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-family",
-							"type": "string"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "gender",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-gender",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "given",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-given",
-							"type": "string"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "identifier",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-identifier",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "name",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-name",
-							"type": "string"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						}
-					],
-					"type": "Practitioner",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "name",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-name",
-							"type": "string"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "identifier",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-identifier",
-							"type": "token"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						}
-					],
-					"type": "PractitionerRole",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchInclude": [
-						"PractitionerRole:endpoint",
-						"PractitionerRole:practitioner"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "specialty",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-specialty",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "practitioner",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-practitioner",
-							"type": "reference"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "code"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Procedure",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure"
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-status",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-patient",
-							"type": "reference"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-date",
-							"type": "date"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "code",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-code",
-							"type": "token"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						}
-					],
-					"type": "Provenance",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance"
-					],
-					"documentation": "If a system receives a provider in `Provenance.agent.who` as free text they must capture who sent them the information as the organization. On request they **SHALL** provide this organization as the source and **MAY** include the free text provider.",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						}
-					],
-					"type": "ValueSet",
-					"operation": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "expand",
-							"definition": "http://hl7.org/fhir/OperationDefinition/ValueSet-expand",
-							"documentation": "A  client can determine the note and report types support by a server by invoking the standard FHIR Value Set Expansion ($expand) operation defined in the FHIR R4 specification. Because servers may support different read and write formats, it also is used to determine the formats (for example, text, pdf) the server supports read and write transactions."
-						}
-					]
-				}
-			],
-			"interaction": [
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "MAY"
-						}
-					],
-					"code": "transaction"
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "MAY"
-						}
-					],
-					"code": "batch"
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "MAY"
-						}
-					],
-					"code": "search-system"
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "MAY"
-						}
-					],
-					"code": "history-system"
-				}
-			]
-		}
-	]
+    "resourceType": "CapabilityStatement",
+    "id": "us-core-server",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/CapabilityStatement/us-core-server",
+    "version": "3.1.1",
+    "name": "UsCoreServerCapabilityStatement",
+    "title": "US Core Server CapabilityStatement",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-28",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "This Section describes the expected capabilities of the US Core Server actor which is responsible for providing responses to the queries submitted by the US Core Requestors. The complete list of FHIR profiles, RESTful operations, and search parameters supported by US Core Servers are defined. Systems implementing this capability statement should meet the ONC 2015 Common Clinical Data Set (CCDS) access requirement for Patient Selection 170.315(g)(7) and Application Access - Data Category Request 170.315(g)(8) and and the ONC [U.S. Core Data for Interoperability (USCDI)](https://www.healthit.gov/isa/sites/isa/files/2020-03/USCDI-Version1-2020-Final-Standard.pdf).  US Core Clients have the option of choosing from this list to access necessary data based on their local use cases and other contextual requirements.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "kind": "requirements",
+    "fhirVersion": "4.0.1",
+    "format": [
+        "xml",
+        "json"
+    ],
+    "patchFormat": [
+        "application/json-patch+json"
+    ],
+    "implementationGuide": [
+        "http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core|3.1.1"
+    ],
+    "rest": [
+        {
+            "mode": "server",
+            "documentation": "The US Core Server **SHALL**:\n\n1. Support the US Core Patient resource profile.\n1. Support at least one additional resource profile from the list of US Core Profiles.\n1. Implement the RESTful behavior according to the FHIR specification.\n1. Return the following response classes:\n   - (Status 400): invalid parameter\n   - (Status 401/4xx): unauthorized request\n   - (Status 403): insufficient scope\n   - (Status 404): unknown resource\n   - (Status 410): deleted resource.\n1. Support json source formats for all US Core interactions.\n\nThe US Core Server **SHOULD**:\n\n1. Support xml source formats for all US Core interactions.\n1. Identify the US Core profiles supported as part of the FHIR `meta.profile` attribute for each instance.\n1. Support xml resource formats for all Argonaut questionnaire interactions.",
+            "security": {
+                "description": "1. See the [General Security Considerations](security.html) section for requirements and recommendations.\n1. A server **SHALL** reject any unauthorized requests by returning an `HTTP 401` unauthorized response code."
+            },
+            "resource": [
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "clinical-status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "AllergyIntolerance",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "clinical-status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-clinical-status",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-patient",
+                            "type": "reference"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "CarePlan",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "category",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-category",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-date",
+                            "type": "date"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-patient",
+                            "type": "reference"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-status",
+                            "type": "token"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "CareTeam",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-patient",
+                            "type": "reference"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-status",
+                            "type": "token"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "onset-date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "clinical-status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "code"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Condition",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "category",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-category",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "clinical-status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-clinical-status",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-patient",
+                            "type": "reference"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "onset-date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-onset-date",
+                            "type": "date"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "code",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-code",
+                            "type": "token"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "type"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Device",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-patient",
+                            "type": "reference"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "type",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-type",
+                            "type": "token"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "code"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "code"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "DiagnosticReport",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "create",
+                            "documentation": "This conformance expectation applies **only**  to the *US Core DiagnosticReport Profile for Report and Note exchange* profile.  The conformance expectation for the *US Core DiagnosticReport Profile for Laboratory Results Reporting* is  **MAY**."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-status",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient",
+                            "type": "reference"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "category",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-category",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "code",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-code",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-date",
+                            "type": "date"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "type"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "period"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "type"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "DocumentReference",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference"
+                    ],
+                    "documentation": "The DocumentReference.type binding SHALL support at a minimum the [5 Common Clinical Notes](ValueSet-us-core-clinical-note-type.html) and may extend to the full US Core DocumentReference Type Value Set",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "_id",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-id",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-status",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient",
+                            "type": "reference"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "category",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-category",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "type",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-type",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-date",
+                            "type": "date"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "period",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-period",
+                            "type": "date"
+                        }
+                    ],
+                    "operation": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "docref",
+                            "definition": "http://hl7.org/fhir/us/core/OperationDefinition/docref",
+                            "documentation": "A server **SHALL** be capable of responding to a $docref operation and  capable of returning at least a reference to a generated CCD document, if available. **MAY** provide references to other 'on-demand' and 'stable' documents (or 'delayed/deferred assembly') that meet the query parameters as well. If a context date range is supplied the server ** SHOULD**  provide references to any document that falls within the date range If no date range is supplied, then the server **SHALL** provide references to last or current encounter.  **SHOULD** document what resources, if any, are returned as included resources\n\n`GET [base]/DocumentReference/$docref?patient=[id]`"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "class"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "type"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Encounter",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "_id",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-id",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "class",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-class",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-date",
+                            "type": "date"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "identifier",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-identifier",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-patient",
+                            "type": "reference"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-status",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "type",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-type",
+                            "type": "token"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "lifecycle-status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "target-date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Goal",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "lifecycle-status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-lifecycle-status",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-patient",
+                            "type": "reference"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "target-date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-target-date",
+                            "type": "date"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Immunization",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-patient",
+                            "type": "reference"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-status",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-date",
+                            "type": "date"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        }
+                    ],
+                    "type": "Location",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-location"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "name",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-name",
+                            "type": "string"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "address",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address",
+                            "type": "string"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "address-city",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-city",
+                            "type": "string"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "address-state",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-state",
+                            "type": "string"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "address-postalcode",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-postalcode",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        }
+                    ],
+                    "type": "Medication",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication"
+                    ],
+                    "documentation": "The  MedicationRequest resource can represent a medication, using an external reference to a Medication resource. If an external Medication Resourcse is used in a MedicationRequest, then the READ  **SHALL**  be supported.",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "intent"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "intent"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "encounter"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "intent"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "authoredon"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "intent"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "MedicationRequest",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest"
+                    ],
+                    "documentation": "The MedicationRequest resources can represent a medication using either a code or refer to the Medication resource. When referencing Medication, the resource may be [contained](http://hl7.org/fhir/R4/references.html#contained) or an external resource. The server application **MAY** choose any one way or more than one method, but if an external reference to Medication is used, the server **SHALL** support the _include` parameter for searching this element. The client application must support all methods.\n\n For example, A server **SHALL** be capable of returning all medications for a patient using one of or both:\n\n `GET /MedicationRequest?patient=[id]`\n\n `GET /MedicationRequest?patient=[id]&_include=MedicationRequest:medication`",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchInclude": [
+                        "MedicationRequest:medication"
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-status",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "intent",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-intent",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-patient",
+                            "type": "reference"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "encounter",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-encounter",
+                            "type": "reference"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "authoredon",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-authoredon",
+                            "type": "date"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "code"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "code"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Observation",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-status",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "category",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-category",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "code",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-code",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-date",
+                            "type": "date"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient",
+                            "type": "reference"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        }
+                    ],
+                    "type": "Organization",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "name",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-name",
+                            "type": "string"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "address",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-address",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "birthdate"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "family"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "family"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "gender"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "birthdate"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "name"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "gender"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "name"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Patient",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "_id",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-id",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "birthdate",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-birthdate",
+                            "type": "date"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "family",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-family",
+                            "type": "string"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "gender",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-gender",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "given",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-given",
+                            "type": "string"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "identifier",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-identifier",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "name",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-name",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        }
+                    ],
+                    "type": "Practitioner",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "name",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-name",
+                            "type": "string"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "identifier",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-identifier",
+                            "type": "token"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        }
+                    ],
+                    "type": "PractitionerRole",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchInclude": [
+                        "PractitionerRole:endpoint",
+                        "PractitionerRole:practitioner"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "specialty",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-specialty",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "practitioner",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-practitioner",
+                            "type": "reference"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "code"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Procedure",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure"
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-status",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-patient",
+                            "type": "reference"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-date",
+                            "type": "date"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "code",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-code",
+                            "type": "token"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        }
+                    ],
+                    "type": "Provenance",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance"
+                    ],
+                    "documentation": "If a system receives a provider in `Provenance.agent.who` as free text they must capture who sent them the information as the organization. On request they **SHALL** provide this organization as the source and **MAY** include the free text provider.",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        }
+                    ],
+                    "type": "ValueSet",
+                    "operation": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "expand",
+                            "definition": "http://hl7.org/fhir/OperationDefinition/ValueSet-expand",
+                            "documentation": "A  client can determine the note and report types support by a server by invoking the standard FHIR Value Set Expansion ($expand) operation defined in the FHIR R4 specification. Because servers may support different read and write formats, it also is used to determine the formats (for example, text, pdf) the server supports read and write transactions."
+                        }
+                    ]
+                }
+            ],
+            "interaction": [
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ],
+                    "code": "transaction"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ],
+                    "code": "batch"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ],
+                    "code": "search-system"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ],
+                    "code": "history-system"
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/CodeSystem-careplan-category.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/CodeSystem-careplan-category.json
@@ -1,36 +1,36 @@
 {
-	"resourceType": "CodeSystem",
-	"id": "careplan-category",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/CodeSystem/careplan-category",
-	"version": "3.1.1",
-	"name": "USCoreCarePlanCategoryExtensionCodes",
-	"title": "US Core CarePlan Category Extension Codes",
-	"status": "active",
-	"date": "2020-08-28T10:54:27+10:00",
-	"publisher": "HL7 US Realm Steering Committee",
-	"description": "Set of codes that are needed for implementation of the US-Core profiles. These codes are used as extensions to the FHIR and US Core value sets.\n",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"caseSensitive": true,
-	"content": "complete",
-	"concept": [
-		{
-			"code": "assess-plan",
-			"display": "Assessment and Plan of Treatment",
-			"definition": "The clinical conclusions and assumptions that guide the patient's treatment and the clinical activities formulated for a patient."
-		}
-	]
+    "resourceType": "CodeSystem",
+    "id": "careplan-category",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/CodeSystem/careplan-category",
+    "version": "3.1.1",
+    "name": "USCoreCarePlanCategoryExtensionCodes",
+    "title": "US Core CarePlan Category Extension Codes",
+    "status": "active",
+    "date": "2020-08-28T10:54:27+10:00",
+    "publisher": "HL7 US Realm Steering Committee",
+    "description": "Set of codes that are needed for implementation of the US-Core profiles. These codes are used as extensions to the FHIR and US Core value sets.\n",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "caseSensitive": true,
+    "content": "complete",
+    "concept": [
+        {
+            "code": "assess-plan",
+            "display": "Assessment and Plan of Treatment",
+            "definition": "The clinical conclusions and assumptions that guide the patient's treatment and the clinical activities formulated for a patient."
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/CodeSystem-cdcrec.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/CodeSystem-cdcrec.json
@@ -1,4914 +1,4914 @@
 {
-	"resourceType": "CodeSystem",
-	"id": "cdcrec",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated</div>"
-	},
-	"url": "urn:oid:2.16.840.1.113883.6.238",
-	"identifier": [
-		{
-			"value": "2.16.840.1.113883.6.238"
-		}
-	],
-	"version": "3.1.1",
-	"name": "RaceAndEthnicityCDC",
-	"title": "Race & Ethnicity - CDC",
-	"status": "active",
-	"experimental": false,
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://hl7.org"
-				}
-			]
-		}
-	],
-	"description": " The U.S. Centers for Disease Control and Prevention (CDC) has prepared a code set for use in codingrace and ethnicity data. This code set is based on current federal standards for classifying data onrace and ethnicity, specifically the minimum race and ethnicity categories defined by the U.S. Office ofManagement and Budget (OMB) and a more detailed set of race and ethnicity categories maintainedby the U.S. Bureau of the Census (BC). The main purpose of the code set is to facilitate use of federalstandards for classifying data on race and ethnicity when these data are exchanged, stored, retrieved,or analyzed in electronic form. At the same time, the code set can be applied to paper-based recordsystems to the extent that these systems are used to collect, maintain, and report data on race andethnicity in accordance with current federal standards. Source: [Race and Ethnicity Code Set Version 1.0](https://www.cdc.gov/phin/resources/vocabulary/documents/cdc-race--ethnicity-background-and-purpose.pdf).",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"caseSensitive": true,
-	"hierarchyMeaning": "is-a",
-	"content": "complete",
-	"count": 966,
-	"property": [
-		{
-			"code": "abstract",
-			"description": "True if an element is considered 'abstract' - in other words, the code is not for use as a real concept",
-			"type": "boolean"
-		}
-	],
-	"concept": [
-		{
-			"code": "1000-9",
-			"display": "Race",
-			"definition": "Race, Note that this is an abstract 'grouping' concept and not for use as a real concept",
-			"property": [
-				{
-					"code": "abstract",
-					"valueBoolean": true
-				}
-			],
-			"concept": [
-				{
-					"code": "1002-5",
-					"display": "American Indian or Alaska Native",
-					"definition": "American Indian or Alaska Native",
-					"concept": [
-						{
-							"code": "1004-1",
-							"display": "American Indian",
-							"definition": "American Indian"
-						},
-						{
-							"code": "1735-0",
-							"display": "Alaska Native",
-							"definition": "Alaska Native"
-						},
-						{
-							"code": "1006-6",
-							"display": "Abenaki",
-							"definition": "Abenaki"
-						},
-						{
-							"code": "1008-2",
-							"display": "Algonquian",
-							"definition": "Algonquian"
-						},
-						{
-							"code": "1010-8",
-							"display": "Apache",
-							"definition": "Apache"
-						},
-						{
-							"code": "1021-5",
-							"display": "Arapaho",
-							"definition": "Arapaho"
-						},
-						{
-							"code": "1026-4",
-							"display": "Arikara",
-							"definition": "Arikara"
-						},
-						{
-							"code": "1028-0",
-							"display": "Assiniboine",
-							"definition": "Assiniboine"
-						},
-						{
-							"code": "1030-6",
-							"display": "Assiniboine Sioux",
-							"definition": "Assiniboine Sioux"
-						},
-						{
-							"code": "1033-0",
-							"display": "Bannock",
-							"definition": "Bannock"
-						},
-						{
-							"code": "1035-5",
-							"display": "Blackfeet",
-							"definition": "Blackfeet"
-						},
-						{
-							"code": "1037-1",
-							"display": "Brotherton",
-							"definition": "Brotherton"
-						},
-						{
-							"code": "1039-7",
-							"display": "Burt Lake Band",
-							"definition": "Burt Lake Band"
-						},
-						{
-							"code": "1041-3",
-							"display": "Caddo",
-							"definition": "Caddo"
-						},
-						{
-							"code": "1044-7",
-							"display": "Cahuilla",
-							"definition": "Cahuilla"
-						},
-						{
-							"code": "1053-8",
-							"display": "California Tribes",
-							"definition": "California Tribes"
-						},
-						{
-							"code": "1068-6",
-							"display": "Canadian and Latin American Indian",
-							"definition": "Canadian and Latin American Indian"
-						},
-						{
-							"code": "1076-9",
-							"display": "Catawba",
-							"definition": "Catawba"
-						},
-						{
-							"code": "1078-5",
-							"display": "Cayuse",
-							"definition": "Cayuse"
-						},
-						{
-							"code": "1080-1",
-							"display": "Chehalis",
-							"definition": "Chehalis"
-						},
-						{
-							"code": "1082-7",
-							"display": "Chemakuan",
-							"definition": "Chemakuan"
-						},
-						{
-							"code": "1086-8",
-							"display": "Chemehuevi",
-							"definition": "Chemehuevi"
-						},
-						{
-							"code": "1088-4",
-							"display": "Cherokee",
-							"definition": "Cherokee"
-						},
-						{
-							"code": "1100-7",
-							"display": "Cherokee Shawnee",
-							"definition": "Cherokee Shawnee"
-						},
-						{
-							"code": "1102-3",
-							"display": "Cheyenne",
-							"definition": "Cheyenne"
-						},
-						{
-							"code": "1106-4",
-							"display": "Cheyenne-Arapaho",
-							"definition": "Cheyenne-Arapaho"
-						},
-						{
-							"code": "1108-0",
-							"display": "Chickahominy",
-							"definition": "Chickahominy"
-						},
-						{
-							"code": "1112-2",
-							"display": "Chickasaw",
-							"definition": "Chickasaw"
-						},
-						{
-							"code": "1114-8",
-							"display": "Chinook",
-							"definition": "Chinook"
-						},
-						{
-							"code": "1123-9",
-							"display": "Chippewa",
-							"definition": "Chippewa"
-						},
-						{
-							"code": "1150-2",
-							"display": "Chippewa Cree",
-							"definition": "Chippewa Cree"
-						},
-						{
-							"code": "1153-6",
-							"display": "Chitimacha",
-							"definition": "Chitimacha"
-						},
-						{
-							"code": "1155-1",
-							"display": "Choctaw",
-							"definition": "Choctaw"
-						},
-						{
-							"code": "1162-7",
-							"display": "Chumash",
-							"definition": "Chumash"
-						},
-						{
-							"code": "1165-0",
-							"display": "Clear Lake",
-							"definition": "Clear Lake"
-						},
-						{
-							"code": "1167-6",
-							"display": "Coeur D'Alene",
-							"definition": "Coeur D'Alene"
-						},
-						{
-							"code": "1169-2",
-							"display": "Coharie",
-							"definition": "Coharie"
-						},
-						{
-							"code": "1171-8",
-							"display": "Colorado River",
-							"definition": "Colorado River"
-						},
-						{
-							"code": "1173-4",
-							"display": "Colville",
-							"definition": "Colville"
-						},
-						{
-							"code": "1175-9",
-							"display": "Comanche",
-							"definition": "Comanche"
-						},
-						{
-							"code": "1178-3",
-							"display": "Coos, Lower Umpqua, Siuslaw",
-							"definition": "Coos, Lower Umpqua, Siuslaw"
-						},
-						{
-							"code": "1180-9",
-							"display": "Coos",
-							"definition": "Coos"
-						},
-						{
-							"code": "1182-5",
-							"display": "Coquilles",
-							"definition": "Coquilles"
-						},
-						{
-							"code": "1184-1",
-							"display": "Costanoan",
-							"definition": "Costanoan"
-						},
-						{
-							"code": "1186-6",
-							"display": "Coushatta",
-							"definition": "Coushatta"
-						},
-						{
-							"code": "1189-0",
-							"display": "Cowlitz",
-							"definition": "Cowlitz"
-						},
-						{
-							"code": "1191-6",
-							"display": "Cree",
-							"definition": "Cree"
-						},
-						{
-							"code": "1193-2",
-							"display": "Creek",
-							"definition": "Creek"
-						},
-						{
-							"code": "1207-0",
-							"display": "Croatan",
-							"definition": "Croatan"
-						},
-						{
-							"code": "1209-6",
-							"display": "Crow",
-							"definition": "Crow"
-						},
-						{
-							"code": "1211-2",
-							"display": "Cupeno",
-							"definition": "Cupeno"
-						},
-						{
-							"code": "1214-6",
-							"display": "Delaware",
-							"definition": "Delaware"
-						},
-						{
-							"code": "1222-9",
-							"display": "Diegueno",
-							"definition": "Diegueno"
-						},
-						{
-							"code": "1233-6",
-							"display": "Eastern Tribes",
-							"definition": "Eastern Tribes"
-						},
-						{
-							"code": "1250-0",
-							"display": "Esselen",
-							"definition": "Esselen"
-						},
-						{
-							"code": "1252-6",
-							"display": "Fort Belknap",
-							"definition": "Fort Belknap"
-						},
-						{
-							"code": "1254-2",
-							"display": "Fort Berthold",
-							"definition": "Fort Berthold"
-						},
-						{
-							"code": "1256-7",
-							"display": "Fort Mcdowell",
-							"definition": "Fort Mcdowell"
-						},
-						{
-							"code": "1258-3",
-							"display": "Fort Hall",
-							"definition": "Fort Hall"
-						},
-						{
-							"code": "1260-9",
-							"display": "Gabrieleno",
-							"definition": "Gabrieleno"
-						},
-						{
-							"code": "1262-5",
-							"display": "Grand Ronde",
-							"definition": "Grand Ronde"
-						},
-						{
-							"code": "1264-1",
-							"display": "Gros Ventres",
-							"definition": "Gros Ventres"
-						},
-						{
-							"code": "1267-4",
-							"display": "Haliwa",
-							"definition": "Haliwa"
-						},
-						{
-							"code": "1269-0",
-							"display": "Hidatsa",
-							"definition": "Hidatsa"
-						},
-						{
-							"code": "1271-6",
-							"display": "Hoopa",
-							"definition": "Hoopa"
-						},
-						{
-							"code": "1275-7",
-							"display": "Hoopa Extension",
-							"definition": "Hoopa Extension"
-						},
-						{
-							"code": "1277-3",
-							"display": "Houma",
-							"definition": "Houma"
-						},
-						{
-							"code": "1279-9",
-							"display": "Inaja-Cosmit",
-							"definition": "Inaja-Cosmit"
-						},
-						{
-							"code": "1281-5",
-							"display": "Iowa",
-							"definition": "Iowa"
-						},
-						{
-							"code": "1285-6",
-							"display": "Iroquois",
-							"definition": "Iroquois"
-						},
-						{
-							"code": "1297-1",
-							"display": "Juaneno",
-							"definition": "Juaneno"
-						},
-						{
-							"code": "1299-7",
-							"display": "Kalispel",
-							"definition": "Kalispel"
-						},
-						{
-							"code": "1301-1",
-							"display": "Karuk",
-							"definition": "Karuk"
-						},
-						{
-							"code": "1303-7",
-							"display": "Kaw",
-							"definition": "Kaw"
-						},
-						{
-							"code": "1305-2",
-							"display": "Kickapoo",
-							"definition": "Kickapoo"
-						},
-						{
-							"code": "1309-4",
-							"display": "Kiowa",
-							"definition": "Kiowa"
-						},
-						{
-							"code": "1312-8",
-							"display": "Klallam",
-							"definition": "Klallam"
-						},
-						{
-							"code": "1317-7",
-							"display": "Klamath",
-							"definition": "Klamath"
-						},
-						{
-							"code": "1319-3",
-							"display": "Konkow",
-							"definition": "Konkow"
-						},
-						{
-							"code": "1321-9",
-							"display": "Kootenai",
-							"definition": "Kootenai"
-						},
-						{
-							"code": "1323-5",
-							"display": "Lassik",
-							"definition": "Lassik"
-						},
-						{
-							"code": "1325-0",
-							"display": "Long Island",
-							"definition": "Long Island"
-						},
-						{
-							"code": "1331-8",
-							"display": "Luiseno",
-							"definition": "Luiseno"
-						},
-						{
-							"code": "1340-9",
-							"display": "Lumbee",
-							"definition": "Lumbee"
-						},
-						{
-							"code": "1342-5",
-							"display": "Lummi",
-							"definition": "Lummi"
-						},
-						{
-							"code": "1344-1",
-							"display": "Maidu",
-							"definition": "Maidu"
-						},
-						{
-							"code": "1348-2",
-							"display": "Makah",
-							"definition": "Makah"
-						},
-						{
-							"code": "1350-8",
-							"display": "Maliseet",
-							"definition": "Maliseet"
-						},
-						{
-							"code": "1352-4",
-							"display": "Mandan",
-							"definition": "Mandan"
-						},
-						{
-							"code": "1354-0",
-							"display": "Mattaponi",
-							"definition": "Mattaponi"
-						},
-						{
-							"code": "1356-5",
-							"display": "Menominee",
-							"definition": "Menominee"
-						},
-						{
-							"code": "1358-1",
-							"display": "Miami",
-							"definition": "Miami"
-						},
-						{
-							"code": "1363-1",
-							"display": "Miccosukee",
-							"definition": "Miccosukee"
-						},
-						{
-							"code": "1365-6",
-							"display": "Micmac",
-							"definition": "Micmac"
-						},
-						{
-							"code": "1368-0",
-							"display": "Mission Indians",
-							"definition": "Mission Indians"
-						},
-						{
-							"code": "1370-6",
-							"display": "Miwok",
-							"definition": "Miwok"
-						},
-						{
-							"code": "1372-2",
-							"display": "Modoc",
-							"definition": "Modoc"
-						},
-						{
-							"code": "1374-8",
-							"display": "Mohegan",
-							"definition": "Mohegan"
-						},
-						{
-							"code": "1376-3",
-							"display": "Mono",
-							"definition": "Mono"
-						},
-						{
-							"code": "1378-9",
-							"display": "Nanticoke",
-							"definition": "Nanticoke"
-						},
-						{
-							"code": "1380-5",
-							"display": "Narragansett",
-							"definition": "Narragansett"
-						},
-						{
-							"code": "1382-1",
-							"display": "Navajo",
-							"definition": "Navajo"
-						},
-						{
-							"code": "1387-0",
-							"display": "Nez Perce",
-							"definition": "Nez Perce"
-						},
-						{
-							"code": "1389-6",
-							"display": "Nomalaki",
-							"definition": "Nomalaki"
-						},
-						{
-							"code": "1391-2",
-							"display": "Northwest Tribes",
-							"definition": "Northwest Tribes"
-						},
-						{
-							"code": "1403-5",
-							"display": "Omaha",
-							"definition": "Omaha"
-						},
-						{
-							"code": "1405-0",
-							"display": "Oregon Athabaskan",
-							"definition": "Oregon Athabaskan"
-						},
-						{
-							"code": "1407-6",
-							"display": "Osage",
-							"definition": "Osage"
-						},
-						{
-							"code": "1409-2",
-							"display": "Otoe-Missouria",
-							"definition": "Otoe-Missouria"
-						},
-						{
-							"code": "1411-8",
-							"display": "Ottawa",
-							"definition": "Ottawa"
-						},
-						{
-							"code": "1416-7",
-							"display": "Paiute",
-							"definition": "Paiute"
-						},
-						{
-							"code": "1439-9",
-							"display": "Pamunkey",
-							"definition": "Pamunkey"
-						},
-						{
-							"code": "1441-5",
-							"display": "Passamaquoddy",
-							"definition": "Passamaquoddy"
-						},
-						{
-							"code": "1445-6",
-							"display": "Pawnee",
-							"definition": "Pawnee"
-						},
-						{
-							"code": "1448-0",
-							"display": "Penobscot",
-							"definition": "Penobscot"
-						},
-						{
-							"code": "1450-6",
-							"display": "Peoria",
-							"definition": "Peoria"
-						},
-						{
-							"code": "1453-0",
-							"display": "Pequot",
-							"definition": "Pequot"
-						},
-						{
-							"code": "1456-3",
-							"display": "Pima",
-							"definition": "Pima"
-						},
-						{
-							"code": "1460-5",
-							"display": "Piscataway",
-							"definition": "Piscataway"
-						},
-						{
-							"code": "1462-1",
-							"display": "Pit River",
-							"definition": "Pit River"
-						},
-						{
-							"code": "1464-7",
-							"display": "Pomo",
-							"definition": "Pomo"
-						},
-						{
-							"code": "1474-6",
-							"display": "Ponca",
-							"definition": "Ponca"
-						},
-						{
-							"code": "1478-7",
-							"display": "Potawatomi",
-							"definition": "Potawatomi"
-						},
-						{
-							"code": "1487-8",
-							"display": "Powhatan",
-							"definition": "Powhatan"
-						},
-						{
-							"code": "1489-4",
-							"display": "Pueblo",
-							"definition": "Pueblo"
-						},
-						{
-							"code": "1518-0",
-							"display": "Puget Sound Salish",
-							"definition": "Puget Sound Salish"
-						},
-						{
-							"code": "1541-2",
-							"display": "Quapaw",
-							"definition": "Quapaw"
-						},
-						{
-							"code": "1543-8",
-							"display": "Quinault",
-							"definition": "Quinault"
-						},
-						{
-							"code": "1545-3",
-							"display": "Rappahannock",
-							"definition": "Rappahannock"
-						},
-						{
-							"code": "1547-9",
-							"display": "Reno-Sparks",
-							"definition": "Reno-Sparks"
-						},
-						{
-							"code": "1549-5",
-							"display": "Round Valley",
-							"definition": "Round Valley"
-						},
-						{
-							"code": "1551-1",
-							"display": "Sac and Fox",
-							"definition": "Sac and Fox"
-						},
-						{
-							"code": "1556-0",
-							"display": "Salinan",
-							"definition": "Salinan"
-						},
-						{
-							"code": "1558-6",
-							"display": "Salish",
-							"definition": "Salish"
-						},
-						{
-							"code": "1560-2",
-							"display": "Salish and Kootenai",
-							"definition": "Salish and Kootenai"
-						},
-						{
-							"code": "1562-8",
-							"display": "Schaghticoke",
-							"definition": "Schaghticoke"
-						},
-						{
-							"code": "1564-4",
-							"display": "Scott Valley",
-							"definition": "Scott Valley"
-						},
-						{
-							"code": "1566-9",
-							"display": "Seminole",
-							"definition": "Seminole"
-						},
-						{
-							"code": "1573-5",
-							"display": "Serrano",
-							"definition": "Serrano"
-						},
-						{
-							"code": "1576-8",
-							"display": "Shasta",
-							"definition": "Shasta"
-						},
-						{
-							"code": "1578-4",
-							"display": "Shawnee",
-							"definition": "Shawnee"
-						},
-						{
-							"code": "1582-6",
-							"display": "Shinnecock",
-							"definition": "Shinnecock"
-						},
-						{
-							"code": "1584-2",
-							"display": "Shoalwater Bay",
-							"definition": "Shoalwater Bay"
-						},
-						{
-							"code": "1586-7",
-							"display": "Shoshone",
-							"definition": "Shoshone"
-						},
-						{
-							"code": "1602-2",
-							"display": "Shoshone Paiute",
-							"definition": "Shoshone Paiute"
-						},
-						{
-							"code": "1607-1",
-							"display": "Siletz",
-							"definition": "Siletz"
-						},
-						{
-							"code": "1609-7",
-							"display": "Sioux",
-							"definition": "Sioux"
-						},
-						{
-							"code": "1643-6",
-							"display": "Siuslaw",
-							"definition": "Siuslaw"
-						},
-						{
-							"code": "1645-1",
-							"display": "Spokane",
-							"definition": "Spokane"
-						},
-						{
-							"code": "1647-7",
-							"display": "Stewart",
-							"definition": "Stewart"
-						},
-						{
-							"code": "1649-3",
-							"display": "Stockbridge",
-							"definition": "Stockbridge"
-						},
-						{
-							"code": "1651-9",
-							"display": "Susanville",
-							"definition": "Susanville"
-						},
-						{
-							"code": "1653-5",
-							"display": "Tohono O'Odham",
-							"definition": "Tohono O'Odham"
-						},
-						{
-							"code": "1659-2",
-							"display": "Tolowa",
-							"definition": "Tolowa"
-						},
-						{
-							"code": "1661-8",
-							"display": "Tonkawa",
-							"definition": "Tonkawa"
-						},
-						{
-							"code": "1663-4",
-							"display": "Tygh",
-							"definition": "Tygh"
-						},
-						{
-							"code": "1665-9",
-							"display": "Umatilla",
-							"definition": "Umatilla"
-						},
-						{
-							"code": "1667-5",
-							"display": "Umpqua",
-							"definition": "Umpqua"
-						},
-						{
-							"code": "1670-9",
-							"display": "Ute",
-							"definition": "Ute"
-						},
-						{
-							"code": "1675-8",
-							"display": "Wailaki",
-							"definition": "Wailaki"
-						},
-						{
-							"code": "1677-4",
-							"display": "Walla-Walla",
-							"definition": "Walla-Walla"
-						},
-						{
-							"code": "1679-0",
-							"display": "Wampanoag",
-							"definition": "Wampanoag"
-						},
-						{
-							"code": "1683-2",
-							"display": "Warm Springs",
-							"definition": "Warm Springs"
-						},
-						{
-							"code": "1685-7",
-							"display": "Wascopum",
-							"definition": "Wascopum"
-						},
-						{
-							"code": "1687-3",
-							"display": "Washoe",
-							"definition": "Washoe"
-						},
-						{
-							"code": "1692-3",
-							"display": "Wichita",
-							"definition": "Wichita"
-						},
-						{
-							"code": "1694-9",
-							"display": "Wind River",
-							"definition": "Wind River"
-						},
-						{
-							"code": "1696-4",
-							"display": "Winnebago",
-							"definition": "Winnebago"
-						},
-						{
-							"code": "1700-4",
-							"display": "Winnemucca",
-							"definition": "Winnemucca"
-						},
-						{
-							"code": "1702-0",
-							"display": "Wintun",
-							"definition": "Wintun"
-						},
-						{
-							"code": "1704-6",
-							"display": "Wiyot",
-							"definition": "Wiyot"
-						},
-						{
-							"code": "1707-9",
-							"display": "Yakama",
-							"definition": "Yakama"
-						},
-						{
-							"code": "1709-5",
-							"display": "Yakama Cowlitz",
-							"definition": "Yakama Cowlitz"
-						},
-						{
-							"code": "1711-1",
-							"display": "Yaqui",
-							"definition": "Yaqui"
-						},
-						{
-							"code": "1715-2",
-							"display": "Yavapai Apache",
-							"definition": "Yavapai Apache"
-						},
-						{
-							"code": "1717-8",
-							"display": "Yokuts",
-							"definition": "Yokuts"
-						},
-						{
-							"code": "1722-8",
-							"display": "Yuchi",
-							"definition": "Yuchi"
-						},
-						{
-							"code": "1724-4",
-							"display": "Yuman",
-							"definition": "Yuman"
-						},
-						{
-							"code": "1732-7",
-							"display": "Yurok",
-							"definition": "Yurok"
-						},
-						{
-							"code": "1011-6",
-							"display": "Chiricahua",
-							"definition": "Chiricahua"
-						},
-						{
-							"code": "1012-4",
-							"display": "Fort Sill Apache",
-							"definition": "Fort Sill Apache"
-						},
-						{
-							"code": "1013-2",
-							"display": "Jicarilla Apache",
-							"definition": "Jicarilla Apache"
-						},
-						{
-							"code": "1014-0",
-							"display": "Lipan Apache",
-							"definition": "Lipan Apache"
-						},
-						{
-							"code": "1015-7",
-							"display": "Mescalero Apache",
-							"definition": "Mescalero Apache"
-						},
-						{
-							"code": "1016-5",
-							"display": "Oklahoma Apache",
-							"definition": "Oklahoma Apache"
-						},
-						{
-							"code": "1017-3",
-							"display": "Payson Apache",
-							"definition": "Payson Apache"
-						},
-						{
-							"code": "1018-1",
-							"display": "San Carlos Apache",
-							"definition": "San Carlos Apache"
-						},
-						{
-							"code": "1019-9",
-							"display": "White Mountain Apache",
-							"definition": "White Mountain Apache"
-						},
-						{
-							"code": "1022-3",
-							"display": "Northern Arapaho",
-							"definition": "Northern Arapaho"
-						},
-						{
-							"code": "1023-1",
-							"display": "Southern Arapaho",
-							"definition": "Southern Arapaho"
-						},
-						{
-							"code": "1024-9",
-							"display": "Wind River Arapaho",
-							"definition": "Wind River Arapaho"
-						},
-						{
-							"code": "1031-4",
-							"display": "Fort Peck Assiniboine Sioux",
-							"definition": "Fort Peck Assiniboine Sioux"
-						},
-						{
-							"code": "1042-1",
-							"display": "Oklahoma Cado",
-							"definition": "Oklahoma Cado"
-						},
-						{
-							"code": "1045-4",
-							"display": "Agua Caliente Cahuilla",
-							"definition": "Agua Caliente Cahuilla"
-						},
-						{
-							"code": "1046-2",
-							"display": "Augustine",
-							"definition": "Augustine"
-						},
-						{
-							"code": "1047-0",
-							"display": "Cabazon",
-							"definition": "Cabazon"
-						},
-						{
-							"code": "1048-8",
-							"display": "Los Coyotes",
-							"definition": "Los Coyotes"
-						},
-						{
-							"code": "1049-6",
-							"display": "Morongo",
-							"definition": "Morongo"
-						},
-						{
-							"code": "1050-4",
-							"display": "Santa Rosa Cahuilla",
-							"definition": "Santa Rosa Cahuilla"
-						},
-						{
-							"code": "1051-2",
-							"display": "Torres-Martinez",
-							"definition": "Torres-Martinez"
-						},
-						{
-							"code": "1054-6",
-							"display": "Cahto",
-							"definition": "Cahto"
-						},
-						{
-							"code": "1055-3",
-							"display": "Chimariko",
-							"definition": "Chimariko"
-						},
-						{
-							"code": "1056-1",
-							"display": "Coast Miwok",
-							"definition": "Coast Miwok"
-						},
-						{
-							"code": "1057-9",
-							"display": "Digger",
-							"definition": "Digger"
-						},
-						{
-							"code": "1058-7",
-							"display": "Kawaiisu",
-							"definition": "Kawaiisu"
-						},
-						{
-							"code": "1059-5",
-							"display": "Kern River",
-							"definition": "Kern River"
-						},
-						{
-							"code": "1060-3",
-							"display": "Mattole",
-							"definition": "Mattole"
-						},
-						{
-							"code": "1061-1",
-							"display": "Red Wood",
-							"definition": "Red Wood"
-						},
-						{
-							"code": "1062-9",
-							"display": "Santa Rosa",
-							"definition": "Santa Rosa"
-						},
-						{
-							"code": "1063-7",
-							"display": "Takelma",
-							"definition": "Takelma"
-						},
-						{
-							"code": "1064-5",
-							"display": "Wappo",
-							"definition": "Wappo"
-						},
-						{
-							"code": "1065-2",
-							"display": "Yana",
-							"definition": "Yana"
-						},
-						{
-							"code": "1066-0",
-							"display": "Yuki",
-							"definition": "Yuki"
-						},
-						{
-							"code": "1069-4",
-							"display": "Canadian Indian",
-							"definition": "Canadian Indian"
-						},
-						{
-							"code": "1070-2",
-							"display": "Central American Indian",
-							"definition": "Central American Indian"
-						},
-						{
-							"code": "1071-0",
-							"display": "French American Indian",
-							"definition": "French American Indian"
-						},
-						{
-							"code": "1072-8",
-							"display": "Mexican American Indian",
-							"definition": "Mexican American Indian"
-						},
-						{
-							"code": "1073-6",
-							"display": "South American Indian",
-							"definition": "South American Indian"
-						},
-						{
-							"code": "1074-4",
-							"display": "Spanish American Indian",
-							"definition": "Spanish American Indian"
-						},
-						{
-							"code": "1083-5",
-							"display": "Hoh",
-							"definition": "Hoh"
-						},
-						{
-							"code": "1084-3",
-							"display": "Quileute",
-							"definition": "Quileute"
-						},
-						{
-							"code": "1089-2",
-							"display": "Cherokee Alabama",
-							"definition": "Cherokee Alabama"
-						},
-						{
-							"code": "1090-0",
-							"display": "Cherokees of Northeast Alabama",
-							"definition": "Cherokees of Northeast Alabama"
-						},
-						{
-							"code": "1091-8",
-							"display": "Cherokees of Southeast Alabama",
-							"definition": "Cherokees of Southeast Alabama"
-						},
-						{
-							"code": "1092-6",
-							"display": "Eastern Cherokee",
-							"definition": "Eastern Cherokee"
-						},
-						{
-							"code": "1093-4",
-							"display": "Echota Cherokee",
-							"definition": "Echota Cherokee"
-						},
-						{
-							"code": "1094-2",
-							"display": "Etowah Cherokee",
-							"definition": "Etowah Cherokee"
-						},
-						{
-							"code": "1095-9",
-							"display": "Northern Cherokee",
-							"definition": "Northern Cherokee"
-						},
-						{
-							"code": "1096-7",
-							"display": "Tuscola",
-							"definition": "Tuscola"
-						},
-						{
-							"code": "1097-5",
-							"display": "United Keetowah Band of Cherokee",
-							"definition": "United Keetowah Band of Cherokee"
-						},
-						{
-							"code": "1098-3",
-							"display": "Western Cherokee",
-							"definition": "Western Cherokee"
-						},
-						{
-							"code": "1103-1",
-							"display": "Northern Cheyenne",
-							"definition": "Northern Cheyenne"
-						},
-						{
-							"code": "1104-9",
-							"display": "Southern Cheyenne",
-							"definition": "Southern Cheyenne"
-						},
-						{
-							"code": "1109-8",
-							"display": "Eastern Chickahominy",
-							"definition": "Eastern Chickahominy"
-						},
-						{
-							"code": "1110-6",
-							"display": "Western Chickahominy",
-							"definition": "Western Chickahominy"
-						},
-						{
-							"code": "1115-5",
-							"display": "Clatsop",
-							"definition": "Clatsop"
-						},
-						{
-							"code": "1116-3",
-							"display": "Columbia River Chinook",
-							"definition": "Columbia River Chinook"
-						},
-						{
-							"code": "1117-1",
-							"display": "Kathlamet",
-							"definition": "Kathlamet"
-						},
-						{
-							"code": "1118-9",
-							"display": "Upper Chinook",
-							"definition": "Upper Chinook"
-						},
-						{
-							"code": "1119-7",
-							"display": "Wakiakum Chinook",
-							"definition": "Wakiakum Chinook"
-						},
-						{
-							"code": "1120-5",
-							"display": "Willapa Chinook",
-							"definition": "Willapa Chinook"
-						},
-						{
-							"code": "1121-3",
-							"display": "Wishram",
-							"definition": "Wishram"
-						},
-						{
-							"code": "1124-7",
-							"display": "Bad River",
-							"definition": "Bad River"
-						},
-						{
-							"code": "1125-4",
-							"display": "Bay Mills Chippewa",
-							"definition": "Bay Mills Chippewa"
-						},
-						{
-							"code": "1126-2",
-							"display": "Bois Forte",
-							"definition": "Bois Forte"
-						},
-						{
-							"code": "1127-0",
-							"display": "Burt Lake Chippewa",
-							"definition": "Burt Lake Chippewa"
-						},
-						{
-							"code": "1128-8",
-							"display": "Fond du Lac",
-							"definition": "Fond du Lac"
-						},
-						{
-							"code": "1129-6",
-							"display": "Grand Portage",
-							"definition": "Grand Portage"
-						},
-						{
-							"code": "1130-4",
-							"display": "Grand Traverse Band of Ottawa/Chippewa",
-							"definition": "Grand Traverse Band of Ottawa/Chippewa"
-						},
-						{
-							"code": "1131-2",
-							"display": "Keweenaw",
-							"definition": "Keweenaw"
-						},
-						{
-							"code": "1132-0",
-							"display": "Lac Courte Oreilles",
-							"definition": "Lac Courte Oreilles"
-						},
-						{
-							"code": "1133-8",
-							"display": "Lac du Flambeau",
-							"definition": "Lac du Flambeau"
-						},
-						{
-							"code": "1134-6",
-							"display": "Lac Vieux Desert Chippewa",
-							"definition": "Lac Vieux Desert Chippewa"
-						},
-						{
-							"code": "1135-3",
-							"display": "Lake Superior",
-							"definition": "Lake Superior"
-						},
-						{
-							"code": "1136-1",
-							"display": "Leech Lake",
-							"definition": "Leech Lake"
-						},
-						{
-							"code": "1137-9",
-							"display": "Little Shell Chippewa",
-							"definition": "Little Shell Chippewa"
-						},
-						{
-							"code": "1138-7",
-							"display": "Mille Lacs",
-							"definition": "Mille Lacs"
-						},
-						{
-							"code": "1139-5",
-							"display": "Minnesota Chippewa",
-							"definition": "Minnesota Chippewa"
-						},
-						{
-							"code": "1140-3",
-							"display": "Ontonagon",
-							"definition": "Ontonagon"
-						},
-						{
-							"code": "1141-1",
-							"display": "Red Cliff Chippewa",
-							"definition": "Red Cliff Chippewa"
-						},
-						{
-							"code": "1142-9",
-							"display": "Red Lake Chippewa",
-							"definition": "Red Lake Chippewa"
-						},
-						{
-							"code": "1143-7",
-							"display": "Saginaw Chippewa",
-							"definition": "Saginaw Chippewa"
-						},
-						{
-							"code": "1144-5",
-							"display": "St. Croix Chippewa",
-							"definition": "St. Croix Chippewa"
-						},
-						{
-							"code": "1145-2",
-							"display": "Sault Ste. Marie Chippewa",
-							"definition": "Sault Ste. Marie Chippewa"
-						},
-						{
-							"code": "1146-0",
-							"display": "Sokoagon Chippewa",
-							"definition": "Sokoagon Chippewa"
-						},
-						{
-							"code": "1147-8",
-							"display": "Turtle Mountain",
-							"definition": "Turtle Mountain"
-						},
-						{
-							"code": "1148-6",
-							"display": "White Earth",
-							"definition": "White Earth"
-						},
-						{
-							"code": "1151-0",
-							"display": "Rocky Boy's Chippewa Cree",
-							"definition": "Rocky Boy's Chippewa Cree"
-						},
-						{
-							"code": "1156-9",
-							"display": "Clifton Choctaw",
-							"definition": "Clifton Choctaw"
-						},
-						{
-							"code": "1157-7",
-							"display": "Jena Choctaw",
-							"definition": "Jena Choctaw"
-						},
-						{
-							"code": "1158-5",
-							"display": "Mississippi Choctaw",
-							"definition": "Mississippi Choctaw"
-						},
-						{
-							"code": "1159-3",
-							"display": "Mowa Band of Choctaw",
-							"definition": "Mowa Band of Choctaw"
-						},
-						{
-							"code": "1160-1",
-							"display": "Oklahoma Choctaw",
-							"definition": "Oklahoma Choctaw"
-						},
-						{
-							"code": "1163-5",
-							"display": "Santa Ynez",
-							"definition": "Santa Ynez"
-						},
-						{
-							"code": "1176-7",
-							"display": "Oklahoma Comanche",
-							"definition": "Oklahoma Comanche"
-						},
-						{
-							"code": "1187-4",
-							"display": "Alabama Coushatta",
-							"definition": "Alabama Coushatta"
-						},
-						{
-							"code": "1194-0",
-							"display": "Alabama Creek",
-							"definition": "Alabama Creek"
-						},
-						{
-							"code": "1195-7",
-							"display": "Alabama Quassarte",
-							"definition": "Alabama Quassarte"
-						},
-						{
-							"code": "1196-5",
-							"display": "Eastern Creek",
-							"definition": "Eastern Creek"
-						},
-						{
-							"code": "1197-3",
-							"display": "Eastern Muscogee",
-							"definition": "Eastern Muscogee"
-						},
-						{
-							"code": "1198-1",
-							"display": "Kialegee",
-							"definition": "Kialegee"
-						},
-						{
-							"code": "1199-9",
-							"display": "Lower Muscogee",
-							"definition": "Lower Muscogee"
-						},
-						{
-							"code": "1200-5",
-							"display": "Machis Lower Creek Indian",
-							"definition": "Machis Lower Creek Indian"
-						},
-						{
-							"code": "1201-3",
-							"display": "Poarch Band",
-							"definition": "Poarch Band"
-						},
-						{
-							"code": "1202-1",
-							"display": "Principal Creek Indian Nation",
-							"definition": "Principal Creek Indian Nation"
-						},
-						{
-							"code": "1203-9",
-							"display": "Star Clan of Muscogee Creeks",
-							"definition": "Star Clan of Muscogee Creeks"
-						},
-						{
-							"code": "1204-7",
-							"display": "Thlopthlocco",
-							"definition": "Thlopthlocco"
-						},
-						{
-							"code": "1205-4",
-							"display": "Tuckabachee",
-							"definition": "Tuckabachee"
-						},
-						{
-							"code": "1212-0",
-							"display": "Agua Caliente",
-							"definition": "Agua Caliente"
-						},
-						{
-							"code": "1215-3",
-							"display": "Eastern Delaware",
-							"definition": "Eastern Delaware"
-						},
-						{
-							"code": "1216-1",
-							"display": "Lenni-Lenape",
-							"definition": "Lenni-Lenape"
-						},
-						{
-							"code": "1217-9",
-							"display": "Munsee",
-							"definition": "Munsee"
-						},
-						{
-							"code": "1218-7",
-							"display": "Oklahoma Delaware",
-							"definition": "Oklahoma Delaware"
-						},
-						{
-							"code": "1219-5",
-							"display": "Rampough Mountain",
-							"definition": "Rampough Mountain"
-						},
-						{
-							"code": "1220-3",
-							"display": "Sand Hill",
-							"definition": "Sand Hill"
-						},
-						{
-							"code": "1223-7",
-							"display": "Campo",
-							"definition": "Campo"
-						},
-						{
-							"code": "1224-5",
-							"display": "Capitan Grande",
-							"definition": "Capitan Grande"
-						},
-						{
-							"code": "1225-2",
-							"display": "Cuyapaipe",
-							"definition": "Cuyapaipe"
-						},
-						{
-							"code": "1226-0",
-							"display": "La Posta",
-							"definition": "La Posta"
-						},
-						{
-							"code": "1227-8",
-							"display": "Manzanita",
-							"definition": "Manzanita"
-						},
-						{
-							"code": "1228-6",
-							"display": "Mesa Grande",
-							"definition": "Mesa Grande"
-						},
-						{
-							"code": "1229-4",
-							"display": "San Pasqual",
-							"definition": "San Pasqual"
-						},
-						{
-							"code": "1230-2",
-							"display": "Santa Ysabel",
-							"definition": "Santa Ysabel"
-						},
-						{
-							"code": "1231-0",
-							"display": "Sycuan",
-							"definition": "Sycuan"
-						},
-						{
-							"code": "1234-4",
-							"display": "Attacapa",
-							"definition": "Attacapa"
-						},
-						{
-							"code": "1235-1",
-							"display": "Biloxi",
-							"definition": "Biloxi"
-						},
-						{
-							"code": "1236-9",
-							"display": "Georgetown (Eastern Tribes)",
-							"definition": "Georgetown (Eastern Tribes)"
-						},
-						{
-							"code": "1237-7",
-							"display": "Moor",
-							"definition": "Moor"
-						},
-						{
-							"code": "1238-5",
-							"display": "Nansemond",
-							"definition": "Nansemond"
-						},
-						{
-							"code": "1239-3",
-							"display": "Natchez",
-							"definition": "Natchez"
-						},
-						{
-							"code": "1240-1",
-							"display": "Nausu Waiwash",
-							"definition": "Nausu Waiwash"
-						},
-						{
-							"code": "1241-9",
-							"display": "Nipmuc",
-							"definition": "Nipmuc"
-						},
-						{
-							"code": "1242-7",
-							"display": "Paugussett",
-							"definition": "Paugussett"
-						},
-						{
-							"code": "1243-5",
-							"display": "Pocomoke Acohonock",
-							"definition": "Pocomoke Acohonock"
-						},
-						{
-							"code": "1244-3",
-							"display": "Southeastern Indians",
-							"definition": "Southeastern Indians"
-						},
-						{
-							"code": "1245-0",
-							"display": "Susquehanock",
-							"definition": "Susquehanock"
-						},
-						{
-							"code": "1246-8",
-							"display": "Tunica Biloxi",
-							"definition": "Tunica Biloxi"
-						},
-						{
-							"code": "1247-6",
-							"display": "Waccamaw-Siousan",
-							"definition": "Waccamaw-Siousan"
-						},
-						{
-							"code": "1248-4",
-							"display": "Wicomico",
-							"definition": "Wicomico"
-						},
-						{
-							"code": "1265-8",
-							"display": "Atsina",
-							"definition": "Atsina"
-						},
-						{
-							"code": "1272-4",
-							"display": "Trinity",
-							"definition": "Trinity"
-						},
-						{
-							"code": "1273-2",
-							"display": "Whilkut",
-							"definition": "Whilkut"
-						},
-						{
-							"code": "1282-3",
-							"display": "Iowa of Kansas-Nebraska",
-							"definition": "Iowa of Kansas-Nebraska"
-						},
-						{
-							"code": "1283-1",
-							"display": "Iowa of Oklahoma",
-							"definition": "Iowa of Oklahoma"
-						},
-						{
-							"code": "1286-4",
-							"display": "Cayuga",
-							"definition": "Cayuga"
-						},
-						{
-							"code": "1287-2",
-							"display": "Mohawk",
-							"definition": "Mohawk"
-						},
-						{
-							"code": "1288-0",
-							"display": "Oneida",
-							"definition": "Oneida"
-						},
-						{
-							"code": "1289-8",
-							"display": "Onondaga",
-							"definition": "Onondaga"
-						},
-						{
-							"code": "1290-6",
-							"display": "Seneca",
-							"definition": "Seneca"
-						},
-						{
-							"code": "1291-4",
-							"display": "Seneca Nation",
-							"definition": "Seneca Nation"
-						},
-						{
-							"code": "1292-2",
-							"display": "Seneca-Cayuga",
-							"definition": "Seneca-Cayuga"
-						},
-						{
-							"code": "1293-0",
-							"display": "Tonawanda Seneca",
-							"definition": "Tonawanda Seneca"
-						},
-						{
-							"code": "1294-8",
-							"display": "Tuscarora",
-							"definition": "Tuscarora"
-						},
-						{
-							"code": "1295-5",
-							"display": "Wyandotte",
-							"definition": "Wyandotte"
-						},
-						{
-							"code": "1306-0",
-							"display": "Oklahoma Kickapoo",
-							"definition": "Oklahoma Kickapoo"
-						},
-						{
-							"code": "1307-8",
-							"display": "Texas Kickapoo",
-							"definition": "Texas Kickapoo"
-						},
-						{
-							"code": "1310-2",
-							"display": "Oklahoma Kiowa",
-							"definition": "Oklahoma Kiowa"
-						},
-						{
-							"code": "1313-6",
-							"display": "Jamestown",
-							"definition": "Jamestown"
-						},
-						{
-							"code": "1314-4",
-							"display": "Lower Elwha",
-							"definition": "Lower Elwha"
-						},
-						{
-							"code": "1315-1",
-							"display": "Port Gamble Klallam",
-							"definition": "Port Gamble Klallam"
-						},
-						{
-							"code": "1326-8",
-							"display": "Matinecock",
-							"definition": "Matinecock"
-						},
-						{
-							"code": "1327-6",
-							"display": "Montauk",
-							"definition": "Montauk"
-						},
-						{
-							"code": "1328-4",
-							"display": "Poospatuck",
-							"definition": "Poospatuck"
-						},
-						{
-							"code": "1329-2",
-							"display": "Setauket",
-							"definition": "Setauket"
-						},
-						{
-							"code": "1332-6",
-							"display": "La Jolla",
-							"definition": "La Jolla"
-						},
-						{
-							"code": "1333-4",
-							"display": "Pala",
-							"definition": "Pala"
-						},
-						{
-							"code": "1334-2",
-							"display": "Pauma",
-							"definition": "Pauma"
-						},
-						{
-							"code": "1335-9",
-							"display": "Pechanga",
-							"definition": "Pechanga"
-						},
-						{
-							"code": "1336-7",
-							"display": "Soboba",
-							"definition": "Soboba"
-						},
-						{
-							"code": "1337-5",
-							"display": "Twenty-Nine Palms",
-							"definition": "Twenty-Nine Palms"
-						},
-						{
-							"code": "1338-3",
-							"display": "Temecula",
-							"definition": "Temecula"
-						},
-						{
-							"code": "1345-8",
-							"display": "Mountain Maidu",
-							"definition": "Mountain Maidu"
-						},
-						{
-							"code": "1346-6",
-							"display": "Nishinam",
-							"definition": "Nishinam"
-						},
-						{
-							"code": "1359-9",
-							"display": "Illinois Miami",
-							"definition": "Illinois Miami"
-						},
-						{
-							"code": "1360-7",
-							"display": "Indiana Miami",
-							"definition": "Indiana Miami"
-						},
-						{
-							"code": "1361-5",
-							"display": "Oklahoma Miami",
-							"definition": "Oklahoma Miami"
-						},
-						{
-							"code": "1366-4",
-							"display": "Aroostook",
-							"definition": "Aroostook"
-						},
-						{
-							"code": "1383-9",
-							"display": "Alamo Navajo",
-							"definition": "Alamo Navajo"
-						},
-						{
-							"code": "1384-7",
-							"display": "Canoncito Navajo",
-							"definition": "Canoncito Navajo"
-						},
-						{
-							"code": "1385-4",
-							"display": "Ramah Navajo",
-							"definition": "Ramah Navajo"
-						},
-						{
-							"code": "1392-0",
-							"display": "Alsea",
-							"definition": "Alsea"
-						},
-						{
-							"code": "1393-8",
-							"display": "Celilo",
-							"definition": "Celilo"
-						},
-						{
-							"code": "1394-6",
-							"display": "Columbia",
-							"definition": "Columbia"
-						},
-						{
-							"code": "1395-3",
-							"display": "Kalapuya",
-							"definition": "Kalapuya"
-						},
-						{
-							"code": "1396-1",
-							"display": "Molala",
-							"definition": "Molala"
-						},
-						{
-							"code": "1397-9",
-							"display": "Talakamish",
-							"definition": "Talakamish"
-						},
-						{
-							"code": "1398-7",
-							"display": "Tenino",
-							"definition": "Tenino"
-						},
-						{
-							"code": "1399-5",
-							"display": "Tillamook",
-							"definition": "Tillamook"
-						},
-						{
-							"code": "1400-1",
-							"display": "Wenatchee",
-							"definition": "Wenatchee"
-						},
-						{
-							"code": "1401-9",
-							"display": "Yahooskin",
-							"definition": "Yahooskin"
-						},
-						{
-							"code": "1412-6",
-							"display": "Burt Lake Ottawa",
-							"definition": "Burt Lake Ottawa"
-						},
-						{
-							"code": "1413-4",
-							"display": "Michigan Ottawa",
-							"definition": "Michigan Ottawa"
-						},
-						{
-							"code": "1414-2",
-							"display": "Oklahoma Ottawa",
-							"definition": "Oklahoma Ottawa"
-						},
-						{
-							"code": "1417-5",
-							"display": "Bishop",
-							"definition": "Bishop"
-						},
-						{
-							"code": "1418-3",
-							"display": "Bridgeport",
-							"definition": "Bridgeport"
-						},
-						{
-							"code": "1419-1",
-							"display": "Burns Paiute",
-							"definition": "Burns Paiute"
-						},
-						{
-							"code": "1420-9",
-							"display": "Cedarville",
-							"definition": "Cedarville"
-						},
-						{
-							"code": "1421-7",
-							"display": "Fort Bidwell",
-							"definition": "Fort Bidwell"
-						},
-						{
-							"code": "1422-5",
-							"display": "Fort Independence",
-							"definition": "Fort Independence"
-						},
-						{
-							"code": "1423-3",
-							"display": "Kaibab",
-							"definition": "Kaibab"
-						},
-						{
-							"code": "1424-1",
-							"display": "Las Vegas",
-							"definition": "Las Vegas"
-						},
-						{
-							"code": "1425-8",
-							"display": "Lone Pine",
-							"definition": "Lone Pine"
-						},
-						{
-							"code": "1426-6",
-							"display": "Lovelock",
-							"definition": "Lovelock"
-						},
-						{
-							"code": "1427-4",
-							"display": "Malheur Paiute",
-							"definition": "Malheur Paiute"
-						},
-						{
-							"code": "1428-2",
-							"display": "Moapa",
-							"definition": "Moapa"
-						},
-						{
-							"code": "1429-0",
-							"display": "Northern Paiute",
-							"definition": "Northern Paiute"
-						},
-						{
-							"code": "1430-8",
-							"display": "Owens Valley",
-							"definition": "Owens Valley"
-						},
-						{
-							"code": "1431-6",
-							"display": "Pyramid Lake",
-							"definition": "Pyramid Lake"
-						},
-						{
-							"code": "1432-4",
-							"display": "San Juan Southern Paiute",
-							"definition": "San Juan Southern Paiute"
-						},
-						{
-							"code": "1433-2",
-							"display": "Southern Paiute",
-							"definition": "Southern Paiute"
-						},
-						{
-							"code": "1434-0",
-							"display": "Summit Lake",
-							"definition": "Summit Lake"
-						},
-						{
-							"code": "1435-7",
-							"display": "Utu Utu Gwaitu Paiute",
-							"definition": "Utu Utu Gwaitu Paiute"
-						},
-						{
-							"code": "1436-5",
-							"display": "Walker River",
-							"definition": "Walker River"
-						},
-						{
-							"code": "1437-3",
-							"display": "Yerington Paiute",
-							"definition": "Yerington Paiute"
-						},
-						{
-							"code": "1442-3",
-							"display": "Indian Township",
-							"definition": "Indian Township"
-						},
-						{
-							"code": "1443-1",
-							"display": "Pleasant Point Passamaquoddy",
-							"definition": "Pleasant Point Passamaquoddy"
-						},
-						{
-							"code": "1446-4",
-							"display": "Oklahoma Pawnee",
-							"definition": "Oklahoma Pawnee"
-						},
-						{
-							"code": "1451-4",
-							"display": "Oklahoma Peoria",
-							"definition": "Oklahoma Peoria"
-						},
-						{
-							"code": "1454-8",
-							"display": "Marshantucket Pequot",
-							"definition": "Marshantucket Pequot"
-						},
-						{
-							"code": "1457-1",
-							"display": "Gila River Pima-Maricopa",
-							"definition": "Gila River Pima-Maricopa"
-						},
-						{
-							"code": "1458-9",
-							"display": "Salt River Pima-Maricopa",
-							"definition": "Salt River Pima-Maricopa"
-						},
-						{
-							"code": "1465-4",
-							"display": "Central Pomo",
-							"definition": "Central Pomo"
-						},
-						{
-							"code": "1466-2",
-							"display": "Dry Creek",
-							"definition": "Dry Creek"
-						},
-						{
-							"code": "1467-0",
-							"display": "Eastern Pomo",
-							"definition": "Eastern Pomo"
-						},
-						{
-							"code": "1468-8",
-							"display": "Kashia",
-							"definition": "Kashia"
-						},
-						{
-							"code": "1469-6",
-							"display": "Northern Pomo",
-							"definition": "Northern Pomo"
-						},
-						{
-							"code": "1470-4",
-							"display": "Scotts Valley",
-							"definition": "Scotts Valley"
-						},
-						{
-							"code": "1471-2",
-							"display": "Stonyford",
-							"definition": "Stonyford"
-						},
-						{
-							"code": "1472-0",
-							"display": "Sulphur Bank",
-							"definition": "Sulphur Bank"
-						},
-						{
-							"code": "1475-3",
-							"display": "Nebraska Ponca",
-							"definition": "Nebraska Ponca"
-						},
-						{
-							"code": "1476-1",
-							"display": "Oklahoma Ponca",
-							"definition": "Oklahoma Ponca"
-						},
-						{
-							"code": "1479-5",
-							"display": "Citizen Band Potawatomi",
-							"definition": "Citizen Band Potawatomi"
-						},
-						{
-							"code": "1480-3",
-							"display": "Forest County",
-							"definition": "Forest County"
-						},
-						{
-							"code": "1481-1",
-							"display": "Hannahville",
-							"definition": "Hannahville"
-						},
-						{
-							"code": "1482-9",
-							"display": "Huron Potawatomi",
-							"definition": "Huron Potawatomi"
-						},
-						{
-							"code": "1483-7",
-							"display": "Pokagon Potawatomi",
-							"definition": "Pokagon Potawatomi"
-						},
-						{
-							"code": "1484-5",
-							"display": "Prairie Band",
-							"definition": "Prairie Band"
-						},
-						{
-							"code": "1485-2",
-							"display": "Wisconsin Potawatomi",
-							"definition": "Wisconsin Potawatomi"
-						},
-						{
-							"code": "1490-2",
-							"display": "Acoma",
-							"definition": "Acoma"
-						},
-						{
-							"code": "1491-0",
-							"display": "Arizona Tewa",
-							"definition": "Arizona Tewa"
-						},
-						{
-							"code": "1492-8",
-							"display": "Cochiti",
-							"definition": "Cochiti"
-						},
-						{
-							"code": "1493-6",
-							"display": "Hopi",
-							"definition": "Hopi"
-						},
-						{
-							"code": "1494-4",
-							"display": "Isleta",
-							"definition": "Isleta"
-						},
-						{
-							"code": "1495-1",
-							"display": "Jemez",
-							"definition": "Jemez"
-						},
-						{
-							"code": "1496-9",
-							"display": "Keres",
-							"definition": "Keres"
-						},
-						{
-							"code": "1497-7",
-							"display": "Laguna",
-							"definition": "Laguna"
-						},
-						{
-							"code": "1498-5",
-							"display": "Nambe",
-							"definition": "Nambe"
-						},
-						{
-							"code": "1499-3",
-							"display": "Picuris",
-							"definition": "Picuris"
-						},
-						{
-							"code": "1500-8",
-							"display": "Piro",
-							"definition": "Piro"
-						},
-						{
-							"code": "1501-6",
-							"display": "Pojoaque",
-							"definition": "Pojoaque"
-						},
-						{
-							"code": "1502-4",
-							"display": "San Felipe",
-							"definition": "San Felipe"
-						},
-						{
-							"code": "1503-2",
-							"display": "San Ildefonso",
-							"definition": "San Ildefonso"
-						},
-						{
-							"code": "1504-0",
-							"display": "San Juan Pueblo",
-							"definition": "San Juan Pueblo"
-						},
-						{
-							"code": "1505-7",
-							"display": "San Juan De",
-							"definition": "San Juan De"
-						},
-						{
-							"code": "1506-5",
-							"display": "San Juan",
-							"definition": "San Juan"
-						},
-						{
-							"code": "1507-3",
-							"display": "Sandia",
-							"definition": "Sandia"
-						},
-						{
-							"code": "1508-1",
-							"display": "Santa Ana",
-							"definition": "Santa Ana"
-						},
-						{
-							"code": "1509-9",
-							"display": "Santa Clara",
-							"definition": "Santa Clara"
-						},
-						{
-							"code": "1510-7",
-							"display": "Santo Domingo",
-							"definition": "Santo Domingo"
-						},
-						{
-							"code": "1511-5",
-							"display": "Taos",
-							"definition": "Taos"
-						},
-						{
-							"code": "1512-3",
-							"display": "Tesuque",
-							"definition": "Tesuque"
-						},
-						{
-							"code": "1513-1",
-							"display": "Tewa",
-							"definition": "Tewa"
-						},
-						{
-							"code": "1514-9",
-							"display": "Tigua",
-							"definition": "Tigua"
-						},
-						{
-							"code": "1515-6",
-							"display": "Zia",
-							"definition": "Zia"
-						},
-						{
-							"code": "1516-4",
-							"display": "Zuni",
-							"definition": "Zuni"
-						},
-						{
-							"code": "1519-8",
-							"display": "Duwamish",
-							"definition": "Duwamish"
-						},
-						{
-							"code": "1520-6",
-							"display": "Kikiallus",
-							"definition": "Kikiallus"
-						},
-						{
-							"code": "1521-4",
-							"display": "Lower Skagit",
-							"definition": "Lower Skagit"
-						},
-						{
-							"code": "1522-2",
-							"display": "Muckleshoot",
-							"definition": "Muckleshoot"
-						},
-						{
-							"code": "1523-0",
-							"display": "Nisqually",
-							"definition": "Nisqually"
-						},
-						{
-							"code": "1524-8",
-							"display": "Nooksack",
-							"definition": "Nooksack"
-						},
-						{
-							"code": "1525-5",
-							"display": "Port Madison",
-							"definition": "Port Madison"
-						},
-						{
-							"code": "1526-3",
-							"display": "Puyallup",
-							"definition": "Puyallup"
-						},
-						{
-							"code": "1527-1",
-							"display": "Samish",
-							"definition": "Samish"
-						},
-						{
-							"code": "1528-9",
-							"display": "Sauk-Suiattle",
-							"definition": "Sauk-Suiattle"
-						},
-						{
-							"code": "1529-7",
-							"display": "Skokomish",
-							"definition": "Skokomish"
-						},
-						{
-							"code": "1530-5",
-							"display": "Skykomish",
-							"definition": "Skykomish"
-						},
-						{
-							"code": "1531-3",
-							"display": "Snohomish",
-							"definition": "Snohomish"
-						},
-						{
-							"code": "1532-1",
-							"display": "Snoqualmie",
-							"definition": "Snoqualmie"
-						},
-						{
-							"code": "1533-9",
-							"display": "Squaxin Island",
-							"definition": "Squaxin Island"
-						},
-						{
-							"code": "1534-7",
-							"display": "Steilacoom",
-							"definition": "Steilacoom"
-						},
-						{
-							"code": "1535-4",
-							"display": "Stillaguamish",
-							"definition": "Stillaguamish"
-						},
-						{
-							"code": "1536-2",
-							"display": "Suquamish",
-							"definition": "Suquamish"
-						},
-						{
-							"code": "1537-0",
-							"display": "Swinomish",
-							"definition": "Swinomish"
-						},
-						{
-							"code": "1538-8",
-							"display": "Tulalip",
-							"definition": "Tulalip"
-						},
-						{
-							"code": "1539-6",
-							"display": "Upper Skagit",
-							"definition": "Upper Skagit"
-						},
-						{
-							"code": "1552-9",
-							"display": "Iowa Sac and Fox",
-							"definition": "Iowa Sac and Fox"
-						},
-						{
-							"code": "1553-7",
-							"display": "Missouri Sac and Fox",
-							"definition": "Missouri Sac and Fox"
-						},
-						{
-							"code": "1554-5",
-							"display": "Oklahoma Sac and Fox",
-							"definition": "Oklahoma Sac and Fox"
-						},
-						{
-							"code": "1567-7",
-							"display": "Big Cypress",
-							"definition": "Big Cypress"
-						},
-						{
-							"code": "1568-5",
-							"display": "Brighton",
-							"definition": "Brighton"
-						},
-						{
-							"code": "1569-3",
-							"display": "Florida Seminole",
-							"definition": "Florida Seminole"
-						},
-						{
-							"code": "1570-1",
-							"display": "Hollywood Seminole",
-							"definition": "Hollywood Seminole"
-						},
-						{
-							"code": "1571-9",
-							"display": "Oklahoma Seminole",
-							"definition": "Oklahoma Seminole"
-						},
-						{
-							"code": "1574-3",
-							"display": "San Manual",
-							"definition": "San Manual"
-						},
-						{
-							"code": "1579-2",
-							"display": "Absentee Shawnee",
-							"definition": "Absentee Shawnee"
-						},
-						{
-							"code": "1580-0",
-							"display": "Eastern Shawnee",
-							"definition": "Eastern Shawnee"
-						},
-						{
-							"code": "1587-5",
-							"display": "Battle Mountain",
-							"definition": "Battle Mountain"
-						},
-						{
-							"code": "1588-3",
-							"display": "Duckwater",
-							"definition": "Duckwater"
-						},
-						{
-							"code": "1589-1",
-							"display": "Elko",
-							"definition": "Elko"
-						},
-						{
-							"code": "1590-9",
-							"display": "Ely",
-							"definition": "Ely"
-						},
-						{
-							"code": "1591-7",
-							"display": "Goshute",
-							"definition": "Goshute"
-						},
-						{
-							"code": "1592-5",
-							"display": "Panamint",
-							"definition": "Panamint"
-						},
-						{
-							"code": "1593-3",
-							"display": "Ruby Valley",
-							"definition": "Ruby Valley"
-						},
-						{
-							"code": "1594-1",
-							"display": "Skull Valley",
-							"definition": "Skull Valley"
-						},
-						{
-							"code": "1595-8",
-							"display": "South Fork Shoshone",
-							"definition": "South Fork Shoshone"
-						},
-						{
-							"code": "1596-6",
-							"display": "Te-Moak Western Shoshone",
-							"definition": "Te-Moak Western Shoshone"
-						},
-						{
-							"code": "1597-4",
-							"display": "Timbi-Sha Shoshone",
-							"definition": "Timbi-Sha Shoshone"
-						},
-						{
-							"code": "1598-2",
-							"display": "Washakie",
-							"definition": "Washakie"
-						},
-						{
-							"code": "1599-0",
-							"display": "Wind River Shoshone",
-							"definition": "Wind River Shoshone"
-						},
-						{
-							"code": "1600-6",
-							"display": "Yomba",
-							"definition": "Yomba"
-						},
-						{
-							"code": "1603-0",
-							"display": "Duck Valley",
-							"definition": "Duck Valley"
-						},
-						{
-							"code": "1604-8",
-							"display": "Fallon",
-							"definition": "Fallon"
-						},
-						{
-							"code": "1605-5",
-							"display": "Fort McDermitt",
-							"definition": "Fort McDermitt"
-						},
-						{
-							"code": "1610-5",
-							"display": "Blackfoot Sioux",
-							"definition": "Blackfoot Sioux"
-						},
-						{
-							"code": "1611-3",
-							"display": "Brule Sioux",
-							"definition": "Brule Sioux"
-						},
-						{
-							"code": "1612-1",
-							"display": "Cheyenne River Sioux",
-							"definition": "Cheyenne River Sioux"
-						},
-						{
-							"code": "1613-9",
-							"display": "Crow Creek Sioux",
-							"definition": "Crow Creek Sioux"
-						},
-						{
-							"code": "1614-7",
-							"display": "Dakota Sioux",
-							"definition": "Dakota Sioux"
-						},
-						{
-							"code": "1615-4",
-							"display": "Flandreau Santee",
-							"definition": "Flandreau Santee"
-						},
-						{
-							"code": "1616-2",
-							"display": "Fort Peck",
-							"definition": "Fort Peck"
-						},
-						{
-							"code": "1617-0",
-							"display": "Lake Traverse Sioux",
-							"definition": "Lake Traverse Sioux"
-						},
-						{
-							"code": "1618-8",
-							"display": "Lower Brule Sioux",
-							"definition": "Lower Brule Sioux"
-						},
-						{
-							"code": "1619-6",
-							"display": "Lower Sioux",
-							"definition": "Lower Sioux"
-						},
-						{
-							"code": "1620-4",
-							"display": "Mdewakanton Sioux",
-							"definition": "Mdewakanton Sioux"
-						},
-						{
-							"code": "1621-2",
-							"display": "Miniconjou",
-							"definition": "Miniconjou"
-						},
-						{
-							"code": "1622-0",
-							"display": "Oglala Sioux",
-							"definition": "Oglala Sioux"
-						},
-						{
-							"code": "1623-8",
-							"display": "Pine Ridge Sioux",
-							"definition": "Pine Ridge Sioux"
-						},
-						{
-							"code": "1624-6",
-							"display": "Pipestone Sioux",
-							"definition": "Pipestone Sioux"
-						},
-						{
-							"code": "1625-3",
-							"display": "Prairie Island Sioux",
-							"definition": "Prairie Island Sioux"
-						},
-						{
-							"code": "1626-1",
-							"display": "Prior Lake Sioux",
-							"definition": "Prior Lake Sioux"
-						},
-						{
-							"code": "1627-9",
-							"display": "Rosebud Sioux",
-							"definition": "Rosebud Sioux"
-						},
-						{
-							"code": "1628-7",
-							"display": "Sans Arc Sioux",
-							"definition": "Sans Arc Sioux"
-						},
-						{
-							"code": "1629-5",
-							"display": "Santee Sioux",
-							"definition": "Santee Sioux"
-						},
-						{
-							"code": "1630-3",
-							"display": "Sisseton-Wahpeton",
-							"definition": "Sisseton-Wahpeton"
-						},
-						{
-							"code": "1631-1",
-							"display": "Sisseton Sioux",
-							"definition": "Sisseton Sioux"
-						},
-						{
-							"code": "1632-9",
-							"display": "Spirit Lake Sioux",
-							"definition": "Spirit Lake Sioux"
-						},
-						{
-							"code": "1633-7",
-							"display": "Standing Rock Sioux",
-							"definition": "Standing Rock Sioux"
-						},
-						{
-							"code": "1634-5",
-							"display": "Teton Sioux",
-							"definition": "Teton Sioux"
-						},
-						{
-							"code": "1635-2",
-							"display": "Two Kettle Sioux",
-							"definition": "Two Kettle Sioux"
-						},
-						{
-							"code": "1636-0",
-							"display": "Upper Sioux",
-							"definition": "Upper Sioux"
-						},
-						{
-							"code": "1637-8",
-							"display": "Wahpekute Sioux",
-							"definition": "Wahpekute Sioux"
-						},
-						{
-							"code": "1638-6",
-							"display": "Wahpeton Sioux",
-							"definition": "Wahpeton Sioux"
-						},
-						{
-							"code": "1639-4",
-							"display": "Wazhaza Sioux",
-							"definition": "Wazhaza Sioux"
-						},
-						{
-							"code": "1640-2",
-							"display": "Yankton Sioux",
-							"definition": "Yankton Sioux"
-						},
-						{
-							"code": "1641-0",
-							"display": "Yanktonai Sioux",
-							"definition": "Yanktonai Sioux"
-						},
-						{
-							"code": "1654-3",
-							"display": "Ak-Chin",
-							"definition": "Ak-Chin"
-						},
-						{
-							"code": "1655-0",
-							"display": "Gila Bend",
-							"definition": "Gila Bend"
-						},
-						{
-							"code": "1656-8",
-							"display": "San Xavier",
-							"definition": "San Xavier"
-						},
-						{
-							"code": "1657-6",
-							"display": "Sells",
-							"definition": "Sells"
-						},
-						{
-							"code": "1668-3",
-							"display": "Cow Creek Umpqua",
-							"definition": "Cow Creek Umpqua"
-						},
-						{
-							"code": "1671-7",
-							"display": "Allen Canyon",
-							"definition": "Allen Canyon"
-						},
-						{
-							"code": "1672-5",
-							"display": "Uintah Ute",
-							"definition": "Uintah Ute"
-						},
-						{
-							"code": "1673-3",
-							"display": "Ute Mountain Ute",
-							"definition": "Ute Mountain Ute"
-						},
-						{
-							"code": "1680-8",
-							"display": "Gay Head Wampanoag",
-							"definition": "Gay Head Wampanoag"
-						},
-						{
-							"code": "1681-6",
-							"display": "Mashpee Wampanoag",
-							"definition": "Mashpee Wampanoag"
-						},
-						{
-							"code": "1688-1",
-							"display": "Alpine",
-							"definition": "Alpine"
-						},
-						{
-							"code": "1689-9",
-							"display": "Carson",
-							"definition": "Carson"
-						},
-						{
-							"code": "1690-7",
-							"display": "Dresslerville",
-							"definition": "Dresslerville"
-						},
-						{
-							"code": "1697-2",
-							"display": "Ho-chunk",
-							"definition": "Ho-chunk"
-						},
-						{
-							"code": "1698-0",
-							"display": "Nebraska Winnebago",
-							"definition": "Nebraska Winnebago"
-						},
-						{
-							"code": "1705-3",
-							"display": "Table Bluff",
-							"definition": "Table Bluff"
-						},
-						{
-							"code": "1712-9",
-							"display": "Barrio Libre",
-							"definition": "Barrio Libre"
-						},
-						{
-							"code": "1713-7",
-							"display": "Pascua Yaqui",
-							"definition": "Pascua Yaqui"
-						},
-						{
-							"code": "1718-6",
-							"display": "Chukchansi",
-							"definition": "Chukchansi"
-						},
-						{
-							"code": "1719-4",
-							"display": "Tachi",
-							"definition": "Tachi"
-						},
-						{
-							"code": "1720-2",
-							"display": "Tule River",
-							"definition": "Tule River"
-						},
-						{
-							"code": "1725-1",
-							"display": "Cocopah",
-							"definition": "Cocopah"
-						},
-						{
-							"code": "1726-9",
-							"display": "Havasupai",
-							"definition": "Havasupai"
-						},
-						{
-							"code": "1727-7",
-							"display": "Hualapai",
-							"definition": "Hualapai"
-						},
-						{
-							"code": "1728-5",
-							"display": "Maricopa",
-							"definition": "Maricopa"
-						},
-						{
-							"code": "1729-3",
-							"display": "Mohave",
-							"definition": "Mohave"
-						},
-						{
-							"code": "1730-1",
-							"display": "Quechan",
-							"definition": "Quechan"
-						},
-						{
-							"code": "1731-9",
-							"display": "Yavapai",
-							"definition": "Yavapai"
-						},
-						{
-							"code": "1733-5",
-							"display": "Coast Yurok",
-							"definition": "Coast Yurok"
-						},
-						{
-							"code": "1737-6",
-							"display": "Alaska Indian",
-							"definition": "Alaska Indian"
-						},
-						{
-							"code": "1840-8",
-							"display": "Eskimo",
-							"definition": "Eskimo"
-						},
-						{
-							"code": "1966-1",
-							"display": "Aleut",
-							"definition": "Aleut"
-						},
-						{
-							"code": "1739-2",
-							"display": "Alaskan Athabascan",
-							"definition": "Alaskan Athabascan"
-						},
-						{
-							"code": "1811-9",
-							"display": "Southeast Alaska",
-							"definition": "Southeast Alaska"
-						},
-						{
-							"code": "1740-0",
-							"display": "Ahtna",
-							"definition": "Ahtna"
-						},
-						{
-							"code": "1741-8",
-							"display": "Alatna",
-							"definition": "Alatna"
-						},
-						{
-							"code": "1742-6",
-							"display": "Alexander",
-							"definition": "Alexander"
-						},
-						{
-							"code": "1743-4",
-							"display": "Allakaket",
-							"definition": "Allakaket"
-						},
-						{
-							"code": "1744-2",
-							"display": "Alanvik",
-							"definition": "Alanvik"
-						},
-						{
-							"code": "1745-9",
-							"display": "Anvik",
-							"definition": "Anvik"
-						},
-						{
-							"code": "1746-7",
-							"display": "Arctic",
-							"definition": "Arctic"
-						},
-						{
-							"code": "1747-5",
-							"display": "Beaver",
-							"definition": "Beaver"
-						},
-						{
-							"code": "1748-3",
-							"display": "Birch Creek",
-							"definition": "Birch Creek"
-						},
-						{
-							"code": "1749-1",
-							"display": "Cantwell",
-							"definition": "Cantwell"
-						},
-						{
-							"code": "1750-9",
-							"display": "Chalkyitsik",
-							"definition": "Chalkyitsik"
-						},
-						{
-							"code": "1751-7",
-							"display": "Chickaloon",
-							"definition": "Chickaloon"
-						},
-						{
-							"code": "1752-5",
-							"display": "Chistochina",
-							"definition": "Chistochina"
-						},
-						{
-							"code": "1753-3",
-							"display": "Chitina",
-							"definition": "Chitina"
-						},
-						{
-							"code": "1754-1",
-							"display": "Circle",
-							"definition": "Circle"
-						},
-						{
-							"code": "1755-8",
-							"display": "Cook Inlet",
-							"definition": "Cook Inlet"
-						},
-						{
-							"code": "1756-6",
-							"display": "Copper Center",
-							"definition": "Copper Center"
-						},
-						{
-							"code": "1757-4",
-							"display": "Copper River",
-							"definition": "Copper River"
-						},
-						{
-							"code": "1758-2",
-							"display": "Dot Lake",
-							"definition": "Dot Lake"
-						},
-						{
-							"code": "1759-0",
-							"display": "Doyon",
-							"definition": "Doyon"
-						},
-						{
-							"code": "1760-8",
-							"display": "Eagle",
-							"definition": "Eagle"
-						},
-						{
-							"code": "1761-6",
-							"display": "Eklutna",
-							"definition": "Eklutna"
-						},
-						{
-							"code": "1762-4",
-							"display": "Evansville",
-							"definition": "Evansville"
-						},
-						{
-							"code": "1763-2",
-							"display": "Fort Yukon",
-							"definition": "Fort Yukon"
-						},
-						{
-							"code": "1764-0",
-							"display": "Gakona",
-							"definition": "Gakona"
-						},
-						{
-							"code": "1765-7",
-							"display": "Galena",
-							"definition": "Galena"
-						},
-						{
-							"code": "1766-5",
-							"display": "Grayling",
-							"definition": "Grayling"
-						},
-						{
-							"code": "1767-3",
-							"display": "Gulkana",
-							"definition": "Gulkana"
-						},
-						{
-							"code": "1768-1",
-							"display": "Healy Lake",
-							"definition": "Healy Lake"
-						},
-						{
-							"code": "1769-9",
-							"display": "Holy Cross",
-							"definition": "Holy Cross"
-						},
-						{
-							"code": "1770-7",
-							"display": "Hughes",
-							"definition": "Hughes"
-						},
-						{
-							"code": "1771-5",
-							"display": "Huslia",
-							"definition": "Huslia"
-						},
-						{
-							"code": "1772-3",
-							"display": "Iliamna",
-							"definition": "Iliamna"
-						},
-						{
-							"code": "1773-1",
-							"display": "Kaltag",
-							"definition": "Kaltag"
-						},
-						{
-							"code": "1774-9",
-							"display": "Kluti Kaah",
-							"definition": "Kluti Kaah"
-						},
-						{
-							"code": "1775-6",
-							"display": "Knik",
-							"definition": "Knik"
-						},
-						{
-							"code": "1776-4",
-							"display": "Koyukuk",
-							"definition": "Koyukuk"
-						},
-						{
-							"code": "1777-2",
-							"display": "Lake Minchumina",
-							"definition": "Lake Minchumina"
-						},
-						{
-							"code": "1778-0",
-							"display": "Lime",
-							"definition": "Lime"
-						},
-						{
-							"code": "1779-8",
-							"display": "Mcgrath",
-							"definition": "Mcgrath"
-						},
-						{
-							"code": "1780-6",
-							"display": "Manley Hot Springs",
-							"definition": "Manley Hot Springs"
-						},
-						{
-							"code": "1781-4",
-							"display": "Mentasta Lake",
-							"definition": "Mentasta Lake"
-						},
-						{
-							"code": "1782-2",
-							"display": "Minto",
-							"definition": "Minto"
-						},
-						{
-							"code": "1783-0",
-							"display": "Nenana",
-							"definition": "Nenana"
-						},
-						{
-							"code": "1784-8",
-							"display": "Nikolai",
-							"definition": "Nikolai"
-						},
-						{
-							"code": "1785-5",
-							"display": "Ninilchik",
-							"definition": "Ninilchik"
-						},
-						{
-							"code": "1786-3",
-							"display": "Nondalton",
-							"definition": "Nondalton"
-						},
-						{
-							"code": "1787-1",
-							"display": "Northway",
-							"definition": "Northway"
-						},
-						{
-							"code": "1788-9",
-							"display": "Nulato",
-							"definition": "Nulato"
-						},
-						{
-							"code": "1789-7",
-							"display": "Pedro Bay",
-							"definition": "Pedro Bay"
-						},
-						{
-							"code": "1790-5",
-							"display": "Rampart",
-							"definition": "Rampart"
-						},
-						{
-							"code": "1791-3",
-							"display": "Ruby",
-							"definition": "Ruby"
-						},
-						{
-							"code": "1792-1",
-							"display": "Salamatof",
-							"definition": "Salamatof"
-						},
-						{
-							"code": "1793-9",
-							"display": "Seldovia",
-							"definition": "Seldovia"
-						},
-						{
-							"code": "1794-7",
-							"display": "Slana",
-							"definition": "Slana"
-						},
-						{
-							"code": "1795-4",
-							"display": "Shageluk",
-							"definition": "Shageluk"
-						},
-						{
-							"code": "1796-2",
-							"display": "Stevens",
-							"definition": "Stevens"
-						},
-						{
-							"code": "1797-0",
-							"display": "Stony River",
-							"definition": "Stony River"
-						},
-						{
-							"code": "1798-8",
-							"display": "Takotna",
-							"definition": "Takotna"
-						},
-						{
-							"code": "1799-6",
-							"display": "Tanacross",
-							"definition": "Tanacross"
-						},
-						{
-							"code": "1800-2",
-							"display": "Tanaina",
-							"definition": "Tanaina"
-						},
-						{
-							"code": "1801-0",
-							"display": "Tanana",
-							"definition": "Tanana"
-						},
-						{
-							"code": "1802-8",
-							"display": "Tanana Chiefs",
-							"definition": "Tanana Chiefs"
-						},
-						{
-							"code": "1803-6",
-							"display": "Tazlina",
-							"definition": "Tazlina"
-						},
-						{
-							"code": "1804-4",
-							"display": "Telida",
-							"definition": "Telida"
-						},
-						{
-							"code": "1805-1",
-							"display": "Tetlin",
-							"definition": "Tetlin"
-						},
-						{
-							"code": "1806-9",
-							"display": "Tok",
-							"definition": "Tok"
-						},
-						{
-							"code": "1807-7",
-							"display": "Tyonek",
-							"definition": "Tyonek"
-						},
-						{
-							"code": "1808-5",
-							"display": "Venetie",
-							"definition": "Venetie"
-						},
-						{
-							"code": "1809-3",
-							"display": "Wiseman",
-							"definition": "Wiseman"
-						},
-						{
-							"code": "1813-5",
-							"display": "Tlingit-Haida",
-							"definition": "Tlingit-Haida"
-						},
-						{
-							"code": "1837-4",
-							"display": "Tsimshian",
-							"definition": "Tsimshian"
-						},
-						{
-							"code": "1814-3",
-							"display": "Angoon",
-							"definition": "Angoon"
-						},
-						{
-							"code": "1815-0",
-							"display": "Central Council of Tlingit and Haida Tribes",
-							"definition": "Central Council of Tlingit and Haida Tribes"
-						},
-						{
-							"code": "1816-8",
-							"display": "Chilkat",
-							"definition": "Chilkat"
-						},
-						{
-							"code": "1817-6",
-							"display": "Chilkoot",
-							"definition": "Chilkoot"
-						},
-						{
-							"code": "1818-4",
-							"display": "Craig",
-							"definition": "Craig"
-						},
-						{
-							"code": "1819-2",
-							"display": "Douglas",
-							"definition": "Douglas"
-						},
-						{
-							"code": "1820-0",
-							"display": "Haida",
-							"definition": "Haida"
-						},
-						{
-							"code": "1821-8",
-							"display": "Hoonah",
-							"definition": "Hoonah"
-						},
-						{
-							"code": "1822-6",
-							"display": "Hydaburg",
-							"definition": "Hydaburg"
-						},
-						{
-							"code": "1823-4",
-							"display": "Kake",
-							"definition": "Kake"
-						},
-						{
-							"code": "1824-2",
-							"display": "Kasaan",
-							"definition": "Kasaan"
-						},
-						{
-							"code": "1825-9",
-							"display": "Kenaitze",
-							"definition": "Kenaitze"
-						},
-						{
-							"code": "1826-7",
-							"display": "Ketchikan",
-							"definition": "Ketchikan"
-						},
-						{
-							"code": "1827-5",
-							"display": "Klawock",
-							"definition": "Klawock"
-						},
-						{
-							"code": "1828-3",
-							"display": "Pelican",
-							"definition": "Pelican"
-						},
-						{
-							"code": "1829-1",
-							"display": "Petersburg",
-							"definition": "Petersburg"
-						},
-						{
-							"code": "1830-9",
-							"display": "Saxman",
-							"definition": "Saxman"
-						},
-						{
-							"code": "1831-7",
-							"display": "Sitka",
-							"definition": "Sitka"
-						},
-						{
-							"code": "1832-5",
-							"display": "Tenakee Springs",
-							"definition": "Tenakee Springs"
-						},
-						{
-							"code": "1833-3",
-							"display": "Tlingit",
-							"definition": "Tlingit"
-						},
-						{
-							"code": "1834-1",
-							"display": "Wrangell",
-							"definition": "Wrangell"
-						},
-						{
-							"code": "1835-8",
-							"display": "Yakutat",
-							"definition": "Yakutat"
-						},
-						{
-							"code": "1838-2",
-							"display": "Metlakatla",
-							"definition": "Metlakatla"
-						},
-						{
-							"code": "1842-4",
-							"display": "Greenland Eskimo",
-							"definition": "Greenland Eskimo"
-						},
-						{
-							"code": "1844-0",
-							"display": "Inupiat Eskimo",
-							"definition": "Inupiat Eskimo"
-						},
-						{
-							"code": "1891-1",
-							"display": "Siberian Eskimo",
-							"definition": "Siberian Eskimo"
-						},
-						{
-							"code": "1896-0",
-							"display": "Yupik Eskimo",
-							"definition": "Yupik Eskimo"
-						},
-						{
-							"code": "1845-7",
-							"display": "Ambler",
-							"definition": "Ambler"
-						},
-						{
-							"code": "1846-5",
-							"display": "Anaktuvuk",
-							"definition": "Anaktuvuk"
-						},
-						{
-							"code": "1847-3",
-							"display": "Anaktuvuk Pass",
-							"definition": "Anaktuvuk Pass"
-						},
-						{
-							"code": "1848-1",
-							"display": "Arctic Slope Inupiat",
-							"definition": "Arctic Slope Inupiat"
-						},
-						{
-							"code": "1849-9",
-							"display": "Arctic Slope Corporation",
-							"definition": "Arctic Slope Corporation"
-						},
-						{
-							"code": "1850-7",
-							"display": "Atqasuk",
-							"definition": "Atqasuk"
-						},
-						{
-							"code": "1851-5",
-							"display": "Barrow",
-							"definition": "Barrow"
-						},
-						{
-							"code": "1852-3",
-							"display": "Bering Straits Inupiat",
-							"definition": "Bering Straits Inupiat"
-						},
-						{
-							"code": "1853-1",
-							"display": "Brevig Mission",
-							"definition": "Brevig Mission"
-						},
-						{
-							"code": "1854-9",
-							"display": "Buckland",
-							"definition": "Buckland"
-						},
-						{
-							"code": "1855-6",
-							"display": "Chinik",
-							"definition": "Chinik"
-						},
-						{
-							"code": "1856-4",
-							"display": "Council",
-							"definition": "Council"
-						},
-						{
-							"code": "1857-2",
-							"display": "Deering",
-							"definition": "Deering"
-						},
-						{
-							"code": "1858-0",
-							"display": "Elim",
-							"definition": "Elim"
-						},
-						{
-							"code": "1859-8",
-							"display": "Golovin",
-							"definition": "Golovin"
-						},
-						{
-							"code": "1860-6",
-							"display": "Inalik Diomede",
-							"definition": "Inalik Diomede"
-						},
-						{
-							"code": "1861-4",
-							"display": "Inupiaq",
-							"definition": "Inupiaq"
-						},
-						{
-							"code": "1862-2",
-							"display": "Kaktovik",
-							"definition": "Kaktovik"
-						},
-						{
-							"code": "1863-0",
-							"display": "Kawerak",
-							"definition": "Kawerak"
-						},
-						{
-							"code": "1864-8",
-							"display": "Kiana",
-							"definition": "Kiana"
-						},
-						{
-							"code": "1865-5",
-							"display": "Kivalina",
-							"definition": "Kivalina"
-						},
-						{
-							"code": "1866-3",
-							"display": "Kobuk",
-							"definition": "Kobuk"
-						},
-						{
-							"code": "1867-1",
-							"display": "Kotzebue",
-							"definition": "Kotzebue"
-						},
-						{
-							"code": "1868-9",
-							"display": "Koyuk",
-							"definition": "Koyuk"
-						},
-						{
-							"code": "1869-7",
-							"display": "Kwiguk",
-							"definition": "Kwiguk"
-						},
-						{
-							"code": "1870-5",
-							"display": "Mauneluk Inupiat",
-							"definition": "Mauneluk Inupiat"
-						},
-						{
-							"code": "1871-3",
-							"display": "Nana Inupiat",
-							"definition": "Nana Inupiat"
-						},
-						{
-							"code": "1872-1",
-							"display": "Noatak",
-							"definition": "Noatak"
-						},
-						{
-							"code": "1873-9",
-							"display": "Nome",
-							"definition": "Nome"
-						},
-						{
-							"code": "1874-7",
-							"display": "Noorvik",
-							"definition": "Noorvik"
-						},
-						{
-							"code": "1875-4",
-							"display": "Nuiqsut",
-							"definition": "Nuiqsut"
-						},
-						{
-							"code": "1876-2",
-							"display": "Point Hope",
-							"definition": "Point Hope"
-						},
-						{
-							"code": "1877-0",
-							"display": "Point Lay",
-							"definition": "Point Lay"
-						},
-						{
-							"code": "1878-8",
-							"display": "Selawik",
-							"definition": "Selawik"
-						},
-						{
-							"code": "1879-6",
-							"display": "Shaktoolik",
-							"definition": "Shaktoolik"
-						},
-						{
-							"code": "1880-4",
-							"display": "Shishmaref",
-							"definition": "Shishmaref"
-						},
-						{
-							"code": "1881-2",
-							"display": "Shungnak",
-							"definition": "Shungnak"
-						},
-						{
-							"code": "1882-0",
-							"display": "Solomon",
-							"definition": "Solomon"
-						},
-						{
-							"code": "1883-8",
-							"display": "Teller",
-							"definition": "Teller"
-						},
-						{
-							"code": "1884-6",
-							"display": "Unalakleet",
-							"definition": "Unalakleet"
-						},
-						{
-							"code": "1885-3",
-							"display": "Wainwright",
-							"definition": "Wainwright"
-						},
-						{
-							"code": "1886-1",
-							"display": "Wales",
-							"definition": "Wales"
-						},
-						{
-							"code": "1887-9",
-							"display": "White Mountain",
-							"definition": "White Mountain"
-						},
-						{
-							"code": "1888-7",
-							"display": "White Mountain Inupiat",
-							"definition": "White Mountain Inupiat"
-						},
-						{
-							"code": "1889-5",
-							"display": "Mary's Igloo",
-							"definition": "Mary's Igloo"
-						},
-						{
-							"code": "1892-9",
-							"display": "Gambell",
-							"definition": "Gambell"
-						},
-						{
-							"code": "1893-7",
-							"display": "Savoonga",
-							"definition": "Savoonga"
-						},
-						{
-							"code": "1894-5",
-							"display": "Siberian Yupik",
-							"definition": "Siberian Yupik"
-						},
-						{
-							"code": "1897-8",
-							"display": "Akiachak",
-							"definition": "Akiachak"
-						},
-						{
-							"code": "1898-6",
-							"display": "Akiak",
-							"definition": "Akiak"
-						},
-						{
-							"code": "1899-4",
-							"display": "Alakanuk",
-							"definition": "Alakanuk"
-						},
-						{
-							"code": "1900-0",
-							"display": "Aleknagik",
-							"definition": "Aleknagik"
-						},
-						{
-							"code": "1901-8",
-							"display": "Andreafsky",
-							"definition": "Andreafsky"
-						},
-						{
-							"code": "1902-6",
-							"display": "Aniak",
-							"definition": "Aniak"
-						},
-						{
-							"code": "1903-4",
-							"display": "Atmautluak",
-							"definition": "Atmautluak"
-						},
-						{
-							"code": "1904-2",
-							"display": "Bethel",
-							"definition": "Bethel"
-						},
-						{
-							"code": "1905-9",
-							"display": "Bill Moore's Slough",
-							"definition": "Bill Moore's Slough"
-						},
-						{
-							"code": "1906-7",
-							"display": "Bristol Bay Yupik",
-							"definition": "Bristol Bay Yupik"
-						},
-						{
-							"code": "1907-5",
-							"display": "Calista Yupik",
-							"definition": "Calista Yupik"
-						},
-						{
-							"code": "1908-3",
-							"display": "Chefornak",
-							"definition": "Chefornak"
-						},
-						{
-							"code": "1909-1",
-							"display": "Chevak",
-							"definition": "Chevak"
-						},
-						{
-							"code": "1910-9",
-							"display": "Chuathbaluk",
-							"definition": "Chuathbaluk"
-						},
-						{
-							"code": "1911-7",
-							"display": "Clark's Point",
-							"definition": "Clark's Point"
-						},
-						{
-							"code": "1912-5",
-							"display": "Crooked Creek",
-							"definition": "Crooked Creek"
-						},
-						{
-							"code": "1913-3",
-							"display": "Dillingham",
-							"definition": "Dillingham"
-						},
-						{
-							"code": "1914-1",
-							"display": "Eek",
-							"definition": "Eek"
-						},
-						{
-							"code": "1915-8",
-							"display": "Ekuk",
-							"definition": "Ekuk"
-						},
-						{
-							"code": "1916-6",
-							"display": "Ekwok",
-							"definition": "Ekwok"
-						},
-						{
-							"code": "1917-4",
-							"display": "Emmonak",
-							"definition": "Emmonak"
-						},
-						{
-							"code": "1918-2",
-							"display": "Goodnews Bay",
-							"definition": "Goodnews Bay"
-						},
-						{
-							"code": "1919-0",
-							"display": "Hooper Bay",
-							"definition": "Hooper Bay"
-						},
-						{
-							"code": "1920-8",
-							"display": "Iqurmuit (Russian Mission)",
-							"definition": "Iqurmuit (Russian Mission)"
-						},
-						{
-							"code": "1921-6",
-							"display": "Kalskag",
-							"definition": "Kalskag"
-						},
-						{
-							"code": "1922-4",
-							"display": "Kasigluk",
-							"definition": "Kasigluk"
-						},
-						{
-							"code": "1923-2",
-							"display": "Kipnuk",
-							"definition": "Kipnuk"
-						},
-						{
-							"code": "1924-0",
-							"display": "Koliganek",
-							"definition": "Koliganek"
-						},
-						{
-							"code": "1925-7",
-							"display": "Kongiganak",
-							"definition": "Kongiganak"
-						},
-						{
-							"code": "1926-5",
-							"display": "Kotlik",
-							"definition": "Kotlik"
-						},
-						{
-							"code": "1927-3",
-							"display": "Kwethluk",
-							"definition": "Kwethluk"
-						},
-						{
-							"code": "1928-1",
-							"display": "Kwigillingok",
-							"definition": "Kwigillingok"
-						},
-						{
-							"code": "1929-9",
-							"display": "Levelock",
-							"definition": "Levelock"
-						},
-						{
-							"code": "1930-7",
-							"display": "Lower Kalskag",
-							"definition": "Lower Kalskag"
-						},
-						{
-							"code": "1931-5",
-							"display": "Manokotak",
-							"definition": "Manokotak"
-						},
-						{
-							"code": "1932-3",
-							"display": "Marshall",
-							"definition": "Marshall"
-						},
-						{
-							"code": "1933-1",
-							"display": "Mekoryuk",
-							"definition": "Mekoryuk"
-						},
-						{
-							"code": "1934-9",
-							"display": "Mountain Village",
-							"definition": "Mountain Village"
-						},
-						{
-							"code": "1935-6",
-							"display": "Naknek",
-							"definition": "Naknek"
-						},
-						{
-							"code": "1936-4",
-							"display": "Napaumute",
-							"definition": "Napaumute"
-						},
-						{
-							"code": "1937-2",
-							"display": "Napakiak",
-							"definition": "Napakiak"
-						},
-						{
-							"code": "1938-0",
-							"display": "Napaskiak",
-							"definition": "Napaskiak"
-						},
-						{
-							"code": "1939-8",
-							"display": "Newhalen",
-							"definition": "Newhalen"
-						},
-						{
-							"code": "1940-6",
-							"display": "New Stuyahok",
-							"definition": "New Stuyahok"
-						},
-						{
-							"code": "1941-4",
-							"display": "Newtok",
-							"definition": "Newtok"
-						},
-						{
-							"code": "1942-2",
-							"display": "Nightmute",
-							"definition": "Nightmute"
-						},
-						{
-							"code": "1943-0",
-							"display": "Nunapitchukv",
-							"definition": "Nunapitchukv"
-						},
-						{
-							"code": "1944-8",
-							"display": "Oscarville",
-							"definition": "Oscarville"
-						},
-						{
-							"code": "1945-5",
-							"display": "Pilot Station",
-							"definition": "Pilot Station"
-						},
-						{
-							"code": "1946-3",
-							"display": "Pitkas Point",
-							"definition": "Pitkas Point"
-						},
-						{
-							"code": "1947-1",
-							"display": "Platinum",
-							"definition": "Platinum"
-						},
-						{
-							"code": "1948-9",
-							"display": "Portage Creek",
-							"definition": "Portage Creek"
-						},
-						{
-							"code": "1949-7",
-							"display": "Quinhagak",
-							"definition": "Quinhagak"
-						},
-						{
-							"code": "1950-5",
-							"display": "Red Devil",
-							"definition": "Red Devil"
-						},
-						{
-							"code": "1951-3",
-							"display": "St. Michael",
-							"definition": "St. Michael"
-						},
-						{
-							"code": "1952-1",
-							"display": "Scammon Bay",
-							"definition": "Scammon Bay"
-						},
-						{
-							"code": "1953-9",
-							"display": "Sheldon's Point",
-							"definition": "Sheldon's Point"
-						},
-						{
-							"code": "1954-7",
-							"display": "Sleetmute",
-							"definition": "Sleetmute"
-						},
-						{
-							"code": "1955-4",
-							"display": "Stebbins",
-							"definition": "Stebbins"
-						},
-						{
-							"code": "1956-2",
-							"display": "Togiak",
-							"definition": "Togiak"
-						},
-						{
-							"code": "1957-0",
-							"display": "Toksook",
-							"definition": "Toksook"
-						},
-						{
-							"code": "1958-8",
-							"display": "Tulukskak",
-							"definition": "Tulukskak"
-						},
-						{
-							"code": "1959-6",
-							"display": "Tuntutuliak",
-							"definition": "Tuntutuliak"
-						},
-						{
-							"code": "1960-4",
-							"display": "Tununak",
-							"definition": "Tununak"
-						},
-						{
-							"code": "1961-2",
-							"display": "Twin Hills",
-							"definition": "Twin Hills"
-						},
-						{
-							"code": "1962-0",
-							"display": "Georgetown (Yupik-Eskimo)",
-							"definition": "Georgetown (Yupik-Eskimo)"
-						},
-						{
-							"code": "1963-8",
-							"display": "St. Mary's",
-							"definition": "St. Mary's"
-						},
-						{
-							"code": "1964-6",
-							"display": "Umkumiate",
-							"definition": "Umkumiate"
-						},
-						{
-							"code": "1968-7",
-							"display": "Alutiiq Aleut",
-							"definition": "Alutiiq Aleut"
-						},
-						{
-							"code": "1972-9",
-							"display": "Bristol Bay Aleut",
-							"definition": "Bristol Bay Aleut"
-						},
-						{
-							"code": "1984-4",
-							"display": "Chugach Aleut",
-							"definition": "Chugach Aleut"
-						},
-						{
-							"code": "1990-1",
-							"display": "Eyak",
-							"definition": "Eyak"
-						},
-						{
-							"code": "1992-7",
-							"display": "Koniag Aleut",
-							"definition": "Koniag Aleut"
-						},
-						{
-							"code": "2002-4",
-							"display": "Sugpiaq",
-							"definition": "Sugpiaq"
-						},
-						{
-							"code": "2004-0",
-							"display": "Suqpigaq",
-							"definition": "Suqpigaq"
-						},
-						{
-							"code": "2006-5",
-							"display": "Unangan Aleut",
-							"definition": "Unangan Aleut"
-						},
-						{
-							"code": "1969-5",
-							"display": "Tatitlek",
-							"definition": "Tatitlek"
-						},
-						{
-							"code": "1970-3",
-							"display": "Ugashik",
-							"definition": "Ugashik"
-						},
-						{
-							"code": "1973-7",
-							"display": "Chignik",
-							"definition": "Chignik"
-						},
-						{
-							"code": "1974-5",
-							"display": "Chignik Lake",
-							"definition": "Chignik Lake"
-						},
-						{
-							"code": "1975-2",
-							"display": "Egegik",
-							"definition": "Egegik"
-						},
-						{
-							"code": "1976-0",
-							"display": "Igiugig",
-							"definition": "Igiugig"
-						},
-						{
-							"code": "1977-8",
-							"display": "Ivanof Bay",
-							"definition": "Ivanof Bay"
-						},
-						{
-							"code": "1978-6",
-							"display": "King Salmon",
-							"definition": "King Salmon"
-						},
-						{
-							"code": "1979-4",
-							"display": "Kokhanok",
-							"definition": "Kokhanok"
-						},
-						{
-							"code": "1980-2",
-							"display": "Perryville",
-							"definition": "Perryville"
-						},
-						{
-							"code": "1981-0",
-							"display": "Pilot Point",
-							"definition": "Pilot Point"
-						},
-						{
-							"code": "1982-8",
-							"display": "Port Heiden",
-							"definition": "Port Heiden"
-						},
-						{
-							"code": "1985-1",
-							"display": "Chenega",
-							"definition": "Chenega"
-						},
-						{
-							"code": "1986-9",
-							"display": "Chugach Corporation",
-							"definition": "Chugach Corporation"
-						},
-						{
-							"code": "1987-7",
-							"display": "English Bay",
-							"definition": "English Bay"
-						},
-						{
-							"code": "1988-5",
-							"display": "Port Graham",
-							"definition": "Port Graham"
-						},
-						{
-							"code": "1993-5",
-							"display": "Akhiok",
-							"definition": "Akhiok"
-						},
-						{
-							"code": "1994-3",
-							"display": "Agdaagux",
-							"definition": "Agdaagux"
-						},
-						{
-							"code": "1995-0",
-							"display": "Karluk",
-							"definition": "Karluk"
-						},
-						{
-							"code": "1996-8",
-							"display": "Kodiak",
-							"definition": "Kodiak"
-						},
-						{
-							"code": "1997-6",
-							"display": "Larsen Bay",
-							"definition": "Larsen Bay"
-						},
-						{
-							"code": "1998-4",
-							"display": "Old Harbor",
-							"definition": "Old Harbor"
-						},
-						{
-							"code": "1999-2",
-							"display": "Ouzinkie",
-							"definition": "Ouzinkie"
-						},
-						{
-							"code": "2000-8",
-							"display": "Port Lions",
-							"definition": "Port Lions"
-						},
-						{
-							"code": "2007-3",
-							"display": "Akutan",
-							"definition": "Akutan"
-						},
-						{
-							"code": "2008-1",
-							"display": "Aleut Corporation",
-							"definition": "Aleut Corporation"
-						},
-						{
-							"code": "2009-9",
-							"display": "Aleutian",
-							"definition": "Aleutian"
-						},
-						{
-							"code": "2010-7",
-							"display": "Aleutian Islander",
-							"definition": "Aleutian Islander"
-						},
-						{
-							"code": "2011-5",
-							"display": "Atka",
-							"definition": "Atka"
-						},
-						{
-							"code": "2012-3",
-							"display": "Belkofski",
-							"definition": "Belkofski"
-						},
-						{
-							"code": "2013-1",
-							"display": "Chignik Lagoon",
-							"definition": "Chignik Lagoon"
-						},
-						{
-							"code": "2014-9",
-							"display": "King Cove",
-							"definition": "King Cove"
-						},
-						{
-							"code": "2015-6",
-							"display": "False Pass",
-							"definition": "False Pass"
-						},
-						{
-							"code": "2016-4",
-							"display": "Nelson Lagoon",
-							"definition": "Nelson Lagoon"
-						},
-						{
-							"code": "2017-2",
-							"display": "Nikolski",
-							"definition": "Nikolski"
-						},
-						{
-							"code": "2018-0",
-							"display": "Pauloff Harbor",
-							"definition": "Pauloff Harbor"
-						},
-						{
-							"code": "2019-8",
-							"display": "Qagan Toyagungin",
-							"definition": "Qagan Toyagungin"
-						},
-						{
-							"code": "2020-6",
-							"display": "Qawalangin",
-							"definition": "Qawalangin"
-						},
-						{
-							"code": "2021-4",
-							"display": "St. George",
-							"definition": "St. George"
-						},
-						{
-							"code": "2022-2",
-							"display": "St. Paul",
-							"definition": "St. Paul"
-						},
-						{
-							"code": "2023-0",
-							"display": "Sand Point",
-							"definition": "Sand Point"
-						},
-						{
-							"code": "2024-8",
-							"display": "South Naknek",
-							"definition": "South Naknek"
-						},
-						{
-							"code": "2025-5",
-							"display": "Unalaska",
-							"definition": "Unalaska"
-						},
-						{
-							"code": "2026-3",
-							"display": "Unga",
-							"definition": "Unga"
-						}
-					]
-				},
-				{
-					"code": "2028-9",
-					"display": "Asian",
-					"definition": "Asian",
-					"concept": [
-						{
-							"code": "2029-7",
-							"display": "Asian Indian",
-							"definition": "Asian Indian"
-						},
-						{
-							"code": "2030-5",
-							"display": "Bangladeshi",
-							"definition": "Bangladeshi"
-						},
-						{
-							"code": "2031-3",
-							"display": "Bhutanese",
-							"definition": "Bhutanese"
-						},
-						{
-							"code": "2032-1",
-							"display": "Burmese",
-							"definition": "Burmese"
-						},
-						{
-							"code": "2033-9",
-							"display": "Cambodian",
-							"definition": "Cambodian"
-						},
-						{
-							"code": "2034-7",
-							"display": "Chinese",
-							"definition": "Chinese"
-						},
-						{
-							"code": "2035-4",
-							"display": "Taiwanese",
-							"definition": "Taiwanese"
-						},
-						{
-							"code": "2036-2",
-							"display": "Filipino",
-							"definition": "Filipino"
-						},
-						{
-							"code": "2037-0",
-							"display": "Hmong",
-							"definition": "Hmong"
-						},
-						{
-							"code": "2038-8",
-							"display": "Indonesian",
-							"definition": "Indonesian"
-						},
-						{
-							"code": "2039-6",
-							"display": "Japanese",
-							"definition": "Japanese"
-						},
-						{
-							"code": "2040-4",
-							"display": "Korean",
-							"definition": "Korean"
-						},
-						{
-							"code": "2041-2",
-							"display": "Laotian",
-							"definition": "Laotian"
-						},
-						{
-							"code": "2042-0",
-							"display": "Malaysian",
-							"definition": "Malaysian"
-						},
-						{
-							"code": "2043-8",
-							"display": "Okinawan",
-							"definition": "Okinawan"
-						},
-						{
-							"code": "2044-6",
-							"display": "Pakistani",
-							"definition": "Pakistani"
-						},
-						{
-							"code": "2045-3",
-							"display": "Sri Lankan",
-							"definition": "Sri Lankan"
-						},
-						{
-							"code": "2046-1",
-							"display": "Thai",
-							"definition": "Thai"
-						},
-						{
-							"code": "2047-9",
-							"display": "Vietnamese",
-							"definition": "Vietnamese"
-						},
-						{
-							"code": "2048-7",
-							"display": "Iwo Jiman",
-							"definition": "Iwo Jiman"
-						},
-						{
-							"code": "2049-5",
-							"display": "Maldivian",
-							"definition": "Maldivian"
-						},
-						{
-							"code": "2050-3",
-							"display": "Nepalese",
-							"definition": "Nepalese"
-						},
-						{
-							"code": "2051-1",
-							"display": "Singaporean",
-							"definition": "Singaporean"
-						},
-						{
-							"code": "2052-9",
-							"display": "Madagascar",
-							"definition": "Madagascar"
-						}
-					]
-				},
-				{
-					"code": "2054-5",
-					"display": "Black or African American",
-					"definition": "Black or African American",
-					"concept": [
-						{
-							"code": "2056-0",
-							"display": "Black",
-							"definition": "Black"
-						},
-						{
-							"code": "2058-6",
-							"display": "African American",
-							"definition": "African American"
-						},
-						{
-							"code": "2060-2",
-							"display": "African",
-							"definition": "African"
-						},
-						{
-							"code": "2067-7",
-							"display": "Bahamian",
-							"definition": "Bahamian"
-						},
-						{
-							"code": "2068-5",
-							"display": "Barbadian",
-							"definition": "Barbadian"
-						},
-						{
-							"code": "2069-3",
-							"display": "Dominican",
-							"definition": "Dominican"
-						},
-						{
-							"code": "2070-1",
-							"display": "Dominica Islander",
-							"definition": "Dominica Islander"
-						},
-						{
-							"code": "2071-9",
-							"display": "Haitian",
-							"definition": "Haitian"
-						},
-						{
-							"code": "2072-7",
-							"display": "Jamaican",
-							"definition": "Jamaican"
-						},
-						{
-							"code": "2073-5",
-							"display": "Tobagoan",
-							"definition": "Tobagoan"
-						},
-						{
-							"code": "2074-3",
-							"display": "Trinidadian",
-							"definition": "Trinidadian"
-						},
-						{
-							"code": "2075-0",
-							"display": "West Indian",
-							"definition": "West Indian"
-						},
-						{
-							"code": "2061-0",
-							"display": "Botswanan",
-							"definition": "Botswanan"
-						},
-						{
-							"code": "2062-8",
-							"display": "Ethiopian",
-							"definition": "Ethiopian"
-						},
-						{
-							"code": "2063-6",
-							"display": "Liberian",
-							"definition": "Liberian"
-						},
-						{
-							"code": "2064-4",
-							"display": "Namibian",
-							"definition": "Namibian"
-						},
-						{
-							"code": "2065-1",
-							"display": "Nigerian",
-							"definition": "Nigerian"
-						},
-						{
-							"code": "2066-9",
-							"display": "Zairean",
-							"definition": "Zairean"
-						}
-					]
-				},
-				{
-					"code": "2076-8",
-					"display": "Native Hawaiian or Other Pacific Islander",
-					"definition": "Native Hawaiian or Other Pacific Islander",
-					"concept": [
-						{
-							"code": "2078-4",
-							"display": "Polynesian",
-							"definition": "Polynesian"
-						},
-						{
-							"code": "2085-9",
-							"display": "Micronesian",
-							"definition": "Micronesian"
-						},
-						{
-							"code": "2100-6",
-							"display": "Melanesian",
-							"definition": "Melanesian"
-						},
-						{
-							"code": "2500-7",
-							"display": "Other Pacific Islander",
-							"definition": "Other Pacific Islander"
-						},
-						{
-							"code": "2079-2",
-							"display": "Native Hawaiian",
-							"definition": "Native Hawaiian"
-						},
-						{
-							"code": "2080-0",
-							"display": "Samoan",
-							"definition": "Samoan"
-						},
-						{
-							"code": "2081-8",
-							"display": "Tahitian",
-							"definition": "Tahitian"
-						},
-						{
-							"code": "2082-6",
-							"display": "Tongan",
-							"definition": "Tongan"
-						},
-						{
-							"code": "2083-4",
-							"display": "Tokelauan",
-							"definition": "Tokelauan"
-						},
-						{
-							"code": "2086-7",
-							"display": "Guamanian or Chamorro",
-							"definition": "Guamanian or Chamorro"
-						},
-						{
-							"code": "2087-5",
-							"display": "Guamanian",
-							"definition": "Guamanian"
-						},
-						{
-							"code": "2088-3",
-							"display": "Chamorro",
-							"definition": "Chamorro"
-						},
-						{
-							"code": "2089-1",
-							"display": "Mariana Islander",
-							"definition": "Mariana Islander"
-						},
-						{
-							"code": "2090-9",
-							"display": "Marshallese",
-							"definition": "Marshallese"
-						},
-						{
-							"code": "2091-7",
-							"display": "Palauan",
-							"definition": "Palauan"
-						},
-						{
-							"code": "2092-5",
-							"display": "Carolinian",
-							"definition": "Carolinian"
-						},
-						{
-							"code": "2093-3",
-							"display": "Kosraean",
-							"definition": "Kosraean"
-						},
-						{
-							"code": "2094-1",
-							"display": "Pohnpeian",
-							"definition": "Pohnpeian"
-						},
-						{
-							"code": "2095-8",
-							"display": "Saipanese",
-							"definition": "Saipanese"
-						},
-						{
-							"code": "2096-6",
-							"display": "Kiribati",
-							"definition": "Kiribati"
-						},
-						{
-							"code": "2097-4",
-							"display": "Chuukese",
-							"definition": "Chuukese"
-						},
-						{
-							"code": "2098-2",
-							"display": "Yapese",
-							"definition": "Yapese"
-						},
-						{
-							"code": "2101-4",
-							"display": "Fijian",
-							"definition": "Fijian"
-						},
-						{
-							"code": "2102-2",
-							"display": "Papua New Guinean",
-							"definition": "Papua New Guinean"
-						},
-						{
-							"code": "2103-0",
-							"display": "Solomon Islander",
-							"definition": "Solomon Islander"
-						},
-						{
-							"code": "2104-8",
-							"display": "New Hebrides",
-							"definition": "New Hebrides"
-						}
-					]
-				},
-				{
-					"code": "2106-3",
-					"display": "White",
-					"definition": "White",
-					"concept": [
-						{
-							"code": "2108-9",
-							"display": "European",
-							"definition": "European"
-						},
-						{
-							"code": "2118-8",
-							"display": "Middle Eastern or North African",
-							"definition": "Middle Eastern or North African"
-						},
-						{
-							"code": "2129-5",
-							"display": "Arab",
-							"definition": "Arab"
-						},
-						{
-							"code": "2109-7",
-							"display": "Armenian",
-							"definition": "Armenian"
-						},
-						{
-							"code": "2110-5",
-							"display": "English",
-							"definition": "English"
-						},
-						{
-							"code": "2111-3",
-							"display": "French",
-							"definition": "French"
-						},
-						{
-							"code": "2112-1",
-							"display": "German",
-							"definition": "German"
-						},
-						{
-							"code": "2113-9",
-							"display": "Irish",
-							"definition": "Irish"
-						},
-						{
-							"code": "2114-7",
-							"display": "Italian",
-							"definition": "Italian"
-						},
-						{
-							"code": "2115-4",
-							"display": "Polish",
-							"definition": "Polish"
-						},
-						{
-							"code": "2116-2",
-							"display": "Scottish",
-							"definition": "Scottish"
-						},
-						{
-							"code": "2119-6",
-							"display": "Assyrian",
-							"definition": "Assyrian"
-						},
-						{
-							"code": "2120-4",
-							"display": "Egyptian",
-							"definition": "Egyptian"
-						},
-						{
-							"code": "2121-2",
-							"display": "Iranian",
-							"definition": "Iranian"
-						},
-						{
-							"code": "2122-0",
-							"display": "Iraqi",
-							"definition": "Iraqi"
-						},
-						{
-							"code": "2123-8",
-							"display": "Lebanese",
-							"definition": "Lebanese"
-						},
-						{
-							"code": "2124-6",
-							"display": "Palestinian",
-							"definition": "Palestinian"
-						},
-						{
-							"code": "2125-3",
-							"display": "Syrian",
-							"definition": "Syrian"
-						},
-						{
-							"code": "2126-1",
-							"display": "Afghanistani",
-							"definition": "Afghanistani"
-						},
-						{
-							"code": "2127-9",
-							"display": "Israeili",
-							"definition": "Israeili"
-						}
-					]
-				},
-				{
-					"code": "2131-1",
-					"display": "Other Race",
-					"definition": "Note that this term remains in the table for completeness, even though within HL7, the notion of Other code is deprecated."
-				}
-			]
-		},
-		{
-			"code": "2133-7",
-			"display": "Ethnicity",
-			"definition": "Ethnicity Note that this is an abstract 'grouping' concept and not for use as a real concept",
-			"property": [
-				{
-					"code": "abstract",
-					"valueBoolean": true
-				}
-			],
-			"concept": [
-				{
-					"code": "2135-2",
-					"display": "Hispanic or Latino",
-					"definition": "Hispanic or Latino",
-					"concept": [
-						{
-							"code": "2137-8",
-							"display": "Spaniard",
-							"definition": "Spaniard"
-						},
-						{
-							"code": "2148-5",
-							"display": "Mexican",
-							"definition": "Mexican"
-						},
-						{
-							"code": "2155-0",
-							"display": "Central American",
-							"definition": "Central American"
-						},
-						{
-							"code": "2165-9",
-							"display": "South American",
-							"definition": "South American"
-						},
-						{
-							"code": "2178-2",
-							"display": "Latin American",
-							"definition": "Latin American"
-						},
-						{
-							"code": "2180-8",
-							"display": "Puerto Rican",
-							"definition": "Puerto Rican"
-						},
-						{
-							"code": "2182-4",
-							"display": "Cuban",
-							"definition": "Cuban"
-						},
-						{
-							"code": "2184-0",
-							"display": "Dominican",
-							"definition": "Dominican"
-						},
-						{
-							"code": "2138-6",
-							"display": "Andalusian",
-							"definition": "Andalusian"
-						},
-						{
-							"code": "2139-4",
-							"display": "Asturian",
-							"definition": "Asturian"
-						},
-						{
-							"code": "2140-2",
-							"display": "Castillian",
-							"definition": "Castillian"
-						},
-						{
-							"code": "2141-0",
-							"display": "Catalonian",
-							"definition": "Catalonian"
-						},
-						{
-							"code": "2142-8",
-							"display": "Belearic Islander",
-							"definition": "Belearic Islander"
-						},
-						{
-							"code": "2143-6",
-							"display": "Gallego",
-							"definition": "Gallego"
-						},
-						{
-							"code": "2144-4",
-							"display": "Valencian",
-							"definition": "Valencian"
-						},
-						{
-							"code": "2145-1",
-							"display": "Canarian",
-							"definition": "Canarian"
-						},
-						{
-							"code": "2146-9",
-							"display": "Spanish Basque",
-							"definition": "Spanish Basque"
-						},
-						{
-							"code": "2149-3",
-							"display": "Mexican American",
-							"definition": "Mexican American"
-						},
-						{
-							"code": "2150-1",
-							"display": "Mexicano",
-							"definition": "Mexicano"
-						},
-						{
-							"code": "2151-9",
-							"display": "Chicano",
-							"definition": "Chicano"
-						},
-						{
-							"code": "2152-7",
-							"display": "La Raza",
-							"definition": "La Raza"
-						},
-						{
-							"code": "2153-5",
-							"display": "Mexican American Indian",
-							"definition": "Mexican American Indian"
-						},
-						{
-							"code": "2156-8",
-							"display": "Costa Rican",
-							"definition": "Costa Rican"
-						},
-						{
-							"code": "2157-6",
-							"display": "Guatemalan",
-							"definition": "Guatemalan"
-						},
-						{
-							"code": "2158-4",
-							"display": "Honduran",
-							"definition": "Honduran"
-						},
-						{
-							"code": "2159-2",
-							"display": "Nicaraguan",
-							"definition": "Nicaraguan"
-						},
-						{
-							"code": "2160-0",
-							"display": "Panamanian",
-							"definition": "Panamanian"
-						},
-						{
-							"code": "2161-8",
-							"display": "Salvadoran",
-							"definition": "Salvadoran"
-						},
-						{
-							"code": "2162-6",
-							"display": "Central American Indian",
-							"definition": "Central American Indian"
-						},
-						{
-							"code": "2163-4",
-							"display": "Canal Zone",
-							"definition": "Canal Zone"
-						},
-						{
-							"code": "2166-7",
-							"display": "Argentinean",
-							"definition": "Argentinean"
-						},
-						{
-							"code": "2167-5",
-							"display": "Bolivian",
-							"definition": "Bolivian"
-						},
-						{
-							"code": "2168-3",
-							"display": "Chilean",
-							"definition": "Chilean"
-						},
-						{
-							"code": "2169-1",
-							"display": "Colombian",
-							"definition": "Colombian"
-						},
-						{
-							"code": "2170-9",
-							"display": "Ecuadorian",
-							"definition": "Ecuadorian"
-						},
-						{
-							"code": "2171-7",
-							"display": "Paraguayan",
-							"definition": "Paraguayan"
-						},
-						{
-							"code": "2172-5",
-							"display": "Peruvian",
-							"definition": "Peruvian"
-						},
-						{
-							"code": "2173-3",
-							"display": "Uruguayan",
-							"definition": "Uruguayan"
-						},
-						{
-							"code": "2174-1",
-							"display": "Venezuelan",
-							"definition": "Venezuelan"
-						},
-						{
-							"code": "2175-8",
-							"display": "South American Indian",
-							"definition": "South American Indian"
-						},
-						{
-							"code": "2176-6",
-							"display": "Criollo",
-							"definition": "Criollo"
-						}
-					]
-				},
-				{
-					"code": "2186-5",
-					"display": "Not Hispanic or Latino",
-					"definition": "Note that this term remains in the table for completeness, even though within HL7, the notion of \"not otherwise coded\" term is deprecated."
-				}
-			]
-		}
-	]
+    "resourceType": "CodeSystem",
+    "id": "cdcrec",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "urn:oid:2.16.840.1.113883.6.238",
+    "identifier": [
+        {
+            "value": "2.16.840.1.113883.6.238"
+        }
+    ],
+    "version": "3.1.1",
+    "name": "RaceAndEthnicityCDC",
+    "title": "Race & Ethnicity - CDC",
+    "status": "active",
+    "experimental": false,
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://hl7.org"
+                }
+            ]
+        }
+    ],
+    "description": " The U.S. Centers for Disease Control and Prevention (CDC) has prepared a code set for use in codingrace and ethnicity data. This code set is based on current federal standards for classifying data onrace and ethnicity, specifically the minimum race and ethnicity categories defined by the U.S. Office ofManagement and Budget (OMB) and a more detailed set of race and ethnicity categories maintainedby the U.S. Bureau of the Census (BC). The main purpose of the code set is to facilitate use of federalstandards for classifying data on race and ethnicity when these data are exchanged, stored, retrieved,or analyzed in electronic form. At the same time, the code set can be applied to paper-based recordsystems to the extent that these systems are used to collect, maintain, and report data on race andethnicity in accordance with current federal standards. Source: [Race and Ethnicity Code Set Version 1.0](https://www.cdc.gov/phin/resources/vocabulary/documents/cdc-race--ethnicity-background-and-purpose.pdf).",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "caseSensitive": true,
+    "hierarchyMeaning": "is-a",
+    "content": "complete",
+    "count": 966,
+    "property": [
+        {
+            "code": "abstract",
+            "description": "True if an element is considered 'abstract' - in other words, the code is not for use as a real concept",
+            "type": "boolean"
+        }
+    ],
+    "concept": [
+        {
+            "code": "1000-9",
+            "display": "Race",
+            "definition": "Race, Note that this is an abstract 'grouping' concept and not for use as a real concept",
+            "property": [
+                {
+                    "code": "abstract",
+                    "valueBoolean": true
+                }
+            ],
+            "concept": [
+                {
+                    "code": "1002-5",
+                    "display": "American Indian or Alaska Native",
+                    "definition": "American Indian or Alaska Native",
+                    "concept": [
+                        {
+                            "code": "1004-1",
+                            "display": "American Indian",
+                            "definition": "American Indian"
+                        },
+                        {
+                            "code": "1735-0",
+                            "display": "Alaska Native",
+                            "definition": "Alaska Native"
+                        },
+                        {
+                            "code": "1006-6",
+                            "display": "Abenaki",
+                            "definition": "Abenaki"
+                        },
+                        {
+                            "code": "1008-2",
+                            "display": "Algonquian",
+                            "definition": "Algonquian"
+                        },
+                        {
+                            "code": "1010-8",
+                            "display": "Apache",
+                            "definition": "Apache"
+                        },
+                        {
+                            "code": "1021-5",
+                            "display": "Arapaho",
+                            "definition": "Arapaho"
+                        },
+                        {
+                            "code": "1026-4",
+                            "display": "Arikara",
+                            "definition": "Arikara"
+                        },
+                        {
+                            "code": "1028-0",
+                            "display": "Assiniboine",
+                            "definition": "Assiniboine"
+                        },
+                        {
+                            "code": "1030-6",
+                            "display": "Assiniboine Sioux",
+                            "definition": "Assiniboine Sioux"
+                        },
+                        {
+                            "code": "1033-0",
+                            "display": "Bannock",
+                            "definition": "Bannock"
+                        },
+                        {
+                            "code": "1035-5",
+                            "display": "Blackfeet",
+                            "definition": "Blackfeet"
+                        },
+                        {
+                            "code": "1037-1",
+                            "display": "Brotherton",
+                            "definition": "Brotherton"
+                        },
+                        {
+                            "code": "1039-7",
+                            "display": "Burt Lake Band",
+                            "definition": "Burt Lake Band"
+                        },
+                        {
+                            "code": "1041-3",
+                            "display": "Caddo",
+                            "definition": "Caddo"
+                        },
+                        {
+                            "code": "1044-7",
+                            "display": "Cahuilla",
+                            "definition": "Cahuilla"
+                        },
+                        {
+                            "code": "1053-8",
+                            "display": "California Tribes",
+                            "definition": "California Tribes"
+                        },
+                        {
+                            "code": "1068-6",
+                            "display": "Canadian and Latin American Indian",
+                            "definition": "Canadian and Latin American Indian"
+                        },
+                        {
+                            "code": "1076-9",
+                            "display": "Catawba",
+                            "definition": "Catawba"
+                        },
+                        {
+                            "code": "1078-5",
+                            "display": "Cayuse",
+                            "definition": "Cayuse"
+                        },
+                        {
+                            "code": "1080-1",
+                            "display": "Chehalis",
+                            "definition": "Chehalis"
+                        },
+                        {
+                            "code": "1082-7",
+                            "display": "Chemakuan",
+                            "definition": "Chemakuan"
+                        },
+                        {
+                            "code": "1086-8",
+                            "display": "Chemehuevi",
+                            "definition": "Chemehuevi"
+                        },
+                        {
+                            "code": "1088-4",
+                            "display": "Cherokee",
+                            "definition": "Cherokee"
+                        },
+                        {
+                            "code": "1100-7",
+                            "display": "Cherokee Shawnee",
+                            "definition": "Cherokee Shawnee"
+                        },
+                        {
+                            "code": "1102-3",
+                            "display": "Cheyenne",
+                            "definition": "Cheyenne"
+                        },
+                        {
+                            "code": "1106-4",
+                            "display": "Cheyenne-Arapaho",
+                            "definition": "Cheyenne-Arapaho"
+                        },
+                        {
+                            "code": "1108-0",
+                            "display": "Chickahominy",
+                            "definition": "Chickahominy"
+                        },
+                        {
+                            "code": "1112-2",
+                            "display": "Chickasaw",
+                            "definition": "Chickasaw"
+                        },
+                        {
+                            "code": "1114-8",
+                            "display": "Chinook",
+                            "definition": "Chinook"
+                        },
+                        {
+                            "code": "1123-9",
+                            "display": "Chippewa",
+                            "definition": "Chippewa"
+                        },
+                        {
+                            "code": "1150-2",
+                            "display": "Chippewa Cree",
+                            "definition": "Chippewa Cree"
+                        },
+                        {
+                            "code": "1153-6",
+                            "display": "Chitimacha",
+                            "definition": "Chitimacha"
+                        },
+                        {
+                            "code": "1155-1",
+                            "display": "Choctaw",
+                            "definition": "Choctaw"
+                        },
+                        {
+                            "code": "1162-7",
+                            "display": "Chumash",
+                            "definition": "Chumash"
+                        },
+                        {
+                            "code": "1165-0",
+                            "display": "Clear Lake",
+                            "definition": "Clear Lake"
+                        },
+                        {
+                            "code": "1167-6",
+                            "display": "Coeur D'Alene",
+                            "definition": "Coeur D'Alene"
+                        },
+                        {
+                            "code": "1169-2",
+                            "display": "Coharie",
+                            "definition": "Coharie"
+                        },
+                        {
+                            "code": "1171-8",
+                            "display": "Colorado River",
+                            "definition": "Colorado River"
+                        },
+                        {
+                            "code": "1173-4",
+                            "display": "Colville",
+                            "definition": "Colville"
+                        },
+                        {
+                            "code": "1175-9",
+                            "display": "Comanche",
+                            "definition": "Comanche"
+                        },
+                        {
+                            "code": "1178-3",
+                            "display": "Coos, Lower Umpqua, Siuslaw",
+                            "definition": "Coos, Lower Umpqua, Siuslaw"
+                        },
+                        {
+                            "code": "1180-9",
+                            "display": "Coos",
+                            "definition": "Coos"
+                        },
+                        {
+                            "code": "1182-5",
+                            "display": "Coquilles",
+                            "definition": "Coquilles"
+                        },
+                        {
+                            "code": "1184-1",
+                            "display": "Costanoan",
+                            "definition": "Costanoan"
+                        },
+                        {
+                            "code": "1186-6",
+                            "display": "Coushatta",
+                            "definition": "Coushatta"
+                        },
+                        {
+                            "code": "1189-0",
+                            "display": "Cowlitz",
+                            "definition": "Cowlitz"
+                        },
+                        {
+                            "code": "1191-6",
+                            "display": "Cree",
+                            "definition": "Cree"
+                        },
+                        {
+                            "code": "1193-2",
+                            "display": "Creek",
+                            "definition": "Creek"
+                        },
+                        {
+                            "code": "1207-0",
+                            "display": "Croatan",
+                            "definition": "Croatan"
+                        },
+                        {
+                            "code": "1209-6",
+                            "display": "Crow",
+                            "definition": "Crow"
+                        },
+                        {
+                            "code": "1211-2",
+                            "display": "Cupeno",
+                            "definition": "Cupeno"
+                        },
+                        {
+                            "code": "1214-6",
+                            "display": "Delaware",
+                            "definition": "Delaware"
+                        },
+                        {
+                            "code": "1222-9",
+                            "display": "Diegueno",
+                            "definition": "Diegueno"
+                        },
+                        {
+                            "code": "1233-6",
+                            "display": "Eastern Tribes",
+                            "definition": "Eastern Tribes"
+                        },
+                        {
+                            "code": "1250-0",
+                            "display": "Esselen",
+                            "definition": "Esselen"
+                        },
+                        {
+                            "code": "1252-6",
+                            "display": "Fort Belknap",
+                            "definition": "Fort Belknap"
+                        },
+                        {
+                            "code": "1254-2",
+                            "display": "Fort Berthold",
+                            "definition": "Fort Berthold"
+                        },
+                        {
+                            "code": "1256-7",
+                            "display": "Fort Mcdowell",
+                            "definition": "Fort Mcdowell"
+                        },
+                        {
+                            "code": "1258-3",
+                            "display": "Fort Hall",
+                            "definition": "Fort Hall"
+                        },
+                        {
+                            "code": "1260-9",
+                            "display": "Gabrieleno",
+                            "definition": "Gabrieleno"
+                        },
+                        {
+                            "code": "1262-5",
+                            "display": "Grand Ronde",
+                            "definition": "Grand Ronde"
+                        },
+                        {
+                            "code": "1264-1",
+                            "display": "Gros Ventres",
+                            "definition": "Gros Ventres"
+                        },
+                        {
+                            "code": "1267-4",
+                            "display": "Haliwa",
+                            "definition": "Haliwa"
+                        },
+                        {
+                            "code": "1269-0",
+                            "display": "Hidatsa",
+                            "definition": "Hidatsa"
+                        },
+                        {
+                            "code": "1271-6",
+                            "display": "Hoopa",
+                            "definition": "Hoopa"
+                        },
+                        {
+                            "code": "1275-7",
+                            "display": "Hoopa Extension",
+                            "definition": "Hoopa Extension"
+                        },
+                        {
+                            "code": "1277-3",
+                            "display": "Houma",
+                            "definition": "Houma"
+                        },
+                        {
+                            "code": "1279-9",
+                            "display": "Inaja-Cosmit",
+                            "definition": "Inaja-Cosmit"
+                        },
+                        {
+                            "code": "1281-5",
+                            "display": "Iowa",
+                            "definition": "Iowa"
+                        },
+                        {
+                            "code": "1285-6",
+                            "display": "Iroquois",
+                            "definition": "Iroquois"
+                        },
+                        {
+                            "code": "1297-1",
+                            "display": "Juaneno",
+                            "definition": "Juaneno"
+                        },
+                        {
+                            "code": "1299-7",
+                            "display": "Kalispel",
+                            "definition": "Kalispel"
+                        },
+                        {
+                            "code": "1301-1",
+                            "display": "Karuk",
+                            "definition": "Karuk"
+                        },
+                        {
+                            "code": "1303-7",
+                            "display": "Kaw",
+                            "definition": "Kaw"
+                        },
+                        {
+                            "code": "1305-2",
+                            "display": "Kickapoo",
+                            "definition": "Kickapoo"
+                        },
+                        {
+                            "code": "1309-4",
+                            "display": "Kiowa",
+                            "definition": "Kiowa"
+                        },
+                        {
+                            "code": "1312-8",
+                            "display": "Klallam",
+                            "definition": "Klallam"
+                        },
+                        {
+                            "code": "1317-7",
+                            "display": "Klamath",
+                            "definition": "Klamath"
+                        },
+                        {
+                            "code": "1319-3",
+                            "display": "Konkow",
+                            "definition": "Konkow"
+                        },
+                        {
+                            "code": "1321-9",
+                            "display": "Kootenai",
+                            "definition": "Kootenai"
+                        },
+                        {
+                            "code": "1323-5",
+                            "display": "Lassik",
+                            "definition": "Lassik"
+                        },
+                        {
+                            "code": "1325-0",
+                            "display": "Long Island",
+                            "definition": "Long Island"
+                        },
+                        {
+                            "code": "1331-8",
+                            "display": "Luiseno",
+                            "definition": "Luiseno"
+                        },
+                        {
+                            "code": "1340-9",
+                            "display": "Lumbee",
+                            "definition": "Lumbee"
+                        },
+                        {
+                            "code": "1342-5",
+                            "display": "Lummi",
+                            "definition": "Lummi"
+                        },
+                        {
+                            "code": "1344-1",
+                            "display": "Maidu",
+                            "definition": "Maidu"
+                        },
+                        {
+                            "code": "1348-2",
+                            "display": "Makah",
+                            "definition": "Makah"
+                        },
+                        {
+                            "code": "1350-8",
+                            "display": "Maliseet",
+                            "definition": "Maliseet"
+                        },
+                        {
+                            "code": "1352-4",
+                            "display": "Mandan",
+                            "definition": "Mandan"
+                        },
+                        {
+                            "code": "1354-0",
+                            "display": "Mattaponi",
+                            "definition": "Mattaponi"
+                        },
+                        {
+                            "code": "1356-5",
+                            "display": "Menominee",
+                            "definition": "Menominee"
+                        },
+                        {
+                            "code": "1358-1",
+                            "display": "Miami",
+                            "definition": "Miami"
+                        },
+                        {
+                            "code": "1363-1",
+                            "display": "Miccosukee",
+                            "definition": "Miccosukee"
+                        },
+                        {
+                            "code": "1365-6",
+                            "display": "Micmac",
+                            "definition": "Micmac"
+                        },
+                        {
+                            "code": "1368-0",
+                            "display": "Mission Indians",
+                            "definition": "Mission Indians"
+                        },
+                        {
+                            "code": "1370-6",
+                            "display": "Miwok",
+                            "definition": "Miwok"
+                        },
+                        {
+                            "code": "1372-2",
+                            "display": "Modoc",
+                            "definition": "Modoc"
+                        },
+                        {
+                            "code": "1374-8",
+                            "display": "Mohegan",
+                            "definition": "Mohegan"
+                        },
+                        {
+                            "code": "1376-3",
+                            "display": "Mono",
+                            "definition": "Mono"
+                        },
+                        {
+                            "code": "1378-9",
+                            "display": "Nanticoke",
+                            "definition": "Nanticoke"
+                        },
+                        {
+                            "code": "1380-5",
+                            "display": "Narragansett",
+                            "definition": "Narragansett"
+                        },
+                        {
+                            "code": "1382-1",
+                            "display": "Navajo",
+                            "definition": "Navajo"
+                        },
+                        {
+                            "code": "1387-0",
+                            "display": "Nez Perce",
+                            "definition": "Nez Perce"
+                        },
+                        {
+                            "code": "1389-6",
+                            "display": "Nomalaki",
+                            "definition": "Nomalaki"
+                        },
+                        {
+                            "code": "1391-2",
+                            "display": "Northwest Tribes",
+                            "definition": "Northwest Tribes"
+                        },
+                        {
+                            "code": "1403-5",
+                            "display": "Omaha",
+                            "definition": "Omaha"
+                        },
+                        {
+                            "code": "1405-0",
+                            "display": "Oregon Athabaskan",
+                            "definition": "Oregon Athabaskan"
+                        },
+                        {
+                            "code": "1407-6",
+                            "display": "Osage",
+                            "definition": "Osage"
+                        },
+                        {
+                            "code": "1409-2",
+                            "display": "Otoe-Missouria",
+                            "definition": "Otoe-Missouria"
+                        },
+                        {
+                            "code": "1411-8",
+                            "display": "Ottawa",
+                            "definition": "Ottawa"
+                        },
+                        {
+                            "code": "1416-7",
+                            "display": "Paiute",
+                            "definition": "Paiute"
+                        },
+                        {
+                            "code": "1439-9",
+                            "display": "Pamunkey",
+                            "definition": "Pamunkey"
+                        },
+                        {
+                            "code": "1441-5",
+                            "display": "Passamaquoddy",
+                            "definition": "Passamaquoddy"
+                        },
+                        {
+                            "code": "1445-6",
+                            "display": "Pawnee",
+                            "definition": "Pawnee"
+                        },
+                        {
+                            "code": "1448-0",
+                            "display": "Penobscot",
+                            "definition": "Penobscot"
+                        },
+                        {
+                            "code": "1450-6",
+                            "display": "Peoria",
+                            "definition": "Peoria"
+                        },
+                        {
+                            "code": "1453-0",
+                            "display": "Pequot",
+                            "definition": "Pequot"
+                        },
+                        {
+                            "code": "1456-3",
+                            "display": "Pima",
+                            "definition": "Pima"
+                        },
+                        {
+                            "code": "1460-5",
+                            "display": "Piscataway",
+                            "definition": "Piscataway"
+                        },
+                        {
+                            "code": "1462-1",
+                            "display": "Pit River",
+                            "definition": "Pit River"
+                        },
+                        {
+                            "code": "1464-7",
+                            "display": "Pomo",
+                            "definition": "Pomo"
+                        },
+                        {
+                            "code": "1474-6",
+                            "display": "Ponca",
+                            "definition": "Ponca"
+                        },
+                        {
+                            "code": "1478-7",
+                            "display": "Potawatomi",
+                            "definition": "Potawatomi"
+                        },
+                        {
+                            "code": "1487-8",
+                            "display": "Powhatan",
+                            "definition": "Powhatan"
+                        },
+                        {
+                            "code": "1489-4",
+                            "display": "Pueblo",
+                            "definition": "Pueblo"
+                        },
+                        {
+                            "code": "1518-0",
+                            "display": "Puget Sound Salish",
+                            "definition": "Puget Sound Salish"
+                        },
+                        {
+                            "code": "1541-2",
+                            "display": "Quapaw",
+                            "definition": "Quapaw"
+                        },
+                        {
+                            "code": "1543-8",
+                            "display": "Quinault",
+                            "definition": "Quinault"
+                        },
+                        {
+                            "code": "1545-3",
+                            "display": "Rappahannock",
+                            "definition": "Rappahannock"
+                        },
+                        {
+                            "code": "1547-9",
+                            "display": "Reno-Sparks",
+                            "definition": "Reno-Sparks"
+                        },
+                        {
+                            "code": "1549-5",
+                            "display": "Round Valley",
+                            "definition": "Round Valley"
+                        },
+                        {
+                            "code": "1551-1",
+                            "display": "Sac and Fox",
+                            "definition": "Sac and Fox"
+                        },
+                        {
+                            "code": "1556-0",
+                            "display": "Salinan",
+                            "definition": "Salinan"
+                        },
+                        {
+                            "code": "1558-6",
+                            "display": "Salish",
+                            "definition": "Salish"
+                        },
+                        {
+                            "code": "1560-2",
+                            "display": "Salish and Kootenai",
+                            "definition": "Salish and Kootenai"
+                        },
+                        {
+                            "code": "1562-8",
+                            "display": "Schaghticoke",
+                            "definition": "Schaghticoke"
+                        },
+                        {
+                            "code": "1564-4",
+                            "display": "Scott Valley",
+                            "definition": "Scott Valley"
+                        },
+                        {
+                            "code": "1566-9",
+                            "display": "Seminole",
+                            "definition": "Seminole"
+                        },
+                        {
+                            "code": "1573-5",
+                            "display": "Serrano",
+                            "definition": "Serrano"
+                        },
+                        {
+                            "code": "1576-8",
+                            "display": "Shasta",
+                            "definition": "Shasta"
+                        },
+                        {
+                            "code": "1578-4",
+                            "display": "Shawnee",
+                            "definition": "Shawnee"
+                        },
+                        {
+                            "code": "1582-6",
+                            "display": "Shinnecock",
+                            "definition": "Shinnecock"
+                        },
+                        {
+                            "code": "1584-2",
+                            "display": "Shoalwater Bay",
+                            "definition": "Shoalwater Bay"
+                        },
+                        {
+                            "code": "1586-7",
+                            "display": "Shoshone",
+                            "definition": "Shoshone"
+                        },
+                        {
+                            "code": "1602-2",
+                            "display": "Shoshone Paiute",
+                            "definition": "Shoshone Paiute"
+                        },
+                        {
+                            "code": "1607-1",
+                            "display": "Siletz",
+                            "definition": "Siletz"
+                        },
+                        {
+                            "code": "1609-7",
+                            "display": "Sioux",
+                            "definition": "Sioux"
+                        },
+                        {
+                            "code": "1643-6",
+                            "display": "Siuslaw",
+                            "definition": "Siuslaw"
+                        },
+                        {
+                            "code": "1645-1",
+                            "display": "Spokane",
+                            "definition": "Spokane"
+                        },
+                        {
+                            "code": "1647-7",
+                            "display": "Stewart",
+                            "definition": "Stewart"
+                        },
+                        {
+                            "code": "1649-3",
+                            "display": "Stockbridge",
+                            "definition": "Stockbridge"
+                        },
+                        {
+                            "code": "1651-9",
+                            "display": "Susanville",
+                            "definition": "Susanville"
+                        },
+                        {
+                            "code": "1653-5",
+                            "display": "Tohono O'Odham",
+                            "definition": "Tohono O'Odham"
+                        },
+                        {
+                            "code": "1659-2",
+                            "display": "Tolowa",
+                            "definition": "Tolowa"
+                        },
+                        {
+                            "code": "1661-8",
+                            "display": "Tonkawa",
+                            "definition": "Tonkawa"
+                        },
+                        {
+                            "code": "1663-4",
+                            "display": "Tygh",
+                            "definition": "Tygh"
+                        },
+                        {
+                            "code": "1665-9",
+                            "display": "Umatilla",
+                            "definition": "Umatilla"
+                        },
+                        {
+                            "code": "1667-5",
+                            "display": "Umpqua",
+                            "definition": "Umpqua"
+                        },
+                        {
+                            "code": "1670-9",
+                            "display": "Ute",
+                            "definition": "Ute"
+                        },
+                        {
+                            "code": "1675-8",
+                            "display": "Wailaki",
+                            "definition": "Wailaki"
+                        },
+                        {
+                            "code": "1677-4",
+                            "display": "Walla-Walla",
+                            "definition": "Walla-Walla"
+                        },
+                        {
+                            "code": "1679-0",
+                            "display": "Wampanoag",
+                            "definition": "Wampanoag"
+                        },
+                        {
+                            "code": "1683-2",
+                            "display": "Warm Springs",
+                            "definition": "Warm Springs"
+                        },
+                        {
+                            "code": "1685-7",
+                            "display": "Wascopum",
+                            "definition": "Wascopum"
+                        },
+                        {
+                            "code": "1687-3",
+                            "display": "Washoe",
+                            "definition": "Washoe"
+                        },
+                        {
+                            "code": "1692-3",
+                            "display": "Wichita",
+                            "definition": "Wichita"
+                        },
+                        {
+                            "code": "1694-9",
+                            "display": "Wind River",
+                            "definition": "Wind River"
+                        },
+                        {
+                            "code": "1696-4",
+                            "display": "Winnebago",
+                            "definition": "Winnebago"
+                        },
+                        {
+                            "code": "1700-4",
+                            "display": "Winnemucca",
+                            "definition": "Winnemucca"
+                        },
+                        {
+                            "code": "1702-0",
+                            "display": "Wintun",
+                            "definition": "Wintun"
+                        },
+                        {
+                            "code": "1704-6",
+                            "display": "Wiyot",
+                            "definition": "Wiyot"
+                        },
+                        {
+                            "code": "1707-9",
+                            "display": "Yakama",
+                            "definition": "Yakama"
+                        },
+                        {
+                            "code": "1709-5",
+                            "display": "Yakama Cowlitz",
+                            "definition": "Yakama Cowlitz"
+                        },
+                        {
+                            "code": "1711-1",
+                            "display": "Yaqui",
+                            "definition": "Yaqui"
+                        },
+                        {
+                            "code": "1715-2",
+                            "display": "Yavapai Apache",
+                            "definition": "Yavapai Apache"
+                        },
+                        {
+                            "code": "1717-8",
+                            "display": "Yokuts",
+                            "definition": "Yokuts"
+                        },
+                        {
+                            "code": "1722-8",
+                            "display": "Yuchi",
+                            "definition": "Yuchi"
+                        },
+                        {
+                            "code": "1724-4",
+                            "display": "Yuman",
+                            "definition": "Yuman"
+                        },
+                        {
+                            "code": "1732-7",
+                            "display": "Yurok",
+                            "definition": "Yurok"
+                        },
+                        {
+                            "code": "1011-6",
+                            "display": "Chiricahua",
+                            "definition": "Chiricahua"
+                        },
+                        {
+                            "code": "1012-4",
+                            "display": "Fort Sill Apache",
+                            "definition": "Fort Sill Apache"
+                        },
+                        {
+                            "code": "1013-2",
+                            "display": "Jicarilla Apache",
+                            "definition": "Jicarilla Apache"
+                        },
+                        {
+                            "code": "1014-0",
+                            "display": "Lipan Apache",
+                            "definition": "Lipan Apache"
+                        },
+                        {
+                            "code": "1015-7",
+                            "display": "Mescalero Apache",
+                            "definition": "Mescalero Apache"
+                        },
+                        {
+                            "code": "1016-5",
+                            "display": "Oklahoma Apache",
+                            "definition": "Oklahoma Apache"
+                        },
+                        {
+                            "code": "1017-3",
+                            "display": "Payson Apache",
+                            "definition": "Payson Apache"
+                        },
+                        {
+                            "code": "1018-1",
+                            "display": "San Carlos Apache",
+                            "definition": "San Carlos Apache"
+                        },
+                        {
+                            "code": "1019-9",
+                            "display": "White Mountain Apache",
+                            "definition": "White Mountain Apache"
+                        },
+                        {
+                            "code": "1022-3",
+                            "display": "Northern Arapaho",
+                            "definition": "Northern Arapaho"
+                        },
+                        {
+                            "code": "1023-1",
+                            "display": "Southern Arapaho",
+                            "definition": "Southern Arapaho"
+                        },
+                        {
+                            "code": "1024-9",
+                            "display": "Wind River Arapaho",
+                            "definition": "Wind River Arapaho"
+                        },
+                        {
+                            "code": "1031-4",
+                            "display": "Fort Peck Assiniboine Sioux",
+                            "definition": "Fort Peck Assiniboine Sioux"
+                        },
+                        {
+                            "code": "1042-1",
+                            "display": "Oklahoma Cado",
+                            "definition": "Oklahoma Cado"
+                        },
+                        {
+                            "code": "1045-4",
+                            "display": "Agua Caliente Cahuilla",
+                            "definition": "Agua Caliente Cahuilla"
+                        },
+                        {
+                            "code": "1046-2",
+                            "display": "Augustine",
+                            "definition": "Augustine"
+                        },
+                        {
+                            "code": "1047-0",
+                            "display": "Cabazon",
+                            "definition": "Cabazon"
+                        },
+                        {
+                            "code": "1048-8",
+                            "display": "Los Coyotes",
+                            "definition": "Los Coyotes"
+                        },
+                        {
+                            "code": "1049-6",
+                            "display": "Morongo",
+                            "definition": "Morongo"
+                        },
+                        {
+                            "code": "1050-4",
+                            "display": "Santa Rosa Cahuilla",
+                            "definition": "Santa Rosa Cahuilla"
+                        },
+                        {
+                            "code": "1051-2",
+                            "display": "Torres-Martinez",
+                            "definition": "Torres-Martinez"
+                        },
+                        {
+                            "code": "1054-6",
+                            "display": "Cahto",
+                            "definition": "Cahto"
+                        },
+                        {
+                            "code": "1055-3",
+                            "display": "Chimariko",
+                            "definition": "Chimariko"
+                        },
+                        {
+                            "code": "1056-1",
+                            "display": "Coast Miwok",
+                            "definition": "Coast Miwok"
+                        },
+                        {
+                            "code": "1057-9",
+                            "display": "Digger",
+                            "definition": "Digger"
+                        },
+                        {
+                            "code": "1058-7",
+                            "display": "Kawaiisu",
+                            "definition": "Kawaiisu"
+                        },
+                        {
+                            "code": "1059-5",
+                            "display": "Kern River",
+                            "definition": "Kern River"
+                        },
+                        {
+                            "code": "1060-3",
+                            "display": "Mattole",
+                            "definition": "Mattole"
+                        },
+                        {
+                            "code": "1061-1",
+                            "display": "Red Wood",
+                            "definition": "Red Wood"
+                        },
+                        {
+                            "code": "1062-9",
+                            "display": "Santa Rosa",
+                            "definition": "Santa Rosa"
+                        },
+                        {
+                            "code": "1063-7",
+                            "display": "Takelma",
+                            "definition": "Takelma"
+                        },
+                        {
+                            "code": "1064-5",
+                            "display": "Wappo",
+                            "definition": "Wappo"
+                        },
+                        {
+                            "code": "1065-2",
+                            "display": "Yana",
+                            "definition": "Yana"
+                        },
+                        {
+                            "code": "1066-0",
+                            "display": "Yuki",
+                            "definition": "Yuki"
+                        },
+                        {
+                            "code": "1069-4",
+                            "display": "Canadian Indian",
+                            "definition": "Canadian Indian"
+                        },
+                        {
+                            "code": "1070-2",
+                            "display": "Central American Indian",
+                            "definition": "Central American Indian"
+                        },
+                        {
+                            "code": "1071-0",
+                            "display": "French American Indian",
+                            "definition": "French American Indian"
+                        },
+                        {
+                            "code": "1072-8",
+                            "display": "Mexican American Indian",
+                            "definition": "Mexican American Indian"
+                        },
+                        {
+                            "code": "1073-6",
+                            "display": "South American Indian",
+                            "definition": "South American Indian"
+                        },
+                        {
+                            "code": "1074-4",
+                            "display": "Spanish American Indian",
+                            "definition": "Spanish American Indian"
+                        },
+                        {
+                            "code": "1083-5",
+                            "display": "Hoh",
+                            "definition": "Hoh"
+                        },
+                        {
+                            "code": "1084-3",
+                            "display": "Quileute",
+                            "definition": "Quileute"
+                        },
+                        {
+                            "code": "1089-2",
+                            "display": "Cherokee Alabama",
+                            "definition": "Cherokee Alabama"
+                        },
+                        {
+                            "code": "1090-0",
+                            "display": "Cherokees of Northeast Alabama",
+                            "definition": "Cherokees of Northeast Alabama"
+                        },
+                        {
+                            "code": "1091-8",
+                            "display": "Cherokees of Southeast Alabama",
+                            "definition": "Cherokees of Southeast Alabama"
+                        },
+                        {
+                            "code": "1092-6",
+                            "display": "Eastern Cherokee",
+                            "definition": "Eastern Cherokee"
+                        },
+                        {
+                            "code": "1093-4",
+                            "display": "Echota Cherokee",
+                            "definition": "Echota Cherokee"
+                        },
+                        {
+                            "code": "1094-2",
+                            "display": "Etowah Cherokee",
+                            "definition": "Etowah Cherokee"
+                        },
+                        {
+                            "code": "1095-9",
+                            "display": "Northern Cherokee",
+                            "definition": "Northern Cherokee"
+                        },
+                        {
+                            "code": "1096-7",
+                            "display": "Tuscola",
+                            "definition": "Tuscola"
+                        },
+                        {
+                            "code": "1097-5",
+                            "display": "United Keetowah Band of Cherokee",
+                            "definition": "United Keetowah Band of Cherokee"
+                        },
+                        {
+                            "code": "1098-3",
+                            "display": "Western Cherokee",
+                            "definition": "Western Cherokee"
+                        },
+                        {
+                            "code": "1103-1",
+                            "display": "Northern Cheyenne",
+                            "definition": "Northern Cheyenne"
+                        },
+                        {
+                            "code": "1104-9",
+                            "display": "Southern Cheyenne",
+                            "definition": "Southern Cheyenne"
+                        },
+                        {
+                            "code": "1109-8",
+                            "display": "Eastern Chickahominy",
+                            "definition": "Eastern Chickahominy"
+                        },
+                        {
+                            "code": "1110-6",
+                            "display": "Western Chickahominy",
+                            "definition": "Western Chickahominy"
+                        },
+                        {
+                            "code": "1115-5",
+                            "display": "Clatsop",
+                            "definition": "Clatsop"
+                        },
+                        {
+                            "code": "1116-3",
+                            "display": "Columbia River Chinook",
+                            "definition": "Columbia River Chinook"
+                        },
+                        {
+                            "code": "1117-1",
+                            "display": "Kathlamet",
+                            "definition": "Kathlamet"
+                        },
+                        {
+                            "code": "1118-9",
+                            "display": "Upper Chinook",
+                            "definition": "Upper Chinook"
+                        },
+                        {
+                            "code": "1119-7",
+                            "display": "Wakiakum Chinook",
+                            "definition": "Wakiakum Chinook"
+                        },
+                        {
+                            "code": "1120-5",
+                            "display": "Willapa Chinook",
+                            "definition": "Willapa Chinook"
+                        },
+                        {
+                            "code": "1121-3",
+                            "display": "Wishram",
+                            "definition": "Wishram"
+                        },
+                        {
+                            "code": "1124-7",
+                            "display": "Bad River",
+                            "definition": "Bad River"
+                        },
+                        {
+                            "code": "1125-4",
+                            "display": "Bay Mills Chippewa",
+                            "definition": "Bay Mills Chippewa"
+                        },
+                        {
+                            "code": "1126-2",
+                            "display": "Bois Forte",
+                            "definition": "Bois Forte"
+                        },
+                        {
+                            "code": "1127-0",
+                            "display": "Burt Lake Chippewa",
+                            "definition": "Burt Lake Chippewa"
+                        },
+                        {
+                            "code": "1128-8",
+                            "display": "Fond du Lac",
+                            "definition": "Fond du Lac"
+                        },
+                        {
+                            "code": "1129-6",
+                            "display": "Grand Portage",
+                            "definition": "Grand Portage"
+                        },
+                        {
+                            "code": "1130-4",
+                            "display": "Grand Traverse Band of Ottawa/Chippewa",
+                            "definition": "Grand Traverse Band of Ottawa/Chippewa"
+                        },
+                        {
+                            "code": "1131-2",
+                            "display": "Keweenaw",
+                            "definition": "Keweenaw"
+                        },
+                        {
+                            "code": "1132-0",
+                            "display": "Lac Courte Oreilles",
+                            "definition": "Lac Courte Oreilles"
+                        },
+                        {
+                            "code": "1133-8",
+                            "display": "Lac du Flambeau",
+                            "definition": "Lac du Flambeau"
+                        },
+                        {
+                            "code": "1134-6",
+                            "display": "Lac Vieux Desert Chippewa",
+                            "definition": "Lac Vieux Desert Chippewa"
+                        },
+                        {
+                            "code": "1135-3",
+                            "display": "Lake Superior",
+                            "definition": "Lake Superior"
+                        },
+                        {
+                            "code": "1136-1",
+                            "display": "Leech Lake",
+                            "definition": "Leech Lake"
+                        },
+                        {
+                            "code": "1137-9",
+                            "display": "Little Shell Chippewa",
+                            "definition": "Little Shell Chippewa"
+                        },
+                        {
+                            "code": "1138-7",
+                            "display": "Mille Lacs",
+                            "definition": "Mille Lacs"
+                        },
+                        {
+                            "code": "1139-5",
+                            "display": "Minnesota Chippewa",
+                            "definition": "Minnesota Chippewa"
+                        },
+                        {
+                            "code": "1140-3",
+                            "display": "Ontonagon",
+                            "definition": "Ontonagon"
+                        },
+                        {
+                            "code": "1141-1",
+                            "display": "Red Cliff Chippewa",
+                            "definition": "Red Cliff Chippewa"
+                        },
+                        {
+                            "code": "1142-9",
+                            "display": "Red Lake Chippewa",
+                            "definition": "Red Lake Chippewa"
+                        },
+                        {
+                            "code": "1143-7",
+                            "display": "Saginaw Chippewa",
+                            "definition": "Saginaw Chippewa"
+                        },
+                        {
+                            "code": "1144-5",
+                            "display": "St. Croix Chippewa",
+                            "definition": "St. Croix Chippewa"
+                        },
+                        {
+                            "code": "1145-2",
+                            "display": "Sault Ste. Marie Chippewa",
+                            "definition": "Sault Ste. Marie Chippewa"
+                        },
+                        {
+                            "code": "1146-0",
+                            "display": "Sokoagon Chippewa",
+                            "definition": "Sokoagon Chippewa"
+                        },
+                        {
+                            "code": "1147-8",
+                            "display": "Turtle Mountain",
+                            "definition": "Turtle Mountain"
+                        },
+                        {
+                            "code": "1148-6",
+                            "display": "White Earth",
+                            "definition": "White Earth"
+                        },
+                        {
+                            "code": "1151-0",
+                            "display": "Rocky Boy's Chippewa Cree",
+                            "definition": "Rocky Boy's Chippewa Cree"
+                        },
+                        {
+                            "code": "1156-9",
+                            "display": "Clifton Choctaw",
+                            "definition": "Clifton Choctaw"
+                        },
+                        {
+                            "code": "1157-7",
+                            "display": "Jena Choctaw",
+                            "definition": "Jena Choctaw"
+                        },
+                        {
+                            "code": "1158-5",
+                            "display": "Mississippi Choctaw",
+                            "definition": "Mississippi Choctaw"
+                        },
+                        {
+                            "code": "1159-3",
+                            "display": "Mowa Band of Choctaw",
+                            "definition": "Mowa Band of Choctaw"
+                        },
+                        {
+                            "code": "1160-1",
+                            "display": "Oklahoma Choctaw",
+                            "definition": "Oklahoma Choctaw"
+                        },
+                        {
+                            "code": "1163-5",
+                            "display": "Santa Ynez",
+                            "definition": "Santa Ynez"
+                        },
+                        {
+                            "code": "1176-7",
+                            "display": "Oklahoma Comanche",
+                            "definition": "Oklahoma Comanche"
+                        },
+                        {
+                            "code": "1187-4",
+                            "display": "Alabama Coushatta",
+                            "definition": "Alabama Coushatta"
+                        },
+                        {
+                            "code": "1194-0",
+                            "display": "Alabama Creek",
+                            "definition": "Alabama Creek"
+                        },
+                        {
+                            "code": "1195-7",
+                            "display": "Alabama Quassarte",
+                            "definition": "Alabama Quassarte"
+                        },
+                        {
+                            "code": "1196-5",
+                            "display": "Eastern Creek",
+                            "definition": "Eastern Creek"
+                        },
+                        {
+                            "code": "1197-3",
+                            "display": "Eastern Muscogee",
+                            "definition": "Eastern Muscogee"
+                        },
+                        {
+                            "code": "1198-1",
+                            "display": "Kialegee",
+                            "definition": "Kialegee"
+                        },
+                        {
+                            "code": "1199-9",
+                            "display": "Lower Muscogee",
+                            "definition": "Lower Muscogee"
+                        },
+                        {
+                            "code": "1200-5",
+                            "display": "Machis Lower Creek Indian",
+                            "definition": "Machis Lower Creek Indian"
+                        },
+                        {
+                            "code": "1201-3",
+                            "display": "Poarch Band",
+                            "definition": "Poarch Band"
+                        },
+                        {
+                            "code": "1202-1",
+                            "display": "Principal Creek Indian Nation",
+                            "definition": "Principal Creek Indian Nation"
+                        },
+                        {
+                            "code": "1203-9",
+                            "display": "Star Clan of Muscogee Creeks",
+                            "definition": "Star Clan of Muscogee Creeks"
+                        },
+                        {
+                            "code": "1204-7",
+                            "display": "Thlopthlocco",
+                            "definition": "Thlopthlocco"
+                        },
+                        {
+                            "code": "1205-4",
+                            "display": "Tuckabachee",
+                            "definition": "Tuckabachee"
+                        },
+                        {
+                            "code": "1212-0",
+                            "display": "Agua Caliente",
+                            "definition": "Agua Caliente"
+                        },
+                        {
+                            "code": "1215-3",
+                            "display": "Eastern Delaware",
+                            "definition": "Eastern Delaware"
+                        },
+                        {
+                            "code": "1216-1",
+                            "display": "Lenni-Lenape",
+                            "definition": "Lenni-Lenape"
+                        },
+                        {
+                            "code": "1217-9",
+                            "display": "Munsee",
+                            "definition": "Munsee"
+                        },
+                        {
+                            "code": "1218-7",
+                            "display": "Oklahoma Delaware",
+                            "definition": "Oklahoma Delaware"
+                        },
+                        {
+                            "code": "1219-5",
+                            "display": "Rampough Mountain",
+                            "definition": "Rampough Mountain"
+                        },
+                        {
+                            "code": "1220-3",
+                            "display": "Sand Hill",
+                            "definition": "Sand Hill"
+                        },
+                        {
+                            "code": "1223-7",
+                            "display": "Campo",
+                            "definition": "Campo"
+                        },
+                        {
+                            "code": "1224-5",
+                            "display": "Capitan Grande",
+                            "definition": "Capitan Grande"
+                        },
+                        {
+                            "code": "1225-2",
+                            "display": "Cuyapaipe",
+                            "definition": "Cuyapaipe"
+                        },
+                        {
+                            "code": "1226-0",
+                            "display": "La Posta",
+                            "definition": "La Posta"
+                        },
+                        {
+                            "code": "1227-8",
+                            "display": "Manzanita",
+                            "definition": "Manzanita"
+                        },
+                        {
+                            "code": "1228-6",
+                            "display": "Mesa Grande",
+                            "definition": "Mesa Grande"
+                        },
+                        {
+                            "code": "1229-4",
+                            "display": "San Pasqual",
+                            "definition": "San Pasqual"
+                        },
+                        {
+                            "code": "1230-2",
+                            "display": "Santa Ysabel",
+                            "definition": "Santa Ysabel"
+                        },
+                        {
+                            "code": "1231-0",
+                            "display": "Sycuan",
+                            "definition": "Sycuan"
+                        },
+                        {
+                            "code": "1234-4",
+                            "display": "Attacapa",
+                            "definition": "Attacapa"
+                        },
+                        {
+                            "code": "1235-1",
+                            "display": "Biloxi",
+                            "definition": "Biloxi"
+                        },
+                        {
+                            "code": "1236-9",
+                            "display": "Georgetown (Eastern Tribes)",
+                            "definition": "Georgetown (Eastern Tribes)"
+                        },
+                        {
+                            "code": "1237-7",
+                            "display": "Moor",
+                            "definition": "Moor"
+                        },
+                        {
+                            "code": "1238-5",
+                            "display": "Nansemond",
+                            "definition": "Nansemond"
+                        },
+                        {
+                            "code": "1239-3",
+                            "display": "Natchez",
+                            "definition": "Natchez"
+                        },
+                        {
+                            "code": "1240-1",
+                            "display": "Nausu Waiwash",
+                            "definition": "Nausu Waiwash"
+                        },
+                        {
+                            "code": "1241-9",
+                            "display": "Nipmuc",
+                            "definition": "Nipmuc"
+                        },
+                        {
+                            "code": "1242-7",
+                            "display": "Paugussett",
+                            "definition": "Paugussett"
+                        },
+                        {
+                            "code": "1243-5",
+                            "display": "Pocomoke Acohonock",
+                            "definition": "Pocomoke Acohonock"
+                        },
+                        {
+                            "code": "1244-3",
+                            "display": "Southeastern Indians",
+                            "definition": "Southeastern Indians"
+                        },
+                        {
+                            "code": "1245-0",
+                            "display": "Susquehanock",
+                            "definition": "Susquehanock"
+                        },
+                        {
+                            "code": "1246-8",
+                            "display": "Tunica Biloxi",
+                            "definition": "Tunica Biloxi"
+                        },
+                        {
+                            "code": "1247-6",
+                            "display": "Waccamaw-Siousan",
+                            "definition": "Waccamaw-Siousan"
+                        },
+                        {
+                            "code": "1248-4",
+                            "display": "Wicomico",
+                            "definition": "Wicomico"
+                        },
+                        {
+                            "code": "1265-8",
+                            "display": "Atsina",
+                            "definition": "Atsina"
+                        },
+                        {
+                            "code": "1272-4",
+                            "display": "Trinity",
+                            "definition": "Trinity"
+                        },
+                        {
+                            "code": "1273-2",
+                            "display": "Whilkut",
+                            "definition": "Whilkut"
+                        },
+                        {
+                            "code": "1282-3",
+                            "display": "Iowa of Kansas-Nebraska",
+                            "definition": "Iowa of Kansas-Nebraska"
+                        },
+                        {
+                            "code": "1283-1",
+                            "display": "Iowa of Oklahoma",
+                            "definition": "Iowa of Oklahoma"
+                        },
+                        {
+                            "code": "1286-4",
+                            "display": "Cayuga",
+                            "definition": "Cayuga"
+                        },
+                        {
+                            "code": "1287-2",
+                            "display": "Mohawk",
+                            "definition": "Mohawk"
+                        },
+                        {
+                            "code": "1288-0",
+                            "display": "Oneida",
+                            "definition": "Oneida"
+                        },
+                        {
+                            "code": "1289-8",
+                            "display": "Onondaga",
+                            "definition": "Onondaga"
+                        },
+                        {
+                            "code": "1290-6",
+                            "display": "Seneca",
+                            "definition": "Seneca"
+                        },
+                        {
+                            "code": "1291-4",
+                            "display": "Seneca Nation",
+                            "definition": "Seneca Nation"
+                        },
+                        {
+                            "code": "1292-2",
+                            "display": "Seneca-Cayuga",
+                            "definition": "Seneca-Cayuga"
+                        },
+                        {
+                            "code": "1293-0",
+                            "display": "Tonawanda Seneca",
+                            "definition": "Tonawanda Seneca"
+                        },
+                        {
+                            "code": "1294-8",
+                            "display": "Tuscarora",
+                            "definition": "Tuscarora"
+                        },
+                        {
+                            "code": "1295-5",
+                            "display": "Wyandotte",
+                            "definition": "Wyandotte"
+                        },
+                        {
+                            "code": "1306-0",
+                            "display": "Oklahoma Kickapoo",
+                            "definition": "Oklahoma Kickapoo"
+                        },
+                        {
+                            "code": "1307-8",
+                            "display": "Texas Kickapoo",
+                            "definition": "Texas Kickapoo"
+                        },
+                        {
+                            "code": "1310-2",
+                            "display": "Oklahoma Kiowa",
+                            "definition": "Oklahoma Kiowa"
+                        },
+                        {
+                            "code": "1313-6",
+                            "display": "Jamestown",
+                            "definition": "Jamestown"
+                        },
+                        {
+                            "code": "1314-4",
+                            "display": "Lower Elwha",
+                            "definition": "Lower Elwha"
+                        },
+                        {
+                            "code": "1315-1",
+                            "display": "Port Gamble Klallam",
+                            "definition": "Port Gamble Klallam"
+                        },
+                        {
+                            "code": "1326-8",
+                            "display": "Matinecock",
+                            "definition": "Matinecock"
+                        },
+                        {
+                            "code": "1327-6",
+                            "display": "Montauk",
+                            "definition": "Montauk"
+                        },
+                        {
+                            "code": "1328-4",
+                            "display": "Poospatuck",
+                            "definition": "Poospatuck"
+                        },
+                        {
+                            "code": "1329-2",
+                            "display": "Setauket",
+                            "definition": "Setauket"
+                        },
+                        {
+                            "code": "1332-6",
+                            "display": "La Jolla",
+                            "definition": "La Jolla"
+                        },
+                        {
+                            "code": "1333-4",
+                            "display": "Pala",
+                            "definition": "Pala"
+                        },
+                        {
+                            "code": "1334-2",
+                            "display": "Pauma",
+                            "definition": "Pauma"
+                        },
+                        {
+                            "code": "1335-9",
+                            "display": "Pechanga",
+                            "definition": "Pechanga"
+                        },
+                        {
+                            "code": "1336-7",
+                            "display": "Soboba",
+                            "definition": "Soboba"
+                        },
+                        {
+                            "code": "1337-5",
+                            "display": "Twenty-Nine Palms",
+                            "definition": "Twenty-Nine Palms"
+                        },
+                        {
+                            "code": "1338-3",
+                            "display": "Temecula",
+                            "definition": "Temecula"
+                        },
+                        {
+                            "code": "1345-8",
+                            "display": "Mountain Maidu",
+                            "definition": "Mountain Maidu"
+                        },
+                        {
+                            "code": "1346-6",
+                            "display": "Nishinam",
+                            "definition": "Nishinam"
+                        },
+                        {
+                            "code": "1359-9",
+                            "display": "Illinois Miami",
+                            "definition": "Illinois Miami"
+                        },
+                        {
+                            "code": "1360-7",
+                            "display": "Indiana Miami",
+                            "definition": "Indiana Miami"
+                        },
+                        {
+                            "code": "1361-5",
+                            "display": "Oklahoma Miami",
+                            "definition": "Oklahoma Miami"
+                        },
+                        {
+                            "code": "1366-4",
+                            "display": "Aroostook",
+                            "definition": "Aroostook"
+                        },
+                        {
+                            "code": "1383-9",
+                            "display": "Alamo Navajo",
+                            "definition": "Alamo Navajo"
+                        },
+                        {
+                            "code": "1384-7",
+                            "display": "Canoncito Navajo",
+                            "definition": "Canoncito Navajo"
+                        },
+                        {
+                            "code": "1385-4",
+                            "display": "Ramah Navajo",
+                            "definition": "Ramah Navajo"
+                        },
+                        {
+                            "code": "1392-0",
+                            "display": "Alsea",
+                            "definition": "Alsea"
+                        },
+                        {
+                            "code": "1393-8",
+                            "display": "Celilo",
+                            "definition": "Celilo"
+                        },
+                        {
+                            "code": "1394-6",
+                            "display": "Columbia",
+                            "definition": "Columbia"
+                        },
+                        {
+                            "code": "1395-3",
+                            "display": "Kalapuya",
+                            "definition": "Kalapuya"
+                        },
+                        {
+                            "code": "1396-1",
+                            "display": "Molala",
+                            "definition": "Molala"
+                        },
+                        {
+                            "code": "1397-9",
+                            "display": "Talakamish",
+                            "definition": "Talakamish"
+                        },
+                        {
+                            "code": "1398-7",
+                            "display": "Tenino",
+                            "definition": "Tenino"
+                        },
+                        {
+                            "code": "1399-5",
+                            "display": "Tillamook",
+                            "definition": "Tillamook"
+                        },
+                        {
+                            "code": "1400-1",
+                            "display": "Wenatchee",
+                            "definition": "Wenatchee"
+                        },
+                        {
+                            "code": "1401-9",
+                            "display": "Yahooskin",
+                            "definition": "Yahooskin"
+                        },
+                        {
+                            "code": "1412-6",
+                            "display": "Burt Lake Ottawa",
+                            "definition": "Burt Lake Ottawa"
+                        },
+                        {
+                            "code": "1413-4",
+                            "display": "Michigan Ottawa",
+                            "definition": "Michigan Ottawa"
+                        },
+                        {
+                            "code": "1414-2",
+                            "display": "Oklahoma Ottawa",
+                            "definition": "Oklahoma Ottawa"
+                        },
+                        {
+                            "code": "1417-5",
+                            "display": "Bishop",
+                            "definition": "Bishop"
+                        },
+                        {
+                            "code": "1418-3",
+                            "display": "Bridgeport",
+                            "definition": "Bridgeport"
+                        },
+                        {
+                            "code": "1419-1",
+                            "display": "Burns Paiute",
+                            "definition": "Burns Paiute"
+                        },
+                        {
+                            "code": "1420-9",
+                            "display": "Cedarville",
+                            "definition": "Cedarville"
+                        },
+                        {
+                            "code": "1421-7",
+                            "display": "Fort Bidwell",
+                            "definition": "Fort Bidwell"
+                        },
+                        {
+                            "code": "1422-5",
+                            "display": "Fort Independence",
+                            "definition": "Fort Independence"
+                        },
+                        {
+                            "code": "1423-3",
+                            "display": "Kaibab",
+                            "definition": "Kaibab"
+                        },
+                        {
+                            "code": "1424-1",
+                            "display": "Las Vegas",
+                            "definition": "Las Vegas"
+                        },
+                        {
+                            "code": "1425-8",
+                            "display": "Lone Pine",
+                            "definition": "Lone Pine"
+                        },
+                        {
+                            "code": "1426-6",
+                            "display": "Lovelock",
+                            "definition": "Lovelock"
+                        },
+                        {
+                            "code": "1427-4",
+                            "display": "Malheur Paiute",
+                            "definition": "Malheur Paiute"
+                        },
+                        {
+                            "code": "1428-2",
+                            "display": "Moapa",
+                            "definition": "Moapa"
+                        },
+                        {
+                            "code": "1429-0",
+                            "display": "Northern Paiute",
+                            "definition": "Northern Paiute"
+                        },
+                        {
+                            "code": "1430-8",
+                            "display": "Owens Valley",
+                            "definition": "Owens Valley"
+                        },
+                        {
+                            "code": "1431-6",
+                            "display": "Pyramid Lake",
+                            "definition": "Pyramid Lake"
+                        },
+                        {
+                            "code": "1432-4",
+                            "display": "San Juan Southern Paiute",
+                            "definition": "San Juan Southern Paiute"
+                        },
+                        {
+                            "code": "1433-2",
+                            "display": "Southern Paiute",
+                            "definition": "Southern Paiute"
+                        },
+                        {
+                            "code": "1434-0",
+                            "display": "Summit Lake",
+                            "definition": "Summit Lake"
+                        },
+                        {
+                            "code": "1435-7",
+                            "display": "Utu Utu Gwaitu Paiute",
+                            "definition": "Utu Utu Gwaitu Paiute"
+                        },
+                        {
+                            "code": "1436-5",
+                            "display": "Walker River",
+                            "definition": "Walker River"
+                        },
+                        {
+                            "code": "1437-3",
+                            "display": "Yerington Paiute",
+                            "definition": "Yerington Paiute"
+                        },
+                        {
+                            "code": "1442-3",
+                            "display": "Indian Township",
+                            "definition": "Indian Township"
+                        },
+                        {
+                            "code": "1443-1",
+                            "display": "Pleasant Point Passamaquoddy",
+                            "definition": "Pleasant Point Passamaquoddy"
+                        },
+                        {
+                            "code": "1446-4",
+                            "display": "Oklahoma Pawnee",
+                            "definition": "Oklahoma Pawnee"
+                        },
+                        {
+                            "code": "1451-4",
+                            "display": "Oklahoma Peoria",
+                            "definition": "Oklahoma Peoria"
+                        },
+                        {
+                            "code": "1454-8",
+                            "display": "Marshantucket Pequot",
+                            "definition": "Marshantucket Pequot"
+                        },
+                        {
+                            "code": "1457-1",
+                            "display": "Gila River Pima-Maricopa",
+                            "definition": "Gila River Pima-Maricopa"
+                        },
+                        {
+                            "code": "1458-9",
+                            "display": "Salt River Pima-Maricopa",
+                            "definition": "Salt River Pima-Maricopa"
+                        },
+                        {
+                            "code": "1465-4",
+                            "display": "Central Pomo",
+                            "definition": "Central Pomo"
+                        },
+                        {
+                            "code": "1466-2",
+                            "display": "Dry Creek",
+                            "definition": "Dry Creek"
+                        },
+                        {
+                            "code": "1467-0",
+                            "display": "Eastern Pomo",
+                            "definition": "Eastern Pomo"
+                        },
+                        {
+                            "code": "1468-8",
+                            "display": "Kashia",
+                            "definition": "Kashia"
+                        },
+                        {
+                            "code": "1469-6",
+                            "display": "Northern Pomo",
+                            "definition": "Northern Pomo"
+                        },
+                        {
+                            "code": "1470-4",
+                            "display": "Scotts Valley",
+                            "definition": "Scotts Valley"
+                        },
+                        {
+                            "code": "1471-2",
+                            "display": "Stonyford",
+                            "definition": "Stonyford"
+                        },
+                        {
+                            "code": "1472-0",
+                            "display": "Sulphur Bank",
+                            "definition": "Sulphur Bank"
+                        },
+                        {
+                            "code": "1475-3",
+                            "display": "Nebraska Ponca",
+                            "definition": "Nebraska Ponca"
+                        },
+                        {
+                            "code": "1476-1",
+                            "display": "Oklahoma Ponca",
+                            "definition": "Oklahoma Ponca"
+                        },
+                        {
+                            "code": "1479-5",
+                            "display": "Citizen Band Potawatomi",
+                            "definition": "Citizen Band Potawatomi"
+                        },
+                        {
+                            "code": "1480-3",
+                            "display": "Forest County",
+                            "definition": "Forest County"
+                        },
+                        {
+                            "code": "1481-1",
+                            "display": "Hannahville",
+                            "definition": "Hannahville"
+                        },
+                        {
+                            "code": "1482-9",
+                            "display": "Huron Potawatomi",
+                            "definition": "Huron Potawatomi"
+                        },
+                        {
+                            "code": "1483-7",
+                            "display": "Pokagon Potawatomi",
+                            "definition": "Pokagon Potawatomi"
+                        },
+                        {
+                            "code": "1484-5",
+                            "display": "Prairie Band",
+                            "definition": "Prairie Band"
+                        },
+                        {
+                            "code": "1485-2",
+                            "display": "Wisconsin Potawatomi",
+                            "definition": "Wisconsin Potawatomi"
+                        },
+                        {
+                            "code": "1490-2",
+                            "display": "Acoma",
+                            "definition": "Acoma"
+                        },
+                        {
+                            "code": "1491-0",
+                            "display": "Arizona Tewa",
+                            "definition": "Arizona Tewa"
+                        },
+                        {
+                            "code": "1492-8",
+                            "display": "Cochiti",
+                            "definition": "Cochiti"
+                        },
+                        {
+                            "code": "1493-6",
+                            "display": "Hopi",
+                            "definition": "Hopi"
+                        },
+                        {
+                            "code": "1494-4",
+                            "display": "Isleta",
+                            "definition": "Isleta"
+                        },
+                        {
+                            "code": "1495-1",
+                            "display": "Jemez",
+                            "definition": "Jemez"
+                        },
+                        {
+                            "code": "1496-9",
+                            "display": "Keres",
+                            "definition": "Keres"
+                        },
+                        {
+                            "code": "1497-7",
+                            "display": "Laguna",
+                            "definition": "Laguna"
+                        },
+                        {
+                            "code": "1498-5",
+                            "display": "Nambe",
+                            "definition": "Nambe"
+                        },
+                        {
+                            "code": "1499-3",
+                            "display": "Picuris",
+                            "definition": "Picuris"
+                        },
+                        {
+                            "code": "1500-8",
+                            "display": "Piro",
+                            "definition": "Piro"
+                        },
+                        {
+                            "code": "1501-6",
+                            "display": "Pojoaque",
+                            "definition": "Pojoaque"
+                        },
+                        {
+                            "code": "1502-4",
+                            "display": "San Felipe",
+                            "definition": "San Felipe"
+                        },
+                        {
+                            "code": "1503-2",
+                            "display": "San Ildefonso",
+                            "definition": "San Ildefonso"
+                        },
+                        {
+                            "code": "1504-0",
+                            "display": "San Juan Pueblo",
+                            "definition": "San Juan Pueblo"
+                        },
+                        {
+                            "code": "1505-7",
+                            "display": "San Juan De",
+                            "definition": "San Juan De"
+                        },
+                        {
+                            "code": "1506-5",
+                            "display": "San Juan",
+                            "definition": "San Juan"
+                        },
+                        {
+                            "code": "1507-3",
+                            "display": "Sandia",
+                            "definition": "Sandia"
+                        },
+                        {
+                            "code": "1508-1",
+                            "display": "Santa Ana",
+                            "definition": "Santa Ana"
+                        },
+                        {
+                            "code": "1509-9",
+                            "display": "Santa Clara",
+                            "definition": "Santa Clara"
+                        },
+                        {
+                            "code": "1510-7",
+                            "display": "Santo Domingo",
+                            "definition": "Santo Domingo"
+                        },
+                        {
+                            "code": "1511-5",
+                            "display": "Taos",
+                            "definition": "Taos"
+                        },
+                        {
+                            "code": "1512-3",
+                            "display": "Tesuque",
+                            "definition": "Tesuque"
+                        },
+                        {
+                            "code": "1513-1",
+                            "display": "Tewa",
+                            "definition": "Tewa"
+                        },
+                        {
+                            "code": "1514-9",
+                            "display": "Tigua",
+                            "definition": "Tigua"
+                        },
+                        {
+                            "code": "1515-6",
+                            "display": "Zia",
+                            "definition": "Zia"
+                        },
+                        {
+                            "code": "1516-4",
+                            "display": "Zuni",
+                            "definition": "Zuni"
+                        },
+                        {
+                            "code": "1519-8",
+                            "display": "Duwamish",
+                            "definition": "Duwamish"
+                        },
+                        {
+                            "code": "1520-6",
+                            "display": "Kikiallus",
+                            "definition": "Kikiallus"
+                        },
+                        {
+                            "code": "1521-4",
+                            "display": "Lower Skagit",
+                            "definition": "Lower Skagit"
+                        },
+                        {
+                            "code": "1522-2",
+                            "display": "Muckleshoot",
+                            "definition": "Muckleshoot"
+                        },
+                        {
+                            "code": "1523-0",
+                            "display": "Nisqually",
+                            "definition": "Nisqually"
+                        },
+                        {
+                            "code": "1524-8",
+                            "display": "Nooksack",
+                            "definition": "Nooksack"
+                        },
+                        {
+                            "code": "1525-5",
+                            "display": "Port Madison",
+                            "definition": "Port Madison"
+                        },
+                        {
+                            "code": "1526-3",
+                            "display": "Puyallup",
+                            "definition": "Puyallup"
+                        },
+                        {
+                            "code": "1527-1",
+                            "display": "Samish",
+                            "definition": "Samish"
+                        },
+                        {
+                            "code": "1528-9",
+                            "display": "Sauk-Suiattle",
+                            "definition": "Sauk-Suiattle"
+                        },
+                        {
+                            "code": "1529-7",
+                            "display": "Skokomish",
+                            "definition": "Skokomish"
+                        },
+                        {
+                            "code": "1530-5",
+                            "display": "Skykomish",
+                            "definition": "Skykomish"
+                        },
+                        {
+                            "code": "1531-3",
+                            "display": "Snohomish",
+                            "definition": "Snohomish"
+                        },
+                        {
+                            "code": "1532-1",
+                            "display": "Snoqualmie",
+                            "definition": "Snoqualmie"
+                        },
+                        {
+                            "code": "1533-9",
+                            "display": "Squaxin Island",
+                            "definition": "Squaxin Island"
+                        },
+                        {
+                            "code": "1534-7",
+                            "display": "Steilacoom",
+                            "definition": "Steilacoom"
+                        },
+                        {
+                            "code": "1535-4",
+                            "display": "Stillaguamish",
+                            "definition": "Stillaguamish"
+                        },
+                        {
+                            "code": "1536-2",
+                            "display": "Suquamish",
+                            "definition": "Suquamish"
+                        },
+                        {
+                            "code": "1537-0",
+                            "display": "Swinomish",
+                            "definition": "Swinomish"
+                        },
+                        {
+                            "code": "1538-8",
+                            "display": "Tulalip",
+                            "definition": "Tulalip"
+                        },
+                        {
+                            "code": "1539-6",
+                            "display": "Upper Skagit",
+                            "definition": "Upper Skagit"
+                        },
+                        {
+                            "code": "1552-9",
+                            "display": "Iowa Sac and Fox",
+                            "definition": "Iowa Sac and Fox"
+                        },
+                        {
+                            "code": "1553-7",
+                            "display": "Missouri Sac and Fox",
+                            "definition": "Missouri Sac and Fox"
+                        },
+                        {
+                            "code": "1554-5",
+                            "display": "Oklahoma Sac and Fox",
+                            "definition": "Oklahoma Sac and Fox"
+                        },
+                        {
+                            "code": "1567-7",
+                            "display": "Big Cypress",
+                            "definition": "Big Cypress"
+                        },
+                        {
+                            "code": "1568-5",
+                            "display": "Brighton",
+                            "definition": "Brighton"
+                        },
+                        {
+                            "code": "1569-3",
+                            "display": "Florida Seminole",
+                            "definition": "Florida Seminole"
+                        },
+                        {
+                            "code": "1570-1",
+                            "display": "Hollywood Seminole",
+                            "definition": "Hollywood Seminole"
+                        },
+                        {
+                            "code": "1571-9",
+                            "display": "Oklahoma Seminole",
+                            "definition": "Oklahoma Seminole"
+                        },
+                        {
+                            "code": "1574-3",
+                            "display": "San Manual",
+                            "definition": "San Manual"
+                        },
+                        {
+                            "code": "1579-2",
+                            "display": "Absentee Shawnee",
+                            "definition": "Absentee Shawnee"
+                        },
+                        {
+                            "code": "1580-0",
+                            "display": "Eastern Shawnee",
+                            "definition": "Eastern Shawnee"
+                        },
+                        {
+                            "code": "1587-5",
+                            "display": "Battle Mountain",
+                            "definition": "Battle Mountain"
+                        },
+                        {
+                            "code": "1588-3",
+                            "display": "Duckwater",
+                            "definition": "Duckwater"
+                        },
+                        {
+                            "code": "1589-1",
+                            "display": "Elko",
+                            "definition": "Elko"
+                        },
+                        {
+                            "code": "1590-9",
+                            "display": "Ely",
+                            "definition": "Ely"
+                        },
+                        {
+                            "code": "1591-7",
+                            "display": "Goshute",
+                            "definition": "Goshute"
+                        },
+                        {
+                            "code": "1592-5",
+                            "display": "Panamint",
+                            "definition": "Panamint"
+                        },
+                        {
+                            "code": "1593-3",
+                            "display": "Ruby Valley",
+                            "definition": "Ruby Valley"
+                        },
+                        {
+                            "code": "1594-1",
+                            "display": "Skull Valley",
+                            "definition": "Skull Valley"
+                        },
+                        {
+                            "code": "1595-8",
+                            "display": "South Fork Shoshone",
+                            "definition": "South Fork Shoshone"
+                        },
+                        {
+                            "code": "1596-6",
+                            "display": "Te-Moak Western Shoshone",
+                            "definition": "Te-Moak Western Shoshone"
+                        },
+                        {
+                            "code": "1597-4",
+                            "display": "Timbi-Sha Shoshone",
+                            "definition": "Timbi-Sha Shoshone"
+                        },
+                        {
+                            "code": "1598-2",
+                            "display": "Washakie",
+                            "definition": "Washakie"
+                        },
+                        {
+                            "code": "1599-0",
+                            "display": "Wind River Shoshone",
+                            "definition": "Wind River Shoshone"
+                        },
+                        {
+                            "code": "1600-6",
+                            "display": "Yomba",
+                            "definition": "Yomba"
+                        },
+                        {
+                            "code": "1603-0",
+                            "display": "Duck Valley",
+                            "definition": "Duck Valley"
+                        },
+                        {
+                            "code": "1604-8",
+                            "display": "Fallon",
+                            "definition": "Fallon"
+                        },
+                        {
+                            "code": "1605-5",
+                            "display": "Fort McDermitt",
+                            "definition": "Fort McDermitt"
+                        },
+                        {
+                            "code": "1610-5",
+                            "display": "Blackfoot Sioux",
+                            "definition": "Blackfoot Sioux"
+                        },
+                        {
+                            "code": "1611-3",
+                            "display": "Brule Sioux",
+                            "definition": "Brule Sioux"
+                        },
+                        {
+                            "code": "1612-1",
+                            "display": "Cheyenne River Sioux",
+                            "definition": "Cheyenne River Sioux"
+                        },
+                        {
+                            "code": "1613-9",
+                            "display": "Crow Creek Sioux",
+                            "definition": "Crow Creek Sioux"
+                        },
+                        {
+                            "code": "1614-7",
+                            "display": "Dakota Sioux",
+                            "definition": "Dakota Sioux"
+                        },
+                        {
+                            "code": "1615-4",
+                            "display": "Flandreau Santee",
+                            "definition": "Flandreau Santee"
+                        },
+                        {
+                            "code": "1616-2",
+                            "display": "Fort Peck",
+                            "definition": "Fort Peck"
+                        },
+                        {
+                            "code": "1617-0",
+                            "display": "Lake Traverse Sioux",
+                            "definition": "Lake Traverse Sioux"
+                        },
+                        {
+                            "code": "1618-8",
+                            "display": "Lower Brule Sioux",
+                            "definition": "Lower Brule Sioux"
+                        },
+                        {
+                            "code": "1619-6",
+                            "display": "Lower Sioux",
+                            "definition": "Lower Sioux"
+                        },
+                        {
+                            "code": "1620-4",
+                            "display": "Mdewakanton Sioux",
+                            "definition": "Mdewakanton Sioux"
+                        },
+                        {
+                            "code": "1621-2",
+                            "display": "Miniconjou",
+                            "definition": "Miniconjou"
+                        },
+                        {
+                            "code": "1622-0",
+                            "display": "Oglala Sioux",
+                            "definition": "Oglala Sioux"
+                        },
+                        {
+                            "code": "1623-8",
+                            "display": "Pine Ridge Sioux",
+                            "definition": "Pine Ridge Sioux"
+                        },
+                        {
+                            "code": "1624-6",
+                            "display": "Pipestone Sioux",
+                            "definition": "Pipestone Sioux"
+                        },
+                        {
+                            "code": "1625-3",
+                            "display": "Prairie Island Sioux",
+                            "definition": "Prairie Island Sioux"
+                        },
+                        {
+                            "code": "1626-1",
+                            "display": "Prior Lake Sioux",
+                            "definition": "Prior Lake Sioux"
+                        },
+                        {
+                            "code": "1627-9",
+                            "display": "Rosebud Sioux",
+                            "definition": "Rosebud Sioux"
+                        },
+                        {
+                            "code": "1628-7",
+                            "display": "Sans Arc Sioux",
+                            "definition": "Sans Arc Sioux"
+                        },
+                        {
+                            "code": "1629-5",
+                            "display": "Santee Sioux",
+                            "definition": "Santee Sioux"
+                        },
+                        {
+                            "code": "1630-3",
+                            "display": "Sisseton-Wahpeton",
+                            "definition": "Sisseton-Wahpeton"
+                        },
+                        {
+                            "code": "1631-1",
+                            "display": "Sisseton Sioux",
+                            "definition": "Sisseton Sioux"
+                        },
+                        {
+                            "code": "1632-9",
+                            "display": "Spirit Lake Sioux",
+                            "definition": "Spirit Lake Sioux"
+                        },
+                        {
+                            "code": "1633-7",
+                            "display": "Standing Rock Sioux",
+                            "definition": "Standing Rock Sioux"
+                        },
+                        {
+                            "code": "1634-5",
+                            "display": "Teton Sioux",
+                            "definition": "Teton Sioux"
+                        },
+                        {
+                            "code": "1635-2",
+                            "display": "Two Kettle Sioux",
+                            "definition": "Two Kettle Sioux"
+                        },
+                        {
+                            "code": "1636-0",
+                            "display": "Upper Sioux",
+                            "definition": "Upper Sioux"
+                        },
+                        {
+                            "code": "1637-8",
+                            "display": "Wahpekute Sioux",
+                            "definition": "Wahpekute Sioux"
+                        },
+                        {
+                            "code": "1638-6",
+                            "display": "Wahpeton Sioux",
+                            "definition": "Wahpeton Sioux"
+                        },
+                        {
+                            "code": "1639-4",
+                            "display": "Wazhaza Sioux",
+                            "definition": "Wazhaza Sioux"
+                        },
+                        {
+                            "code": "1640-2",
+                            "display": "Yankton Sioux",
+                            "definition": "Yankton Sioux"
+                        },
+                        {
+                            "code": "1641-0",
+                            "display": "Yanktonai Sioux",
+                            "definition": "Yanktonai Sioux"
+                        },
+                        {
+                            "code": "1654-3",
+                            "display": "Ak-Chin",
+                            "definition": "Ak-Chin"
+                        },
+                        {
+                            "code": "1655-0",
+                            "display": "Gila Bend",
+                            "definition": "Gila Bend"
+                        },
+                        {
+                            "code": "1656-8",
+                            "display": "San Xavier",
+                            "definition": "San Xavier"
+                        },
+                        {
+                            "code": "1657-6",
+                            "display": "Sells",
+                            "definition": "Sells"
+                        },
+                        {
+                            "code": "1668-3",
+                            "display": "Cow Creek Umpqua",
+                            "definition": "Cow Creek Umpqua"
+                        },
+                        {
+                            "code": "1671-7",
+                            "display": "Allen Canyon",
+                            "definition": "Allen Canyon"
+                        },
+                        {
+                            "code": "1672-5",
+                            "display": "Uintah Ute",
+                            "definition": "Uintah Ute"
+                        },
+                        {
+                            "code": "1673-3",
+                            "display": "Ute Mountain Ute",
+                            "definition": "Ute Mountain Ute"
+                        },
+                        {
+                            "code": "1680-8",
+                            "display": "Gay Head Wampanoag",
+                            "definition": "Gay Head Wampanoag"
+                        },
+                        {
+                            "code": "1681-6",
+                            "display": "Mashpee Wampanoag",
+                            "definition": "Mashpee Wampanoag"
+                        },
+                        {
+                            "code": "1688-1",
+                            "display": "Alpine",
+                            "definition": "Alpine"
+                        },
+                        {
+                            "code": "1689-9",
+                            "display": "Carson",
+                            "definition": "Carson"
+                        },
+                        {
+                            "code": "1690-7",
+                            "display": "Dresslerville",
+                            "definition": "Dresslerville"
+                        },
+                        {
+                            "code": "1697-2",
+                            "display": "Ho-chunk",
+                            "definition": "Ho-chunk"
+                        },
+                        {
+                            "code": "1698-0",
+                            "display": "Nebraska Winnebago",
+                            "definition": "Nebraska Winnebago"
+                        },
+                        {
+                            "code": "1705-3",
+                            "display": "Table Bluff",
+                            "definition": "Table Bluff"
+                        },
+                        {
+                            "code": "1712-9",
+                            "display": "Barrio Libre",
+                            "definition": "Barrio Libre"
+                        },
+                        {
+                            "code": "1713-7",
+                            "display": "Pascua Yaqui",
+                            "definition": "Pascua Yaqui"
+                        },
+                        {
+                            "code": "1718-6",
+                            "display": "Chukchansi",
+                            "definition": "Chukchansi"
+                        },
+                        {
+                            "code": "1719-4",
+                            "display": "Tachi",
+                            "definition": "Tachi"
+                        },
+                        {
+                            "code": "1720-2",
+                            "display": "Tule River",
+                            "definition": "Tule River"
+                        },
+                        {
+                            "code": "1725-1",
+                            "display": "Cocopah",
+                            "definition": "Cocopah"
+                        },
+                        {
+                            "code": "1726-9",
+                            "display": "Havasupai",
+                            "definition": "Havasupai"
+                        },
+                        {
+                            "code": "1727-7",
+                            "display": "Hualapai",
+                            "definition": "Hualapai"
+                        },
+                        {
+                            "code": "1728-5",
+                            "display": "Maricopa",
+                            "definition": "Maricopa"
+                        },
+                        {
+                            "code": "1729-3",
+                            "display": "Mohave",
+                            "definition": "Mohave"
+                        },
+                        {
+                            "code": "1730-1",
+                            "display": "Quechan",
+                            "definition": "Quechan"
+                        },
+                        {
+                            "code": "1731-9",
+                            "display": "Yavapai",
+                            "definition": "Yavapai"
+                        },
+                        {
+                            "code": "1733-5",
+                            "display": "Coast Yurok",
+                            "definition": "Coast Yurok"
+                        },
+                        {
+                            "code": "1737-6",
+                            "display": "Alaska Indian",
+                            "definition": "Alaska Indian"
+                        },
+                        {
+                            "code": "1840-8",
+                            "display": "Eskimo",
+                            "definition": "Eskimo"
+                        },
+                        {
+                            "code": "1966-1",
+                            "display": "Aleut",
+                            "definition": "Aleut"
+                        },
+                        {
+                            "code": "1739-2",
+                            "display": "Alaskan Athabascan",
+                            "definition": "Alaskan Athabascan"
+                        },
+                        {
+                            "code": "1811-9",
+                            "display": "Southeast Alaska",
+                            "definition": "Southeast Alaska"
+                        },
+                        {
+                            "code": "1740-0",
+                            "display": "Ahtna",
+                            "definition": "Ahtna"
+                        },
+                        {
+                            "code": "1741-8",
+                            "display": "Alatna",
+                            "definition": "Alatna"
+                        },
+                        {
+                            "code": "1742-6",
+                            "display": "Alexander",
+                            "definition": "Alexander"
+                        },
+                        {
+                            "code": "1743-4",
+                            "display": "Allakaket",
+                            "definition": "Allakaket"
+                        },
+                        {
+                            "code": "1744-2",
+                            "display": "Alanvik",
+                            "definition": "Alanvik"
+                        },
+                        {
+                            "code": "1745-9",
+                            "display": "Anvik",
+                            "definition": "Anvik"
+                        },
+                        {
+                            "code": "1746-7",
+                            "display": "Arctic",
+                            "definition": "Arctic"
+                        },
+                        {
+                            "code": "1747-5",
+                            "display": "Beaver",
+                            "definition": "Beaver"
+                        },
+                        {
+                            "code": "1748-3",
+                            "display": "Birch Creek",
+                            "definition": "Birch Creek"
+                        },
+                        {
+                            "code": "1749-1",
+                            "display": "Cantwell",
+                            "definition": "Cantwell"
+                        },
+                        {
+                            "code": "1750-9",
+                            "display": "Chalkyitsik",
+                            "definition": "Chalkyitsik"
+                        },
+                        {
+                            "code": "1751-7",
+                            "display": "Chickaloon",
+                            "definition": "Chickaloon"
+                        },
+                        {
+                            "code": "1752-5",
+                            "display": "Chistochina",
+                            "definition": "Chistochina"
+                        },
+                        {
+                            "code": "1753-3",
+                            "display": "Chitina",
+                            "definition": "Chitina"
+                        },
+                        {
+                            "code": "1754-1",
+                            "display": "Circle",
+                            "definition": "Circle"
+                        },
+                        {
+                            "code": "1755-8",
+                            "display": "Cook Inlet",
+                            "definition": "Cook Inlet"
+                        },
+                        {
+                            "code": "1756-6",
+                            "display": "Copper Center",
+                            "definition": "Copper Center"
+                        },
+                        {
+                            "code": "1757-4",
+                            "display": "Copper River",
+                            "definition": "Copper River"
+                        },
+                        {
+                            "code": "1758-2",
+                            "display": "Dot Lake",
+                            "definition": "Dot Lake"
+                        },
+                        {
+                            "code": "1759-0",
+                            "display": "Doyon",
+                            "definition": "Doyon"
+                        },
+                        {
+                            "code": "1760-8",
+                            "display": "Eagle",
+                            "definition": "Eagle"
+                        },
+                        {
+                            "code": "1761-6",
+                            "display": "Eklutna",
+                            "definition": "Eklutna"
+                        },
+                        {
+                            "code": "1762-4",
+                            "display": "Evansville",
+                            "definition": "Evansville"
+                        },
+                        {
+                            "code": "1763-2",
+                            "display": "Fort Yukon",
+                            "definition": "Fort Yukon"
+                        },
+                        {
+                            "code": "1764-0",
+                            "display": "Gakona",
+                            "definition": "Gakona"
+                        },
+                        {
+                            "code": "1765-7",
+                            "display": "Galena",
+                            "definition": "Galena"
+                        },
+                        {
+                            "code": "1766-5",
+                            "display": "Grayling",
+                            "definition": "Grayling"
+                        },
+                        {
+                            "code": "1767-3",
+                            "display": "Gulkana",
+                            "definition": "Gulkana"
+                        },
+                        {
+                            "code": "1768-1",
+                            "display": "Healy Lake",
+                            "definition": "Healy Lake"
+                        },
+                        {
+                            "code": "1769-9",
+                            "display": "Holy Cross",
+                            "definition": "Holy Cross"
+                        },
+                        {
+                            "code": "1770-7",
+                            "display": "Hughes",
+                            "definition": "Hughes"
+                        },
+                        {
+                            "code": "1771-5",
+                            "display": "Huslia",
+                            "definition": "Huslia"
+                        },
+                        {
+                            "code": "1772-3",
+                            "display": "Iliamna",
+                            "definition": "Iliamna"
+                        },
+                        {
+                            "code": "1773-1",
+                            "display": "Kaltag",
+                            "definition": "Kaltag"
+                        },
+                        {
+                            "code": "1774-9",
+                            "display": "Kluti Kaah",
+                            "definition": "Kluti Kaah"
+                        },
+                        {
+                            "code": "1775-6",
+                            "display": "Knik",
+                            "definition": "Knik"
+                        },
+                        {
+                            "code": "1776-4",
+                            "display": "Koyukuk",
+                            "definition": "Koyukuk"
+                        },
+                        {
+                            "code": "1777-2",
+                            "display": "Lake Minchumina",
+                            "definition": "Lake Minchumina"
+                        },
+                        {
+                            "code": "1778-0",
+                            "display": "Lime",
+                            "definition": "Lime"
+                        },
+                        {
+                            "code": "1779-8",
+                            "display": "Mcgrath",
+                            "definition": "Mcgrath"
+                        },
+                        {
+                            "code": "1780-6",
+                            "display": "Manley Hot Springs",
+                            "definition": "Manley Hot Springs"
+                        },
+                        {
+                            "code": "1781-4",
+                            "display": "Mentasta Lake",
+                            "definition": "Mentasta Lake"
+                        },
+                        {
+                            "code": "1782-2",
+                            "display": "Minto",
+                            "definition": "Minto"
+                        },
+                        {
+                            "code": "1783-0",
+                            "display": "Nenana",
+                            "definition": "Nenana"
+                        },
+                        {
+                            "code": "1784-8",
+                            "display": "Nikolai",
+                            "definition": "Nikolai"
+                        },
+                        {
+                            "code": "1785-5",
+                            "display": "Ninilchik",
+                            "definition": "Ninilchik"
+                        },
+                        {
+                            "code": "1786-3",
+                            "display": "Nondalton",
+                            "definition": "Nondalton"
+                        },
+                        {
+                            "code": "1787-1",
+                            "display": "Northway",
+                            "definition": "Northway"
+                        },
+                        {
+                            "code": "1788-9",
+                            "display": "Nulato",
+                            "definition": "Nulato"
+                        },
+                        {
+                            "code": "1789-7",
+                            "display": "Pedro Bay",
+                            "definition": "Pedro Bay"
+                        },
+                        {
+                            "code": "1790-5",
+                            "display": "Rampart",
+                            "definition": "Rampart"
+                        },
+                        {
+                            "code": "1791-3",
+                            "display": "Ruby",
+                            "definition": "Ruby"
+                        },
+                        {
+                            "code": "1792-1",
+                            "display": "Salamatof",
+                            "definition": "Salamatof"
+                        },
+                        {
+                            "code": "1793-9",
+                            "display": "Seldovia",
+                            "definition": "Seldovia"
+                        },
+                        {
+                            "code": "1794-7",
+                            "display": "Slana",
+                            "definition": "Slana"
+                        },
+                        {
+                            "code": "1795-4",
+                            "display": "Shageluk",
+                            "definition": "Shageluk"
+                        },
+                        {
+                            "code": "1796-2",
+                            "display": "Stevens",
+                            "definition": "Stevens"
+                        },
+                        {
+                            "code": "1797-0",
+                            "display": "Stony River",
+                            "definition": "Stony River"
+                        },
+                        {
+                            "code": "1798-8",
+                            "display": "Takotna",
+                            "definition": "Takotna"
+                        },
+                        {
+                            "code": "1799-6",
+                            "display": "Tanacross",
+                            "definition": "Tanacross"
+                        },
+                        {
+                            "code": "1800-2",
+                            "display": "Tanaina",
+                            "definition": "Tanaina"
+                        },
+                        {
+                            "code": "1801-0",
+                            "display": "Tanana",
+                            "definition": "Tanana"
+                        },
+                        {
+                            "code": "1802-8",
+                            "display": "Tanana Chiefs",
+                            "definition": "Tanana Chiefs"
+                        },
+                        {
+                            "code": "1803-6",
+                            "display": "Tazlina",
+                            "definition": "Tazlina"
+                        },
+                        {
+                            "code": "1804-4",
+                            "display": "Telida",
+                            "definition": "Telida"
+                        },
+                        {
+                            "code": "1805-1",
+                            "display": "Tetlin",
+                            "definition": "Tetlin"
+                        },
+                        {
+                            "code": "1806-9",
+                            "display": "Tok",
+                            "definition": "Tok"
+                        },
+                        {
+                            "code": "1807-7",
+                            "display": "Tyonek",
+                            "definition": "Tyonek"
+                        },
+                        {
+                            "code": "1808-5",
+                            "display": "Venetie",
+                            "definition": "Venetie"
+                        },
+                        {
+                            "code": "1809-3",
+                            "display": "Wiseman",
+                            "definition": "Wiseman"
+                        },
+                        {
+                            "code": "1813-5",
+                            "display": "Tlingit-Haida",
+                            "definition": "Tlingit-Haida"
+                        },
+                        {
+                            "code": "1837-4",
+                            "display": "Tsimshian",
+                            "definition": "Tsimshian"
+                        },
+                        {
+                            "code": "1814-3",
+                            "display": "Angoon",
+                            "definition": "Angoon"
+                        },
+                        {
+                            "code": "1815-0",
+                            "display": "Central Council of Tlingit and Haida Tribes",
+                            "definition": "Central Council of Tlingit and Haida Tribes"
+                        },
+                        {
+                            "code": "1816-8",
+                            "display": "Chilkat",
+                            "definition": "Chilkat"
+                        },
+                        {
+                            "code": "1817-6",
+                            "display": "Chilkoot",
+                            "definition": "Chilkoot"
+                        },
+                        {
+                            "code": "1818-4",
+                            "display": "Craig",
+                            "definition": "Craig"
+                        },
+                        {
+                            "code": "1819-2",
+                            "display": "Douglas",
+                            "definition": "Douglas"
+                        },
+                        {
+                            "code": "1820-0",
+                            "display": "Haida",
+                            "definition": "Haida"
+                        },
+                        {
+                            "code": "1821-8",
+                            "display": "Hoonah",
+                            "definition": "Hoonah"
+                        },
+                        {
+                            "code": "1822-6",
+                            "display": "Hydaburg",
+                            "definition": "Hydaburg"
+                        },
+                        {
+                            "code": "1823-4",
+                            "display": "Kake",
+                            "definition": "Kake"
+                        },
+                        {
+                            "code": "1824-2",
+                            "display": "Kasaan",
+                            "definition": "Kasaan"
+                        },
+                        {
+                            "code": "1825-9",
+                            "display": "Kenaitze",
+                            "definition": "Kenaitze"
+                        },
+                        {
+                            "code": "1826-7",
+                            "display": "Ketchikan",
+                            "definition": "Ketchikan"
+                        },
+                        {
+                            "code": "1827-5",
+                            "display": "Klawock",
+                            "definition": "Klawock"
+                        },
+                        {
+                            "code": "1828-3",
+                            "display": "Pelican",
+                            "definition": "Pelican"
+                        },
+                        {
+                            "code": "1829-1",
+                            "display": "Petersburg",
+                            "definition": "Petersburg"
+                        },
+                        {
+                            "code": "1830-9",
+                            "display": "Saxman",
+                            "definition": "Saxman"
+                        },
+                        {
+                            "code": "1831-7",
+                            "display": "Sitka",
+                            "definition": "Sitka"
+                        },
+                        {
+                            "code": "1832-5",
+                            "display": "Tenakee Springs",
+                            "definition": "Tenakee Springs"
+                        },
+                        {
+                            "code": "1833-3",
+                            "display": "Tlingit",
+                            "definition": "Tlingit"
+                        },
+                        {
+                            "code": "1834-1",
+                            "display": "Wrangell",
+                            "definition": "Wrangell"
+                        },
+                        {
+                            "code": "1835-8",
+                            "display": "Yakutat",
+                            "definition": "Yakutat"
+                        },
+                        {
+                            "code": "1838-2",
+                            "display": "Metlakatla",
+                            "definition": "Metlakatla"
+                        },
+                        {
+                            "code": "1842-4",
+                            "display": "Greenland Eskimo",
+                            "definition": "Greenland Eskimo"
+                        },
+                        {
+                            "code": "1844-0",
+                            "display": "Inupiat Eskimo",
+                            "definition": "Inupiat Eskimo"
+                        },
+                        {
+                            "code": "1891-1",
+                            "display": "Siberian Eskimo",
+                            "definition": "Siberian Eskimo"
+                        },
+                        {
+                            "code": "1896-0",
+                            "display": "Yupik Eskimo",
+                            "definition": "Yupik Eskimo"
+                        },
+                        {
+                            "code": "1845-7",
+                            "display": "Ambler",
+                            "definition": "Ambler"
+                        },
+                        {
+                            "code": "1846-5",
+                            "display": "Anaktuvuk",
+                            "definition": "Anaktuvuk"
+                        },
+                        {
+                            "code": "1847-3",
+                            "display": "Anaktuvuk Pass",
+                            "definition": "Anaktuvuk Pass"
+                        },
+                        {
+                            "code": "1848-1",
+                            "display": "Arctic Slope Inupiat",
+                            "definition": "Arctic Slope Inupiat"
+                        },
+                        {
+                            "code": "1849-9",
+                            "display": "Arctic Slope Corporation",
+                            "definition": "Arctic Slope Corporation"
+                        },
+                        {
+                            "code": "1850-7",
+                            "display": "Atqasuk",
+                            "definition": "Atqasuk"
+                        },
+                        {
+                            "code": "1851-5",
+                            "display": "Barrow",
+                            "definition": "Barrow"
+                        },
+                        {
+                            "code": "1852-3",
+                            "display": "Bering Straits Inupiat",
+                            "definition": "Bering Straits Inupiat"
+                        },
+                        {
+                            "code": "1853-1",
+                            "display": "Brevig Mission",
+                            "definition": "Brevig Mission"
+                        },
+                        {
+                            "code": "1854-9",
+                            "display": "Buckland",
+                            "definition": "Buckland"
+                        },
+                        {
+                            "code": "1855-6",
+                            "display": "Chinik",
+                            "definition": "Chinik"
+                        },
+                        {
+                            "code": "1856-4",
+                            "display": "Council",
+                            "definition": "Council"
+                        },
+                        {
+                            "code": "1857-2",
+                            "display": "Deering",
+                            "definition": "Deering"
+                        },
+                        {
+                            "code": "1858-0",
+                            "display": "Elim",
+                            "definition": "Elim"
+                        },
+                        {
+                            "code": "1859-8",
+                            "display": "Golovin",
+                            "definition": "Golovin"
+                        },
+                        {
+                            "code": "1860-6",
+                            "display": "Inalik Diomede",
+                            "definition": "Inalik Diomede"
+                        },
+                        {
+                            "code": "1861-4",
+                            "display": "Inupiaq",
+                            "definition": "Inupiaq"
+                        },
+                        {
+                            "code": "1862-2",
+                            "display": "Kaktovik",
+                            "definition": "Kaktovik"
+                        },
+                        {
+                            "code": "1863-0",
+                            "display": "Kawerak",
+                            "definition": "Kawerak"
+                        },
+                        {
+                            "code": "1864-8",
+                            "display": "Kiana",
+                            "definition": "Kiana"
+                        },
+                        {
+                            "code": "1865-5",
+                            "display": "Kivalina",
+                            "definition": "Kivalina"
+                        },
+                        {
+                            "code": "1866-3",
+                            "display": "Kobuk",
+                            "definition": "Kobuk"
+                        },
+                        {
+                            "code": "1867-1",
+                            "display": "Kotzebue",
+                            "definition": "Kotzebue"
+                        },
+                        {
+                            "code": "1868-9",
+                            "display": "Koyuk",
+                            "definition": "Koyuk"
+                        },
+                        {
+                            "code": "1869-7",
+                            "display": "Kwiguk",
+                            "definition": "Kwiguk"
+                        },
+                        {
+                            "code": "1870-5",
+                            "display": "Mauneluk Inupiat",
+                            "definition": "Mauneluk Inupiat"
+                        },
+                        {
+                            "code": "1871-3",
+                            "display": "Nana Inupiat",
+                            "definition": "Nana Inupiat"
+                        },
+                        {
+                            "code": "1872-1",
+                            "display": "Noatak",
+                            "definition": "Noatak"
+                        },
+                        {
+                            "code": "1873-9",
+                            "display": "Nome",
+                            "definition": "Nome"
+                        },
+                        {
+                            "code": "1874-7",
+                            "display": "Noorvik",
+                            "definition": "Noorvik"
+                        },
+                        {
+                            "code": "1875-4",
+                            "display": "Nuiqsut",
+                            "definition": "Nuiqsut"
+                        },
+                        {
+                            "code": "1876-2",
+                            "display": "Point Hope",
+                            "definition": "Point Hope"
+                        },
+                        {
+                            "code": "1877-0",
+                            "display": "Point Lay",
+                            "definition": "Point Lay"
+                        },
+                        {
+                            "code": "1878-8",
+                            "display": "Selawik",
+                            "definition": "Selawik"
+                        },
+                        {
+                            "code": "1879-6",
+                            "display": "Shaktoolik",
+                            "definition": "Shaktoolik"
+                        },
+                        {
+                            "code": "1880-4",
+                            "display": "Shishmaref",
+                            "definition": "Shishmaref"
+                        },
+                        {
+                            "code": "1881-2",
+                            "display": "Shungnak",
+                            "definition": "Shungnak"
+                        },
+                        {
+                            "code": "1882-0",
+                            "display": "Solomon",
+                            "definition": "Solomon"
+                        },
+                        {
+                            "code": "1883-8",
+                            "display": "Teller",
+                            "definition": "Teller"
+                        },
+                        {
+                            "code": "1884-6",
+                            "display": "Unalakleet",
+                            "definition": "Unalakleet"
+                        },
+                        {
+                            "code": "1885-3",
+                            "display": "Wainwright",
+                            "definition": "Wainwright"
+                        },
+                        {
+                            "code": "1886-1",
+                            "display": "Wales",
+                            "definition": "Wales"
+                        },
+                        {
+                            "code": "1887-9",
+                            "display": "White Mountain",
+                            "definition": "White Mountain"
+                        },
+                        {
+                            "code": "1888-7",
+                            "display": "White Mountain Inupiat",
+                            "definition": "White Mountain Inupiat"
+                        },
+                        {
+                            "code": "1889-5",
+                            "display": "Mary's Igloo",
+                            "definition": "Mary's Igloo"
+                        },
+                        {
+                            "code": "1892-9",
+                            "display": "Gambell",
+                            "definition": "Gambell"
+                        },
+                        {
+                            "code": "1893-7",
+                            "display": "Savoonga",
+                            "definition": "Savoonga"
+                        },
+                        {
+                            "code": "1894-5",
+                            "display": "Siberian Yupik",
+                            "definition": "Siberian Yupik"
+                        },
+                        {
+                            "code": "1897-8",
+                            "display": "Akiachak",
+                            "definition": "Akiachak"
+                        },
+                        {
+                            "code": "1898-6",
+                            "display": "Akiak",
+                            "definition": "Akiak"
+                        },
+                        {
+                            "code": "1899-4",
+                            "display": "Alakanuk",
+                            "definition": "Alakanuk"
+                        },
+                        {
+                            "code": "1900-0",
+                            "display": "Aleknagik",
+                            "definition": "Aleknagik"
+                        },
+                        {
+                            "code": "1901-8",
+                            "display": "Andreafsky",
+                            "definition": "Andreafsky"
+                        },
+                        {
+                            "code": "1902-6",
+                            "display": "Aniak",
+                            "definition": "Aniak"
+                        },
+                        {
+                            "code": "1903-4",
+                            "display": "Atmautluak",
+                            "definition": "Atmautluak"
+                        },
+                        {
+                            "code": "1904-2",
+                            "display": "Bethel",
+                            "definition": "Bethel"
+                        },
+                        {
+                            "code": "1905-9",
+                            "display": "Bill Moore's Slough",
+                            "definition": "Bill Moore's Slough"
+                        },
+                        {
+                            "code": "1906-7",
+                            "display": "Bristol Bay Yupik",
+                            "definition": "Bristol Bay Yupik"
+                        },
+                        {
+                            "code": "1907-5",
+                            "display": "Calista Yupik",
+                            "definition": "Calista Yupik"
+                        },
+                        {
+                            "code": "1908-3",
+                            "display": "Chefornak",
+                            "definition": "Chefornak"
+                        },
+                        {
+                            "code": "1909-1",
+                            "display": "Chevak",
+                            "definition": "Chevak"
+                        },
+                        {
+                            "code": "1910-9",
+                            "display": "Chuathbaluk",
+                            "definition": "Chuathbaluk"
+                        },
+                        {
+                            "code": "1911-7",
+                            "display": "Clark's Point",
+                            "definition": "Clark's Point"
+                        },
+                        {
+                            "code": "1912-5",
+                            "display": "Crooked Creek",
+                            "definition": "Crooked Creek"
+                        },
+                        {
+                            "code": "1913-3",
+                            "display": "Dillingham",
+                            "definition": "Dillingham"
+                        },
+                        {
+                            "code": "1914-1",
+                            "display": "Eek",
+                            "definition": "Eek"
+                        },
+                        {
+                            "code": "1915-8",
+                            "display": "Ekuk",
+                            "definition": "Ekuk"
+                        },
+                        {
+                            "code": "1916-6",
+                            "display": "Ekwok",
+                            "definition": "Ekwok"
+                        },
+                        {
+                            "code": "1917-4",
+                            "display": "Emmonak",
+                            "definition": "Emmonak"
+                        },
+                        {
+                            "code": "1918-2",
+                            "display": "Goodnews Bay",
+                            "definition": "Goodnews Bay"
+                        },
+                        {
+                            "code": "1919-0",
+                            "display": "Hooper Bay",
+                            "definition": "Hooper Bay"
+                        },
+                        {
+                            "code": "1920-8",
+                            "display": "Iqurmuit (Russian Mission)",
+                            "definition": "Iqurmuit (Russian Mission)"
+                        },
+                        {
+                            "code": "1921-6",
+                            "display": "Kalskag",
+                            "definition": "Kalskag"
+                        },
+                        {
+                            "code": "1922-4",
+                            "display": "Kasigluk",
+                            "definition": "Kasigluk"
+                        },
+                        {
+                            "code": "1923-2",
+                            "display": "Kipnuk",
+                            "definition": "Kipnuk"
+                        },
+                        {
+                            "code": "1924-0",
+                            "display": "Koliganek",
+                            "definition": "Koliganek"
+                        },
+                        {
+                            "code": "1925-7",
+                            "display": "Kongiganak",
+                            "definition": "Kongiganak"
+                        },
+                        {
+                            "code": "1926-5",
+                            "display": "Kotlik",
+                            "definition": "Kotlik"
+                        },
+                        {
+                            "code": "1927-3",
+                            "display": "Kwethluk",
+                            "definition": "Kwethluk"
+                        },
+                        {
+                            "code": "1928-1",
+                            "display": "Kwigillingok",
+                            "definition": "Kwigillingok"
+                        },
+                        {
+                            "code": "1929-9",
+                            "display": "Levelock",
+                            "definition": "Levelock"
+                        },
+                        {
+                            "code": "1930-7",
+                            "display": "Lower Kalskag",
+                            "definition": "Lower Kalskag"
+                        },
+                        {
+                            "code": "1931-5",
+                            "display": "Manokotak",
+                            "definition": "Manokotak"
+                        },
+                        {
+                            "code": "1932-3",
+                            "display": "Marshall",
+                            "definition": "Marshall"
+                        },
+                        {
+                            "code": "1933-1",
+                            "display": "Mekoryuk",
+                            "definition": "Mekoryuk"
+                        },
+                        {
+                            "code": "1934-9",
+                            "display": "Mountain Village",
+                            "definition": "Mountain Village"
+                        },
+                        {
+                            "code": "1935-6",
+                            "display": "Naknek",
+                            "definition": "Naknek"
+                        },
+                        {
+                            "code": "1936-4",
+                            "display": "Napaumute",
+                            "definition": "Napaumute"
+                        },
+                        {
+                            "code": "1937-2",
+                            "display": "Napakiak",
+                            "definition": "Napakiak"
+                        },
+                        {
+                            "code": "1938-0",
+                            "display": "Napaskiak",
+                            "definition": "Napaskiak"
+                        },
+                        {
+                            "code": "1939-8",
+                            "display": "Newhalen",
+                            "definition": "Newhalen"
+                        },
+                        {
+                            "code": "1940-6",
+                            "display": "New Stuyahok",
+                            "definition": "New Stuyahok"
+                        },
+                        {
+                            "code": "1941-4",
+                            "display": "Newtok",
+                            "definition": "Newtok"
+                        },
+                        {
+                            "code": "1942-2",
+                            "display": "Nightmute",
+                            "definition": "Nightmute"
+                        },
+                        {
+                            "code": "1943-0",
+                            "display": "Nunapitchukv",
+                            "definition": "Nunapitchukv"
+                        },
+                        {
+                            "code": "1944-8",
+                            "display": "Oscarville",
+                            "definition": "Oscarville"
+                        },
+                        {
+                            "code": "1945-5",
+                            "display": "Pilot Station",
+                            "definition": "Pilot Station"
+                        },
+                        {
+                            "code": "1946-3",
+                            "display": "Pitkas Point",
+                            "definition": "Pitkas Point"
+                        },
+                        {
+                            "code": "1947-1",
+                            "display": "Platinum",
+                            "definition": "Platinum"
+                        },
+                        {
+                            "code": "1948-9",
+                            "display": "Portage Creek",
+                            "definition": "Portage Creek"
+                        },
+                        {
+                            "code": "1949-7",
+                            "display": "Quinhagak",
+                            "definition": "Quinhagak"
+                        },
+                        {
+                            "code": "1950-5",
+                            "display": "Red Devil",
+                            "definition": "Red Devil"
+                        },
+                        {
+                            "code": "1951-3",
+                            "display": "St. Michael",
+                            "definition": "St. Michael"
+                        },
+                        {
+                            "code": "1952-1",
+                            "display": "Scammon Bay",
+                            "definition": "Scammon Bay"
+                        },
+                        {
+                            "code": "1953-9",
+                            "display": "Sheldon's Point",
+                            "definition": "Sheldon's Point"
+                        },
+                        {
+                            "code": "1954-7",
+                            "display": "Sleetmute",
+                            "definition": "Sleetmute"
+                        },
+                        {
+                            "code": "1955-4",
+                            "display": "Stebbins",
+                            "definition": "Stebbins"
+                        },
+                        {
+                            "code": "1956-2",
+                            "display": "Togiak",
+                            "definition": "Togiak"
+                        },
+                        {
+                            "code": "1957-0",
+                            "display": "Toksook",
+                            "definition": "Toksook"
+                        },
+                        {
+                            "code": "1958-8",
+                            "display": "Tulukskak",
+                            "definition": "Tulukskak"
+                        },
+                        {
+                            "code": "1959-6",
+                            "display": "Tuntutuliak",
+                            "definition": "Tuntutuliak"
+                        },
+                        {
+                            "code": "1960-4",
+                            "display": "Tununak",
+                            "definition": "Tununak"
+                        },
+                        {
+                            "code": "1961-2",
+                            "display": "Twin Hills",
+                            "definition": "Twin Hills"
+                        },
+                        {
+                            "code": "1962-0",
+                            "display": "Georgetown (Yupik-Eskimo)",
+                            "definition": "Georgetown (Yupik-Eskimo)"
+                        },
+                        {
+                            "code": "1963-8",
+                            "display": "St. Mary's",
+                            "definition": "St. Mary's"
+                        },
+                        {
+                            "code": "1964-6",
+                            "display": "Umkumiate",
+                            "definition": "Umkumiate"
+                        },
+                        {
+                            "code": "1968-7",
+                            "display": "Alutiiq Aleut",
+                            "definition": "Alutiiq Aleut"
+                        },
+                        {
+                            "code": "1972-9",
+                            "display": "Bristol Bay Aleut",
+                            "definition": "Bristol Bay Aleut"
+                        },
+                        {
+                            "code": "1984-4",
+                            "display": "Chugach Aleut",
+                            "definition": "Chugach Aleut"
+                        },
+                        {
+                            "code": "1990-1",
+                            "display": "Eyak",
+                            "definition": "Eyak"
+                        },
+                        {
+                            "code": "1992-7",
+                            "display": "Koniag Aleut",
+                            "definition": "Koniag Aleut"
+                        },
+                        {
+                            "code": "2002-4",
+                            "display": "Sugpiaq",
+                            "definition": "Sugpiaq"
+                        },
+                        {
+                            "code": "2004-0",
+                            "display": "Suqpigaq",
+                            "definition": "Suqpigaq"
+                        },
+                        {
+                            "code": "2006-5",
+                            "display": "Unangan Aleut",
+                            "definition": "Unangan Aleut"
+                        },
+                        {
+                            "code": "1969-5",
+                            "display": "Tatitlek",
+                            "definition": "Tatitlek"
+                        },
+                        {
+                            "code": "1970-3",
+                            "display": "Ugashik",
+                            "definition": "Ugashik"
+                        },
+                        {
+                            "code": "1973-7",
+                            "display": "Chignik",
+                            "definition": "Chignik"
+                        },
+                        {
+                            "code": "1974-5",
+                            "display": "Chignik Lake",
+                            "definition": "Chignik Lake"
+                        },
+                        {
+                            "code": "1975-2",
+                            "display": "Egegik",
+                            "definition": "Egegik"
+                        },
+                        {
+                            "code": "1976-0",
+                            "display": "Igiugig",
+                            "definition": "Igiugig"
+                        },
+                        {
+                            "code": "1977-8",
+                            "display": "Ivanof Bay",
+                            "definition": "Ivanof Bay"
+                        },
+                        {
+                            "code": "1978-6",
+                            "display": "King Salmon",
+                            "definition": "King Salmon"
+                        },
+                        {
+                            "code": "1979-4",
+                            "display": "Kokhanok",
+                            "definition": "Kokhanok"
+                        },
+                        {
+                            "code": "1980-2",
+                            "display": "Perryville",
+                            "definition": "Perryville"
+                        },
+                        {
+                            "code": "1981-0",
+                            "display": "Pilot Point",
+                            "definition": "Pilot Point"
+                        },
+                        {
+                            "code": "1982-8",
+                            "display": "Port Heiden",
+                            "definition": "Port Heiden"
+                        },
+                        {
+                            "code": "1985-1",
+                            "display": "Chenega",
+                            "definition": "Chenega"
+                        },
+                        {
+                            "code": "1986-9",
+                            "display": "Chugach Corporation",
+                            "definition": "Chugach Corporation"
+                        },
+                        {
+                            "code": "1987-7",
+                            "display": "English Bay",
+                            "definition": "English Bay"
+                        },
+                        {
+                            "code": "1988-5",
+                            "display": "Port Graham",
+                            "definition": "Port Graham"
+                        },
+                        {
+                            "code": "1993-5",
+                            "display": "Akhiok",
+                            "definition": "Akhiok"
+                        },
+                        {
+                            "code": "1994-3",
+                            "display": "Agdaagux",
+                            "definition": "Agdaagux"
+                        },
+                        {
+                            "code": "1995-0",
+                            "display": "Karluk",
+                            "definition": "Karluk"
+                        },
+                        {
+                            "code": "1996-8",
+                            "display": "Kodiak",
+                            "definition": "Kodiak"
+                        },
+                        {
+                            "code": "1997-6",
+                            "display": "Larsen Bay",
+                            "definition": "Larsen Bay"
+                        },
+                        {
+                            "code": "1998-4",
+                            "display": "Old Harbor",
+                            "definition": "Old Harbor"
+                        },
+                        {
+                            "code": "1999-2",
+                            "display": "Ouzinkie",
+                            "definition": "Ouzinkie"
+                        },
+                        {
+                            "code": "2000-8",
+                            "display": "Port Lions",
+                            "definition": "Port Lions"
+                        },
+                        {
+                            "code": "2007-3",
+                            "display": "Akutan",
+                            "definition": "Akutan"
+                        },
+                        {
+                            "code": "2008-1",
+                            "display": "Aleut Corporation",
+                            "definition": "Aleut Corporation"
+                        },
+                        {
+                            "code": "2009-9",
+                            "display": "Aleutian",
+                            "definition": "Aleutian"
+                        },
+                        {
+                            "code": "2010-7",
+                            "display": "Aleutian Islander",
+                            "definition": "Aleutian Islander"
+                        },
+                        {
+                            "code": "2011-5",
+                            "display": "Atka",
+                            "definition": "Atka"
+                        },
+                        {
+                            "code": "2012-3",
+                            "display": "Belkofski",
+                            "definition": "Belkofski"
+                        },
+                        {
+                            "code": "2013-1",
+                            "display": "Chignik Lagoon",
+                            "definition": "Chignik Lagoon"
+                        },
+                        {
+                            "code": "2014-9",
+                            "display": "King Cove",
+                            "definition": "King Cove"
+                        },
+                        {
+                            "code": "2015-6",
+                            "display": "False Pass",
+                            "definition": "False Pass"
+                        },
+                        {
+                            "code": "2016-4",
+                            "display": "Nelson Lagoon",
+                            "definition": "Nelson Lagoon"
+                        },
+                        {
+                            "code": "2017-2",
+                            "display": "Nikolski",
+                            "definition": "Nikolski"
+                        },
+                        {
+                            "code": "2018-0",
+                            "display": "Pauloff Harbor",
+                            "definition": "Pauloff Harbor"
+                        },
+                        {
+                            "code": "2019-8",
+                            "display": "Qagan Toyagungin",
+                            "definition": "Qagan Toyagungin"
+                        },
+                        {
+                            "code": "2020-6",
+                            "display": "Qawalangin",
+                            "definition": "Qawalangin"
+                        },
+                        {
+                            "code": "2021-4",
+                            "display": "St. George",
+                            "definition": "St. George"
+                        },
+                        {
+                            "code": "2022-2",
+                            "display": "St. Paul",
+                            "definition": "St. Paul"
+                        },
+                        {
+                            "code": "2023-0",
+                            "display": "Sand Point",
+                            "definition": "Sand Point"
+                        },
+                        {
+                            "code": "2024-8",
+                            "display": "South Naknek",
+                            "definition": "South Naknek"
+                        },
+                        {
+                            "code": "2025-5",
+                            "display": "Unalaska",
+                            "definition": "Unalaska"
+                        },
+                        {
+                            "code": "2026-3",
+                            "display": "Unga",
+                            "definition": "Unga"
+                        }
+                    ]
+                },
+                {
+                    "code": "2028-9",
+                    "display": "Asian",
+                    "definition": "Asian",
+                    "concept": [
+                        {
+                            "code": "2029-7",
+                            "display": "Asian Indian",
+                            "definition": "Asian Indian"
+                        },
+                        {
+                            "code": "2030-5",
+                            "display": "Bangladeshi",
+                            "definition": "Bangladeshi"
+                        },
+                        {
+                            "code": "2031-3",
+                            "display": "Bhutanese",
+                            "definition": "Bhutanese"
+                        },
+                        {
+                            "code": "2032-1",
+                            "display": "Burmese",
+                            "definition": "Burmese"
+                        },
+                        {
+                            "code": "2033-9",
+                            "display": "Cambodian",
+                            "definition": "Cambodian"
+                        },
+                        {
+                            "code": "2034-7",
+                            "display": "Chinese",
+                            "definition": "Chinese"
+                        },
+                        {
+                            "code": "2035-4",
+                            "display": "Taiwanese",
+                            "definition": "Taiwanese"
+                        },
+                        {
+                            "code": "2036-2",
+                            "display": "Filipino",
+                            "definition": "Filipino"
+                        },
+                        {
+                            "code": "2037-0",
+                            "display": "Hmong",
+                            "definition": "Hmong"
+                        },
+                        {
+                            "code": "2038-8",
+                            "display": "Indonesian",
+                            "definition": "Indonesian"
+                        },
+                        {
+                            "code": "2039-6",
+                            "display": "Japanese",
+                            "definition": "Japanese"
+                        },
+                        {
+                            "code": "2040-4",
+                            "display": "Korean",
+                            "definition": "Korean"
+                        },
+                        {
+                            "code": "2041-2",
+                            "display": "Laotian",
+                            "definition": "Laotian"
+                        },
+                        {
+                            "code": "2042-0",
+                            "display": "Malaysian",
+                            "definition": "Malaysian"
+                        },
+                        {
+                            "code": "2043-8",
+                            "display": "Okinawan",
+                            "definition": "Okinawan"
+                        },
+                        {
+                            "code": "2044-6",
+                            "display": "Pakistani",
+                            "definition": "Pakistani"
+                        },
+                        {
+                            "code": "2045-3",
+                            "display": "Sri Lankan",
+                            "definition": "Sri Lankan"
+                        },
+                        {
+                            "code": "2046-1",
+                            "display": "Thai",
+                            "definition": "Thai"
+                        },
+                        {
+                            "code": "2047-9",
+                            "display": "Vietnamese",
+                            "definition": "Vietnamese"
+                        },
+                        {
+                            "code": "2048-7",
+                            "display": "Iwo Jiman",
+                            "definition": "Iwo Jiman"
+                        },
+                        {
+                            "code": "2049-5",
+                            "display": "Maldivian",
+                            "definition": "Maldivian"
+                        },
+                        {
+                            "code": "2050-3",
+                            "display": "Nepalese",
+                            "definition": "Nepalese"
+                        },
+                        {
+                            "code": "2051-1",
+                            "display": "Singaporean",
+                            "definition": "Singaporean"
+                        },
+                        {
+                            "code": "2052-9",
+                            "display": "Madagascar",
+                            "definition": "Madagascar"
+                        }
+                    ]
+                },
+                {
+                    "code": "2054-5",
+                    "display": "Black or African American",
+                    "definition": "Black or African American",
+                    "concept": [
+                        {
+                            "code": "2056-0",
+                            "display": "Black",
+                            "definition": "Black"
+                        },
+                        {
+                            "code": "2058-6",
+                            "display": "African American",
+                            "definition": "African American"
+                        },
+                        {
+                            "code": "2060-2",
+                            "display": "African",
+                            "definition": "African"
+                        },
+                        {
+                            "code": "2067-7",
+                            "display": "Bahamian",
+                            "definition": "Bahamian"
+                        },
+                        {
+                            "code": "2068-5",
+                            "display": "Barbadian",
+                            "definition": "Barbadian"
+                        },
+                        {
+                            "code": "2069-3",
+                            "display": "Dominican",
+                            "definition": "Dominican"
+                        },
+                        {
+                            "code": "2070-1",
+                            "display": "Dominica Islander",
+                            "definition": "Dominica Islander"
+                        },
+                        {
+                            "code": "2071-9",
+                            "display": "Haitian",
+                            "definition": "Haitian"
+                        },
+                        {
+                            "code": "2072-7",
+                            "display": "Jamaican",
+                            "definition": "Jamaican"
+                        },
+                        {
+                            "code": "2073-5",
+                            "display": "Tobagoan",
+                            "definition": "Tobagoan"
+                        },
+                        {
+                            "code": "2074-3",
+                            "display": "Trinidadian",
+                            "definition": "Trinidadian"
+                        },
+                        {
+                            "code": "2075-0",
+                            "display": "West Indian",
+                            "definition": "West Indian"
+                        },
+                        {
+                            "code": "2061-0",
+                            "display": "Botswanan",
+                            "definition": "Botswanan"
+                        },
+                        {
+                            "code": "2062-8",
+                            "display": "Ethiopian",
+                            "definition": "Ethiopian"
+                        },
+                        {
+                            "code": "2063-6",
+                            "display": "Liberian",
+                            "definition": "Liberian"
+                        },
+                        {
+                            "code": "2064-4",
+                            "display": "Namibian",
+                            "definition": "Namibian"
+                        },
+                        {
+                            "code": "2065-1",
+                            "display": "Nigerian",
+                            "definition": "Nigerian"
+                        },
+                        {
+                            "code": "2066-9",
+                            "display": "Zairean",
+                            "definition": "Zairean"
+                        }
+                    ]
+                },
+                {
+                    "code": "2076-8",
+                    "display": "Native Hawaiian or Other Pacific Islander",
+                    "definition": "Native Hawaiian or Other Pacific Islander",
+                    "concept": [
+                        {
+                            "code": "2078-4",
+                            "display": "Polynesian",
+                            "definition": "Polynesian"
+                        },
+                        {
+                            "code": "2085-9",
+                            "display": "Micronesian",
+                            "definition": "Micronesian"
+                        },
+                        {
+                            "code": "2100-6",
+                            "display": "Melanesian",
+                            "definition": "Melanesian"
+                        },
+                        {
+                            "code": "2500-7",
+                            "display": "Other Pacific Islander",
+                            "definition": "Other Pacific Islander"
+                        },
+                        {
+                            "code": "2079-2",
+                            "display": "Native Hawaiian",
+                            "definition": "Native Hawaiian"
+                        },
+                        {
+                            "code": "2080-0",
+                            "display": "Samoan",
+                            "definition": "Samoan"
+                        },
+                        {
+                            "code": "2081-8",
+                            "display": "Tahitian",
+                            "definition": "Tahitian"
+                        },
+                        {
+                            "code": "2082-6",
+                            "display": "Tongan",
+                            "definition": "Tongan"
+                        },
+                        {
+                            "code": "2083-4",
+                            "display": "Tokelauan",
+                            "definition": "Tokelauan"
+                        },
+                        {
+                            "code": "2086-7",
+                            "display": "Guamanian or Chamorro",
+                            "definition": "Guamanian or Chamorro"
+                        },
+                        {
+                            "code": "2087-5",
+                            "display": "Guamanian",
+                            "definition": "Guamanian"
+                        },
+                        {
+                            "code": "2088-3",
+                            "display": "Chamorro",
+                            "definition": "Chamorro"
+                        },
+                        {
+                            "code": "2089-1",
+                            "display": "Mariana Islander",
+                            "definition": "Mariana Islander"
+                        },
+                        {
+                            "code": "2090-9",
+                            "display": "Marshallese",
+                            "definition": "Marshallese"
+                        },
+                        {
+                            "code": "2091-7",
+                            "display": "Palauan",
+                            "definition": "Palauan"
+                        },
+                        {
+                            "code": "2092-5",
+                            "display": "Carolinian",
+                            "definition": "Carolinian"
+                        },
+                        {
+                            "code": "2093-3",
+                            "display": "Kosraean",
+                            "definition": "Kosraean"
+                        },
+                        {
+                            "code": "2094-1",
+                            "display": "Pohnpeian",
+                            "definition": "Pohnpeian"
+                        },
+                        {
+                            "code": "2095-8",
+                            "display": "Saipanese",
+                            "definition": "Saipanese"
+                        },
+                        {
+                            "code": "2096-6",
+                            "display": "Kiribati",
+                            "definition": "Kiribati"
+                        },
+                        {
+                            "code": "2097-4",
+                            "display": "Chuukese",
+                            "definition": "Chuukese"
+                        },
+                        {
+                            "code": "2098-2",
+                            "display": "Yapese",
+                            "definition": "Yapese"
+                        },
+                        {
+                            "code": "2101-4",
+                            "display": "Fijian",
+                            "definition": "Fijian"
+                        },
+                        {
+                            "code": "2102-2",
+                            "display": "Papua New Guinean",
+                            "definition": "Papua New Guinean"
+                        },
+                        {
+                            "code": "2103-0",
+                            "display": "Solomon Islander",
+                            "definition": "Solomon Islander"
+                        },
+                        {
+                            "code": "2104-8",
+                            "display": "New Hebrides",
+                            "definition": "New Hebrides"
+                        }
+                    ]
+                },
+                {
+                    "code": "2106-3",
+                    "display": "White",
+                    "definition": "White",
+                    "concept": [
+                        {
+                            "code": "2108-9",
+                            "display": "European",
+                            "definition": "European"
+                        },
+                        {
+                            "code": "2118-8",
+                            "display": "Middle Eastern or North African",
+                            "definition": "Middle Eastern or North African"
+                        },
+                        {
+                            "code": "2129-5",
+                            "display": "Arab",
+                            "definition": "Arab"
+                        },
+                        {
+                            "code": "2109-7",
+                            "display": "Armenian",
+                            "definition": "Armenian"
+                        },
+                        {
+                            "code": "2110-5",
+                            "display": "English",
+                            "definition": "English"
+                        },
+                        {
+                            "code": "2111-3",
+                            "display": "French",
+                            "definition": "French"
+                        },
+                        {
+                            "code": "2112-1",
+                            "display": "German",
+                            "definition": "German"
+                        },
+                        {
+                            "code": "2113-9",
+                            "display": "Irish",
+                            "definition": "Irish"
+                        },
+                        {
+                            "code": "2114-7",
+                            "display": "Italian",
+                            "definition": "Italian"
+                        },
+                        {
+                            "code": "2115-4",
+                            "display": "Polish",
+                            "definition": "Polish"
+                        },
+                        {
+                            "code": "2116-2",
+                            "display": "Scottish",
+                            "definition": "Scottish"
+                        },
+                        {
+                            "code": "2119-6",
+                            "display": "Assyrian",
+                            "definition": "Assyrian"
+                        },
+                        {
+                            "code": "2120-4",
+                            "display": "Egyptian",
+                            "definition": "Egyptian"
+                        },
+                        {
+                            "code": "2121-2",
+                            "display": "Iranian",
+                            "definition": "Iranian"
+                        },
+                        {
+                            "code": "2122-0",
+                            "display": "Iraqi",
+                            "definition": "Iraqi"
+                        },
+                        {
+                            "code": "2123-8",
+                            "display": "Lebanese",
+                            "definition": "Lebanese"
+                        },
+                        {
+                            "code": "2124-6",
+                            "display": "Palestinian",
+                            "definition": "Palestinian"
+                        },
+                        {
+                            "code": "2125-3",
+                            "display": "Syrian",
+                            "definition": "Syrian"
+                        },
+                        {
+                            "code": "2126-1",
+                            "display": "Afghanistani",
+                            "definition": "Afghanistani"
+                        },
+                        {
+                            "code": "2127-9",
+                            "display": "Israeili",
+                            "definition": "Israeili"
+                        }
+                    ]
+                },
+                {
+                    "code": "2131-1",
+                    "display": "Other Race",
+                    "definition": "Note that this term remains in the table for completeness, even though within HL7, the notion of Other code is deprecated."
+                }
+            ]
+        },
+        {
+            "code": "2133-7",
+            "display": "Ethnicity",
+            "definition": "Ethnicity Note that this is an abstract 'grouping' concept and not for use as a real concept",
+            "property": [
+                {
+                    "code": "abstract",
+                    "valueBoolean": true
+                }
+            ],
+            "concept": [
+                {
+                    "code": "2135-2",
+                    "display": "Hispanic or Latino",
+                    "definition": "Hispanic or Latino",
+                    "concept": [
+                        {
+                            "code": "2137-8",
+                            "display": "Spaniard",
+                            "definition": "Spaniard"
+                        },
+                        {
+                            "code": "2148-5",
+                            "display": "Mexican",
+                            "definition": "Mexican"
+                        },
+                        {
+                            "code": "2155-0",
+                            "display": "Central American",
+                            "definition": "Central American"
+                        },
+                        {
+                            "code": "2165-9",
+                            "display": "South American",
+                            "definition": "South American"
+                        },
+                        {
+                            "code": "2178-2",
+                            "display": "Latin American",
+                            "definition": "Latin American"
+                        },
+                        {
+                            "code": "2180-8",
+                            "display": "Puerto Rican",
+                            "definition": "Puerto Rican"
+                        },
+                        {
+                            "code": "2182-4",
+                            "display": "Cuban",
+                            "definition": "Cuban"
+                        },
+                        {
+                            "code": "2184-0",
+                            "display": "Dominican",
+                            "definition": "Dominican"
+                        },
+                        {
+                            "code": "2138-6",
+                            "display": "Andalusian",
+                            "definition": "Andalusian"
+                        },
+                        {
+                            "code": "2139-4",
+                            "display": "Asturian",
+                            "definition": "Asturian"
+                        },
+                        {
+                            "code": "2140-2",
+                            "display": "Castillian",
+                            "definition": "Castillian"
+                        },
+                        {
+                            "code": "2141-0",
+                            "display": "Catalonian",
+                            "definition": "Catalonian"
+                        },
+                        {
+                            "code": "2142-8",
+                            "display": "Belearic Islander",
+                            "definition": "Belearic Islander"
+                        },
+                        {
+                            "code": "2143-6",
+                            "display": "Gallego",
+                            "definition": "Gallego"
+                        },
+                        {
+                            "code": "2144-4",
+                            "display": "Valencian",
+                            "definition": "Valencian"
+                        },
+                        {
+                            "code": "2145-1",
+                            "display": "Canarian",
+                            "definition": "Canarian"
+                        },
+                        {
+                            "code": "2146-9",
+                            "display": "Spanish Basque",
+                            "definition": "Spanish Basque"
+                        },
+                        {
+                            "code": "2149-3",
+                            "display": "Mexican American",
+                            "definition": "Mexican American"
+                        },
+                        {
+                            "code": "2150-1",
+                            "display": "Mexicano",
+                            "definition": "Mexicano"
+                        },
+                        {
+                            "code": "2151-9",
+                            "display": "Chicano",
+                            "definition": "Chicano"
+                        },
+                        {
+                            "code": "2152-7",
+                            "display": "La Raza",
+                            "definition": "La Raza"
+                        },
+                        {
+                            "code": "2153-5",
+                            "display": "Mexican American Indian",
+                            "definition": "Mexican American Indian"
+                        },
+                        {
+                            "code": "2156-8",
+                            "display": "Costa Rican",
+                            "definition": "Costa Rican"
+                        },
+                        {
+                            "code": "2157-6",
+                            "display": "Guatemalan",
+                            "definition": "Guatemalan"
+                        },
+                        {
+                            "code": "2158-4",
+                            "display": "Honduran",
+                            "definition": "Honduran"
+                        },
+                        {
+                            "code": "2159-2",
+                            "display": "Nicaraguan",
+                            "definition": "Nicaraguan"
+                        },
+                        {
+                            "code": "2160-0",
+                            "display": "Panamanian",
+                            "definition": "Panamanian"
+                        },
+                        {
+                            "code": "2161-8",
+                            "display": "Salvadoran",
+                            "definition": "Salvadoran"
+                        },
+                        {
+                            "code": "2162-6",
+                            "display": "Central American Indian",
+                            "definition": "Central American Indian"
+                        },
+                        {
+                            "code": "2163-4",
+                            "display": "Canal Zone",
+                            "definition": "Canal Zone"
+                        },
+                        {
+                            "code": "2166-7",
+                            "display": "Argentinean",
+                            "definition": "Argentinean"
+                        },
+                        {
+                            "code": "2167-5",
+                            "display": "Bolivian",
+                            "definition": "Bolivian"
+                        },
+                        {
+                            "code": "2168-3",
+                            "display": "Chilean",
+                            "definition": "Chilean"
+                        },
+                        {
+                            "code": "2169-1",
+                            "display": "Colombian",
+                            "definition": "Colombian"
+                        },
+                        {
+                            "code": "2170-9",
+                            "display": "Ecuadorian",
+                            "definition": "Ecuadorian"
+                        },
+                        {
+                            "code": "2171-7",
+                            "display": "Paraguayan",
+                            "definition": "Paraguayan"
+                        },
+                        {
+                            "code": "2172-5",
+                            "display": "Peruvian",
+                            "definition": "Peruvian"
+                        },
+                        {
+                            "code": "2173-3",
+                            "display": "Uruguayan",
+                            "definition": "Uruguayan"
+                        },
+                        {
+                            "code": "2174-1",
+                            "display": "Venezuelan",
+                            "definition": "Venezuelan"
+                        },
+                        {
+                            "code": "2175-8",
+                            "display": "South American Indian",
+                            "definition": "South American Indian"
+                        },
+                        {
+                            "code": "2176-6",
+                            "display": "Criollo",
+                            "definition": "Criollo"
+                        }
+                    ]
+                },
+                {
+                    "code": "2186-5",
+                    "display": "Not Hispanic or Latino",
+                    "definition": "Note that this term remains in the table for completeness, even though within HL7, the notion of \"not otherwise coded\" term is deprecated."
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/CodeSystem-condition-category.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/CodeSystem-condition-category.json
@@ -1,65 +1,65 @@
 {
-	"resourceType": "CodeSystem",
-	"id": "condition-category",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/CodeSystem/condition-category",
-	"version": "3.1.1",
-	"name": "USCoreConditionCategoryExtensionCodes",
-	"title": "US Core Condition Category Extension Codes",
-	"status": "active",
-	"date": "2020-08-28T10:54:27+10:00",
-	"publisher": "HL7 US Realm Steering Committee",
-	"description": "Set of codes that are needed for implementation of the US-Core profiles. These codes are used as extensions to the FHIR and US Core value sets.\n",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"caseSensitive": true,
-	"content": "complete",
-	"property": [
-		{
-			"code": "status",
-			"uri": "http://hl7.org/fhir/concept-properties#status",
-			"description": "A property that indicates the status of the concept. One of active, experimental, deprecated,        retired",
-			"type": "code"
-		}
-	],
-	"concept": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/codesystem-replacedby",
-					"valueCoding": {
-						"system": "http://terminology.hl7.org/CodeSystem/condition-category",
-						"code": "problem-list-item",
-						"display": "Problem List Item"
-					}
-				}
-			],
-			"code": "problem",
-			"display": "Problem",
-			"definition": "The patients problems as identified by the provider(s). Items on the provider’s problem list",
-			"property": [
-				{
-					"code": "status",
-					"valueCode": "deprecated"
-				}
-			]
-		},
-		{
-			"code": "health-concern",
-			"display": "Health Concern",
-			"definition": "Additional health concerns from other stakeholders which are outside the provider’s problem list."
-		}
-	]
+    "resourceType": "CodeSystem",
+    "id": "condition-category",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/CodeSystem/condition-category",
+    "version": "3.1.1",
+    "name": "USCoreConditionCategoryExtensionCodes",
+    "title": "US Core Condition Category Extension Codes",
+    "status": "active",
+    "date": "2020-08-28T10:54:27+10:00",
+    "publisher": "HL7 US Realm Steering Committee",
+    "description": "Set of codes that are needed for implementation of the US-Core profiles. These codes are used as extensions to the FHIR and US Core value sets.\n",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "caseSensitive": true,
+    "content": "complete",
+    "property": [
+        {
+            "code": "status",
+            "uri": "http://hl7.org/fhir/concept-properties#status",
+            "description": "A property that indicates the status of the concept. One of active, experimental, deprecated,        retired",
+            "type": "code"
+        }
+    ],
+    "concept": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/codesystem-replacedby",
+                    "valueCoding": {
+                        "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                        "code": "problem-list-item",
+                        "display": "Problem List Item"
+                    }
+                }
+            ],
+            "code": "problem",
+            "display": "Problem",
+            "definition": "The patients problems as identified by the provider(s). Items on the provider’s problem list",
+            "property": [
+                {
+                    "code": "status",
+                    "valueCode": "deprecated"
+                }
+            ]
+        },
+        {
+            "code": "health-concern",
+            "display": "Health Concern",
+            "definition": "Additional health concerns from other stakeholders which are outside the provider’s problem list."
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/CodeSystem-us-core-documentreference-category.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/CodeSystem-us-core-documentreference-category.json
@@ -1,37 +1,37 @@
 {
-	"resourceType": "CodeSystem",
-	"id": "us-core-documentreference-category",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category",
-	"version": "3.1.1",
-	"name": "USCoreDocumentReferencesCategoryCodes",
-	"title": "US Core DocumentReferences Category Codes",
-	"status": "active",
-	"date": "2019-05-21",
-	"description": "The US Core DocumentReferences Type Code System is a 'starter set' of categories supported for fetching and storing DocumentReference Resources.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"caseSensitive": true,
-	"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-category|3.1.1",
-	"content": "complete",
-	"count": 2,
-	"concept": [
-		{
-			"code": "clinical-note",
-			"display": "Clinical Note",
-			"definition": "Part of health record where healthcare professionals record details to document a patient's clinical status or achievements during the course of a hospitalization or over the course of outpatient care ([Wikipedia](https://en.wikipedia.org/wiki/Progress_note))"
-		}
-	]
+    "resourceType": "CodeSystem",
+    "id": "us-core-documentreference-category",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category",
+    "version": "3.1.1",
+    "name": "USCoreDocumentReferencesCategoryCodes",
+    "title": "US Core DocumentReferences Category Codes",
+    "status": "active",
+    "date": "2019-05-21",
+    "description": "The US Core DocumentReferences Type Code System is a 'starter set' of categories supported for fetching and storing DocumentReference Resources.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "caseSensitive": true,
+    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-category|3.1.1",
+    "content": "complete",
+    "count": 2,
+    "concept": [
+        {
+            "code": "clinical-note",
+            "display": "Clinical Note",
+            "definition": "Part of health record where healthcare professionals record details to document a patient's clinical status or achievements during the course of a hospitalization or over the course of outpatient care ([Wikipedia](https://en.wikipedia.org/wiki/Progress_note))"
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/CodeSystem-us-core-provenance-participant-type.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/CodeSystem-us-core-provenance-participant-type.json
@@ -1,36 +1,36 @@
 {
-	"resourceType": "CodeSystem",
-	"id": "us-core-provenance-participant-type",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/CodeSystem/us-core-provenance-participant-type",
-	"version": "3.1.1",
-	"name": "USCoreProvenancePaticipantTypeExtensionCodes",
-	"title": "US Core Provenance Participant Type Extension Codes",
-	"status": "active",
-	"date": "2020-08-28T10:54:27+10:00",
-	"publisher": "HL7 US Realm Steering Committee",
-	"description": "Set of codes that are needed for implementation of the US-Core profiles. These codes are used as extensions to the FHIR and US Core value sets.\n",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"caseSensitive": true,
-	"content": "complete",
-	"concept": [
-		{
-			"code": "transmitter",
-			"display": "Transmitter",
-			"definition": "The entity that provided the copy to your system."
-		}
-	]
+    "resourceType": "CodeSystem",
+    "id": "us-core-provenance-participant-type",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/CodeSystem/us-core-provenance-participant-type",
+    "version": "3.1.1",
+    "name": "USCoreProvenancePaticipantTypeExtensionCodes",
+    "title": "US Core Provenance Participant Type Extension Codes",
+    "status": "active",
+    "date": "2020-08-28T10:54:27+10:00",
+    "publisher": "HL7 US Realm Steering Committee",
+    "description": "Set of codes that are needed for implementation of the US-Core profiles. These codes are used as extensions to the FHIR and US Core value sets.\n",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "caseSensitive": true,
+    "content": "complete",
+    "concept": [
+        {
+            "code": "transmitter",
+            "display": "Transmitter",
+            "definition": "The entity that provided the copy to your system."
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ConceptMap-ndc-cvx.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ConceptMap-ndc-cvx.json
@@ -1,2961 +1,2961 @@
 {
-	"resourceType": "ConceptMap",
-	"id": "ndc-cvx",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ConceptMap/ndc-cvx",
-	"version": "3.1.1",
-	"name": "USCoreNDCtoCVXCodeMapping",
-	"title": "US Core NDC to CVX Code Mapping",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"description": "Unit of Use [NDC code] (https://www2a.cdc.gov/vaccines/iis/iisstandards/ndc_crosswalk.asp) mapping  to the [CVX Vaccine codes](https://www2a.cdc.gov/vaccines/iis/iisstandards/vaccines.asp?rpt=cvx).  Note: source = NDC and target = CVX",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"purpose": "Based upon the 2015 Edition Certification Requirements, the NDC vaccine codes SHOULD be supported as translations to the CVX vaccine codes.",
-	"sourceCanonical": "http://hl7.org/fhir/us/core/ValueSet/us-core-ndc-vaccine-codes|3.1.1",
-	"targetCanonical": "http://hl7.org/fhir/us/core/ValueSet/us-core-vaccines-cvx|3.1.1",
-	"group": [
-		{
-			"element": [
-				{
-					"code": "00005-0100-02",
-					"target": [
-						{
-							"code": "162",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00005-0100-05",
-					"target": [
-						{
-							"code": "162",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00005-0100-10",
-					"target": [
-						{
-							"code": "162",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00005-1970-50",
-					"target": [
-						{
-							"code": "100",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00005-1971-02",
-					"target": [
-						{
-							"code": "133",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00005-1971-04",
-					"target": [
-						{
-							"code": "133",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00005-1971-05",
-					"target": [
-						{
-							"code": "133",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4045-00",
-					"target": [
-						{
-							"code": "62",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4045-41",
-					"target": [
-						{
-							"code": "62",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4047-20",
-					"target": [
-						{
-							"code": "116",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4047-41",
-					"target": [
-						{
-							"code": "116",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4093-02",
-					"target": [
-						{
-							"code": "08",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4093-09",
-					"target": [
-						{
-							"code": "08",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4094-02",
-					"target": [
-						{
-							"code": "43",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4094-09",
-					"target": [
-						{
-							"code": "43",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4095-02",
-					"target": [
-						{
-							"code": "83",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4095-09",
-					"target": [
-						{
-							"code": "83",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4096-02",
-					"target": [
-						{
-							"code": "52",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4096-09",
-					"target": [
-						{
-							"code": "52",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4109-02",
-					"target": [
-						{
-							"code": "62",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4109-09",
-					"target": [
-						{
-							"code": "62",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4119-02",
-					"target": [
-						{
-							"code": "165",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4119-03",
-					"target": [
-						{
-							"code": "165",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4121-02",
-					"target": [
-						{
-							"code": "165",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4133-41",
-					"target": [
-						{
-							"code": "09",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4171-00",
-					"target": [
-						{
-							"code": "94",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4681-00",
-					"target": [
-						{
-							"code": "03",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4739-00",
-					"target": [
-						{
-							"code": "33",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4826-00",
-					"target": [
-						{
-							"code": "21",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4827-00",
-					"target": [
-						{
-							"code": "21",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4831-41",
-					"target": [
-						{
-							"code": "83",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4837-02",
-					"target": [
-						{
-							"code": "33",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4837-03",
-					"target": [
-						{
-							"code": "33",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4841-00",
-					"target": [
-						{
-							"code": "52",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4841-41",
-					"target": [
-						{
-							"code": "52",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4897-00",
-					"target": [
-						{
-							"code": "49",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4898-00",
-					"target": [
-						{
-							"code": "51",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4943-00",
-					"target": [
-						{
-							"code": "33",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4963-00",
-					"target": [
-						{
-							"code": "121",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4963-41",
-					"target": [
-						{
-							"code": "121",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4980-00",
-					"target": [
-						{
-							"code": "08",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4981-00",
-					"target": [
-						{
-							"code": "08",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4992-00",
-					"target": [
-						{
-							"code": "44",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4995-00",
-					"target": [
-						{
-							"code": "43",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4995-41",
-					"target": [
-						{
-							"code": "43",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00006-4999-00",
-					"target": [
-						{
-							"code": "94",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "00052-0603-02",
-					"target": [
-						{
-							"code": "19",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "13533-0131-01",
-					"target": [
-						{
-							"code": "09",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "14362-0111-04",
-					"target": [
-						{
-							"code": "09",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "17478-0131-01",
-					"target": [
-						{
-							"code": "09",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "19515-0845-11",
-					"target": [
-						{
-							"code": "141",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "19515-0850-52",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "19515-0889-07",
-					"target": [
-						{
-							"code": "141",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "19515-0890-07",
-					"target": [
-						{
-							"code": "141",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "19515-0891-11",
-					"target": [
-						{
-							"code": "158",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "19515-0893-07",
-					"target": [
-						{
-							"code": "141",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "19515-0894-52",
-					"target": [
-						{
-							"code": "150",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "19515-0895-11",
-					"target": [
-						{
-							"code": "158",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "19515-0896-11",
-					"target": [
-						{
-							"code": "158",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "19515-0898-11",
-					"target": [
-						{
-							"code": "158",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "19515-0900-11",
-					"target": [
-						{
-							"code": "158",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "19515-0901-52",
-					"target": [
-						{
-							"code": "150",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "19515-0903-11",
-					"target": [
-						{
-							"code": "158",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "19515-0908-52",
-					"target": [
-						{
-							"code": "150",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "19515-0909-52",
-					"target": [
-						{
-							"code": "150",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "19515-0912-52",
-					"target": [
-						{
-							"code": "150",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "21695-0413-01",
-					"target": [
-						{
-							"code": "09",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "33332-0010-01",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "33332-0013-01",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "33332-0014-01",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "33332-0015-01",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "33332-0016-01",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "33332-0017-01",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "33332-0018-01",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "33332-0110-10",
-					"target": [
-						{
-							"code": "141",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "33332-0113-10",
-					"target": [
-						{
-							"code": "141",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "33332-0114-10",
-					"target": [
-						{
-							"code": "141",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "33332-0115-10",
-					"target": [
-						{
-							"code": "141",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "33332-0116-10",
-					"target": [
-						{
-							"code": "141",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "33332-0117-10",
-					"target": [
-						{
-							"code": "141",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "33332-0118-10",
-					"target": [
-						{
-							"code": "141",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "33332-0316-01",
-					"target": [
-						{
-							"code": "150",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "33332-0317-01",
-					"target": [
-						{
-							"code": "150",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "33332-0318-01",
-					"target": [
-						{
-							"code": "150",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "33332-0416-10",
-					"target": [
-						{
-							"code": "158",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "33332-0417-10",
-					"target": [
-						{
-							"code": "158",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "33332-0418-10",
-					"target": [
-						{
-							"code": "158",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "33332-0519-01",
-					"target": [
-						{
-							"code": "126",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "33332-0519-25",
-					"target": [
-						{
-							"code": "126",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "33332-0629-10",
-					"target": [
-						{
-							"code": "127",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "42515-0001-01",
-					"target": [
-						{
-							"code": "134",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "42515-0001-01",
-					"target": [
-						{
-							"code": "134",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "42515-0001-01",
-					"target": [
-						{
-							"code": "134",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "42515-0001-01",
-					"target": [
-						{
-							"code": "134",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "42515-0002-01",
-					"target": [
-						{
-							"code": "134",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "42874-0012-10",
-					"target": [
-						{
-							"code": "155",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "42874-0013-10",
-					"target": [
-						{
-							"code": "155",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "42874-0014-10",
-					"target": [
-						{
-							"code": "155",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "42874-0015-10",
-					"target": [
-						{
-							"code": "155",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "42874-0016-10",
-					"target": [
-						{
-							"code": "155",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "42874-0017-10",
-					"target": [
-						{
-							"code": "155",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "42874-0117-10",
-					"target": [
-						{
-							"code": "185",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "43528-0002-05",
-					"target": [
-						{
-							"code": "189",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "43528-0003-05",
-					"target": [
-						{
-							"code": "189",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "46028-0114-01",
-					"target": [
-						{
-							"code": "163",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "46028-0114-02",
-					"target": [
-						{
-							"code": "163",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "46028-0208-01",
-					"target": [
-						{
-							"code": "136",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "46028-0208-01",
-					"target": [
-						{
-							"code": "136",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0010-10",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0010-25",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0010-50",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0011-10",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0011-50",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0012-10",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0012-50",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0013-10",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0013-50",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0014-50",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0111-25",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0112-25",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0113-25",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0215-10",
-					"target": [
-						{
-							"code": "113",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0215-15",
-					"target": [
-						{
-							"code": "113",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0225-10",
-					"target": [
-						{
-							"code": "28",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0250-51",
-					"target": [
-						{
-							"code": "175",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0278-10",
-					"target": [
-						{
-							"code": "28",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0286-01",
-					"target": [
-						{
-							"code": "106",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0286-05",
-					"target": [
-						{
-							"code": "106",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0286-10",
-					"target": [
-						{
-							"code": "106",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0291-10",
-					"target": [
-						{
-							"code": "113",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0291-83",
-					"target": [
-						{
-							"code": "113",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0298-10",
-					"target": [
-						{
-							"code": "20",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0386-15",
-					"target": [
-						{
-							"code": "141",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0387-65",
-					"target": [
-						{
-							"code": "135",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0388-15",
-					"target": [
-						{
-							"code": "141",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0389-65",
-					"target": [
-						{
-							"code": "135",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0390-15",
-					"target": [
-						{
-							"code": "141",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0391-65",
-					"target": [
-						{
-							"code": "135",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0392-15",
-					"target": [
-						{
-							"code": "141",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0393-65",
-					"target": [
-						{
-							"code": "135",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0394-15",
-					"target": [
-						{
-							"code": "141",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0395-65",
-					"target": [
-						{
-							"code": "135",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0396-15",
-					"target": [
-						{
-							"code": "141",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0397-65",
-					"target": [
-						{
-							"code": "135",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0399-65",
-					"target": [
-						{
-							"code": "135",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0400-05",
-					"target": [
-						{
-							"code": "115",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0400-10",
-					"target": [
-						{
-							"code": "115",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0400-15",
-					"target": [
-						{
-							"code": "115",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0400-20",
-					"target": [
-						{
-							"code": "115",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0401-65",
-					"target": [
-						{
-							"code": "135",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0403-65",
-					"target": [
-						{
-							"code": "135",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0413-10",
-					"target": [
-						{
-							"code": "150",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0413-50",
-					"target": [
-						{
-							"code": "150",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0414-10",
-					"target": [
-						{
-							"code": "150",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0414-50",
-					"target": [
-						{
-							"code": "150",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0415-10",
-					"target": [
-						{
-							"code": "150",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0416-10",
-					"target": [
-						{
-							"code": "150",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0416-50",
-					"target": [
-						{
-							"code": "150",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0417-10",
-					"target": [
-						{
-							"code": "150",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0417-50",
-					"target": [
-						{
-							"code": "150",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0418-10",
-					"target": [
-						{
-							"code": "150",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0418-50",
-					"target": [
-						{
-							"code": "150",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0489-01",
-					"target": [
-						{
-							"code": "32",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0489-91",
-					"target": [
-						{
-							"code": "32",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0510-05",
-					"target": [
-						{
-							"code": "120",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0510-05",
-					"target": [
-						{
-							"code": "120",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0513-25",
-					"target": [
-						{
-							"code": "161",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0514-25",
-					"target": [
-						{
-							"code": "161",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0516-25",
-					"target": [
-						{
-							"code": "161",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0517-25",
-					"target": [
-						{
-							"code": "161",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0518-25",
-					"target": [
-						{
-							"code": "161",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0545-03",
-					"target": [
-						{
-							"code": "48",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0545-05",
-					"target": [
-						{
-							"code": "48",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0562-10",
-					"target": [
-						{
-							"code": "130",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0589-05",
-					"target": [
-						{
-							"code": "114",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0621-15",
-					"target": [
-						{
-							"code": "158",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0625-15",
-					"target": [
-						{
-							"code": "158",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0627-15",
-					"target": [
-						{
-							"code": "158",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0629-15",
-					"target": [
-						{
-							"code": "158",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0640-15",
-					"target": [
-						{
-							"code": "127",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0650-10",
-					"target": [
-						{
-							"code": "126",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0650-25",
-					"target": [
-						{
-							"code": "126",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0650-50",
-					"target": [
-						{
-							"code": "126",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0650-70",
-					"target": [
-						{
-							"code": "126",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0650-90",
-					"target": [
-						{
-							"code": "126",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0703-55",
-					"target": [
-						{
-							"code": "144",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0705-55",
-					"target": [
-						{
-							"code": "144",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0707-55",
-					"target": [
-						{
-							"code": "144",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0708-40",
-					"target": [
-						{
-							"code": "166",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0709-55",
-					"target": [
-						{
-							"code": "144",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0710-40",
-					"target": [
-						{
-							"code": "166",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0712-40",
-					"target": [
-						{
-							"code": "166",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0718-10",
-					"target": [
-						{
-							"code": "185",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0790-20",
-					"target": [
-						{
-							"code": "101",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0790-51",
-					"target": [
-						{
-							"code": "101",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0800-83",
-					"target": [
-						{
-							"code": "35",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0820-10",
-					"target": [
-						{
-							"code": "35",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0860-10",
-					"target": [
-						{
-							"code": "10",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0860-10",
-					"target": [
-						{
-							"code": "10",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0860-55",
-					"target": [
-						{
-							"code": "10",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0913-01",
-					"target": [
-						{
-							"code": "183",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0915-01",
-					"target": [
-						{
-							"code": "37",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "49281-0915-05",
-					"target": [
-						{
-							"code": "37",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "50090-1693-09",
-					"target": [
-						{
-							"code": "10",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "50090-2883-00",
-					"target": [
-						{
-							"code": "20",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "50090-3096-00",
-					"target": [
-						{
-							"code": "176",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "50090-3469-00",
-					"target": [
-						{
-							"code": "189",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "51285-0138-50",
-					"target": [
-						{
-							"code": "143",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "51285-0138-50",
-					"target": [
-						{
-							"code": "143",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "54868-0734-00",
-					"target": [
-						{
-							"code": "43",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "54868-0980-00",
-					"target": [
-						{
-							"code": "03",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "54868-2219-00",
-					"target": [
-						{
-							"code": "43",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "54868-2219-01",
-					"target": [
-						{
-							"code": "43",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "54868-3339-01",
-					"target": [
-						{
-							"code": "33",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "54868-4320-00",
-					"target": [
-						{
-							"code": "33",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "54868-6177-00",
-					"target": [
-						{
-							"code": "141",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "54868-6180-00",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "55045-3841-01",
-					"target": [
-						{
-							"code": "52",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0801-11",
-					"target": [
-						{
-							"code": "148",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0806-05",
-					"target": [
-						{
-							"code": "48",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0808-15",
-					"target": [
-						{
-							"code": "160",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0808-15",
-					"target": [
-						{
-							"code": "160",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0809-05",
-					"target": [
-						{
-							"code": "148",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0810-11",
-					"target": [
-						{
-							"code": "20",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0810-52",
-					"target": [
-						{
-							"code": "20",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0811-51",
-					"target": [
-						{
-							"code": "110",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0811-52",
-					"target": [
-						{
-							"code": "110",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0812-11",
-					"target": [
-						{
-							"code": "130",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0812-52",
-					"target": [
-						{
-							"code": "130",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0815-11",
-					"target": [
-						{
-							"code": "104",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0815-34",
-					"target": [
-						{
-							"code": "104",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0815-46",
-					"target": [
-						{
-							"code": "104",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0815-48",
-					"target": [
-						{
-							"code": "104",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0815-52",
-					"target": [
-						{
-							"code": "104",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0816-05",
-					"target": [
-						{
-							"code": "48",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0818-11",
-					"target": [
-						{
-							"code": "48",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0819-12",
-					"target": [
-						{
-							"code": "187",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0820-11",
-					"target": [
-						{
-							"code": "08",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0820-52",
-					"target": [
-						{
-							"code": "08",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0821-11",
-					"target": [
-						{
-							"code": "43",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0821-34",
-					"target": [
-						{
-							"code": "43",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0821-52",
-					"target": [
-						{
-							"code": "43",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0823-11",
-					"target": [
-						{
-							"code": "187",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0825-11",
-					"target": [
-						{
-							"code": "83",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0825-52",
-					"target": [
-						{
-							"code": "83",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0826-11",
-					"target": [
-						{
-							"code": "52",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0826-34",
-					"target": [
-						{
-							"code": "52",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0826-52",
-					"target": [
-						{
-							"code": "52",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0830-34",
-					"target": [
-						{
-							"code": "118",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0830-52",
-					"target": [
-						{
-							"code": "118",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0842-11",
-					"target": [
-						{
-							"code": "115",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0842-34",
-					"target": [
-						{
-							"code": "115",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0842-51",
-					"target": [
-						{
-							"code": "115",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0842-52",
-					"target": [
-						{
-							"code": "115",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0854-52",
-					"target": [
-						{
-							"code": "119",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0879-52",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0880-52",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0881-52",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0883-52",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0898-52",
-					"target": [
-						{
-							"code": "150",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0900-52",
-					"target": [
-						{
-							"code": "150",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0901-52",
-					"target": [
-						{
-							"code": "150",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0903-52",
-					"target": [
-						{
-							"code": "150",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0905-52",
-					"target": [
-						{
-							"code": "150",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0907-52",
-					"target": [
-						{
-							"code": "150",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0955-09",
-					"target": [
-						{
-							"code": "136",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0955-09",
-					"target": [
-						{
-							"code": "136",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0964-12",
-					"target": [
-						{
-							"code": "176",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0964-12",
-					"target": [
-						{
-							"code": "176",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0976-06",
-					"target": [
-						{
-							"code": "163",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "58160-0976-20",
-					"target": [
-						{
-							"code": "163",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "62195-0051-10",
-					"target": [
-						{
-							"code": "134",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "62577-0613-01",
-					"target": [
-						{
-							"code": "153",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "62577-0614-01",
-					"target": [
-						{
-							"code": "153",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "63851-0501-01",
-					"target": [
-						{
-							"code": "176",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "63851-0501-02",
-					"target": [
-						{
-							"code": "176",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "63851-0612-01",
-					"target": [
-						{
-							"code": "153",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "63851-0613-01",
-					"target": [
-						{
-							"code": "153",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "64678-0211-01",
-					"target": [
-						{
-							"code": "24",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "66019-0107-01",
-					"target": [
-						{
-							"code": "111",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "66019-0108-10",
-					"target": [
-						{
-							"code": "111",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "66019-0109-10",
-					"target": [
-						{
-							"code": "111",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "66019-0110-10",
-					"target": [
-						{
-							"code": "111",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "66019-0200-10",
-					"target": [
-						{
-							"code": "125",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "66019-0300-10",
-					"target": [
-						{
-							"code": "149",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "66019-0301-10",
-					"target": [
-						{
-							"code": "149",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "66019-0302-10",
-					"target": [
-						{
-							"code": "149",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "66019-0303-10",
-					"target": [
-						{
-							"code": "149",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "66019-0304-10",
-					"target": [
-						{
-							"code": "149",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "66019-0305-10",
-					"target": [
-						{
-							"code": "149",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "66521-0000-01",
-					"target": [
-						{
-							"code": "168",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "66521-0112-02",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "66521-0112-10",
-					"target": [
-						{
-							"code": "141",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "66521-0113-02",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "66521-0113-10",
-					"target": [
-						{
-							"code": "141",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "66521-0114-02",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "66521-0114-10",
-					"target": [
-						{
-							"code": "141",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "66521-0115-02",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "66521-0115-10",
-					"target": [
-						{
-							"code": "141",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "66521-0116-02",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "66521-0116-10",
-					"target": [
-						{
-							"code": "141",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "66521-0117-02",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "66521-0117-10",
-					"target": [
-						{
-							"code": "141",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "66521-0118-02",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "66521-0118-10",
-					"target": [
-						{
-							"code": "141",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "66521-0200-02",
-					"target": [
-						{
-							"code": "127",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "66521-0200-10",
-					"target": [
-						{
-							"code": "126",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "69401-0000-01",
-					"target": [
-						{
-							"code": "25",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "69401-0000-02",
-					"target": [
-						{
-							"code": "25",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "70460-0001-01",
-					"target": [
-						{
-							"code": "174",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "70461-0001-01",
-					"target": [
-						{
-							"code": "168",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "70461-0002-01",
-					"target": [
-						{
-							"code": "168",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "70461-0018-03",
-					"target": [
-						{
-							"code": "168",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "70461-0119-02",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "70461-0119-10",
-					"target": [
-						{
-							"code": "141",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "70461-0120-02",
-					"target": [
-						{
-							"code": "140",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "70461-0120-10",
-					"target": [
-						{
-							"code": "141",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "70461-0200-01",
-					"target": [
-						{
-							"code": "171",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "70461-0201-01",
-					"target": [
-						{
-							"code": "171",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "70461-0301-10",
-					"target": [
-						{
-							"code": "186",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "70461-0318-03",
-					"target": [
-						{
-							"code": "171",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "70461-0418-10",
-					"target": [
-						{
-							"code": "186",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "76420-0482-01",
-					"target": [
-						{
-							"code": "150",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "76420-0483-01",
-					"target": [
-						{
-							"code": "150",
-							"equivalence": "wider"
-						}
-					]
-				},
-				{
-					"code": "63361-0245-10",
-					"target": [
-						{
-							"code": "146",
-							"equivalence": "wider"
-						}
-					]
-				}
-			]
-		}
-	]
+    "resourceType": "ConceptMap",
+    "id": "ndc-cvx",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ConceptMap/ndc-cvx",
+    "version": "3.1.1",
+    "name": "USCoreNDCtoCVXCodeMapping",
+    "title": "US Core NDC to CVX Code Mapping",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "description": "Unit of Use [NDC code] (https://www2a.cdc.gov/vaccines/iis/iisstandards/ndc_crosswalk.asp) mapping  to the [CVX Vaccine codes](https://www2a.cdc.gov/vaccines/iis/iisstandards/vaccines.asp?rpt=cvx).  Note: source = NDC and target = CVX",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "purpose": "Based upon the 2015 Edition Certification Requirements, the NDC vaccine codes SHOULD be supported as translations to the CVX vaccine codes.",
+    "sourceCanonical": "http://hl7.org/fhir/us/core/ValueSet/us-core-ndc-vaccine-codes|3.1.1",
+    "targetCanonical": "http://hl7.org/fhir/us/core/ValueSet/us-core-vaccines-cvx|3.1.1",
+    "group": [
+        {
+            "element": [
+                {
+                    "code": "00005-0100-02",
+                    "target": [
+                        {
+                            "code": "162",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00005-0100-05",
+                    "target": [
+                        {
+                            "code": "162",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00005-0100-10",
+                    "target": [
+                        {
+                            "code": "162",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00005-1970-50",
+                    "target": [
+                        {
+                            "code": "100",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00005-1971-02",
+                    "target": [
+                        {
+                            "code": "133",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00005-1971-04",
+                    "target": [
+                        {
+                            "code": "133",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00005-1971-05",
+                    "target": [
+                        {
+                            "code": "133",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4045-00",
+                    "target": [
+                        {
+                            "code": "62",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4045-41",
+                    "target": [
+                        {
+                            "code": "62",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4047-20",
+                    "target": [
+                        {
+                            "code": "116",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4047-41",
+                    "target": [
+                        {
+                            "code": "116",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4093-02",
+                    "target": [
+                        {
+                            "code": "08",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4093-09",
+                    "target": [
+                        {
+                            "code": "08",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4094-02",
+                    "target": [
+                        {
+                            "code": "43",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4094-09",
+                    "target": [
+                        {
+                            "code": "43",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4095-02",
+                    "target": [
+                        {
+                            "code": "83",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4095-09",
+                    "target": [
+                        {
+                            "code": "83",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4096-02",
+                    "target": [
+                        {
+                            "code": "52",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4096-09",
+                    "target": [
+                        {
+                            "code": "52",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4109-02",
+                    "target": [
+                        {
+                            "code": "62",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4109-09",
+                    "target": [
+                        {
+                            "code": "62",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4119-02",
+                    "target": [
+                        {
+                            "code": "165",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4119-03",
+                    "target": [
+                        {
+                            "code": "165",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4121-02",
+                    "target": [
+                        {
+                            "code": "165",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4133-41",
+                    "target": [
+                        {
+                            "code": "09",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4171-00",
+                    "target": [
+                        {
+                            "code": "94",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4681-00",
+                    "target": [
+                        {
+                            "code": "03",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4739-00",
+                    "target": [
+                        {
+                            "code": "33",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4826-00",
+                    "target": [
+                        {
+                            "code": "21",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4827-00",
+                    "target": [
+                        {
+                            "code": "21",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4831-41",
+                    "target": [
+                        {
+                            "code": "83",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4837-02",
+                    "target": [
+                        {
+                            "code": "33",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4837-03",
+                    "target": [
+                        {
+                            "code": "33",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4841-00",
+                    "target": [
+                        {
+                            "code": "52",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4841-41",
+                    "target": [
+                        {
+                            "code": "52",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4897-00",
+                    "target": [
+                        {
+                            "code": "49",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4898-00",
+                    "target": [
+                        {
+                            "code": "51",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4943-00",
+                    "target": [
+                        {
+                            "code": "33",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4963-00",
+                    "target": [
+                        {
+                            "code": "121",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4963-41",
+                    "target": [
+                        {
+                            "code": "121",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4980-00",
+                    "target": [
+                        {
+                            "code": "08",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4981-00",
+                    "target": [
+                        {
+                            "code": "08",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4992-00",
+                    "target": [
+                        {
+                            "code": "44",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4995-00",
+                    "target": [
+                        {
+                            "code": "43",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4995-41",
+                    "target": [
+                        {
+                            "code": "43",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00006-4999-00",
+                    "target": [
+                        {
+                            "code": "94",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "00052-0603-02",
+                    "target": [
+                        {
+                            "code": "19",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "13533-0131-01",
+                    "target": [
+                        {
+                            "code": "09",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "14362-0111-04",
+                    "target": [
+                        {
+                            "code": "09",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "17478-0131-01",
+                    "target": [
+                        {
+                            "code": "09",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "19515-0845-11",
+                    "target": [
+                        {
+                            "code": "141",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "19515-0850-52",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "19515-0889-07",
+                    "target": [
+                        {
+                            "code": "141",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "19515-0890-07",
+                    "target": [
+                        {
+                            "code": "141",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "19515-0891-11",
+                    "target": [
+                        {
+                            "code": "158",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "19515-0893-07",
+                    "target": [
+                        {
+                            "code": "141",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "19515-0894-52",
+                    "target": [
+                        {
+                            "code": "150",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "19515-0895-11",
+                    "target": [
+                        {
+                            "code": "158",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "19515-0896-11",
+                    "target": [
+                        {
+                            "code": "158",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "19515-0898-11",
+                    "target": [
+                        {
+                            "code": "158",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "19515-0900-11",
+                    "target": [
+                        {
+                            "code": "158",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "19515-0901-52",
+                    "target": [
+                        {
+                            "code": "150",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "19515-0903-11",
+                    "target": [
+                        {
+                            "code": "158",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "19515-0908-52",
+                    "target": [
+                        {
+                            "code": "150",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "19515-0909-52",
+                    "target": [
+                        {
+                            "code": "150",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "19515-0912-52",
+                    "target": [
+                        {
+                            "code": "150",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "21695-0413-01",
+                    "target": [
+                        {
+                            "code": "09",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "33332-0010-01",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "33332-0013-01",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "33332-0014-01",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "33332-0015-01",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "33332-0016-01",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "33332-0017-01",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "33332-0018-01",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "33332-0110-10",
+                    "target": [
+                        {
+                            "code": "141",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "33332-0113-10",
+                    "target": [
+                        {
+                            "code": "141",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "33332-0114-10",
+                    "target": [
+                        {
+                            "code": "141",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "33332-0115-10",
+                    "target": [
+                        {
+                            "code": "141",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "33332-0116-10",
+                    "target": [
+                        {
+                            "code": "141",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "33332-0117-10",
+                    "target": [
+                        {
+                            "code": "141",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "33332-0118-10",
+                    "target": [
+                        {
+                            "code": "141",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "33332-0316-01",
+                    "target": [
+                        {
+                            "code": "150",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "33332-0317-01",
+                    "target": [
+                        {
+                            "code": "150",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "33332-0318-01",
+                    "target": [
+                        {
+                            "code": "150",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "33332-0416-10",
+                    "target": [
+                        {
+                            "code": "158",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "33332-0417-10",
+                    "target": [
+                        {
+                            "code": "158",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "33332-0418-10",
+                    "target": [
+                        {
+                            "code": "158",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "33332-0519-01",
+                    "target": [
+                        {
+                            "code": "126",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "33332-0519-25",
+                    "target": [
+                        {
+                            "code": "126",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "33332-0629-10",
+                    "target": [
+                        {
+                            "code": "127",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "42515-0001-01",
+                    "target": [
+                        {
+                            "code": "134",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "42515-0001-01",
+                    "target": [
+                        {
+                            "code": "134",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "42515-0001-01",
+                    "target": [
+                        {
+                            "code": "134",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "42515-0001-01",
+                    "target": [
+                        {
+                            "code": "134",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "42515-0002-01",
+                    "target": [
+                        {
+                            "code": "134",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "42874-0012-10",
+                    "target": [
+                        {
+                            "code": "155",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "42874-0013-10",
+                    "target": [
+                        {
+                            "code": "155",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "42874-0014-10",
+                    "target": [
+                        {
+                            "code": "155",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "42874-0015-10",
+                    "target": [
+                        {
+                            "code": "155",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "42874-0016-10",
+                    "target": [
+                        {
+                            "code": "155",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "42874-0017-10",
+                    "target": [
+                        {
+                            "code": "155",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "42874-0117-10",
+                    "target": [
+                        {
+                            "code": "185",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "43528-0002-05",
+                    "target": [
+                        {
+                            "code": "189",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "43528-0003-05",
+                    "target": [
+                        {
+                            "code": "189",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "46028-0114-01",
+                    "target": [
+                        {
+                            "code": "163",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "46028-0114-02",
+                    "target": [
+                        {
+                            "code": "163",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "46028-0208-01",
+                    "target": [
+                        {
+                            "code": "136",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "46028-0208-01",
+                    "target": [
+                        {
+                            "code": "136",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0010-10",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0010-25",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0010-50",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0011-10",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0011-50",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0012-10",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0012-50",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0013-10",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0013-50",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0014-50",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0111-25",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0112-25",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0113-25",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0215-10",
+                    "target": [
+                        {
+                            "code": "113",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0215-15",
+                    "target": [
+                        {
+                            "code": "113",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0225-10",
+                    "target": [
+                        {
+                            "code": "28",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0250-51",
+                    "target": [
+                        {
+                            "code": "175",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0278-10",
+                    "target": [
+                        {
+                            "code": "28",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0286-01",
+                    "target": [
+                        {
+                            "code": "106",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0286-05",
+                    "target": [
+                        {
+                            "code": "106",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0286-10",
+                    "target": [
+                        {
+                            "code": "106",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0291-10",
+                    "target": [
+                        {
+                            "code": "113",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0291-83",
+                    "target": [
+                        {
+                            "code": "113",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0298-10",
+                    "target": [
+                        {
+                            "code": "20",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0386-15",
+                    "target": [
+                        {
+                            "code": "141",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0387-65",
+                    "target": [
+                        {
+                            "code": "135",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0388-15",
+                    "target": [
+                        {
+                            "code": "141",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0389-65",
+                    "target": [
+                        {
+                            "code": "135",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0390-15",
+                    "target": [
+                        {
+                            "code": "141",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0391-65",
+                    "target": [
+                        {
+                            "code": "135",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0392-15",
+                    "target": [
+                        {
+                            "code": "141",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0393-65",
+                    "target": [
+                        {
+                            "code": "135",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0394-15",
+                    "target": [
+                        {
+                            "code": "141",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0395-65",
+                    "target": [
+                        {
+                            "code": "135",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0396-15",
+                    "target": [
+                        {
+                            "code": "141",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0397-65",
+                    "target": [
+                        {
+                            "code": "135",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0399-65",
+                    "target": [
+                        {
+                            "code": "135",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0400-05",
+                    "target": [
+                        {
+                            "code": "115",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0400-10",
+                    "target": [
+                        {
+                            "code": "115",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0400-15",
+                    "target": [
+                        {
+                            "code": "115",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0400-20",
+                    "target": [
+                        {
+                            "code": "115",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0401-65",
+                    "target": [
+                        {
+                            "code": "135",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0403-65",
+                    "target": [
+                        {
+                            "code": "135",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0413-10",
+                    "target": [
+                        {
+                            "code": "150",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0413-50",
+                    "target": [
+                        {
+                            "code": "150",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0414-10",
+                    "target": [
+                        {
+                            "code": "150",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0414-50",
+                    "target": [
+                        {
+                            "code": "150",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0415-10",
+                    "target": [
+                        {
+                            "code": "150",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0416-10",
+                    "target": [
+                        {
+                            "code": "150",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0416-50",
+                    "target": [
+                        {
+                            "code": "150",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0417-10",
+                    "target": [
+                        {
+                            "code": "150",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0417-50",
+                    "target": [
+                        {
+                            "code": "150",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0418-10",
+                    "target": [
+                        {
+                            "code": "150",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0418-50",
+                    "target": [
+                        {
+                            "code": "150",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0489-01",
+                    "target": [
+                        {
+                            "code": "32",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0489-91",
+                    "target": [
+                        {
+                            "code": "32",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0510-05",
+                    "target": [
+                        {
+                            "code": "120",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0510-05",
+                    "target": [
+                        {
+                            "code": "120",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0513-25",
+                    "target": [
+                        {
+                            "code": "161",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0514-25",
+                    "target": [
+                        {
+                            "code": "161",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0516-25",
+                    "target": [
+                        {
+                            "code": "161",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0517-25",
+                    "target": [
+                        {
+                            "code": "161",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0518-25",
+                    "target": [
+                        {
+                            "code": "161",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0545-03",
+                    "target": [
+                        {
+                            "code": "48",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0545-05",
+                    "target": [
+                        {
+                            "code": "48",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0562-10",
+                    "target": [
+                        {
+                            "code": "130",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0589-05",
+                    "target": [
+                        {
+                            "code": "114",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0621-15",
+                    "target": [
+                        {
+                            "code": "158",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0625-15",
+                    "target": [
+                        {
+                            "code": "158",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0627-15",
+                    "target": [
+                        {
+                            "code": "158",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0629-15",
+                    "target": [
+                        {
+                            "code": "158",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0640-15",
+                    "target": [
+                        {
+                            "code": "127",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0650-10",
+                    "target": [
+                        {
+                            "code": "126",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0650-25",
+                    "target": [
+                        {
+                            "code": "126",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0650-50",
+                    "target": [
+                        {
+                            "code": "126",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0650-70",
+                    "target": [
+                        {
+                            "code": "126",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0650-90",
+                    "target": [
+                        {
+                            "code": "126",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0703-55",
+                    "target": [
+                        {
+                            "code": "144",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0705-55",
+                    "target": [
+                        {
+                            "code": "144",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0707-55",
+                    "target": [
+                        {
+                            "code": "144",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0708-40",
+                    "target": [
+                        {
+                            "code": "166",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0709-55",
+                    "target": [
+                        {
+                            "code": "144",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0710-40",
+                    "target": [
+                        {
+                            "code": "166",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0712-40",
+                    "target": [
+                        {
+                            "code": "166",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0718-10",
+                    "target": [
+                        {
+                            "code": "185",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0790-20",
+                    "target": [
+                        {
+                            "code": "101",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0790-51",
+                    "target": [
+                        {
+                            "code": "101",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0800-83",
+                    "target": [
+                        {
+                            "code": "35",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0820-10",
+                    "target": [
+                        {
+                            "code": "35",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0860-10",
+                    "target": [
+                        {
+                            "code": "10",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0860-10",
+                    "target": [
+                        {
+                            "code": "10",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0860-55",
+                    "target": [
+                        {
+                            "code": "10",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0913-01",
+                    "target": [
+                        {
+                            "code": "183",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0915-01",
+                    "target": [
+                        {
+                            "code": "37",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "49281-0915-05",
+                    "target": [
+                        {
+                            "code": "37",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "50090-1693-09",
+                    "target": [
+                        {
+                            "code": "10",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "50090-2883-00",
+                    "target": [
+                        {
+                            "code": "20",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "50090-3096-00",
+                    "target": [
+                        {
+                            "code": "176",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "50090-3469-00",
+                    "target": [
+                        {
+                            "code": "189",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "51285-0138-50",
+                    "target": [
+                        {
+                            "code": "143",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "51285-0138-50",
+                    "target": [
+                        {
+                            "code": "143",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "54868-0734-00",
+                    "target": [
+                        {
+                            "code": "43",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "54868-0980-00",
+                    "target": [
+                        {
+                            "code": "03",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "54868-2219-00",
+                    "target": [
+                        {
+                            "code": "43",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "54868-2219-01",
+                    "target": [
+                        {
+                            "code": "43",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "54868-3339-01",
+                    "target": [
+                        {
+                            "code": "33",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "54868-4320-00",
+                    "target": [
+                        {
+                            "code": "33",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "54868-6177-00",
+                    "target": [
+                        {
+                            "code": "141",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "54868-6180-00",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "55045-3841-01",
+                    "target": [
+                        {
+                            "code": "52",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0801-11",
+                    "target": [
+                        {
+                            "code": "148",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0806-05",
+                    "target": [
+                        {
+                            "code": "48",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0808-15",
+                    "target": [
+                        {
+                            "code": "160",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0808-15",
+                    "target": [
+                        {
+                            "code": "160",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0809-05",
+                    "target": [
+                        {
+                            "code": "148",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0810-11",
+                    "target": [
+                        {
+                            "code": "20",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0810-52",
+                    "target": [
+                        {
+                            "code": "20",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0811-51",
+                    "target": [
+                        {
+                            "code": "110",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0811-52",
+                    "target": [
+                        {
+                            "code": "110",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0812-11",
+                    "target": [
+                        {
+                            "code": "130",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0812-52",
+                    "target": [
+                        {
+                            "code": "130",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0815-11",
+                    "target": [
+                        {
+                            "code": "104",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0815-34",
+                    "target": [
+                        {
+                            "code": "104",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0815-46",
+                    "target": [
+                        {
+                            "code": "104",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0815-48",
+                    "target": [
+                        {
+                            "code": "104",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0815-52",
+                    "target": [
+                        {
+                            "code": "104",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0816-05",
+                    "target": [
+                        {
+                            "code": "48",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0818-11",
+                    "target": [
+                        {
+                            "code": "48",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0819-12",
+                    "target": [
+                        {
+                            "code": "187",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0820-11",
+                    "target": [
+                        {
+                            "code": "08",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0820-52",
+                    "target": [
+                        {
+                            "code": "08",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0821-11",
+                    "target": [
+                        {
+                            "code": "43",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0821-34",
+                    "target": [
+                        {
+                            "code": "43",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0821-52",
+                    "target": [
+                        {
+                            "code": "43",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0823-11",
+                    "target": [
+                        {
+                            "code": "187",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0825-11",
+                    "target": [
+                        {
+                            "code": "83",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0825-52",
+                    "target": [
+                        {
+                            "code": "83",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0826-11",
+                    "target": [
+                        {
+                            "code": "52",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0826-34",
+                    "target": [
+                        {
+                            "code": "52",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0826-52",
+                    "target": [
+                        {
+                            "code": "52",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0830-34",
+                    "target": [
+                        {
+                            "code": "118",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0830-52",
+                    "target": [
+                        {
+                            "code": "118",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0842-11",
+                    "target": [
+                        {
+                            "code": "115",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0842-34",
+                    "target": [
+                        {
+                            "code": "115",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0842-51",
+                    "target": [
+                        {
+                            "code": "115",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0842-52",
+                    "target": [
+                        {
+                            "code": "115",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0854-52",
+                    "target": [
+                        {
+                            "code": "119",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0879-52",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0880-52",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0881-52",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0883-52",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0898-52",
+                    "target": [
+                        {
+                            "code": "150",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0900-52",
+                    "target": [
+                        {
+                            "code": "150",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0901-52",
+                    "target": [
+                        {
+                            "code": "150",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0903-52",
+                    "target": [
+                        {
+                            "code": "150",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0905-52",
+                    "target": [
+                        {
+                            "code": "150",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0907-52",
+                    "target": [
+                        {
+                            "code": "150",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0955-09",
+                    "target": [
+                        {
+                            "code": "136",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0955-09",
+                    "target": [
+                        {
+                            "code": "136",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0964-12",
+                    "target": [
+                        {
+                            "code": "176",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0964-12",
+                    "target": [
+                        {
+                            "code": "176",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0976-06",
+                    "target": [
+                        {
+                            "code": "163",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "58160-0976-20",
+                    "target": [
+                        {
+                            "code": "163",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "62195-0051-10",
+                    "target": [
+                        {
+                            "code": "134",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "62577-0613-01",
+                    "target": [
+                        {
+                            "code": "153",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "62577-0614-01",
+                    "target": [
+                        {
+                            "code": "153",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "63851-0501-01",
+                    "target": [
+                        {
+                            "code": "176",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "63851-0501-02",
+                    "target": [
+                        {
+                            "code": "176",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "63851-0612-01",
+                    "target": [
+                        {
+                            "code": "153",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "63851-0613-01",
+                    "target": [
+                        {
+                            "code": "153",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "64678-0211-01",
+                    "target": [
+                        {
+                            "code": "24",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "66019-0107-01",
+                    "target": [
+                        {
+                            "code": "111",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "66019-0108-10",
+                    "target": [
+                        {
+                            "code": "111",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "66019-0109-10",
+                    "target": [
+                        {
+                            "code": "111",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "66019-0110-10",
+                    "target": [
+                        {
+                            "code": "111",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "66019-0200-10",
+                    "target": [
+                        {
+                            "code": "125",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "66019-0300-10",
+                    "target": [
+                        {
+                            "code": "149",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "66019-0301-10",
+                    "target": [
+                        {
+                            "code": "149",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "66019-0302-10",
+                    "target": [
+                        {
+                            "code": "149",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "66019-0303-10",
+                    "target": [
+                        {
+                            "code": "149",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "66019-0304-10",
+                    "target": [
+                        {
+                            "code": "149",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "66019-0305-10",
+                    "target": [
+                        {
+                            "code": "149",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "66521-0000-01",
+                    "target": [
+                        {
+                            "code": "168",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "66521-0112-02",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "66521-0112-10",
+                    "target": [
+                        {
+                            "code": "141",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "66521-0113-02",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "66521-0113-10",
+                    "target": [
+                        {
+                            "code": "141",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "66521-0114-02",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "66521-0114-10",
+                    "target": [
+                        {
+                            "code": "141",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "66521-0115-02",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "66521-0115-10",
+                    "target": [
+                        {
+                            "code": "141",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "66521-0116-02",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "66521-0116-10",
+                    "target": [
+                        {
+                            "code": "141",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "66521-0117-02",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "66521-0117-10",
+                    "target": [
+                        {
+                            "code": "141",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "66521-0118-02",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "66521-0118-10",
+                    "target": [
+                        {
+                            "code": "141",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "66521-0200-02",
+                    "target": [
+                        {
+                            "code": "127",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "66521-0200-10",
+                    "target": [
+                        {
+                            "code": "126",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "69401-0000-01",
+                    "target": [
+                        {
+                            "code": "25",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "69401-0000-02",
+                    "target": [
+                        {
+                            "code": "25",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "70460-0001-01",
+                    "target": [
+                        {
+                            "code": "174",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "70461-0001-01",
+                    "target": [
+                        {
+                            "code": "168",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "70461-0002-01",
+                    "target": [
+                        {
+                            "code": "168",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "70461-0018-03",
+                    "target": [
+                        {
+                            "code": "168",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "70461-0119-02",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "70461-0119-10",
+                    "target": [
+                        {
+                            "code": "141",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "70461-0120-02",
+                    "target": [
+                        {
+                            "code": "140",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "70461-0120-10",
+                    "target": [
+                        {
+                            "code": "141",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "70461-0200-01",
+                    "target": [
+                        {
+                            "code": "171",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "70461-0201-01",
+                    "target": [
+                        {
+                            "code": "171",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "70461-0301-10",
+                    "target": [
+                        {
+                            "code": "186",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "70461-0318-03",
+                    "target": [
+                        {
+                            "code": "171",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "70461-0418-10",
+                    "target": [
+                        {
+                            "code": "186",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "76420-0482-01",
+                    "target": [
+                        {
+                            "code": "150",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "76420-0483-01",
+                    "target": [
+                        {
+                            "code": "150",
+                            "equivalence": "wider"
+                        }
+                    ]
+                },
+                {
+                    "code": "63361-0245-10",
+                    "target": [
+                        {
+                            "code": "146",
+                            "equivalence": "wider"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ImplementationGuide-hl7.fhir.us.core.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ImplementationGuide-hl7.fhir.us.core.json
@@ -1,4529 +1,4529 @@
 {
-	"resourceType": "ImplementationGuide",
-	"id": "hl7.fhir.us.core",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>USCore</h2><p>The official URL for this implementation guide is: </p><pre>http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core</pre></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core",
-	"version": "3.1.1",
-	"name": "USCore",
-	"title": "US Core",
-	"status": "active",
-	"date": "2020-08-28T10:54:27+10:00",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"packageId": "hl7.fhir.us.core",
-	"license": "CC0-1.0",
-	"fhirVersion": [
-		"4.0.1"
-	],
-	"definition": {
-		"grouping": [
-			{
-				"name": "base"
-			}
-		],
-		"resource": [
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-glucose.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-glucose"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Procedure"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Procedure-rehab.html"
-					}
-				],
-				"reference": {
-					"reference": "Procedure/rehab"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CareTeam"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "CareTeam-example.html"
-					}
-				],
-				"reference": {
-					"reference": "CareTeam/example"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-leukocyte-esterase.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-leukocyte-esterase"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Bundle"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Bundle-66c8856b-ba11-4876-8aa8-467aad8c11a2.html"
-					}
-				],
-				"reference": {
-					"reference": "Bundle/66c8856b-ba11-4876-8aa8-467aad8c11a2"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-bilirubin.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-bilirubin"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Condition"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Condition-hc1.html"
-					}
-				],
-				"reference": {
-					"reference": "Condition/hc1"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-sediment.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-sediment"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Immunization"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Immunization-imm-1.html"
-					}
-				],
-				"reference": {
-					"reference": "Immunization/imm-1"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-pediatric-wt-example.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/pediatric-wt-example"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Organization"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Organization-saint-luke-w-endpoint.html"
-					}
-				],
-				"reference": {
-					"reference": "Organization/saint-luke-w-endpoint"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-ph.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-ph"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Encounter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Encounter-example-1.html"
-					}
-				],
-				"reference": {
-					"reference": "Encounter/example-1"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "DiagnosticReport"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "DiagnosticReport-chest-xray-report.html"
-					}
-				],
-				"reference": {
-					"reference": "DiagnosticReport/chest-xray-report"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-serum-sodium.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/serum-sodium"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "DiagnosticReport"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "DiagnosticReport-cbc.html"
-					}
-				],
-				"reference": {
-					"reference": "DiagnosticReport/cbc"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-serum-potassium.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/serum-potassium"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Encounter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Encounter-1036.html"
-					}
-				],
-				"reference": {
-					"reference": "Encounter/1036"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-some-day-smoker.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/some-day-smoker"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Location"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Location-hl7east.html"
-					}
-				],
-				"reference": {
-					"reference": "Location/hl7east"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-serum-co2.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/serum-co2"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-protein.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-protein"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Procedure"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Procedure-defib-implant.html"
-					}
-				],
-				"reference": {
-					"reference": "Procedure/defib-implant"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-usg.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/usg"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-serum-chloride.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/serum-chloride"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-serum-calcium.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/serum-calcium"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-color.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-color"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-bp-data-absent.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/bp-data-absent"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Patient"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Patient-example.html"
-					}
-				],
-				"reference": {
-					"reference": "Patient/example"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Patient"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Patient-child-example.html"
-					}
-				],
-				"reference": {
-					"reference": "Patient/child-example"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Patient"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Patient-infant-example.html"
-					}
-				],
-				"reference": {
-					"reference": "Patient/infant-example"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-temperature.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/temperature"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-bmi.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/bmi"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Medication"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Medication-uscore-med2.html"
-					}
-				],
-				"reference": {
-					"reference": "Medication/uscore-med2"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-cells.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-cells"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-length.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/length"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Device"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Device-udi-2.html"
-					}
-				],
-				"reference": {
-					"reference": "Device/udi-2"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "MedicationRequest"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "MedicationRequest-uscore-mo1.html"
-					}
-				],
-				"reference": {
-					"reference": "MedicationRequest/uscore-mo1"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Practitioner"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Practitioner-practitioner-2.html"
-					}
-				],
-				"reference": {
-					"reference": "Practitioner/practitioner-2"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Goal"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Goal-goal-1.html"
-					}
-				],
-				"reference": {
-					"reference": "Goal/goal-1"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-rbcs.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-rbcs"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urobilinogen.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urobilinogen"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Medication"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Medication-uscore-med1.html"
-					}
-				],
-				"reference": {
-					"reference": "Medication/uscore-med1"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-bacteria.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-bacteria"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Bundle"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Bundle-uscore-mo3.html"
-					}
-				],
-				"reference": {
-					"reference": "Bundle/uscore-mo3"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-ofc-percentile.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/ofc-percentile"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "MedicationRequest"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "MedicationRequest-self-tylenol.html"
-					}
-				],
-				"reference": {
-					"reference": "MedicationRequest/self-tylenol"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "DiagnosticReport"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "DiagnosticReport-metabolic-panel.html"
-					}
-				],
-				"reference": {
-					"reference": "DiagnosticReport/metabolic-panel"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Device"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Device-udi-3.html"
-					}
-				],
-				"reference": {
-					"reference": "Device/udi-3"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "MedicationRequest"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "MedicationRequest-uscore-mo2.html"
-					}
-				],
-				"reference": {
-					"reference": "MedicationRequest/uscore-mo2"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Bundle"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Bundle-c887e62f-6166-419f-8268-b5ecd6c7b901.html"
-					}
-				],
-				"reference": {
-					"reference": "Bundle/c887e62f-6166-419f-8268-b5ecd6c7b901"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-bun.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/bun"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Practitioner"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Practitioner-practitioner-1.html"
-					}
-				],
-				"reference": {
-					"reference": "Practitioner/practitioner-1"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-neutrophils.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/neutrophils"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-nitrite.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-nitrite"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-oxygen-saturation.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/oxygen-saturation"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "DiagnosticReport"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "DiagnosticReport-cardiology-report.html"
-					}
-				],
-				"reference": {
-					"reference": "DiagnosticReport/cardiology-report"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-vitals-panel.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/vitals-panel"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-blood-pressure.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/blood-pressure"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-wbcs.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-wbcs"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-height.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/height"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Organization"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Organization-acme-lab.html"
-					}
-				],
-				"reference": {
-					"reference": "Organization/acme-lab"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Device"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Device-udi-1.html"
-					}
-				],
-				"reference": {
-					"reference": "Device/udi-1"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-hemoglobin.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/hemoglobin"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "DocumentReference"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "DocumentReference-episode-summary.html"
-					}
-				],
-				"reference": {
-					"reference": "DocumentReference/episode-summary"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-hemoglobin.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-hemoglobin"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-heart-rate.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/heart-rate"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-epi-cells.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-epi-cells"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "AllergyIntolerance"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "AllergyIntolerance-example.html"
-					}
-				],
-				"reference": {
-					"reference": "AllergyIntolerance/example"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-blood-glucose.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/blood-glucose"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "DiagnosticReport"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "DiagnosticReport-urinalysis.html"
-					}
-				],
-				"reference": {
-					"reference": "DiagnosticReport/urinalysis"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Condition"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Condition-example.html"
-					}
-				],
-				"reference": {
-					"reference": "Condition/example"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-serum-creatinine.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/serum-creatinine"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-satO2-fiO2.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/satO2-fiO2"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-serum-total-bilirubin.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/serum-total-bilirubin"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-pediatric-bmi-example.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/pediatric-bmi-example"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Organization"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Organization-example-organization-2.html"
-					}
-				],
-				"reference": {
-					"reference": "Organization/example-organization-2"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-weight.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/weight"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-mchc.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/mchc"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-clarity.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-clarity"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CarePlan"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "CarePlan-colonoscopy.html"
-					}
-				],
-				"reference": {
-					"reference": "CarePlan/colonoscopy"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-erythrocytes.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/erythrocytes"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-ketone.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-ketone"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-respiratory-rate.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/respiratory-rate"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-medication-codes.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-medication-codes"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-immunization.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-immunization"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-location-address-state.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-location-address-state"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-practitionerrole-practitioner.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-practitionerrole-practitioner"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-observation-smokingstatus.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-observation-smokingstatus"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-observation-smokingstatus-max.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-observation-smokingstatus-max"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-omb-race-category.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/omb-race-category"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-practitionerrole.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-practitionerrole"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-allergy-substance.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-allergy-substance"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-narrative-status.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-narrative-status"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CodeSystem"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "CodeSystem-cdcrec.html"
-					}
-				],
-				"reference": {
-					"reference": "CodeSystem/cdcrec"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-organization-name.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-organization-name"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-observation-lab.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-observation-lab"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-diagnosticreport-code.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-diagnosticreport-code"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-pediatric-bmi-for-age.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/pediatric-bmi-for-age"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-head-occipital-frontal-circumference-percentile.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/head-occipital-frontal-circumference-percentile"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-allergyintolerance.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-allergyintolerance"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-goal-lifecycle-status.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-goal-lifecycle-status"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-procedure-code.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-procedure-code"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-documentreference-type.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-documentreference-type"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-provenance-participant-type.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-provenance-participant-type"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-patient-gender.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-patient-gender"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-practitioner.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-practitioner"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-diagnosticreport-note.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-diagnosticreport-note"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-omb-ethnicity-category.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/omb-ethnicity-category"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-provenance.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-provenance"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "OperationDefinition"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "OperationDefinition-docref.html"
-					}
-				],
-				"reference": {
-					"reference": "OperationDefinition/docref"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-condition-clinical-status.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-condition-clinical-status"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:extension"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-birthsex.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-birthsex"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-documentreference-id.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-documentreference-id"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-careplan-category.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-careplan-category"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-encounter-class.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-encounter-class"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-medicationrequest-patient.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-medicationrequest-patient"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CapabilityStatement"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "CapabilityStatement-us-core-server.html"
-					}
-				],
-				"reference": {
-					"reference": "CapabilityStatement/us-core-server"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-condition-category.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-condition-category"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-detailed-ethnicity.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/detailed-ethnicity"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-documentreference-patient.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-documentreference-patient"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-encounter.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-encounter"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-ndc-vaccine-codes.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-ndc-vaccine-codes"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-patient.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-patient"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-diagnosticreport-date.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-diagnosticreport-date"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-procedure-icd10pcs.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-procedure-icd10pcs"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-provider-specialty.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-provider-specialty"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-procedure-date.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-procedure-date"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-vaccines-cvx.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-vaccines-cvx"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-pulse-oximetry.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-pulse-oximetry"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-allergyintolerance-clinical-status.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-allergyintolerance-clinical-status"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-documentreference-date.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-documentreference-date"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-medicationrequest-intent.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-medicationrequest-intent"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-location.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-location"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-location-address.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-location-address"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-observation-smoking-status-status.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-observation-smoking-status-status"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-usps-state.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-usps-state"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-practitioner-name.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-practitioner-name"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-encounter-type.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-encounter-type"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-documentreference-period.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-documentreference-period"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-observation-code.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-observation-code"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-location-name.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-location-name"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-condition-onset-date.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-condition-onset-date"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-patient-given.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-patient-given"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-procedure.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-procedure"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-encounter-type.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-encounter-type"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-condition-code.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-condition-code"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CodeSystem"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "CodeSystem-condition-category.html"
-					}
-				],
-				"reference": {
-					"reference": "CodeSystem/condition-category"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-medicationrequest-encounter.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-medicationrequest-encounter"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-encounter-patient.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-encounter-patient"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-organization-address.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-organization-address"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-observation-category.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-observation-category"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-medication.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-medication"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-diagnosticreport-status.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-diagnosticreport-status"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-observation-date.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-observation-date"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-birthsex.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/birthsex"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-diagnosticreport-category.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-diagnosticreport-category"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-observation-status.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-observation-status"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-diagnosticreport-report-and-note-codes.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-diagnosticreport-report-and-note-codes"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-provider-role.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-provider-role"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-ethnicity.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-ethnicity"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-documentreference.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-documentreference"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:extension"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-direct.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-direct"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-smoking-status-observation-codes.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-smoking-status-observation-codes"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-careteam-provider-roles.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-careteam-provider-roles"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-documentreference-type.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-documentreference-type"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-encounter-date.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-encounter-date"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-diagnosticreport-category.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-diagnosticreport-category"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-patient-birthdate.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-patient-birthdate"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-careteam.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-careteam"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-procedure-status.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-procedure-status"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-clinical-note-type.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-clinical-note-type"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-encounter-status.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-encounter-status"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ConceptMap"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ConceptMap-ndc-cvx.html"
-					}
-				],
-				"reference": {
-					"reference": "ConceptMap/ndc-cvx"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:extension"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-ethnicity.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-ethnicity"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-careplan-status.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-careplan-status"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-careplan.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-careplan"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-condition-patient.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-condition-patient"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-allergyintolerance-patient.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-allergyintolerance-patient"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-device-patient.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-device-patient"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-condition-code.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-condition-code"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-observation-patient.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-observation-patient"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-race.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-race"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-careplan-patient.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-careplan-patient"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-patient-family.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-patient-family"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-smokingstatus.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-smokingstatus"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-medicationrequest-status.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-medicationrequest-status"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:extension"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-race.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-race"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-location-address-postalcode.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-location-address-postalcode"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-encounter-id.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-encounter-id"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-medicationrequest-authoredon.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-medicationrequest-authoredon"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-documentreference-status.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-documentreference-status"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-documentreference-category.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-documentreference-category"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-procedure-patient.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-procedure-patient"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-goal-target-date.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-goal-target-date"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-diagnosticreport-patient.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-diagnosticreport-patient"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-careplan-date.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-careplan-date"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-careteam-patient.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-careteam-patient"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-organization.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-organization"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-immunization-date.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-immunization-date"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-encounter-identifier.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-encounter-identifier"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-practitionerrole-specialty.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-practitionerrole-specialty"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-patient-name.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-patient-name"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-device-type.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-device-type"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-procedure-code.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-procedure-code"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-diagnosticreport-lab.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-diagnosticreport-lab"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-goal-patient.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-goal-patient"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-simple-language.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/simple-language"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-immunization-patient.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-immunization-patient"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-condition.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-condition"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-pediatric-weight-for-height.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/pediatric-weight-for-height"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-observation-value-codes.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-observation-value-codes"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-patient-id.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-patient-id"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-location-address-city.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-location-address-city"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-goal.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-goal"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-careteam-status.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-careteam-status"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CodeSystem"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "CodeSystem-us-core-documentreference-category.html"
-					}
-				],
-				"reference": {
-					"reference": "CodeSystem/us-core-documentreference-category"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CodeSystem"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "CodeSystem-us-core-provenance-participant-type.html"
-					}
-				],
-				"reference": {
-					"reference": "CodeSystem/us-core-provenance-participant-type"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-diagnosticreport-lab-codes.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-diagnosticreport-lab-codes"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CodeSystem"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "CodeSystem-careplan-category.html"
-					}
-				],
-				"reference": {
-					"reference": "CodeSystem/careplan-category"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-documentreference-category.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-documentreference-category"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CapabilityStatement"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "CapabilityStatement-us-core-client.html"
-					}
-				],
-				"reference": {
-					"reference": "CapabilityStatement/us-core-client"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-practitioner-identifier.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-practitioner-identifier"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-patient-identifier.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-patient-identifier"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-condition-category.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-condition-category"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-immunization-status.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-immunization-status"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-medicationrequest.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-medicationrequest"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-implantable-device.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-implantable-device"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-detailed-race.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/detailed-race"
-				},
-				"exampleBoolean": false
-			}
-		],
-		"page": {
-			"nameUrl": "index.html",
-			"title": "Home",
-			"generation": "markdown",
-			"page": [
-				{
-					"nameUrl": "guidance.html",
-					"title": "Guidance",
-					"generation": "markdown",
-					"page": [
-						{
-							"nameUrl": "general-guidance.html",
-							"title": "General Guidance",
-							"generation": "markdown"
-						},
-						{
-							"nameUrl": "clinical-notes-guidance.html",
-							"title": "Clinical Notes Guidance",
-							"generation": "markdown"
-						},
-						{
-							"nameUrl": "all-meds.html",
-							"title": "Medication List Guidance",
-							"generation": "markdown"
-						},
-						{
-							"nameUrl": "basic-provenance.html",
-							"title": "Basic Provenance",
-							"generation": "markdown"
-						},
-						{
-							"nameUrl": "r2-r4-guidance.html",
-							"title": "DSTU2 to R4 Conversion",
-							"generation": "markdown"
-						},
-						{
-							"nameUrl": "future-of-us-core.html",
-							"title": "Future of US Core",
-							"generation": "markdown"
-						}
-					]
-				},
-				{
-					"nameUrl": "profiles.html",
-					"title": "Profiles and Extensions",
-					"generation": "markdown",
-					"page": [
-						{
-							"nameUrl": "StructureDefinition-us-core-immunization.html",
-							"title": "StructureDefinition US Core Immunization",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-practitionerrole.html",
-							"title": "StructureDefinition US Core PractitionerRole",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-observation-lab.html",
-							"title": "StructureDefinition US Core Observation Lab",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-pediatric-bmi-for-age.html",
-							"title": "StructureDefinition Pediatric BMI For Age",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-head-occipital-frontal-circumference-percentile.html",
-							"title": "StructureDefinition Pediatric Head Occipital-frontal Circumference Percentile",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-allergyintolerance.html",
-							"title": "StructureDefinition US Core AllergyIntolerance",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-practitioner.html",
-							"title": "StructureDefinition US Core Practitioner",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-diagnosticreport-note.html",
-							"title": "StructureDefinition US Core DiagnosticReport Note",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-provenance.html",
-							"title": "StructureDefinition US Core Provenance",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-birthsex.html",
-							"title": "StructureDefinition US Core Birthsex",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-encounter.html",
-							"title": "StructureDefinition US Core Encounter",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-patient.html",
-							"title": "StructureDefinition US Core Patient",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-pulse-oximetry.html",
-							"title": "StructureDefinition US Core Pulse Oximetry",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-location.html",
-							"title": "StructureDefinition US Core Location",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-procedure.html",
-							"title": "StructureDefinition US Core Procedure",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-medication.html",
-							"title": "StructureDefinition US Core Medication",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-documentreference.html",
-							"title": "StructureDefinition US Core DocumentReference",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-direct.html",
-							"title": "StructureDefinition US Core Direct",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-careteam.html",
-							"title": "StructureDefinition US Core CareTeam",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-ethnicity.html",
-							"title": "StructureDefinition US Core Ethnicity",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-careplan.html",
-							"title": "StructureDefinition US Core CarePlan",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-smokingstatus.html",
-							"title": "StructureDefinition US Core Smokingstatus",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-race.html",
-							"title": "StructureDefinition US Core Race",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-organization.html",
-							"title": "StructureDefinition US Core Organization",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-diagnosticreport-lab.html",
-							"title": "StructureDefinition US Core DiagnosticReport Lab",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-condition.html",
-							"title": "StructureDefinition US Core Condition",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-pediatric-weight-for-height.html",
-							"title": "StructureDefinition Pediatric Weight For Height",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-goal.html",
-							"title": "StructureDefinition US Core Goal",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-medicationrequest.html",
-							"title": "StructureDefinition US Core MedicationRequest",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-implantable-device.html",
-							"title": "StructureDefinition US Core Implantable Device",
-							"generation": "generated"
-						}
-					]
-				},
-				{
-					"nameUrl": "operations.html",
-					"title": "Operations",
-					"generation": "markdown",
-					"page": [
-						{
-							"nameUrl": "OperationDefinition-docref.html",
-							"title": "OperationDefinition Docref",
-							"generation": "generated"
-						}
-					]
-				},
-				{
-					"nameUrl": "terminology.html",
-					"title": "Terminology",
-					"generation": "markdown",
-					"page": [
-						{
-							"nameUrl": "ValueSet-us-core-medication-codes.html",
-							"title": "ValueSet US Core Medication Codes",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-observation-smokingstatus.html",
-							"title": "ValueSet US Core Observation Smokingstatus Preferred",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-observation-smokingstatus-max.html",
-							"title": "ValueSet US Core Observation Smokingstatus Max-Binding",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-omb-race-category.html",
-							"title": "ValueSet Omb Race Category",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-allergy-substance.html",
-							"title": "ValueSet US Core Allergy Substance",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-narrative-status.html",
-							"title": "ValueSet US Core Narrative Status",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-documentreference-type.html",
-							"title": "ValueSet US Core DocumentReference Type",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-omb-ethnicity-category.html",
-							"title": "ValueSet Omb Ethnicity Category",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-condition-category.html",
-							"title": "ValueSet US Core Condition Category",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-detailed-ethnicity.html",
-							"title": "ValueSet Detailed Ethnicity",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-ndc-vaccine-codes.html",
-							"title": "ValueSet US Core Ndc Vaccine Codes",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-procedure-icd10pcs.html",
-							"title": "ValueSet US Core Procedure Icd10pcs",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-provider-specialty.html",
-							"title": "ValueSet US Core Provider Specialty",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-vaccines-cvx.html",
-							"title": "ValueSet US Core Vaccines Cvx",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-observation-smoking-status-status.html",
-							"title": "ValueSet US Core Observation SmokingStatus Status",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-usps-state.html",
-							"title": "ValueSet US Core Usps State",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-encounter-type.html",
-							"title": "ValueSet US Core Encounter Type",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-condition-code.html",
-							"title": "ValueSet US Core Condition Code",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-birthsex.html",
-							"title": "ValueSet Birthsex",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-diagnosticreport-report-and-note-codes.html",
-							"title": "ValueSet US Core DiagnosticReport Report And Note Codes",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-provider-role.html",
-							"title": "ValueSet US Core Provider Role",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-smoking-status-observation-codes.html",
-							"title": "ValueSet US Core Smoking Status Observation Codes",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-careteam-provider-roles.html",
-							"title": "ValueSet US Core CareTeam Provider Roles",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-diagnosticreport-category.html",
-							"title": "ValueSet US Core DiagnosticReport Category",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-clinical-note-type.html",
-							"title": "ValueSet US Core Clinical Note Type",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-documentreference-category.html",
-							"title": "ValueSet US Core DocumentReference Category",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-procedure-code.html",
-							"title": "ValueSet US Core Procedure Code",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-simple-language.html",
-							"title": "ValueSet Simple Language",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-observation-value-codes.html",
-							"title": "ValueSet US Core Observation Value Codes",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-diagnosticreport-lab-codes.html",
-							"title": "ValueSet US Core DiagnosticReport Lab Codes",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-detailed-race.html",
-							"title": "ValueSet Detailed Race",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "CodeSystem-cdcrec.html",
-							"title": "CodeSystem Cdcrec",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "CodeSystem-condition-category.html",
-							"title": "CodeSystem Condition Category",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "CodeSystem-us-core-documentreference-category.html",
-							"title": "CodeSystem US Core DocumentReference Category",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "CodeSystem-careplan-category.html",
-							"title": "CodeSystem CarePlan Category",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ConceptMap-ndc-cvx.html",
-							"title": "ConceptMap Ndc Cvx",
-							"generation": "generated"
-						}
-					]
-				},
-				{
-					"nameUrl": "searchparameters.html",
-					"title": "Search Parameters",
-					"generation": "markdown",
-					"page": [
-						{
-							"nameUrl": "SearchParameter-us-core-location-address-state.html",
-							"title": "SearchParameter US Core Location Address State",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-practitionerrole-practitioner.html",
-							"title": "SearchParameter US Core PractitionerRole Practitioner",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-organization-name.html",
-							"title": "SearchParameter US Core Organization Name",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-diagnosticreport-code.html",
-							"title": "SearchParameter US Core DiagnosticReport Code",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-goal-lifecycle-status.html",
-							"title": "SearchParameter US Core Goal Lifecycle Status",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-procedure-code.html",
-							"title": "SearchParameter US Core Procedure Code",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-patient-gender.html",
-							"title": "SearchParameter US Core Patient Gender",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-condition-clinical-status.html",
-							"title": "SearchParameter US Core Condition Clinical Status",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-documentreference-id.html",
-							"title": "SearchParameter US Core DocumentReference Id",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-careplan-category.html",
-							"title": "SearchParameter US Core CarePlan Category",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-encounter-class.html",
-							"title": "SearchParameter US Core Encounter Class",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-medicationrequest-patient.html",
-							"title": "SearchParameter US Core MedicationRequest Patient",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-documentreference-patient.html",
-							"title": "SearchParameter US Core DocumentReference Patient",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-diagnosticreport-date.html",
-							"title": "SearchParameter US Core DiagnosticReport Date",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-procedure-date.html",
-							"title": "SearchParameter US Core Procedure Date",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-allergyintolerance-clinical-status.html",
-							"title": "SearchParameter US Core AllergyIntolerance Clinical Status",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-documentreference-date.html",
-							"title": "SearchParameter US Core DocumentReference Date",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-medicationrequest-intent.html",
-							"title": "SearchParameter US Core MedicationRequest Intent",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-location-address.html",
-							"title": "SearchParameter US Core Location Address",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-practitioner-name.html",
-							"title": "SearchParameter US Core Practitioner Name",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-documentreference-period.html",
-							"title": "SearchParameter US Core DocumentReference Period",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-observation-code.html",
-							"title": "SearchParameter US Core Observation Code",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-location-name.html",
-							"title": "SearchParameter US Core Location Name",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-condition-onset-date.html",
-							"title": "SearchParameter US Core Condition Onset Date",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-patient-given.html",
-							"title": "SearchParameter US Core Patient Given",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-encounter-type.html",
-							"title": "SearchParameter US Core Encounter Type",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-medicationrequest-encounter.html",
-							"title": "SearchParameter US Core MedicationRequest Encounter",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-encounter-patient.html",
-							"title": "SearchParameter US Core Encounter Patient",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-organization-address.html",
-							"title": "SearchParameter US Core Organization Address",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-observation-category.html",
-							"title": "SearchParameter US Core Observation Category",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-diagnosticreport-status.html",
-							"title": "SearchParameter US Core DiagnosticReport Status",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-observation-date.html",
-							"title": "SearchParameter US Core Observation Date",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-diagnosticreport-category.html",
-							"title": "SearchParameter US Core DiagnosticReport Category",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-observation-status.html",
-							"title": "SearchParameter US Core Observation Status",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-ethnicity.html",
-							"title": "SearchParameter US Core Ethnicity",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-documentreference-type.html",
-							"title": "SearchParameter US Core DocumentReference Type",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-encounter-date.html",
-							"title": "SearchParameter US Core Encounter Date",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-patient-birthdate.html",
-							"title": "SearchParameter US Core Patient Birthdate",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-procedure-status.html",
-							"title": "SearchParameter US Core Procedure Status",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-encounter-status.html",
-							"title": "SearchParameter US Core Encounter Status",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-careplan-status.html",
-							"title": "SearchParameter US Core CarePlan Status",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-condition-patient.html",
-							"title": "SearchParameter US Core Condition Patient",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-allergyintolerance-patient.html",
-							"title": "SearchParameter US Core AllergyIntolerance Patient",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-device-patient.html",
-							"title": "SearchParameter US Core Device Patient",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-condition-code.html",
-							"title": "SearchParameter US Core Condition Code",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-observation-patient.html",
-							"title": "SearchParameter US Core Observation Patient",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-race.html",
-							"title": "SearchParameter US Core Race",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-careplan-patient.html",
-							"title": "SearchParameter US Core CarePlan Patient",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-patient-family.html",
-							"title": "SearchParameter US Core Patient Family",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-medicationrequest-status.html",
-							"title": "SearchParameter US Core MedicationRequest Status",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-location-address-postalcode.html",
-							"title": "SearchParameter US Core Location Address Postalcode",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-encounter-id.html",
-							"title": "SearchParameter US Core Encounter Id",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-medicationrequest-authoredon.html",
-							"title": "SearchParameter US Core MedicationRequest Authoredon",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-documentreference-status.html",
-							"title": "SearchParameter US Core DocumentReference Status",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-procedure-patient.html",
-							"title": "SearchParameter US Core Procedure Patient",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-goal-target-date.html",
-							"title": "SearchParameter US Core Goal Target Date",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-diagnosticreport-patient.html",
-							"title": "SearchParameter US Core DiagnosticReport Patient",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-careplan-date.html",
-							"title": "SearchParameter US Core CarePlan Date",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-careteam-patient.html",
-							"title": "SearchParameter US Core CareTeam Patient",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-immunization-date.html",
-							"title": "SearchParameter US Core Immunization Date",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-encounter-identifier.html",
-							"title": "SearchParameter US Core Encounter Identifier",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-practitionerrole-specialty.html",
-							"title": "SearchParameter US Core PractitionerRole Specialty",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-patient-name.html",
-							"title": "SearchParameter US Core Patient Name",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-device-type.html",
-							"title": "SearchParameter US Core Device Type",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-goal-patient.html",
-							"title": "SearchParameter US Core Goal Patient",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-immunization-patient.html",
-							"title": "SearchParameter US Core Immunization Patient",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-patient-id.html",
-							"title": "SearchParameter US Core Patient Id",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-location-address-city.html",
-							"title": "SearchParameter US Core Location Address City",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-careteam-status.html",
-							"title": "SearchParameter US Core CareTeam Status",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-documentreference-category.html",
-							"title": "SearchParameter US Core DocumentReference Category",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-practitioner-identifier.html",
-							"title": "SearchParameter US Core Practitioner Identifier",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-patient-identifier.html",
-							"title": "SearchParameter US Core Patient Identifier",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-condition-category.html",
-							"title": "SearchParameter US Core Condition Category",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-immunization-status.html",
-							"title": "SearchParameter US Core Immunization Status",
-							"generation": "generated"
-						}
-					]
-				},
-				{
-					"nameUrl": "capstatements.html",
-					"title": "Capability Statements",
-					"generation": "markdown",
-					"page": [
-						{
-							"nameUrl": "CapabilityStatement-us-core-server.html",
-							"title": "CapabilityStatement US Core Server",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "CapabilityStatement-us-core-client.html",
-							"title": "CapabilityStatement US Core Client",
-							"generation": "generated"
-						}
-					]
-				},
-				{
-					"nameUrl": "security.html",
-					"title": "Security",
-					"generation": "markdown"
-				},
-				{
-					"nameUrl": "downloads.html",
-					"title": "Downloads",
-					"generation": "markdown"
-				},
-				{
-					"nameUrl": "all-examples.html",
-					"title": "All Examples",
-					"generation": "markdown"
-				},
-				{
-					"nameUrl": "toc.html",
-					"title": "Table of Contents",
-					"generation": "html"
-				}
-			]
-		}
-	}
+    "resourceType": "ImplementationGuide",
+    "id": "hl7.fhir.us.core",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core",
+    "version": "3.1.1",
+    "name": "USCore",
+    "title": "US Core",
+    "status": "active",
+    "date": "2020-08-28T10:54:27+10:00",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "packageId": "hl7.fhir.us.core",
+    "license": "CC0-1.0",
+    "fhirVersion": [
+        "4.0.1"
+    ],
+    "definition": {
+        "grouping": [
+            {
+                "name": "base"
+            }
+        ],
+        "resource": [
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-glucose.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-glucose"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Procedure"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Procedure-rehab.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Procedure/rehab"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CareTeam"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "CareTeam-example.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "CareTeam/example"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-leukocyte-esterase.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-leukocyte-esterase"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Bundle"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Bundle-66c8856b-ba11-4876-8aa8-467aad8c11a2.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Bundle/66c8856b-ba11-4876-8aa8-467aad8c11a2"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-bilirubin.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-bilirubin"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Condition"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Condition-hc1.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Condition/hc1"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-sediment.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-sediment"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Immunization"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Immunization-imm-1.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Immunization/imm-1"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-pediatric-wt-example.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/pediatric-wt-example"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Organization"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Organization-saint-luke-w-endpoint.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Organization/saint-luke-w-endpoint"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-ph.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-ph"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Encounter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Encounter-example-1.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Encounter/example-1"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "DiagnosticReport"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "DiagnosticReport-chest-xray-report.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "DiagnosticReport/chest-xray-report"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-serum-sodium.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/serum-sodium"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "DiagnosticReport"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "DiagnosticReport-cbc.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "DiagnosticReport/cbc"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-serum-potassium.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/serum-potassium"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Encounter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Encounter-1036.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Encounter/1036"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-some-day-smoker.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/some-day-smoker"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Location"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Location-hl7east.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Location/hl7east"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-serum-co2.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/serum-co2"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-protein.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-protein"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Procedure"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Procedure-defib-implant.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Procedure/defib-implant"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-usg.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/usg"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-serum-chloride.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/serum-chloride"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-serum-calcium.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/serum-calcium"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-color.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-color"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-bp-data-absent.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/bp-data-absent"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Patient"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Patient-example.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Patient/example"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Patient"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Patient-child-example.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Patient/child-example"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Patient"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Patient-infant-example.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Patient/infant-example"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-temperature.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/temperature"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-bmi.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/bmi"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Medication"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Medication-uscore-med2.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Medication/uscore-med2"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-cells.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-cells"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-length.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/length"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Device"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Device-udi-2.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Device/udi-2"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "MedicationRequest"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "MedicationRequest-uscore-mo1.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "MedicationRequest/uscore-mo1"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Practitioner"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Practitioner-practitioner-2.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Practitioner/practitioner-2"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Goal"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Goal-goal-1.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Goal/goal-1"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-rbcs.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-rbcs"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urobilinogen.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urobilinogen"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Medication"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Medication-uscore-med1.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Medication/uscore-med1"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-bacteria.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-bacteria"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Bundle"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Bundle-uscore-mo3.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Bundle/uscore-mo3"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-ofc-percentile.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/ofc-percentile"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "MedicationRequest"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "MedicationRequest-self-tylenol.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "MedicationRequest/self-tylenol"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "DiagnosticReport"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "DiagnosticReport-metabolic-panel.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "DiagnosticReport/metabolic-panel"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Device"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Device-udi-3.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Device/udi-3"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "MedicationRequest"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "MedicationRequest-uscore-mo2.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "MedicationRequest/uscore-mo2"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Bundle"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Bundle-c887e62f-6166-419f-8268-b5ecd6c7b901.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Bundle/c887e62f-6166-419f-8268-b5ecd6c7b901"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-bun.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/bun"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Practitioner"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Practitioner-practitioner-1.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Practitioner/practitioner-1"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-neutrophils.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/neutrophils"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-nitrite.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-nitrite"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-oxygen-saturation.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/oxygen-saturation"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "DiagnosticReport"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "DiagnosticReport-cardiology-report.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "DiagnosticReport/cardiology-report"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-vitals-panel.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/vitals-panel"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-blood-pressure.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/blood-pressure"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-wbcs.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-wbcs"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-height.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/height"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Organization"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Organization-acme-lab.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Organization/acme-lab"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Device"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Device-udi-1.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Device/udi-1"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-hemoglobin.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/hemoglobin"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "DocumentReference"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "DocumentReference-episode-summary.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "DocumentReference/episode-summary"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-hemoglobin.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-hemoglobin"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-heart-rate.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/heart-rate"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-epi-cells.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-epi-cells"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "AllergyIntolerance"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "AllergyIntolerance-example.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "AllergyIntolerance/example"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-blood-glucose.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/blood-glucose"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "DiagnosticReport"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "DiagnosticReport-urinalysis.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "DiagnosticReport/urinalysis"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Condition"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Condition-example.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Condition/example"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-serum-creatinine.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/serum-creatinine"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-satO2-fiO2.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/satO2-fiO2"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-serum-total-bilirubin.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/serum-total-bilirubin"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-pediatric-bmi-example.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/pediatric-bmi-example"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Organization"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Organization-example-organization-2.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Organization/example-organization-2"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-weight.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/weight"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-mchc.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/mchc"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-clarity.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-clarity"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CarePlan"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "CarePlan-colonoscopy.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "CarePlan/colonoscopy"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-erythrocytes.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/erythrocytes"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-ketone.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-ketone"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-respiratory-rate.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/respiratory-rate"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-medication-codes.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-medication-codes"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-immunization.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-immunization"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-location-address-state.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-location-address-state"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-practitionerrole-practitioner.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-practitionerrole-practitioner"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-observation-smokingstatus.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-observation-smokingstatus"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-observation-smokingstatus-max.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-observation-smokingstatus-max"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-omb-race-category.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/omb-race-category"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-practitionerrole.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-practitionerrole"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-allergy-substance.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-allergy-substance"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-narrative-status.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-narrative-status"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CodeSystem"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "CodeSystem-cdcrec.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "CodeSystem/cdcrec"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-organization-name.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-organization-name"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-observation-lab.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-observation-lab"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-diagnosticreport-code.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-diagnosticreport-code"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-pediatric-bmi-for-age.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/pediatric-bmi-for-age"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-head-occipital-frontal-circumference-percentile.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/head-occipital-frontal-circumference-percentile"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-allergyintolerance.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-allergyintolerance"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-goal-lifecycle-status.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-goal-lifecycle-status"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-procedure-code.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-procedure-code"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-documentreference-type.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-documentreference-type"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-provenance-participant-type.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-provenance-participant-type"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-patient-gender.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-patient-gender"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-practitioner.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-practitioner"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-diagnosticreport-note.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-diagnosticreport-note"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-omb-ethnicity-category.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/omb-ethnicity-category"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-provenance.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-provenance"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "OperationDefinition"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "OperationDefinition-docref.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "OperationDefinition/docref"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-condition-clinical-status.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-condition-clinical-status"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:extension"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-birthsex.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-birthsex"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-documentreference-id.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-documentreference-id"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-careplan-category.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-careplan-category"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-encounter-class.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-encounter-class"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-medicationrequest-patient.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-medicationrequest-patient"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CapabilityStatement"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "CapabilityStatement-us-core-server.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "CapabilityStatement/us-core-server"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-condition-category.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-condition-category"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-detailed-ethnicity.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/detailed-ethnicity"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-documentreference-patient.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-documentreference-patient"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-encounter.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-encounter"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-ndc-vaccine-codes.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-ndc-vaccine-codes"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-patient.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-patient"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-diagnosticreport-date.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-diagnosticreport-date"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-procedure-icd10pcs.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-procedure-icd10pcs"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-provider-specialty.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-provider-specialty"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-procedure-date.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-procedure-date"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-vaccines-cvx.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-vaccines-cvx"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-pulse-oximetry.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-pulse-oximetry"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-allergyintolerance-clinical-status.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-allergyintolerance-clinical-status"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-documentreference-date.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-documentreference-date"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-medicationrequest-intent.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-medicationrequest-intent"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-location.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-location"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-location-address.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-location-address"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-observation-smoking-status-status.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-observation-smoking-status-status"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-usps-state.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-usps-state"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-practitioner-name.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-practitioner-name"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-encounter-type.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-encounter-type"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-documentreference-period.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-documentreference-period"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-observation-code.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-observation-code"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-location-name.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-location-name"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-condition-onset-date.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-condition-onset-date"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-patient-given.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-patient-given"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-procedure.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-procedure"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-encounter-type.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-encounter-type"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-condition-code.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-condition-code"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CodeSystem"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "CodeSystem-condition-category.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "CodeSystem/condition-category"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-medicationrequest-encounter.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-medicationrequest-encounter"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-encounter-patient.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-encounter-patient"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-organization-address.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-organization-address"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-observation-category.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-observation-category"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-medication.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-medication"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-diagnosticreport-status.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-diagnosticreport-status"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-observation-date.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-observation-date"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-birthsex.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/birthsex"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-diagnosticreport-category.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-diagnosticreport-category"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-observation-status.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-observation-status"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-diagnosticreport-report-and-note-codes.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-diagnosticreport-report-and-note-codes"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-provider-role.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-provider-role"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-ethnicity.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-ethnicity"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-documentreference.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-documentreference"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:extension"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-direct.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-direct"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-smoking-status-observation-codes.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-smoking-status-observation-codes"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-careteam-provider-roles.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-careteam-provider-roles"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-documentreference-type.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-documentreference-type"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-encounter-date.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-encounter-date"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-diagnosticreport-category.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-diagnosticreport-category"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-patient-birthdate.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-patient-birthdate"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-careteam.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-careteam"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-procedure-status.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-procedure-status"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-clinical-note-type.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-clinical-note-type"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-encounter-status.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-encounter-status"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ConceptMap"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ConceptMap-ndc-cvx.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ConceptMap/ndc-cvx"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:extension"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-ethnicity.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-ethnicity"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-careplan-status.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-careplan-status"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-careplan.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-careplan"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-condition-patient.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-condition-patient"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-allergyintolerance-patient.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-allergyintolerance-patient"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-device-patient.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-device-patient"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-condition-code.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-condition-code"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-observation-patient.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-observation-patient"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-race.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-race"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-careplan-patient.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-careplan-patient"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-patient-family.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-patient-family"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-smokingstatus.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-smokingstatus"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-medicationrequest-status.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-medicationrequest-status"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:extension"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-race.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-race"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-location-address-postalcode.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-location-address-postalcode"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-encounter-id.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-encounter-id"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-medicationrequest-authoredon.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-medicationrequest-authoredon"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-documentreference-status.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-documentreference-status"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-documentreference-category.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-documentreference-category"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-procedure-patient.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-procedure-patient"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-goal-target-date.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-goal-target-date"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-diagnosticreport-patient.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-diagnosticreport-patient"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-careplan-date.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-careplan-date"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-careteam-patient.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-careteam-patient"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-organization.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-organization"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-immunization-date.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-immunization-date"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-encounter-identifier.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-encounter-identifier"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-practitionerrole-specialty.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-practitionerrole-specialty"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-patient-name.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-patient-name"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-device-type.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-device-type"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-procedure-code.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-procedure-code"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-diagnosticreport-lab.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-diagnosticreport-lab"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-goal-patient.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-goal-patient"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-simple-language.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/simple-language"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-immunization-patient.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-immunization-patient"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-condition.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-condition"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-pediatric-weight-for-height.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/pediatric-weight-for-height"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-observation-value-codes.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-observation-value-codes"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-patient-id.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-patient-id"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-location-address-city.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-location-address-city"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-goal.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-goal"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-careteam-status.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-careteam-status"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CodeSystem"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "CodeSystem-us-core-documentreference-category.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "CodeSystem/us-core-documentreference-category"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CodeSystem"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "CodeSystem-us-core-provenance-participant-type.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "CodeSystem/us-core-provenance-participant-type"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-diagnosticreport-lab-codes.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-diagnosticreport-lab-codes"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CodeSystem"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "CodeSystem-careplan-category.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "CodeSystem/careplan-category"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-documentreference-category.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-documentreference-category"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CapabilityStatement"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "CapabilityStatement-us-core-client.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "CapabilityStatement/us-core-client"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-practitioner-identifier.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-practitioner-identifier"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-patient-identifier.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-patient-identifier"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-condition-category.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-condition-category"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-immunization-status.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-immunization-status"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-medicationrequest.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-medicationrequest"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-implantable-device.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-implantable-device"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-detailed-race.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/detailed-race"
+                },
+                "exampleBoolean": false
+            }
+        ],
+        "page": {
+            "nameUrl": "index.html",
+            "title": "Home",
+            "generation": "markdown",
+            "page": [
+                {
+                    "nameUrl": "guidance.html",
+                    "title": "Guidance",
+                    "generation": "markdown",
+                    "page": [
+                        {
+                            "nameUrl": "general-guidance.html",
+                            "title": "General Guidance",
+                            "generation": "markdown"
+                        },
+                        {
+                            "nameUrl": "clinical-notes-guidance.html",
+                            "title": "Clinical Notes Guidance",
+                            "generation": "markdown"
+                        },
+                        {
+                            "nameUrl": "all-meds.html",
+                            "title": "Medication List Guidance",
+                            "generation": "markdown"
+                        },
+                        {
+                            "nameUrl": "basic-provenance.html",
+                            "title": "Basic Provenance",
+                            "generation": "markdown"
+                        },
+                        {
+                            "nameUrl": "r2-r4-guidance.html",
+                            "title": "DSTU2 to R4 Conversion",
+                            "generation": "markdown"
+                        },
+                        {
+                            "nameUrl": "future-of-us-core.html",
+                            "title": "Future of US Core",
+                            "generation": "markdown"
+                        }
+                    ]
+                },
+                {
+                    "nameUrl": "profiles.html",
+                    "title": "Profiles and Extensions",
+                    "generation": "markdown",
+                    "page": [
+                        {
+                            "nameUrl": "StructureDefinition-us-core-immunization.html",
+                            "title": "StructureDefinition US Core Immunization",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-practitionerrole.html",
+                            "title": "StructureDefinition US Core PractitionerRole",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-observation-lab.html",
+                            "title": "StructureDefinition US Core Observation Lab",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-pediatric-bmi-for-age.html",
+                            "title": "StructureDefinition Pediatric BMI For Age",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-head-occipital-frontal-circumference-percentile.html",
+                            "title": "StructureDefinition Pediatric Head Occipital-frontal Circumference Percentile",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-allergyintolerance.html",
+                            "title": "StructureDefinition US Core AllergyIntolerance",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-practitioner.html",
+                            "title": "StructureDefinition US Core Practitioner",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-diagnosticreport-note.html",
+                            "title": "StructureDefinition US Core DiagnosticReport Note",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-provenance.html",
+                            "title": "StructureDefinition US Core Provenance",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-birthsex.html",
+                            "title": "StructureDefinition US Core Birthsex",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-encounter.html",
+                            "title": "StructureDefinition US Core Encounter",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-patient.html",
+                            "title": "StructureDefinition US Core Patient",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-pulse-oximetry.html",
+                            "title": "StructureDefinition US Core Pulse Oximetry",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-location.html",
+                            "title": "StructureDefinition US Core Location",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-procedure.html",
+                            "title": "StructureDefinition US Core Procedure",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-medication.html",
+                            "title": "StructureDefinition US Core Medication",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-documentreference.html",
+                            "title": "StructureDefinition US Core DocumentReference",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-direct.html",
+                            "title": "StructureDefinition US Core Direct",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-careteam.html",
+                            "title": "StructureDefinition US Core CareTeam",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-ethnicity.html",
+                            "title": "StructureDefinition US Core Ethnicity",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-careplan.html",
+                            "title": "StructureDefinition US Core CarePlan",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-smokingstatus.html",
+                            "title": "StructureDefinition US Core Smokingstatus",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-race.html",
+                            "title": "StructureDefinition US Core Race",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-organization.html",
+                            "title": "StructureDefinition US Core Organization",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-diagnosticreport-lab.html",
+                            "title": "StructureDefinition US Core DiagnosticReport Lab",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-condition.html",
+                            "title": "StructureDefinition US Core Condition",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-pediatric-weight-for-height.html",
+                            "title": "StructureDefinition Pediatric Weight For Height",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-goal.html",
+                            "title": "StructureDefinition US Core Goal",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-medicationrequest.html",
+                            "title": "StructureDefinition US Core MedicationRequest",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-implantable-device.html",
+                            "title": "StructureDefinition US Core Implantable Device",
+                            "generation": "generated"
+                        }
+                    ]
+                },
+                {
+                    "nameUrl": "operations.html",
+                    "title": "Operations",
+                    "generation": "markdown",
+                    "page": [
+                        {
+                            "nameUrl": "OperationDefinition-docref.html",
+                            "title": "OperationDefinition Docref",
+                            "generation": "generated"
+                        }
+                    ]
+                },
+                {
+                    "nameUrl": "terminology.html",
+                    "title": "Terminology",
+                    "generation": "markdown",
+                    "page": [
+                        {
+                            "nameUrl": "ValueSet-us-core-medication-codes.html",
+                            "title": "ValueSet US Core Medication Codes",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-observation-smokingstatus.html",
+                            "title": "ValueSet US Core Observation Smokingstatus Preferred",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-observation-smokingstatus-max.html",
+                            "title": "ValueSet US Core Observation Smokingstatus Max-Binding",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-omb-race-category.html",
+                            "title": "ValueSet Omb Race Category",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-allergy-substance.html",
+                            "title": "ValueSet US Core Allergy Substance",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-narrative-status.html",
+                            "title": "ValueSet US Core Narrative Status",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-documentreference-type.html",
+                            "title": "ValueSet US Core DocumentReference Type",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-omb-ethnicity-category.html",
+                            "title": "ValueSet Omb Ethnicity Category",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-condition-category.html",
+                            "title": "ValueSet US Core Condition Category",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-detailed-ethnicity.html",
+                            "title": "ValueSet Detailed Ethnicity",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-ndc-vaccine-codes.html",
+                            "title": "ValueSet US Core Ndc Vaccine Codes",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-procedure-icd10pcs.html",
+                            "title": "ValueSet US Core Procedure Icd10pcs",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-provider-specialty.html",
+                            "title": "ValueSet US Core Provider Specialty",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-vaccines-cvx.html",
+                            "title": "ValueSet US Core Vaccines Cvx",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-observation-smoking-status-status.html",
+                            "title": "ValueSet US Core Observation SmokingStatus Status",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-usps-state.html",
+                            "title": "ValueSet US Core Usps State",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-encounter-type.html",
+                            "title": "ValueSet US Core Encounter Type",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-condition-code.html",
+                            "title": "ValueSet US Core Condition Code",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-birthsex.html",
+                            "title": "ValueSet Birthsex",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-diagnosticreport-report-and-note-codes.html",
+                            "title": "ValueSet US Core DiagnosticReport Report And Note Codes",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-provider-role.html",
+                            "title": "ValueSet US Core Provider Role",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-smoking-status-observation-codes.html",
+                            "title": "ValueSet US Core Smoking Status Observation Codes",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-careteam-provider-roles.html",
+                            "title": "ValueSet US Core CareTeam Provider Roles",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-diagnosticreport-category.html",
+                            "title": "ValueSet US Core DiagnosticReport Category",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-clinical-note-type.html",
+                            "title": "ValueSet US Core Clinical Note Type",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-documentreference-category.html",
+                            "title": "ValueSet US Core DocumentReference Category",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-procedure-code.html",
+                            "title": "ValueSet US Core Procedure Code",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-simple-language.html",
+                            "title": "ValueSet Simple Language",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-observation-value-codes.html",
+                            "title": "ValueSet US Core Observation Value Codes",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-diagnosticreport-lab-codes.html",
+                            "title": "ValueSet US Core DiagnosticReport Lab Codes",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-detailed-race.html",
+                            "title": "ValueSet Detailed Race",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "CodeSystem-cdcrec.html",
+                            "title": "CodeSystem Cdcrec",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "CodeSystem-condition-category.html",
+                            "title": "CodeSystem Condition Category",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "CodeSystem-us-core-documentreference-category.html",
+                            "title": "CodeSystem US Core DocumentReference Category",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "CodeSystem-careplan-category.html",
+                            "title": "CodeSystem CarePlan Category",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ConceptMap-ndc-cvx.html",
+                            "title": "ConceptMap Ndc Cvx",
+                            "generation": "generated"
+                        }
+                    ]
+                },
+                {
+                    "nameUrl": "searchparameters.html",
+                    "title": "Search Parameters",
+                    "generation": "markdown",
+                    "page": [
+                        {
+                            "nameUrl": "SearchParameter-us-core-location-address-state.html",
+                            "title": "SearchParameter US Core Location Address State",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-practitionerrole-practitioner.html",
+                            "title": "SearchParameter US Core PractitionerRole Practitioner",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-organization-name.html",
+                            "title": "SearchParameter US Core Organization Name",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-diagnosticreport-code.html",
+                            "title": "SearchParameter US Core DiagnosticReport Code",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-goal-lifecycle-status.html",
+                            "title": "SearchParameter US Core Goal Lifecycle Status",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-procedure-code.html",
+                            "title": "SearchParameter US Core Procedure Code",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-patient-gender.html",
+                            "title": "SearchParameter US Core Patient Gender",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-condition-clinical-status.html",
+                            "title": "SearchParameter US Core Condition Clinical Status",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-documentreference-id.html",
+                            "title": "SearchParameter US Core DocumentReference Id",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-careplan-category.html",
+                            "title": "SearchParameter US Core CarePlan Category",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-encounter-class.html",
+                            "title": "SearchParameter US Core Encounter Class",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-medicationrequest-patient.html",
+                            "title": "SearchParameter US Core MedicationRequest Patient",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-documentreference-patient.html",
+                            "title": "SearchParameter US Core DocumentReference Patient",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-diagnosticreport-date.html",
+                            "title": "SearchParameter US Core DiagnosticReport Date",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-procedure-date.html",
+                            "title": "SearchParameter US Core Procedure Date",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-allergyintolerance-clinical-status.html",
+                            "title": "SearchParameter US Core AllergyIntolerance Clinical Status",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-documentreference-date.html",
+                            "title": "SearchParameter US Core DocumentReference Date",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-medicationrequest-intent.html",
+                            "title": "SearchParameter US Core MedicationRequest Intent",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-location-address.html",
+                            "title": "SearchParameter US Core Location Address",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-practitioner-name.html",
+                            "title": "SearchParameter US Core Practitioner Name",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-documentreference-period.html",
+                            "title": "SearchParameter US Core DocumentReference Period",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-observation-code.html",
+                            "title": "SearchParameter US Core Observation Code",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-location-name.html",
+                            "title": "SearchParameter US Core Location Name",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-condition-onset-date.html",
+                            "title": "SearchParameter US Core Condition Onset Date",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-patient-given.html",
+                            "title": "SearchParameter US Core Patient Given",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-encounter-type.html",
+                            "title": "SearchParameter US Core Encounter Type",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-medicationrequest-encounter.html",
+                            "title": "SearchParameter US Core MedicationRequest Encounter",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-encounter-patient.html",
+                            "title": "SearchParameter US Core Encounter Patient",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-organization-address.html",
+                            "title": "SearchParameter US Core Organization Address",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-observation-category.html",
+                            "title": "SearchParameter US Core Observation Category",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-diagnosticreport-status.html",
+                            "title": "SearchParameter US Core DiagnosticReport Status",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-observation-date.html",
+                            "title": "SearchParameter US Core Observation Date",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-diagnosticreport-category.html",
+                            "title": "SearchParameter US Core DiagnosticReport Category",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-observation-status.html",
+                            "title": "SearchParameter US Core Observation Status",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-ethnicity.html",
+                            "title": "SearchParameter US Core Ethnicity",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-documentreference-type.html",
+                            "title": "SearchParameter US Core DocumentReference Type",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-encounter-date.html",
+                            "title": "SearchParameter US Core Encounter Date",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-patient-birthdate.html",
+                            "title": "SearchParameter US Core Patient Birthdate",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-procedure-status.html",
+                            "title": "SearchParameter US Core Procedure Status",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-encounter-status.html",
+                            "title": "SearchParameter US Core Encounter Status",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-careplan-status.html",
+                            "title": "SearchParameter US Core CarePlan Status",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-condition-patient.html",
+                            "title": "SearchParameter US Core Condition Patient",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-allergyintolerance-patient.html",
+                            "title": "SearchParameter US Core AllergyIntolerance Patient",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-device-patient.html",
+                            "title": "SearchParameter US Core Device Patient",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-condition-code.html",
+                            "title": "SearchParameter US Core Condition Code",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-observation-patient.html",
+                            "title": "SearchParameter US Core Observation Patient",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-race.html",
+                            "title": "SearchParameter US Core Race",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-careplan-patient.html",
+                            "title": "SearchParameter US Core CarePlan Patient",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-patient-family.html",
+                            "title": "SearchParameter US Core Patient Family",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-medicationrequest-status.html",
+                            "title": "SearchParameter US Core MedicationRequest Status",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-location-address-postalcode.html",
+                            "title": "SearchParameter US Core Location Address Postalcode",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-encounter-id.html",
+                            "title": "SearchParameter US Core Encounter Id",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-medicationrequest-authoredon.html",
+                            "title": "SearchParameter US Core MedicationRequest Authoredon",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-documentreference-status.html",
+                            "title": "SearchParameter US Core DocumentReference Status",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-procedure-patient.html",
+                            "title": "SearchParameter US Core Procedure Patient",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-goal-target-date.html",
+                            "title": "SearchParameter US Core Goal Target Date",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-diagnosticreport-patient.html",
+                            "title": "SearchParameter US Core DiagnosticReport Patient",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-careplan-date.html",
+                            "title": "SearchParameter US Core CarePlan Date",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-careteam-patient.html",
+                            "title": "SearchParameter US Core CareTeam Patient",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-immunization-date.html",
+                            "title": "SearchParameter US Core Immunization Date",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-encounter-identifier.html",
+                            "title": "SearchParameter US Core Encounter Identifier",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-practitionerrole-specialty.html",
+                            "title": "SearchParameter US Core PractitionerRole Specialty",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-patient-name.html",
+                            "title": "SearchParameter US Core Patient Name",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-device-type.html",
+                            "title": "SearchParameter US Core Device Type",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-goal-patient.html",
+                            "title": "SearchParameter US Core Goal Patient",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-immunization-patient.html",
+                            "title": "SearchParameter US Core Immunization Patient",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-patient-id.html",
+                            "title": "SearchParameter US Core Patient Id",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-location-address-city.html",
+                            "title": "SearchParameter US Core Location Address City",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-careteam-status.html",
+                            "title": "SearchParameter US Core CareTeam Status",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-documentreference-category.html",
+                            "title": "SearchParameter US Core DocumentReference Category",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-practitioner-identifier.html",
+                            "title": "SearchParameter US Core Practitioner Identifier",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-patient-identifier.html",
+                            "title": "SearchParameter US Core Patient Identifier",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-condition-category.html",
+                            "title": "SearchParameter US Core Condition Category",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-immunization-status.html",
+                            "title": "SearchParameter US Core Immunization Status",
+                            "generation": "generated"
+                        }
+                    ]
+                },
+                {
+                    "nameUrl": "capstatements.html",
+                    "title": "Capability Statements",
+                    "generation": "markdown",
+                    "page": [
+                        {
+                            "nameUrl": "CapabilityStatement-us-core-server.html",
+                            "title": "CapabilityStatement US Core Server",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "CapabilityStatement-us-core-client.html",
+                            "title": "CapabilityStatement US Core Client",
+                            "generation": "generated"
+                        }
+                    ]
+                },
+                {
+                    "nameUrl": "security.html",
+                    "title": "Security",
+                    "generation": "markdown"
+                },
+                {
+                    "nameUrl": "downloads.html",
+                    "title": "Downloads",
+                    "generation": "markdown"
+                },
+                {
+                    "nameUrl": "all-examples.html",
+                    "title": "All Examples",
+                    "generation": "markdown"
+                },
+                {
+                    "nameUrl": "toc.html",
+                    "title": "Table of Contents",
+                    "generation": "html"
+                }
+            ]
+        }
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/OperationDefinition-docref.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/OperationDefinition-docref.json
@@ -1,87 +1,87 @@
 {
-	"resourceType": "OperationDefinition",
-	"id": "docref",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/OperationDefinition/docref",
-	"version": "3.1.1",
-	"name": "USCoreFetchDocumentReferences",
-	"title": "US Core Fetch DocumentReferences",
-	"status": "active",
-	"kind": "operation",
-	"date": "2019-05-21",
-	"publisher": "US Core Project",
-	"description": "This operation is used to return all the references to documents related to a patient. \n\n The operation takes the optional input parameters: \n  - patient id\n  - start date\n  - end date\n  - document type \n\n and returns a [Bundle](http://hl7.org/fhir/bundle.html) of type \"searchset\" containing [US Core DocumentReference Profiles](http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference) for the patient. If the server has or can create documents that are related to the patient, and that are available for the given user, the server returns the DocumentReference profiles needed to support the records.  The principle intended use for this operation is to provide a provider or patient with access to their available document information. \n\n This operation is *different* from a search by patient and type and date range because: \n\n 1. It is used to request a server *generate* a document based on the specified parameters. \n\n 1. If no parameters are specified, the server SHALL return a DocumentReference to the patient's most current CCD \n\n 1. If the server cannot *generate* a document based on the specified parameters, the operation will return an empty search bundle. \n\n This operation is the *same* as a FHIR RESTful search by patient,type and date range because: \n\n 1. References for *existing* documents that meet the requirements of the request SHOULD also be returned unless the client indicates they are only interested in 'on-demand' documents using the *on-demand* parameter.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "docref",
-	"comment": " - The server is responsible for determining what resources, if any, to return as [included](http://hl7.org/fhir/R4/search.html#revinclude) resources rather than the client specifying which ones. This frees the client from needing to determine what it could or should ask for. For example, the server may return the referenced document as an included FHIR Binary resource within the return bundle. The server's CapabilityStatement should document this behavior. \n\n - The document itself can be subsequently retrieved using the link provided  in the `DocumentReference.content.attachment.url element`. The link could be a FHIR endpoint to a [Binary](http://hl7.org/fhir/R4/binary.html) Resource or some other document repository. \n\n - It is assumed that the server has identified and secured the context appropriately, and can either associate the authorization context with a single patient, or determine whether the context has the rights to the nominated patient, if there is one. If there is no nominated patient (e.g. the operation is invoked at the system level) and the context is not associated with a single patient record, then the server should return an error. Specifying the relationship between the context, a user and patient records is outside the scope of this specification",
-	"system": false,
-	"type": true,
-	"instance": false,
-	"parameter": [
-		{
-			"name": "patient",
-			"use": "in",
-			"min": 1,
-			"max": "1",
-			"documentation": "The id of the patient resource located on the server on which this operation is executed.  If there is no match, an empty Bundle is returned",
-			"type": "id"
-		},
-		{
-			"name": "start",
-			"use": "in",
-			"min": 0,
-			"max": "1",
-			"documentation": "The date range relates to care dates, not record currency dates - e.g. all records relating to care provided in a certain date range. If no start date is provided, all documents prior to the end date are in scope.  If neither a start date nor an end date is provided, the most recent or current document is in scope.",
-			"type": "date"
-		},
-		{
-			"name": "end",
-			"use": "in",
-			"min": 0,
-			"max": "1",
-			"documentation": "The date range relates to care dates, not record currency dates - e.g. all records relating to care provided in a certain date range. If no end date is provided, all documents subsequent to the start date are in scope. If neither a start date nor an end date is provided, the most recent or current document is in scope",
-			"type": "date"
-		},
-		{
-			"name": "type",
-			"use": "in",
-			"min": 0,
-			"max": "1",
-			"documentation": "The type relates to document type e.g. for the LOINC code for a C-CDA Clinical Summary of Care (CCD) is 34133-9 (Summary of episode note). If no type is provided, the CCD document, if available, SHALL be in scope and all other document types MAY be in scope",
-			"type": "CodeableConcept",
-			"binding": {
-				"strength": "required",
-				"valueSet": "http://hl7.org/fhir/ValueSet/c80-doc-typecodes"
-			}
-		},
-		{
-			"name": "on-demand",
-			"use": "in",
-			"min": 0,
-			"max": "1",
-			"documentation": "This on-demand parameter allows client to dictate whether they are requesting only ‘on-demand’ or both ‘on-demand’ and 'stable' documents (or delayed/deferred assembly) that meet the query parameters",
-			"type": "boolean"
-		},
-		{
-			"name": "return",
-			"use": "out",
-			"min": 1,
-			"max": "1",
-			"documentation": "The bundle type is \"searchset\"containing [US Core DocumentReference Profiles](http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference)",
-			"type": "Bundle"
-		}
-	]
+    "resourceType": "OperationDefinition",
+    "id": "docref",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/OperationDefinition/docref",
+    "version": "3.1.1",
+    "name": "USCoreFetchDocumentReferences",
+    "title": "US Core Fetch DocumentReferences",
+    "status": "active",
+    "kind": "operation",
+    "date": "2019-05-21",
+    "publisher": "US Core Project",
+    "description": "This operation is used to return all the references to documents related to a patient. \n\n The operation takes the optional input parameters: \n  - patient id\n  - start date\n  - end date\n  - document type \n\n and returns a [Bundle](http://hl7.org/fhir/bundle.html) of type \"searchset\" containing [US Core DocumentReference Profiles](http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference) for the patient. If the server has or can create documents that are related to the patient, and that are available for the given user, the server returns the DocumentReference profiles needed to support the records.  The principle intended use for this operation is to provide a provider or patient with access to their available document information. \n\n This operation is *different* from a search by patient and type and date range because: \n\n 1. It is used to request a server *generate* a document based on the specified parameters. \n\n 1. If no parameters are specified, the server SHALL return a DocumentReference to the patient's most current CCD \n\n 1. If the server cannot *generate* a document based on the specified parameters, the operation will return an empty search bundle. \n\n This operation is the *same* as a FHIR RESTful search by patient,type and date range because: \n\n 1. References for *existing* documents that meet the requirements of the request SHOULD also be returned unless the client indicates they are only interested in 'on-demand' documents using the *on-demand* parameter.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "docref",
+    "comment": " - The server is responsible for determining what resources, if any, to return as [included](http://hl7.org/fhir/R4/search.html#revinclude) resources rather than the client specifying which ones. This frees the client from needing to determine what it could or should ask for. For example, the server may return the referenced document as an included FHIR Binary resource within the return bundle. The server's CapabilityStatement should document this behavior. \n\n - The document itself can be subsequently retrieved using the link provided  in the `DocumentReference.content.attachment.url element`. The link could be a FHIR endpoint to a [Binary](http://hl7.org/fhir/R4/binary.html) Resource or some other document repository. \n\n - It is assumed that the server has identified and secured the context appropriately, and can either associate the authorization context with a single patient, or determine whether the context has the rights to the nominated patient, if there is one. If there is no nominated patient (e.g. the operation is invoked at the system level) and the context is not associated with a single patient record, then the server should return an error. Specifying the relationship between the context, a user and patient records is outside the scope of this specification",
+    "system": false,
+    "type": true,
+    "instance": false,
+    "parameter": [
+        {
+            "name": "patient",
+            "use": "in",
+            "min": 1,
+            "max": "1",
+            "documentation": "The id of the patient resource located on the server on which this operation is executed.  If there is no match, an empty Bundle is returned",
+            "type": "id"
+        },
+        {
+            "name": "start",
+            "use": "in",
+            "min": 0,
+            "max": "1",
+            "documentation": "The date range relates to care dates, not record currency dates - e.g. all records relating to care provided in a certain date range. If no start date is provided, all documents prior to the end date are in scope.  If neither a start date nor an end date is provided, the most recent or current document is in scope.",
+            "type": "date"
+        },
+        {
+            "name": "end",
+            "use": "in",
+            "min": 0,
+            "max": "1",
+            "documentation": "The date range relates to care dates, not record currency dates - e.g. all records relating to care provided in a certain date range. If no end date is provided, all documents subsequent to the start date are in scope. If neither a start date nor an end date is provided, the most recent or current document is in scope",
+            "type": "date"
+        },
+        {
+            "name": "type",
+            "use": "in",
+            "min": 0,
+            "max": "1",
+            "documentation": "The type relates to document type e.g. for the LOINC code for a C-CDA Clinical Summary of Care (CCD) is 34133-9 (Summary of episode note). If no type is provided, the CCD document, if available, SHALL be in scope and all other document types MAY be in scope",
+            "type": "CodeableConcept",
+            "binding": {
+                "strength": "required",
+                "valueSet": "http://hl7.org/fhir/ValueSet/c80-doc-typecodes"
+            }
+        },
+        {
+            "name": "on-demand",
+            "use": "in",
+            "min": 0,
+            "max": "1",
+            "documentation": "This on-demand parameter allows client to dictate whether they are requesting only ‘on-demand’ or both ‘on-demand’ and 'stable' documents (or delayed/deferred assembly) that meet the query parameters",
+            "type": "boolean"
+        },
+        {
+            "name": "return",
+            "use": "out",
+            "min": 1,
+            "max": "1",
+            "documentation": "The bundle type is \"searchset\"containing [US Core DocumentReference Profiles](http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference)",
+            "type": "Bundle"
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-allergyintolerance-clinical-status.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-allergyintolerance-clinical-status.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-allergyintolerance-clinical-status",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreAllergyintoleranceClinicalStatus</h2><p><b> description</b> : active | inactive | resolved<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-allergyintolerance-clinical-status</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-clinical-status</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreAllergyintoleranceClinicalStatus</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/AllergyIntolerance-clinical-status\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>clinical-status</code>\n\t\t\t</p><p><b> base</b> :AllergyIntolerance</p><p><b> type</b> : token</p><p><b> expression</b> : <code>AllergyIntolerance.clinicalStatus</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:AllergyIntolerance/f:clinicalStatus</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-clinical-status",
-	"version": "3.1.1",
-	"name": "USCoreAllergyintoleranceClinicalStatus",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/AllergyIntolerance-clinical-status",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.193068Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "active | inactive | resolved<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "clinical-status",
-	"base": [
-		"AllergyIntolerance"
-	],
-	"type": "token",
-	"expression": "AllergyIntolerance.clinicalStatus",
-	"xpath": "f:AllergyIntolerance/f:clinicalStatus",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-allergyintolerance-clinical-status",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-clinical-status",
+    "version": "3.1.1",
+    "name": "USCoreAllergyintoleranceClinicalStatus",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/AllergyIntolerance-clinical-status",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.193068Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "active | inactive | resolved<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "clinical-status",
+    "base": [
+        "AllergyIntolerance"
+    ],
+    "type": "token",
+    "expression": "AllergyIntolerance.clinicalStatus",
+    "xpath": "f:AllergyIntolerance/f:clinicalStatus",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-allergyintolerance-patient.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-allergyintolerance-patient.json
@@ -1,68 +1,68 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-allergyintolerance-patient",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreAllergyintolerancePatient</h2><p><b> description</b> : Who the sensitivity is for<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-allergyintolerance-patient</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-patient</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreAllergyintolerancePatient</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-patient\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>patient</code>\n\t\t\t</p><p><b> base</b> :AllergyIntolerance</p><p><b> type</b> : reference</p><p><b> expression</b> : <code>AllergyIntolerance.patient</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:AllergyIntolerance/f:patient</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-patient",
-	"version": "3.1.1",
-	"name": "USCoreAllergyintolerancePatient",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.234110Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Who the sensitivity is for<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "patient",
-	"base": [
-		"AllergyIntolerance"
-	],
-	"type": "reference",
-	"expression": "AllergyIntolerance.patient",
-	"xpath": "f:AllergyIntolerance/f:patient",
-	"xpathUsage": "normal",
-	"target": [
-		"Patient",
-		"Group"
-	],
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-allergyintolerance-patient",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-patient",
+    "version": "3.1.1",
+    "name": "USCoreAllergyintolerancePatient",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.234110Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Who the sensitivity is for<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "patient",
+    "base": [
+        "AllergyIntolerance"
+    ],
+    "type": "reference",
+    "expression": "AllergyIntolerance.patient",
+    "xpath": "f:AllergyIntolerance/f:patient",
+    "xpathUsage": "normal",
+    "target": [
+        "Patient",
+        "Group"
+    ],
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-careplan-category.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-careplan-category.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-careplan-category",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreCareplanCategory</h2><p><b> description</b> : Type of plan<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-careplan-category</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-category</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreCareplanCategory</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/CarePlan-category\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>category</code>\n\t\t\t</p><p><b> base</b> :CarePlan</p><p><b> type</b> : token</p><p><b> expression</b> : <code>CarePlan.category</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:CarePlan/f:category</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-category",
-	"version": "3.1.1",
-	"name": "USCoreCareplanCategory",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/CarePlan-category",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.240921Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Type of plan<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "category",
-	"base": [
-		"CarePlan"
-	],
-	"type": "token",
-	"expression": "CarePlan.category",
-	"xpath": "f:CarePlan/f:category",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-careplan-category",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-category",
+    "version": "3.1.1",
+    "name": "USCoreCareplanCategory",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/CarePlan-category",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.240921Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Type of plan<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "category",
+    "base": [
+        "CarePlan"
+    ],
+    "type": "token",
+    "expression": "CarePlan.category",
+    "xpath": "f:CarePlan/f:category",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-careplan-date.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-careplan-date.json
@@ -1,149 +1,149 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-careplan-date",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreCareplanDate</h2><p><b> description</b> : Time period plan covers<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-careplan-date</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-date</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreCareplanDate</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-date\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>date</code>\n\t\t\t</p><p><b> base</b> :CarePlan</p><p><b> type</b> : date</p><p><b> expression</b> : <code>CarePlan.period</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:CarePlan/f:period</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = SHOULD)</p><p><b> comparator</b> : <code>eq</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>ne</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>gt</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>ge</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>lt</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>le</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>sa</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>eb</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>ap</code> ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-date",
-	"version": "3.1.1",
-	"name": "USCoreCareplanDate",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-date",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.252955Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Time period plan covers<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "date",
-	"base": [
-		"CarePlan"
-	],
-	"type": "date",
-	"expression": "CarePlan.period",
-	"xpath": "f:CarePlan/f:period",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHOULD"
-			}
-		]
-	},
-	"comparator": [
-		"eq",
-		"ne",
-		"gt",
-		"ge",
-		"lt",
-		"le",
-		"sa",
-		"eb",
-		"ap"
-	],
-	"_comparator": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		}
-	]
+    "resourceType": "SearchParameter",
+    "id": "us-core-careplan-date",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-date",
+    "version": "3.1.1",
+    "name": "USCoreCareplanDate",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-date",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.252955Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Time period plan covers<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "date",
+    "base": [
+        "CarePlan"
+    ],
+    "type": "date",
+    "expression": "CarePlan.period",
+    "xpath": "f:CarePlan/f:period",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHOULD"
+            }
+        ]
+    },
+    "comparator": [
+        "eq",
+        "ne",
+        "gt",
+        "ge",
+        "lt",
+        "le",
+        "sa",
+        "eb",
+        "ap"
+    ],
+    "_comparator": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-careplan-patient.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-careplan-patient.json
@@ -1,68 +1,68 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-careplan-patient",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreCareplanPatient</h2><p><b> description</b> : Who the care plan is for<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-careplan-patient</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-patient</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreCareplanPatient</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-patient\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>patient</code>\n\t\t\t</p><p><b> base</b> :CarePlan</p><p><b> type</b> : reference</p><p><b> expression</b> : <code>CarePlan.subject.where(resolve() is Patient)</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:CarePlan/f:subject</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-patient",
-	"version": "3.1.1",
-	"name": "USCoreCareplanPatient",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.267188Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Who the care plan is for<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "patient",
-	"base": [
-		"CarePlan"
-	],
-	"type": "reference",
-	"expression": "CarePlan.subject.where(resolve() is Patient)",
-	"xpath": "f:CarePlan/f:subject",
-	"xpathUsage": "normal",
-	"target": [
-		"Patient",
-		"Group"
-	],
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-careplan-patient",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-patient",
+    "version": "3.1.1",
+    "name": "USCoreCareplanPatient",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.267188Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Who the care plan is for<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "patient",
+    "base": [
+        "CarePlan"
+    ],
+    "type": "reference",
+    "expression": "CarePlan.subject.where(resolve() is Patient)",
+    "xpath": "f:CarePlan/f:subject",
+    "xpathUsage": "normal",
+    "target": [
+        "Patient",
+        "Group"
+    ],
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-careplan-status.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-careplan-status.json
@@ -1,70 +1,70 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-careplan-status",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreCareplanStatus</h2><p><b> description</b> : draft | active | on-hold | revoked | completed | entered-in-error | unknown<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-careplan-status</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-status</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreCareplanStatus</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/CarePlan-status\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>status</code>\n\t\t\t</p><p><b> base</b> :CarePlan</p><p><b> type</b> : token</p><p><b> expression</b> : <code>CarePlan.status</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:CarePlan/f:status</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = SHALL)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"extension": [
-		{
-			"url": "http://ibm.com/fhir/extension/implicit-system",
-			"valueUri": "http://hl7.org/fhir/request-status"
-		}
-	],
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-status",
-	"version": "3.1.1",
-	"name": "USCoreCareplanStatus",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/CarePlan-status",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.282052Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "draft | active | on-hold | revoked | completed | entered-in-error | unknown<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "status",
-	"base": [
-		"CarePlan"
-	],
-	"type": "token",
-	"expression": "CarePlan.status",
-	"xpath": "f:CarePlan/f:status",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHALL"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-careplan-status",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "extension": [
+        {
+            "url": "http://ibm.com/fhir/extension/implicit-system",
+            "valueUri": "http://hl7.org/fhir/request-status"
+        }
+    ],
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-status",
+    "version": "3.1.1",
+    "name": "USCoreCareplanStatus",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/CarePlan-status",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.282052Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "draft | active | on-hold | revoked | completed | entered-in-error | unknown<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "status",
+    "base": [
+        "CarePlan"
+    ],
+    "type": "token",
+    "expression": "CarePlan.status",
+    "xpath": "f:CarePlan/f:status",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHALL"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-careteam-patient.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-careteam-patient.json
@@ -1,68 +1,68 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-careteam-patient",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreCareteamPatient</h2><p><b> description</b> : Who care team is for<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-careteam-patient</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-patient</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreCareteamPatient</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-patient\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>patient</code>\n\t\t\t</p><p><b> base</b> :CareTeam</p><p><b> type</b> : reference</p><p><b> expression</b> : <code>CareTeam.subject.where(resolve() is Patient)</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:CareTeam/f:subject</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-patient",
-	"version": "3.1.1",
-	"name": "USCoreCareteamPatient",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.294355Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Who care team is for<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "patient",
-	"base": [
-		"CareTeam"
-	],
-	"type": "reference",
-	"expression": "CareTeam.subject.where(resolve() is Patient)",
-	"xpath": "f:CareTeam/f:subject",
-	"xpathUsage": "normal",
-	"target": [
-		"Patient",
-		"Group"
-	],
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-careteam-patient",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-patient",
+    "version": "3.1.1",
+    "name": "USCoreCareteamPatient",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.294355Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Who care team is for<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "patient",
+    "base": [
+        "CareTeam"
+    ],
+    "type": "reference",
+    "expression": "CareTeam.subject.where(resolve() is Patient)",
+    "xpath": "f:CareTeam/f:subject",
+    "xpathUsage": "normal",
+    "target": [
+        "Patient",
+        "Group"
+    ],
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-careteam-status.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-careteam-status.json
@@ -1,70 +1,70 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-careteam-status",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreCareteamStatus</h2><p><b> description</b> : proposed | active | suspended | inactive | entered-in-error<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-careteam-status</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-status</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreCareteamStatus</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/CareTeam-status\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>status</code>\n\t\t\t</p><p><b> base</b> :CareTeam</p><p><b> type</b> : token</p><p><b> expression</b> : <code>CareTeam.status</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:CareTeam/f:status</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = SHALL)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"extension": [
-		{
-			"url": "http://ibm.com/fhir/extension/implicit-system",
-			"valueUri": "http://hl7.org/fhir/care-team-status"
-		}
-	],
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-status",
-	"version": "3.1.1",
-	"name": "USCoreCareteamStatus",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/CareTeam-status",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.330023Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "proposed | active | suspended | inactive | entered-in-error<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "status",
-	"base": [
-		"CareTeam"
-	],
-	"type": "token",
-	"expression": "CareTeam.status",
-	"xpath": "f:CareTeam/f:status",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHALL"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-careteam-status",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "extension": [
+        {
+            "url": "http://ibm.com/fhir/extension/implicit-system",
+            "valueUri": "http://hl7.org/fhir/care-team-status"
+        }
+    ],
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-status",
+    "version": "3.1.1",
+    "name": "USCoreCareteamStatus",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/CareTeam-status",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.330023Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "proposed | active | suspended | inactive | entered-in-error<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "status",
+    "base": [
+        "CareTeam"
+    ],
+    "type": "token",
+    "expression": "CareTeam.status",
+    "xpath": "f:CareTeam/f:status",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHALL"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-condition-category.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-condition-category.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-condition-category",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreConditionCategory</h2><p><b> description</b> : The category of the condition<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-condition-category</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-category</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreConditionCategory</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Condition-category\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>category</code>\n\t\t\t</p><p><b> base</b> :Condition</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Condition.category</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Condition/f:category</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-category",
-	"version": "3.1.1",
-	"name": "USCoreConditionCategory",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Condition-category",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.252432Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The category of the condition<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "category",
-	"base": [
-		"Condition"
-	],
-	"type": "token",
-	"expression": "Condition.category",
-	"xpath": "f:Condition/f:category",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-condition-category",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-category",
+    "version": "3.1.1",
+    "name": "USCoreConditionCategory",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Condition-category",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.252432Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The category of the condition<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "category",
+    "base": [
+        "Condition"
+    ],
+    "type": "token",
+    "expression": "Condition.category",
+    "xpath": "f:Condition/f:category",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-condition-clinical-status.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-condition-clinical-status.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-condition-clinical-status",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreConditionClinicalStatus</h2><p><b> description</b> : The clinical status of the condition<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-condition-clinical-status</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-clinical-status</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreConditionClinicalStatus</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Condition-clinical-status\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>clinical-status</code>\n\t\t\t</p><p><b> base</b> :Condition</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Condition.clinicalStatus</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Condition/f:clinicalStatus</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-clinical-status",
-	"version": "3.1.1",
-	"name": "USCoreConditionClinicalStatus",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Condition-clinical-status",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.273619Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The clinical status of the condition<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "clinical-status",
-	"base": [
-		"Condition"
-	],
-	"type": "token",
-	"expression": "Condition.clinicalStatus",
-	"xpath": "f:Condition/f:clinicalStatus",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-condition-clinical-status",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-clinical-status",
+    "version": "3.1.1",
+    "name": "USCoreConditionClinicalStatus",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Condition-clinical-status",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.273619Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The clinical status of the condition<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "clinical-status",
+    "base": [
+        "Condition"
+    ],
+    "type": "token",
+    "expression": "Condition.clinicalStatus",
+    "xpath": "f:Condition/f:clinicalStatus",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-condition-code.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-condition-code.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-condition-code",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreConditionCode</h2><p><b> description</b> : Code for the condition<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-condition-code</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-code</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreConditionCode</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-code\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>code</code>\n\t\t\t</p><p><b> base</b> :Condition</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Condition.code</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Condition/f:code</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-code",
-	"version": "3.1.1",
-	"name": "USCoreConditionCode",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-code",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.657922Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Code for the condition<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "code",
-	"base": [
-		"Condition"
-	],
-	"type": "token",
-	"expression": "Condition.code",
-	"xpath": "f:Condition/f:code",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-condition-code",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-code",
+    "version": "3.1.1",
+    "name": "USCoreConditionCode",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-code",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.657922Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Code for the condition<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "code",
+    "base": [
+        "Condition"
+    ],
+    "type": "token",
+    "expression": "Condition.code",
+    "xpath": "f:Condition/f:code",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-condition-onset-date.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-condition-onset-date.json
@@ -1,149 +1,149 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-condition-onset-date",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreConditionOnsetDate</h2><p><b> description</b> : Date related onsets (dateTime and Period)<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-condition-onset-date</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-onset-date</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreConditionOnsetDate</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Condition-onset-date\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>onset-date</code>\n\t\t\t</p><p><b> base</b> :Condition</p><p><b> type</b> : date</p><p><b> expression</b> : <code>Condition.onset.as(dateTime)</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Condition/f:onsetDateTime</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = SHOULD)</p><p><b> comparator</b> : <code>eq</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>ne</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>gt</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>ge</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>lt</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>le</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>sa</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>eb</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>ap</code> ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-onset-date",
-	"version": "3.1.1",
-	"name": "USCoreConditionOnsetDate",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Condition-onset-date",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.644555Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Date related onsets (dateTime and Period)<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "onset-date",
-	"base": [
-		"Condition"
-	],
-	"type": "date",
-	"expression": "Condition.onset.as(dateTime)",
-	"xpath": "f:Condition/f:onsetDateTime",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHOULD"
-			}
-		]
-	},
-	"comparator": [
-		"eq",
-		"ne",
-		"gt",
-		"ge",
-		"lt",
-		"le",
-		"sa",
-		"eb",
-		"ap"
-	],
-	"_comparator": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		}
-	]
+    "resourceType": "SearchParameter",
+    "id": "us-core-condition-onset-date",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-onset-date",
+    "version": "3.1.1",
+    "name": "USCoreConditionOnsetDate",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Condition-onset-date",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.644555Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Date related onsets (dateTime and Period)<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "onset-date",
+    "base": [
+        "Condition"
+    ],
+    "type": "date",
+    "expression": "Condition.onset.as(dateTime)",
+    "xpath": "f:Condition/f:onsetDateTime",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHOULD"
+            }
+        ]
+    },
+    "comparator": [
+        "eq",
+        "ne",
+        "gt",
+        "ge",
+        "lt",
+        "le",
+        "sa",
+        "eb",
+        "ap"
+    ],
+    "_comparator": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-condition-patient.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-condition-patient.json
@@ -1,68 +1,68 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-condition-patient",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreConditionPatient</h2><p><b> description</b> : Who has the condition?<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-condition-patient</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-patient</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreConditionPatient</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-patient\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>patient</code>\n\t\t\t</p><p><b> base</b> :Condition</p><p><b> type</b> : reference</p><p><b> expression</b> : <code>Condition.subject.where(resolve() is Patient)</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Condition/f:subject</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-patient",
-	"version": "3.1.1",
-	"name": "USCoreConditionPatient",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.330539Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Who has the condition?<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "patient",
-	"base": [
-		"Condition"
-	],
-	"type": "reference",
-	"expression": "Condition.subject.where(resolve() is Patient)",
-	"xpath": "f:Condition/f:subject",
-	"xpathUsage": "normal",
-	"target": [
-		"Patient",
-		"Group"
-	],
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-condition-patient",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-patient",
+    "version": "3.1.1",
+    "name": "USCoreConditionPatient",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.330539Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Who has the condition?<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "patient",
+    "base": [
+        "Condition"
+    ],
+    "type": "reference",
+    "expression": "Condition.subject.where(resolve() is Patient)",
+    "xpath": "f:Condition/f:subject",
+    "xpathUsage": "normal",
+    "target": [
+        "Patient",
+        "Group"
+    ],
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-device-patient.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-device-patient.json
@@ -1,67 +1,67 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-device-patient",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreDevicePatient</h2><p><b> description</b> : Patient information, if the resource is affixed to a person<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-device-patient</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-device-patient</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreDevicePatient</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Device-patient\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>patient</code>\n\t\t\t</p><p><b> base</b> :Device</p><p><b> type</b> : reference</p><p><b> expression</b> : <code>Device.patient</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Device/f:patient</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-patient",
-	"version": "3.1.1",
-	"name": "USCoreDevicePatient",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Device-patient",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.352744Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Patient information, if the resource is affixed to a person<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "patient",
-	"base": [
-		"Device"
-	],
-	"type": "reference",
-	"expression": "Device.patient",
-	"xpath": "f:Device/f:patient",
-	"xpathUsage": "normal",
-	"target": [
-		"Patient"
-	],
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-device-patient",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-patient",
+    "version": "3.1.1",
+    "name": "USCoreDevicePatient",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Device-patient",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.352744Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Patient information, if the resource is affixed to a person<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "patient",
+    "base": [
+        "Device"
+    ],
+    "type": "reference",
+    "expression": "Device.patient",
+    "xpath": "f:Device/f:patient",
+    "xpathUsage": "normal",
+    "target": [
+        "Patient"
+    ],
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-device-type.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-device-type.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-device-type",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreDeviceType</h2><p><b> description</b> : The type of the device<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-device-type</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-device-type</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreDeviceType</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Device-type\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>type</code>\n\t\t\t</p><p><b> base</b> :Device</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Device.type</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Device/f:type</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-type",
-	"version": "3.1.1",
-	"name": "USCoreDeviceType",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Device-type",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.361965Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The type of the device<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "type",
-	"base": [
-		"Device"
-	],
-	"type": "token",
-	"expression": "Device.type",
-	"xpath": "f:Device/f:type",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-device-type",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-type",
+    "version": "3.1.1",
+    "name": "USCoreDeviceType",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Device-type",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.361965Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The type of the device<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "type",
+    "base": [
+        "Device"
+    ],
+    "type": "token",
+    "expression": "Device.type",
+    "xpath": "f:Device/f:type",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-diagnosticreport-category.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-diagnosticreport-category.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-diagnosticreport-category",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreDiagnosticreportCategory</h2><p><b> description</b> : Which diagnostic discipline/department created the report<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-diagnosticreport-category</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-category</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreDiagnosticreportCategory</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/DiagnosticReport-category\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>category</code>\n\t\t\t</p><p><b> base</b> :DiagnosticReport</p><p><b> type</b> : token</p><p><b> expression</b> : <code>DiagnosticReport.category</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:DiagnosticReport/f:category</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-category",
-	"version": "3.1.1",
-	"name": "USCoreDiagnosticreportCategory",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/DiagnosticReport-category",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.911245Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Which diagnostic discipline/department created the report<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "category",
-	"base": [
-		"DiagnosticReport"
-	],
-	"type": "token",
-	"expression": "DiagnosticReport.category",
-	"xpath": "f:DiagnosticReport/f:category",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-diagnosticreport-category",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-category",
+    "version": "3.1.1",
+    "name": "USCoreDiagnosticreportCategory",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/DiagnosticReport-category",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.911245Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Which diagnostic discipline/department created the report<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "category",
+    "base": [
+        "DiagnosticReport"
+    ],
+    "type": "token",
+    "expression": "DiagnosticReport.category",
+    "xpath": "f:DiagnosticReport/f:category",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-diagnosticreport-code.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-diagnosticreport-code.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-diagnosticreport-code",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreDiagnosticreportCode</h2><p><b> description</b> : The code for the report, as opposed to codes for the atomic results, which are the names on the observation resource referred to from the result<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-diagnosticreport-code</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-code</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreDiagnosticreportCode</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-code\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>code</code>\n\t\t\t</p><p><b> base</b> :DiagnosticReport</p><p><b> type</b> : token</p><p><b> expression</b> : <code>DiagnosticReport.code</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:DiagnosticReport/f:code</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = SHOULD)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-code",
-	"version": "3.1.1",
-	"name": "USCoreDiagnosticreportCode",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-code",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.929864Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The code for the report, as opposed to codes for the atomic results, which are the names on the observation resource referred to from the result<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "code",
-	"base": [
-		"DiagnosticReport"
-	],
-	"type": "token",
-	"expression": "DiagnosticReport.code",
-	"xpath": "f:DiagnosticReport/f:code",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHOULD"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-diagnosticreport-code",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-code",
+    "version": "3.1.1",
+    "name": "USCoreDiagnosticreportCode",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-code",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.929864Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The code for the report, as opposed to codes for the atomic results, which are the names on the observation resource referred to from the result<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "code",
+    "base": [
+        "DiagnosticReport"
+    ],
+    "type": "token",
+    "expression": "DiagnosticReport.code",
+    "xpath": "f:DiagnosticReport/f:code",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHOULD"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-diagnosticreport-date.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-diagnosticreport-date.json
@@ -1,149 +1,149 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-diagnosticreport-date",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreDiagnosticreportDate</h2><p><b> description</b> : The clinically relevant time of the report<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-diagnosticreport-date</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-date</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreDiagnosticreportDate</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-date\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>date</code>\n\t\t\t</p><p><b> base</b> :DiagnosticReport</p><p><b> type</b> : date</p><p><b> expression</b> : <code>DiagnosticReport.effective</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:DiagnosticReport/f:effectiveDateTime</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = SHOULD)</p><p><b> comparator</b> : <code>eq</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>ne</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>gt</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>ge</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>lt</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>le</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>sa</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>eb</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>ap</code> ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-date",
-	"version": "3.1.1",
-	"name": "USCoreDiagnosticreportDate",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-date",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.939751Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The clinically relevant time of the report<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "date",
-	"base": [
-		"DiagnosticReport"
-	],
-	"type": "date",
-	"expression": "DiagnosticReport.effective",
-	"xpath": "f:DiagnosticReport/f:effectiveDateTime",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHOULD"
-			}
-		]
-	},
-	"comparator": [
-		"eq",
-		"ne",
-		"gt",
-		"ge",
-		"lt",
-		"le",
-		"sa",
-		"eb",
-		"ap"
-	],
-	"_comparator": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		}
-	]
+    "resourceType": "SearchParameter",
+    "id": "us-core-diagnosticreport-date",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-date",
+    "version": "3.1.1",
+    "name": "USCoreDiagnosticreportDate",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-date",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.939751Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The clinically relevant time of the report<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "date",
+    "base": [
+        "DiagnosticReport"
+    ],
+    "type": "date",
+    "expression": "DiagnosticReport.effective",
+    "xpath": "f:DiagnosticReport/f:effectiveDateTime",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHOULD"
+            }
+        ]
+    },
+    "comparator": [
+        "eq",
+        "ne",
+        "gt",
+        "ge",
+        "lt",
+        "le",
+        "sa",
+        "eb",
+        "ap"
+    ],
+    "_comparator": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-diagnosticreport-patient.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-diagnosticreport-patient.json
@@ -1,68 +1,68 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-diagnosticreport-patient",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreDiagnosticreportPatient</h2><p><b> description</b> : The subject of the report if a patient<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-diagnosticreport-patient</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreDiagnosticreportPatient</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-patient\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>patient</code>\n\t\t\t</p><p><b> base</b> :DiagnosticReport</p><p><b> type</b> : reference</p><p><b> expression</b> : <code>DiagnosticReport.subject.where(resolve() is Patient)</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:DiagnosticReport/f:subject</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient",
-	"version": "3.1.1",
-	"name": "USCoreDiagnosticreportPatient",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.885499Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The subject of the report if a patient<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "patient",
-	"base": [
-		"DiagnosticReport"
-	],
-	"type": "reference",
-	"expression": "DiagnosticReport.subject.where(resolve() is Patient)",
-	"xpath": "f:DiagnosticReport/f:subject",
-	"xpathUsage": "normal",
-	"target": [
-		"Patient",
-		"Group"
-	],
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-diagnosticreport-patient",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient",
+    "version": "3.1.1",
+    "name": "USCoreDiagnosticreportPatient",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.885499Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The subject of the report if a patient<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "patient",
+    "base": [
+        "DiagnosticReport"
+    ],
+    "type": "reference",
+    "expression": "DiagnosticReport.subject.where(resolve() is Patient)",
+    "xpath": "f:DiagnosticReport/f:subject",
+    "xpathUsage": "normal",
+    "target": [
+        "Patient",
+        "Group"
+    ],
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-diagnosticreport-status.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-diagnosticreport-status.json
@@ -1,70 +1,70 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-diagnosticreport-status",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreDiagnosticreportStatus</h2><p><b> description</b> : The status of the report<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-diagnosticreport-status</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-status</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreDiagnosticreportStatus</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/DiagnosticReport-status\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>status</code>\n\t\t\t</p><p><b> base</b> :DiagnosticReport</p><p><b> type</b> : token</p><p><b> expression</b> : <code>DiagnosticReport.status</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:DiagnosticReport/f:status</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = SHALL)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"extension": [
-		{
-			"url": "http://ibm.com/fhir/extension/implicit-system",
-			"valueUri": "http://hl7.org/fhir/diagnostic-report-status"
-		}
-	],
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-status",
-	"version": "3.1.1",
-	"name": "USCoreDiagnosticreportStatus",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/DiagnosticReport-status",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.843388Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The status of the report<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "status",
-	"base": [
-		"DiagnosticReport"
-	],
-	"type": "token",
-	"expression": "DiagnosticReport.status",
-	"xpath": "f:DiagnosticReport/f:status",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHALL"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-diagnosticreport-status",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "extension": [
+        {
+            "url": "http://ibm.com/fhir/extension/implicit-system",
+            "valueUri": "http://hl7.org/fhir/diagnostic-report-status"
+        }
+    ],
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-status",
+    "version": "3.1.1",
+    "name": "USCoreDiagnosticreportStatus",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/DiagnosticReport-status",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.843388Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The status of the report<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "status",
+    "base": [
+        "DiagnosticReport"
+    ],
+    "type": "token",
+    "expression": "DiagnosticReport.status",
+    "xpath": "f:DiagnosticReport/f:status",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHALL"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-documentreference-category.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-documentreference-category.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-documentreference-category",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreDocumentreferenceCategory</h2><p><b> description</b> : Categorization of document<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-documentreference-category</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-category</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreDocumentreferenceCategory</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/DocumentReference-category\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>category</code>\n\t\t\t</p><p><b> base</b> :DocumentReference</p><p><b> type</b> : token</p><p><b> expression</b> : <code>DocumentReference.category</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:DocumentReference/f:category</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-category",
-	"version": "3.1.1",
-	"name": "USCoreDocumentreferenceCategory",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/DocumentReference-category",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.745873Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Categorization of document<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "category",
-	"base": [
-		"DocumentReference"
-	],
-	"type": "token",
-	"expression": "DocumentReference.category",
-	"xpath": "f:DocumentReference/f:category",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-documentreference-category",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-category",
+    "version": "3.1.1",
+    "name": "USCoreDocumentreferenceCategory",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/DocumentReference-category",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.745873Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Categorization of document<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "category",
+    "base": [
+        "DocumentReference"
+    ],
+    "type": "token",
+    "expression": "DocumentReference.category",
+    "xpath": "f:DocumentReference/f:category",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-documentreference-date.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-documentreference-date.json
@@ -1,149 +1,149 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-documentreference-date",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreDocumentreferenceDate</h2><p><b> description</b> : When this document reference was created<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-documentreference-date</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-date</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreDocumentreferenceDate</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/DocumentReference-date\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>date</code>\n\t\t\t</p><p><b> base</b> :DocumentReference</p><p><b> type</b> : date</p><p><b> expression</b> : <code>DocumentReference.date</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:DocumentReference/f:date</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = SHOULD)</p><p><b> comparator</b> : <code>eq</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>ne</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>gt</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>ge</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>lt</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>le</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>sa</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>eb</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>ap</code> ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-date",
-	"version": "3.1.1",
-	"name": "USCoreDocumentreferenceDate",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/DocumentReference-date",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.768751Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "When this document reference was created<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "date",
-	"base": [
-		"DocumentReference"
-	],
-	"type": "date",
-	"expression": "DocumentReference.date",
-	"xpath": "f:DocumentReference/f:date",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHOULD"
-			}
-		]
-	},
-	"comparator": [
-		"eq",
-		"ne",
-		"gt",
-		"ge",
-		"lt",
-		"le",
-		"sa",
-		"eb",
-		"ap"
-	],
-	"_comparator": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		}
-	]
+    "resourceType": "SearchParameter",
+    "id": "us-core-documentreference-date",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-date",
+    "version": "3.1.1",
+    "name": "USCoreDocumentreferenceDate",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/DocumentReference-date",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.768751Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "When this document reference was created<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "date",
+    "base": [
+        "DocumentReference"
+    ],
+    "type": "date",
+    "expression": "DocumentReference.date",
+    "xpath": "f:DocumentReference/f:date",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHOULD"
+            }
+        ]
+    },
+    "comparator": [
+        "eq",
+        "ne",
+        "gt",
+        "ge",
+        "lt",
+        "le",
+        "sa",
+        "eb",
+        "ap"
+    ],
+    "_comparator": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-documentreference-id.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-documentreference-id.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-documentreference-id",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreDocumentreferenceId</h2><p><b> description</b> : Logical id of this artifact<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-documentreference-id</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-id</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreDocumentreferenceId</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Resource-id\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>_id</code>\n\t\t\t</p><p><b> base</b> :DocumentReference</p><p><b> type</b> : token</p><p><b> expression</b> : <code>DocumentReference.id</code>\n\t\t\t</p><p><b> xpath</b> : <code>DocumentReference.id</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-id",
-	"version": "3.1.1",
-	"name": "USCoreDocumentreferenceId",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Resource-id",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.702134Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Logical id of this artifact<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "_id",
-	"base": [
-		"DocumentReference"
-	],
-	"type": "token",
-	"expression": "DocumentReference.id",
-	"xpath": "DocumentReference.id",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-documentreference-id",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-id",
+    "version": "3.1.1",
+    "name": "USCoreDocumentreferenceId",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Resource-id",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.702134Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Logical id of this artifact<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "_id",
+    "base": [
+        "DocumentReference"
+    ],
+    "type": "token",
+    "expression": "DocumentReference.id",
+    "xpath": "DocumentReference.id",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-documentreference-patient.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-documentreference-patient.json
@@ -1,68 +1,68 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-documentreference-patient",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreDocumentreferencePatient</h2><p><b> description</b> : Who/what is the subject of the document<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-documentreference-patient</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreDocumentreferencePatient</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-patient\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>patient</code>\n\t\t\t</p><p><b> base</b> :DocumentReference</p><p><b> type</b> : reference</p><p><b> expression</b> : <code>DocumentReference.subject.where(resolve() is Patient)</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:DocumentReference/f:subject</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient",
-	"version": "3.1.1",
-	"name": "USCoreDocumentreferencePatient",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.735682Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Who/what is the subject of the document<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "patient",
-	"base": [
-		"DocumentReference"
-	],
-	"type": "reference",
-	"expression": "DocumentReference.subject.where(resolve() is Patient)",
-	"xpath": "f:DocumentReference/f:subject",
-	"xpathUsage": "normal",
-	"target": [
-		"Patient",
-		"Group"
-	],
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-documentreference-patient",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient",
+    "version": "3.1.1",
+    "name": "USCoreDocumentreferencePatient",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.735682Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Who/what is the subject of the document<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "patient",
+    "base": [
+        "DocumentReference"
+    ],
+    "type": "reference",
+    "expression": "DocumentReference.subject.where(resolve() is Patient)",
+    "xpath": "f:DocumentReference/f:subject",
+    "xpathUsage": "normal",
+    "target": [
+        "Patient",
+        "Group"
+    ],
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-documentreference-period.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-documentreference-period.json
@@ -1,149 +1,149 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-documentreference-period",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreDocumentreferencePeriod</h2><p><b> description</b> : Time of service that is being documented<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-documentreference-period</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-period</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreDocumentreferencePeriod</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/DocumentReference-period\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>period</code>\n\t\t\t</p><p><b> base</b> :DocumentReference</p><p><b> type</b> : date</p><p><b> expression</b> : <code>DocumentReference.context.period</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:DocumentReference/f:context/f:period</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = SHOULD)</p><p><b> comparator</b> : <code>eq</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>ne</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>gt</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>ge</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>lt</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>le</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>sa</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>eb</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>ap</code> ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-period",
-	"version": "3.1.1",
-	"name": "USCoreDocumentreferencePeriod",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/DocumentReference-period",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.789454Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Time of service that is being documented<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "period",
-	"base": [
-		"DocumentReference"
-	],
-	"type": "date",
-	"expression": "DocumentReference.context.period",
-	"xpath": "f:DocumentReference/f:context/f:period",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHOULD"
-			}
-		]
-	},
-	"comparator": [
-		"eq",
-		"ne",
-		"gt",
-		"ge",
-		"lt",
-		"le",
-		"sa",
-		"eb",
-		"ap"
-	],
-	"_comparator": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		}
-	]
+    "resourceType": "SearchParameter",
+    "id": "us-core-documentreference-period",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-period",
+    "version": "3.1.1",
+    "name": "USCoreDocumentreferencePeriod",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/DocumentReference-period",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.789454Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Time of service that is being documented<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "period",
+    "base": [
+        "DocumentReference"
+    ],
+    "type": "date",
+    "expression": "DocumentReference.context.period",
+    "xpath": "f:DocumentReference/f:context/f:period",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHOULD"
+            }
+        ]
+    },
+    "comparator": [
+        "eq",
+        "ne",
+        "gt",
+        "ge",
+        "lt",
+        "le",
+        "sa",
+        "eb",
+        "ap"
+    ],
+    "_comparator": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-documentreference-status.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-documentreference-status.json
@@ -1,70 +1,70 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-documentreference-status",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreDocumentreferenceStatus</h2><p><b> description</b> : current | superseded | entered-in-error<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-documentreference-status</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-status</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreDocumentreferenceStatus</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/DocumentReference-status\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>status</code>\n\t\t\t</p><p><b> base</b> :DocumentReference</p><p><b> type</b> : token</p><p><b> expression</b> : <code>DocumentReference.status</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:DocumentReference/f:status</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = SHALL)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"extension": [
-		{
-			"url": "http://ibm.com/fhir/extension/implicit-system",
-			"valueUri": "http://hl7.org/fhir/document-reference-status"
-		}
-	],
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-status",
-	"version": "3.1.1",
-	"name": "USCoreDocumentreferenceStatus",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/DocumentReference-status",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.721457Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "current | superseded | entered-in-error<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "status",
-	"base": [
-		"DocumentReference"
-	],
-	"type": "token",
-	"expression": "DocumentReference.status",
-	"xpath": "f:DocumentReference/f:status",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHALL"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-documentreference-status",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "extension": [
+        {
+            "url": "http://ibm.com/fhir/extension/implicit-system",
+            "valueUri": "http://hl7.org/fhir/document-reference-status"
+        }
+    ],
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-status",
+    "version": "3.1.1",
+    "name": "USCoreDocumentreferenceStatus",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/DocumentReference-status",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.721457Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "current | superseded | entered-in-error<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "status",
+    "base": [
+        "DocumentReference"
+    ],
+    "type": "token",
+    "expression": "DocumentReference.status",
+    "xpath": "f:DocumentReference/f:status",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHALL"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-documentreference-type.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-documentreference-type.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-documentreference-type",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreDocumentreferenceType</h2><p><b> description</b> : Kind of document (LOINC if possible)<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-documentreference-type</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-type</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreDocumentreferenceType</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-type\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>type</code>\n\t\t\t</p><p><b> base</b> :DocumentReference</p><p><b> type</b> : token</p><p><b> expression</b> : <code>DocumentReference.type</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:DocumentReference/f:type</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-type",
-	"version": "3.1.1",
-	"name": "USCoreDocumentreferenceType",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-type",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.753275Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Kind of document (LOINC if possible)<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "type",
-	"base": [
-		"DocumentReference"
-	],
-	"type": "token",
-	"expression": "DocumentReference.type",
-	"xpath": "f:DocumentReference/f:type",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-documentreference-type",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-type",
+    "version": "3.1.1",
+    "name": "USCoreDocumentreferenceType",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-type",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.753275Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Kind of document (LOINC if possible)<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "type",
+    "base": [
+        "DocumentReference"
+    ],
+    "type": "token",
+    "expression": "DocumentReference.type",
+    "xpath": "f:DocumentReference/f:type",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-encounter-class.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-encounter-class.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-encounter-class",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreEncounterClass</h2><p><b> description</b> : Classification of patient encounter<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-encounter-class</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-class</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreEncounterClass</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Encounter-class\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>class</code>\n\t\t\t</p><p><b> base</b> :Encounter</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Encounter.class</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Encounter/f:class</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-class",
-	"version": "3.1.1",
-	"name": "USCoreEncounterClass",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Encounter-class",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.368583Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Classification of patient encounter<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "class",
-	"base": [
-		"Encounter"
-	],
-	"type": "token",
-	"expression": "Encounter.class",
-	"xpath": "f:Encounter/f:class",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-encounter-class",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-class",
+    "version": "3.1.1",
+    "name": "USCoreEncounterClass",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Encounter-class",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.368583Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Classification of patient encounter<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "class",
+    "base": [
+        "Encounter"
+    ],
+    "type": "token",
+    "expression": "Encounter.class",
+    "xpath": "f:Encounter/f:class",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-encounter-date.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-encounter-date.json
@@ -1,149 +1,149 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-encounter-date",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreEncounterDate</h2><p><b> description</b> : A date within the period the Encounter lasted<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-encounter-date</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-date</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreEncounterDate</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-date\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>date</code>\n\t\t\t</p><p><b> base</b> :Encounter</p><p><b> type</b> : date</p><p><b> expression</b> : <code>Encounter.period</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Encounter/f:period</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = SHOULD)</p><p><b> comparator</b> : <code>eq</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>ne</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>gt</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>ge</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>lt</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>le</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>sa</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>eb</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>ap</code> ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-date",
-	"version": "3.1.1",
-	"name": "USCoreEncounterDate",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-date",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.385939Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "A date within the period the Encounter lasted<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "date",
-	"base": [
-		"Encounter"
-	],
-	"type": "date",
-	"expression": "Encounter.period",
-	"xpath": "f:Encounter/f:period",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHOULD"
-			}
-		]
-	},
-	"comparator": [
-		"eq",
-		"ne",
-		"gt",
-		"ge",
-		"lt",
-		"le",
-		"sa",
-		"eb",
-		"ap"
-	],
-	"_comparator": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		}
-	]
+    "resourceType": "SearchParameter",
+    "id": "us-core-encounter-date",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-date",
+    "version": "3.1.1",
+    "name": "USCoreEncounterDate",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-date",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.385939Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "A date within the period the Encounter lasted<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "date",
+    "base": [
+        "Encounter"
+    ],
+    "type": "date",
+    "expression": "Encounter.period",
+    "xpath": "f:Encounter/f:period",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHOULD"
+            }
+        ]
+    },
+    "comparator": [
+        "eq",
+        "ne",
+        "gt",
+        "ge",
+        "lt",
+        "le",
+        "sa",
+        "eb",
+        "ap"
+    ],
+    "_comparator": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-encounter-id.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-encounter-id.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-encounter-id",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreEncounterId</h2><p><b> description</b> : Logical id of this artifact<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-encounter-id</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-id</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreEncounterId</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Resource-id\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>_id</code>\n\t\t\t</p><p><b> base</b> :Encounter</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Encounter.id</code>\n\t\t\t</p><p><b> xpath</b> : <code>Encounter.id</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-id",
-	"version": "3.1.1",
-	"name": "USCoreEncounterId",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Resource-id",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.351982Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Logical id of this artifact<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "_id",
-	"base": [
-		"Encounter"
-	],
-	"type": "token",
-	"expression": "Encounter.id",
-	"xpath": "Encounter.id",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-encounter-id",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-id",
+    "version": "3.1.1",
+    "name": "USCoreEncounterId",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Resource-id",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.351982Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Logical id of this artifact<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "_id",
+    "base": [
+        "Encounter"
+    ],
+    "type": "token",
+    "expression": "Encounter.id",
+    "xpath": "Encounter.id",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-encounter-identifier.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-encounter-identifier.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-encounter-identifier",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreEncounterIdentifier</h2><p><b> description</b> : Identifier(s) by which this encounter is known<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-encounter-identifier</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-identifier</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreEncounterIdentifier</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-identifier\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>identifier</code>\n\t\t\t</p><p><b> base</b> :Encounter</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Encounter.identifier</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Encounter/f:identifier</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-identifier",
-	"version": "3.1.1",
-	"name": "USCoreEncounterIdentifier",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-identifier",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.433157Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Identifier(s) by which this encounter is known<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "identifier",
-	"base": [
-		"Encounter"
-	],
-	"type": "token",
-	"expression": "Encounter.identifier",
-	"xpath": "f:Encounter/f:identifier",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-encounter-identifier",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-identifier",
+    "version": "3.1.1",
+    "name": "USCoreEncounterIdentifier",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-identifier",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.433157Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Identifier(s) by which this encounter is known<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "identifier",
+    "base": [
+        "Encounter"
+    ],
+    "type": "token",
+    "expression": "Encounter.identifier",
+    "xpath": "f:Encounter/f:identifier",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-encounter-patient.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-encounter-patient.json
@@ -1,68 +1,68 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-encounter-patient",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreEncounterPatient</h2><p><b> description</b> : The patient or group present at the encounter<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-encounter-patient</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-patient</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreEncounterPatient</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-patient\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>patient</code>\n\t\t\t</p><p><b> base</b> :Encounter</p><p><b> type</b> : reference</p><p><b> expression</b> : <code>Encounter.subject.where(resolve() is Patient)</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Encounter/f:subject</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-patient",
-	"version": "3.1.1",
-	"name": "USCoreEncounterPatient",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.446705Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The patient or group present at the encounter<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "patient",
-	"base": [
-		"Encounter"
-	],
-	"type": "reference",
-	"expression": "Encounter.subject.where(resolve() is Patient)",
-	"xpath": "f:Encounter/f:subject",
-	"xpathUsage": "normal",
-	"target": [
-		"Patient",
-		"Group"
-	],
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-encounter-patient",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-patient",
+    "version": "3.1.1",
+    "name": "USCoreEncounterPatient",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.446705Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The patient or group present at the encounter<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "patient",
+    "base": [
+        "Encounter"
+    ],
+    "type": "reference",
+    "expression": "Encounter.subject.where(resolve() is Patient)",
+    "xpath": "f:Encounter/f:subject",
+    "xpathUsage": "normal",
+    "target": [
+        "Patient",
+        "Group"
+    ],
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-encounter-status.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-encounter-status.json
@@ -1,70 +1,70 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-encounter-status",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreEncounterStatus</h2><p><b> description</b> : planned | arrived | triaged | in-progress | onleave | finished | cancelled +<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-encounter-status</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-status</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreEncounterStatus</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Encounter-status\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>status</code>\n\t\t\t</p><p><b> base</b> :Encounter</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Encounter.status</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Encounter/f:status</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"extension": [
-		{
-			"url": "http://ibm.com/fhir/extension/implicit-system",
-			"valueUri": "http://hl7.org/fhir/encounter-status"
-		}
-	],
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-status",
-	"version": "3.1.1",
-	"name": "USCoreEncounterStatus",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Encounter-status",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.457978Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "planned | arrived | triaged | in-progress | onleave | finished | cancelled +<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "status",
-	"base": [
-		"Encounter"
-	],
-	"type": "token",
-	"expression": "Encounter.status",
-	"xpath": "f:Encounter/f:status",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-encounter-status",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "extension": [
+        {
+            "url": "http://ibm.com/fhir/extension/implicit-system",
+            "valueUri": "http://hl7.org/fhir/encounter-status"
+        }
+    ],
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-status",
+    "version": "3.1.1",
+    "name": "USCoreEncounterStatus",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Encounter-status",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.457978Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "planned | arrived | triaged | in-progress | onleave | finished | cancelled +<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "status",
+    "base": [
+        "Encounter"
+    ],
+    "type": "token",
+    "expression": "Encounter.status",
+    "xpath": "f:Encounter/f:status",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-encounter-type.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-encounter-type.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-encounter-type",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreEncounterType</h2><p><b> description</b> : Specific type of encounter<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-encounter-type</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-type</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreEncounterType</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-type\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>type</code>\n\t\t\t</p><p><b> base</b> :Encounter</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Encounter.type</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Encounter/f:type</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-type",
-	"version": "3.1.1",
-	"name": "USCoreEncounterType",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-type",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.478701Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Specific type of encounter<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "type",
-	"base": [
-		"Encounter"
-	],
-	"type": "token",
-	"expression": "Encounter.type",
-	"xpath": "f:Encounter/f:type",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-encounter-type",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-type",
+    "version": "3.1.1",
+    "name": "USCoreEncounterType",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-type",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.478701Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Specific type of encounter<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "type",
+    "base": [
+        "Encounter"
+    ],
+    "type": "token",
+    "expression": "Encounter.type",
+    "xpath": "f:Encounter/f:type",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-ethnicity.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-ethnicity.json
@@ -1,44 +1,44 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-ethnicity",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative</b></p><p><b>id</b>: us-core-ethnicity</p><p><b>url</b>: <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-ethnicity\">http://hl7.org/fhir/us/core/SearchParameter/us-core-ethnicity</a></p><p><b>version</b>: 3.1.1</p><p><b>name</b>: USCoreEthnicity</p><p><b>status</b>: active</p><p><b>date</b>: 2019-05-21</p><p><b>publisher</b>: US Realm Steering Committee</p><p><b>contact</b>: http://www.healthit.gov/</p><p><b>description</b>: Returns patients with an ethnicity extension matching the specified code.</p><p><b>jurisdiction</b>: <span title=\"Codes: {urn:iso:std:iso:3166 US}\">United States of America</span></p><p><b>code</b>: ethnicity</p><p><b>base</b>: Patient</p><p><b>type</b>: token</p><p><b>expression</b>: Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity').extension.value.code</p><p><b>xpath</b>: f:Patient/f:extension[@url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity']/f:extension/f:valueCoding/f:code/@value</p><p><b>xpathUsage</b>: normal</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-ethnicity",
-	"version": "3.1.1",
-	"name": "USCoreEthnicity",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "other",
-					"value": "http://www.healthit.gov/"
-				}
-			]
-		}
-	],
-	"description": "Returns patients with an ethnicity extension matching the specified code.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "ethnicity",
-	"base": [
-		"Patient"
-	],
-	"type": "token",
-	"expression": "Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity').extension.value.code",
-	"xpath": "f:Patient/f:extension[@url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity']/f:extension/f:valueCoding/f:code/@value",
-	"xpathUsage": "normal"
+    "resourceType": "SearchParameter",
+    "id": "us-core-ethnicity",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-ethnicity",
+    "version": "3.1.1",
+    "name": "USCoreEthnicity",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "other",
+                    "value": "http://www.healthit.gov/"
+                }
+            ]
+        }
+    ],
+    "description": "Returns patients with an ethnicity extension matching the specified code.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "ethnicity",
+    "base": [
+        "Patient"
+    ],
+    "type": "token",
+    "expression": "Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity').extension.value.code",
+    "xpath": "f:Patient/f:extension[@url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity']/f:extension/f:valueCoding/f:code/@value",
+    "xpathUsage": "normal"
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-goal-lifecycle-status.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-goal-lifecycle-status.json
@@ -1,70 +1,70 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-goal-lifecycle-status",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreGoalLifecycleStatus</h2><p><b> description</b> : proposed | planned | accepted | active | on-hold | completed | cancelled | entered-in-error | rejected<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-goal-lifecycle-status</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-lifecycle-status</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreGoalLifecycleStatus</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Goal-lifecycle-status\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>lifecycle-status</code>\n\t\t\t</p><p><b> base</b> :Goal</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Goal.lifecycleStatus</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Goal/f:lifecycleStatus</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"extension": [
-		{
-			"url": "http://ibm.com/fhir/extension/implicit-system",
-			"valueUri": "http://hl7.org/fhir/goal-status"
-		}
-	],
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-lifecycle-status",
-	"version": "3.1.1",
-	"name": "USCoreGoalLifecycleStatus",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Goal-lifecycle-status",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.953637Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "proposed | planned | accepted | active | on-hold | completed | cancelled | entered-in-error | rejected<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "lifecycle-status",
-	"base": [
-		"Goal"
-	],
-	"type": "token",
-	"expression": "Goal.lifecycleStatus",
-	"xpath": "f:Goal/f:lifecycleStatus",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-goal-lifecycle-status",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "extension": [
+        {
+            "url": "http://ibm.com/fhir/extension/implicit-system",
+            "valueUri": "http://hl7.org/fhir/goal-status"
+        }
+    ],
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-lifecycle-status",
+    "version": "3.1.1",
+    "name": "USCoreGoalLifecycleStatus",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Goal-lifecycle-status",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.953637Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "proposed | planned | accepted | active | on-hold | completed | cancelled | entered-in-error | rejected<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "lifecycle-status",
+    "base": [
+        "Goal"
+    ],
+    "type": "token",
+    "expression": "Goal.lifecycleStatus",
+    "xpath": "f:Goal/f:lifecycleStatus",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-goal-patient.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-goal-patient.json
@@ -1,68 +1,68 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-goal-patient",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreGoalPatient</h2><p><b> description</b> : Who this goal is intended for<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-goal-patient</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-patient</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreGoalPatient</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-patient\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>patient</code>\n\t\t\t</p><p><b> base</b> :Goal</p><p><b> type</b> : reference</p><p><b> expression</b> : <code>Goal.subject.where(resolve() is Patient)</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Goal/f:subject</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-patient",
-	"version": "3.1.1",
-	"name": "USCoreGoalPatient",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.964712Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Who this goal is intended for<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "patient",
-	"base": [
-		"Goal"
-	],
-	"type": "reference",
-	"expression": "Goal.subject.where(resolve() is Patient)",
-	"xpath": "f:Goal/f:subject",
-	"xpathUsage": "normal",
-	"target": [
-		"Patient",
-		"Group"
-	],
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-goal-patient",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-patient",
+    "version": "3.1.1",
+    "name": "USCoreGoalPatient",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.964712Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Who this goal is intended for<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "patient",
+    "base": [
+        "Goal"
+    ],
+    "type": "reference",
+    "expression": "Goal.subject.where(resolve() is Patient)",
+    "xpath": "f:Goal/f:subject",
+    "xpathUsage": "normal",
+    "target": [
+        "Patient",
+        "Group"
+    ],
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-goal-target-date.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-goal-target-date.json
@@ -1,149 +1,149 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-goal-target-date",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreGoalTargetDate</h2><p><b> description</b> : Reach goal on or before<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-goal-target-date</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-target-date</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreGoalTargetDate</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Goal-target-date\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>target-date</code>\n\t\t\t</p><p><b> base</b> :Goal</p><p><b> type</b> : date</p><p><b> expression</b> : <code>(Goal.target.due as date)</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Goal/f:target/f:dueDate</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = SHOULD)</p><p><b> comparator</b> : <code>eq</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>ne</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>gt</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>ge</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>lt</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>le</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>sa</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>eb</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>ap</code> ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-target-date",
-	"version": "3.1.1",
-	"name": "USCoreGoalTargetDate",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Goal-target-date",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.971462Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Reach goal on or before<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "target-date",
-	"base": [
-		"Goal"
-	],
-	"type": "date",
-	"expression": "(Goal.target.due as date)",
-	"xpath": "f:Goal/f:target/f:dueDate",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHOULD"
-			}
-		]
-	},
-	"comparator": [
-		"eq",
-		"ne",
-		"gt",
-		"ge",
-		"lt",
-		"le",
-		"sa",
-		"eb",
-		"ap"
-	],
-	"_comparator": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		}
-	]
+    "resourceType": "SearchParameter",
+    "id": "us-core-goal-target-date",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-target-date",
+    "version": "3.1.1",
+    "name": "USCoreGoalTargetDate",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Goal-target-date",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.971462Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Reach goal on or before<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "target-date",
+    "base": [
+        "Goal"
+    ],
+    "type": "date",
+    "expression": "(Goal.target.due as date)",
+    "xpath": "f:Goal/f:target/f:dueDate",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHOULD"
+            }
+        ]
+    },
+    "comparator": [
+        "eq",
+        "ne",
+        "gt",
+        "ge",
+        "lt",
+        "le",
+        "sa",
+        "eb",
+        "ap"
+    ],
+    "_comparator": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-immunization-date.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-immunization-date.json
@@ -1,149 +1,149 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-immunization-date",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreImmunizationDate</h2><p><b> description</b> : Vaccination  (non)-Administration Date<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-immunization-date</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-date</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreImmunizationDate</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-date\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>date</code>\n\t\t\t</p><p><b> base</b> :Immunization</p><p><b> type</b> : date</p><p><b> expression</b> : <code>Immunization.occurrence</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Immunization/f:occurrenceDateTime</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = SHOULD)</p><p><b> comparator</b> : <code>eq</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>ne</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>gt</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>ge</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>lt</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>le</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>sa</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>eb</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>ap</code> ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-date",
-	"version": "3.1.1",
-	"name": "USCoreImmunizationDate",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-date",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.688565Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Vaccination  (non)-Administration Date<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "date",
-	"base": [
-		"Immunization"
-	],
-	"type": "date",
-	"expression": "Immunization.occurrence",
-	"xpath": "f:Immunization/f:occurrenceDateTime",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHOULD"
-			}
-		]
-	},
-	"comparator": [
-		"eq",
-		"ne",
-		"gt",
-		"ge",
-		"lt",
-		"le",
-		"sa",
-		"eb",
-		"ap"
-	],
-	"_comparator": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		}
-	]
+    "resourceType": "SearchParameter",
+    "id": "us-core-immunization-date",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-date",
+    "version": "3.1.1",
+    "name": "USCoreImmunizationDate",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-date",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.688565Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Vaccination  (non)-Administration Date<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "date",
+    "base": [
+        "Immunization"
+    ],
+    "type": "date",
+    "expression": "Immunization.occurrence",
+    "xpath": "f:Immunization/f:occurrenceDateTime",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHOULD"
+            }
+        ]
+    },
+    "comparator": [
+        "eq",
+        "ne",
+        "gt",
+        "ge",
+        "lt",
+        "le",
+        "sa",
+        "eb",
+        "ap"
+    ],
+    "_comparator": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-immunization-patient.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-immunization-patient.json
@@ -1,68 +1,68 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-immunization-patient",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreImmunizationPatient</h2><p><b> description</b> : The patient for the vaccination record<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-immunization-patient</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-patient</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreImmunizationPatient</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-patient\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>patient</code>\n\t\t\t</p><p><b> base</b> :Immunization</p><p><b> type</b> : reference</p><p><b> expression</b> : <code>Immunization.patient</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Immunization/f:patient</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-patient",
-	"version": "3.1.1",
-	"name": "USCoreImmunizationPatient",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.669969Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The patient for the vaccination record<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "patient",
-	"base": [
-		"Immunization"
-	],
-	"type": "reference",
-	"expression": "Immunization.patient",
-	"xpath": "f:Immunization/f:patient",
-	"xpathUsage": "normal",
-	"target": [
-		"Patient",
-		"Group"
-	],
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-immunization-patient",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-patient",
+    "version": "3.1.1",
+    "name": "USCoreImmunizationPatient",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.669969Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The patient for the vaccination record<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "patient",
+    "base": [
+        "Immunization"
+    ],
+    "type": "reference",
+    "expression": "Immunization.patient",
+    "xpath": "f:Immunization/f:patient",
+    "xpathUsage": "normal",
+    "target": [
+        "Patient",
+        "Group"
+    ],
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-immunization-status.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-immunization-status.json
@@ -1,70 +1,70 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-immunization-status",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreImmunizationStatus</h2><p><b> description</b> : Immunization event status<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-immunization-status</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-status</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreImmunizationStatus</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Immunization-status\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>status</code>\n\t\t\t</p><p><b> base</b> :Immunization</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Immunization.status</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Immunization/f:status</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"extension": [
-		{
-			"url": "http://ibm.com/fhir/extension/implicit-system",
-			"valueUri": "http://hl7.org/fhir/event-status"
-		}
-	],
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-status",
-	"version": "3.1.1",
-	"name": "USCoreImmunizationStatus",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Immunization-status",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.67909Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Immunization event status<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "status",
-	"base": [
-		"Immunization"
-	],
-	"type": "token",
-	"expression": "Immunization.status",
-	"xpath": "f:Immunization/f:status",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-immunization-status",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "extension": [
+        {
+            "url": "http://ibm.com/fhir/extension/implicit-system",
+            "valueUri": "http://hl7.org/fhir/event-status"
+        }
+    ],
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-status",
+    "version": "3.1.1",
+    "name": "USCoreImmunizationStatus",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Immunization-status",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.67909Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Immunization event status<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "status",
+    "base": [
+        "Immunization"
+    ],
+    "type": "token",
+    "expression": "Immunization.status",
+    "xpath": "f:Immunization/f:status",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-location-address-city.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-location-address-city.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-location-address-city",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreLocationAddressCity</h2><p><b> description</b> : A city specified in an address<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-location-address-city</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-city</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreLocationAddressCity</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Location-address-city\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>address-city</code>\n\t\t\t</p><p><b> base</b> :Location</p><p><b> type</b> : string</p><p><b> expression</b> : <code>Location.address.city</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Location/f:address/f:city</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-city",
-	"version": "3.1.1",
-	"name": "USCoreLocationAddressCity",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Location-address-city",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.394960Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "A city specified in an address<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "address-city",
-	"base": [
-		"Location"
-	],
-	"type": "string",
-	"expression": "Location.address.city",
-	"xpath": "f:Location/f:address/f:city",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-location-address-city",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-city",
+    "version": "3.1.1",
+    "name": "USCoreLocationAddressCity",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Location-address-city",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.394960Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "A city specified in an address<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "address-city",
+    "base": [
+        "Location"
+    ],
+    "type": "string",
+    "expression": "Location.address.city",
+    "xpath": "f:Location/f:address/f:city",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-location-address-postalcode.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-location-address-postalcode.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-location-address-postalcode",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreLocationAddressPostalcode</h2><p><b> description</b> : A postal code specified in an address<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-location-address-postalcode</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-postalcode</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreLocationAddressPostalcode</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Location-address-postalcode\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>address-postalcode</code>\n\t\t\t</p><p><b> base</b> :Location</p><p><b> type</b> : string</p><p><b> expression</b> : <code>Location.address.postalCode</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Location/f:address/f:postalCode</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-postalcode",
-	"version": "3.1.1",
-	"name": "USCoreLocationAddressPostalcode",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Location-address-postalcode",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.437165Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "A postal code specified in an address<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "address-postalcode",
-	"base": [
-		"Location"
-	],
-	"type": "string",
-	"expression": "Location.address.postalCode",
-	"xpath": "f:Location/f:address/f:postalCode",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-location-address-postalcode",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-postalcode",
+    "version": "3.1.1",
+    "name": "USCoreLocationAddressPostalcode",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Location-address-postalcode",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.437165Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "A postal code specified in an address<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "address-postalcode",
+    "base": [
+        "Location"
+    ],
+    "type": "string",
+    "expression": "Location.address.postalCode",
+    "xpath": "f:Location/f:address/f:postalCode",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-location-address-state.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-location-address-state.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-location-address-state",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreLocationAddressState</h2><p><b> description</b> : A state specified in an address<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-location-address-state</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-state</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreLocationAddressState</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Location-address-state\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>address-state</code>\n\t\t\t</p><p><b> base</b> :Location</p><p><b> type</b> : string</p><p><b> expression</b> : <code>Location.address.state</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Location/f:address/f:state</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-state",
-	"version": "3.1.1",
-	"name": "USCoreLocationAddressState",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Location-address-state",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.406178Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "A state specified in an address<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "address-state",
-	"base": [
-		"Location"
-	],
-	"type": "string",
-	"expression": "Location.address.state",
-	"xpath": "f:Location/f:address/f:state",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-location-address-state",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-state",
+    "version": "3.1.1",
+    "name": "USCoreLocationAddressState",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Location-address-state",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.406178Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "A state specified in an address<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "address-state",
+    "base": [
+        "Location"
+    ],
+    "type": "string",
+    "expression": "Location.address.state",
+    "xpath": "f:Location/f:address/f:state",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-location-address.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-location-address.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-location-address",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreLocationAddress</h2><p><b> description</b> : A (part of the) address of the location<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-location-address</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreLocationAddress</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Location-address\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>address</code>\n\t\t\t</p><p><b> base</b> :Location</p><p><b> type</b> : string</p><p><b> expression</b> : <code>Location.address</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Location/f:address</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address",
-	"version": "3.1.1",
-	"name": "USCoreLocationAddress",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Location-address",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.381612Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "A (part of the) address of the location<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "address",
-	"base": [
-		"Location"
-	],
-	"type": "string",
-	"expression": "Location.address",
-	"xpath": "f:Location/f:address",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-location-address",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address",
+    "version": "3.1.1",
+    "name": "USCoreLocationAddress",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Location-address",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.381612Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "A (part of the) address of the location<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "address",
+    "base": [
+        "Location"
+    ],
+    "type": "string",
+    "expression": "Location.address",
+    "xpath": "f:Location/f:address",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-location-name.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-location-name.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-location-name",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreLocationName</h2><p><b> description</b> : A portion of the location's name or alias<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-location-name</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-location-name</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreLocationName</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Location-name\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>name</code>\n\t\t\t</p><p><b> base</b> :Location</p><p><b> type</b> : string</p><p><b> expression</b> : <code>Location.name</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Location/f:name</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-name",
-	"version": "3.1.1",
-	"name": "USCoreLocationName",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Location-name",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.373003Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "A portion of the location's name or alias<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "name",
-	"base": [
-		"Location"
-	],
-	"type": "string",
-	"expression": "Location.name",
-	"xpath": "f:Location/f:name",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-location-name",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-name",
+    "version": "3.1.1",
+    "name": "USCoreLocationName",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Location-name",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.373003Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "A portion of the location's name or alias<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "name",
+    "base": [
+        "Location"
+    ],
+    "type": "string",
+    "expression": "Location.name",
+    "xpath": "f:Location/f:name",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-medicationrequest-authoredon.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-medicationrequest-authoredon.json
@@ -1,149 +1,149 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-medicationrequest-authoredon",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreMedicationrequestAuthoredon</h2><p><b> description</b> : Return prescriptions written on this date<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-medicationrequest-authoredon</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-authoredon</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreMedicationrequestAuthoredon</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/MedicationRequest-authoredon\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>authoredon</code>\n\t\t\t</p><p><b> base</b> :MedicationRequest</p><p><b> type</b> : date</p><p><b> expression</b> : <code>MedicationRequest.authoredOn</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:MedicationRequest/f:authoredOn</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = SHOULD)</p><p><b> comparator</b> : <code>eq</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>ne</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>gt</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>ge</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>lt</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>le</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>sa</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>eb</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>ap</code> ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-authoredon",
-	"version": "3.1.1",
-	"name": "USCoreMedicationrequestAuthoredon",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/MedicationRequest-authoredon",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.042729Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Return prescriptions written on this date<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "authoredon",
-	"base": [
-		"MedicationRequest"
-	],
-	"type": "date",
-	"expression": "MedicationRequest.authoredOn",
-	"xpath": "f:MedicationRequest/f:authoredOn",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHOULD"
-			}
-		]
-	},
-	"comparator": [
-		"eq",
-		"ne",
-		"gt",
-		"ge",
-		"lt",
-		"le",
-		"sa",
-		"eb",
-		"ap"
-	],
-	"_comparator": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		}
-	]
+    "resourceType": "SearchParameter",
+    "id": "us-core-medicationrequest-authoredon",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-authoredon",
+    "version": "3.1.1",
+    "name": "USCoreMedicationrequestAuthoredon",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/MedicationRequest-authoredon",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.042729Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Return prescriptions written on this date<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "authoredon",
+    "base": [
+        "MedicationRequest"
+    ],
+    "type": "date",
+    "expression": "MedicationRequest.authoredOn",
+    "xpath": "f:MedicationRequest/f:authoredOn",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHOULD"
+            }
+        ]
+    },
+    "comparator": [
+        "eq",
+        "ne",
+        "gt",
+        "ge",
+        "lt",
+        "le",
+        "sa",
+        "eb",
+        "ap"
+    ],
+    "_comparator": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-medicationrequest-encounter.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-medicationrequest-encounter.json
@@ -1,67 +1,67 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-medicationrequest-encounter",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreMedicationrequestEncounter</h2><p><b> description</b> : Return prescriptions with this encounter identifier<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-medicationrequest-encounter</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-encounter</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreMedicationrequestEncounter</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/medications-encounter\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>encounter</code>\n\t\t\t</p><p><b> base</b> :MedicationRequest</p><p><b> type</b> : reference</p><p><b> expression</b> : <code>MedicationRequest.encounter</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:MedicationRequest/f:encounter</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-encounter",
-	"version": "3.1.1",
-	"name": "USCoreMedicationrequestEncounter",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/medications-encounter",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.028565Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Return prescriptions with this encounter identifier<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "encounter",
-	"base": [
-		"MedicationRequest"
-	],
-	"type": "reference",
-	"expression": "MedicationRequest.encounter",
-	"xpath": "f:MedicationRequest/f:encounter",
-	"xpathUsage": "normal",
-	"target": [
-		"Encounter"
-	],
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-medicationrequest-encounter",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-encounter",
+    "version": "3.1.1",
+    "name": "USCoreMedicationrequestEncounter",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/medications-encounter",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.028565Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Return prescriptions with this encounter identifier<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "encounter",
+    "base": [
+        "MedicationRequest"
+    ],
+    "type": "reference",
+    "expression": "MedicationRequest.encounter",
+    "xpath": "f:MedicationRequest/f:encounter",
+    "xpathUsage": "normal",
+    "target": [
+        "Encounter"
+    ],
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-medicationrequest-intent.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-medicationrequest-intent.json
@@ -1,70 +1,70 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-medicationrequest-intent",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreMedicationrequestIntent</h2><p><b> description</b> : Returns prescriptions with different intents<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-medicationrequest-intent</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-intent</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreMedicationrequestIntent</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/MedicationRequest-intent\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>intent</code>\n\t\t\t</p><p><b> base</b> :MedicationRequest</p><p><b> type</b> : token</p><p><b> expression</b> : <code>MedicationRequest.intent</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:MedicationRequest/f:intent</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = SHALL)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"extension": [
-		{
-			"url": "http://ibm.com/fhir/extension/implicit-system",
-			"valueUri": "http://hl7.org/fhir/CodeSystem/medicationrequest-intent"
-		}
-	],
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-intent",
-	"version": "3.1.1",
-	"name": "USCoreMedicationrequestIntent",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/MedicationRequest-intent",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.00284Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Returns prescriptions with different intents<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "intent",
-	"base": [
-		"MedicationRequest"
-	],
-	"type": "token",
-	"expression": "MedicationRequest.intent",
-	"xpath": "f:MedicationRequest/f:intent",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHALL"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-medicationrequest-intent",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "extension": [
+        {
+            "url": "http://ibm.com/fhir/extension/implicit-system",
+            "valueUri": "http://hl7.org/fhir/CodeSystem/medicationrequest-intent"
+        }
+    ],
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-intent",
+    "version": "3.1.1",
+    "name": "USCoreMedicationrequestIntent",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/MedicationRequest-intent",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.00284Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Returns prescriptions with different intents<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "intent",
+    "base": [
+        "MedicationRequest"
+    ],
+    "type": "token",
+    "expression": "MedicationRequest.intent",
+    "xpath": "f:MedicationRequest/f:intent",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHALL"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-medicationrequest-patient.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-medicationrequest-patient.json
@@ -1,68 +1,68 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-medicationrequest-patient",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreMedicationrequestPatient</h2><p><b> description</b> : Returns prescriptions for a specific patient<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-medicationrequest-patient</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-patient</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreMedicationrequestPatient</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-patient\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>patient</code>\n\t\t\t</p><p><b> base</b> :MedicationRequest</p><p><b> type</b> : reference</p><p><b> expression</b> : <code>MedicationRequest.subject.where(resolve() is Patient)</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:MedicationRequest/f:subject</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-patient",
-	"version": "3.1.1",
-	"name": "USCoreMedicationrequestPatient",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.017219Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Returns prescriptions for a specific patient<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "patient",
-	"base": [
-		"MedicationRequest"
-	],
-	"type": "reference",
-	"expression": "MedicationRequest.subject.where(resolve() is Patient)",
-	"xpath": "f:MedicationRequest/f:subject",
-	"xpathUsage": "normal",
-	"target": [
-		"Patient",
-		"Group"
-	],
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-medicationrequest-patient",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-patient",
+    "version": "3.1.1",
+    "name": "USCoreMedicationrequestPatient",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.017219Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Returns prescriptions for a specific patient<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "patient",
+    "base": [
+        "MedicationRequest"
+    ],
+    "type": "reference",
+    "expression": "MedicationRequest.subject.where(resolve() is Patient)",
+    "xpath": "f:MedicationRequest/f:subject",
+    "xpathUsage": "normal",
+    "target": [
+        "Patient",
+        "Group"
+    ],
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-medicationrequest-status.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-medicationrequest-status.json
@@ -1,70 +1,70 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-medicationrequest-status",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreMedicationrequestStatus</h2><p><b> description</b> : Status of the prescription<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-medicationrequest-status</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-status</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreMedicationrequestStatus</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/medications-status\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>status</code>\n\t\t\t</p><p><b> base</b> :MedicationRequest</p><p><b> type</b> : token</p><p><b> expression</b> : <code>MedicationRequest.status</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:MedicationRequest/f:status</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = SHALL)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"extension": [
-		{
-			"url": "http://ibm.com/fhir/extension/implicit-system",
-			"valueUri": "http://hl7.org/fhir/CodeSystem/medicationrequest-status"
-		}
-	],
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-status",
-	"version": "3.1.1",
-	"name": "USCoreMedicationrequestStatus",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/medications-status",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.986692Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Status of the prescription<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "status",
-	"base": [
-		"MedicationRequest"
-	],
-	"type": "token",
-	"expression": "MedicationRequest.status",
-	"xpath": "f:MedicationRequest/f:status",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHALL"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-medicationrequest-status",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "extension": [
+        {
+            "url": "http://ibm.com/fhir/extension/implicit-system",
+            "valueUri": "http://hl7.org/fhir/CodeSystem/medicationrequest-status"
+        }
+    ],
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-status",
+    "version": "3.1.1",
+    "name": "USCoreMedicationrequestStatus",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/medications-status",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.986692Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Status of the prescription<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "status",
+    "base": [
+        "MedicationRequest"
+    ],
+    "type": "token",
+    "expression": "MedicationRequest.status",
+    "xpath": "f:MedicationRequest/f:status",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHALL"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-observation-category.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-observation-category.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-observation-category",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreObservationCategory</h2><p><b> description</b> : The classification of the type of observation<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-observation-category</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-category</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreObservationCategory</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Observation-category\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>category</code>\n\t\t\t</p><p><b> base</b> :Observation</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Observation.category</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Observation/f:category</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-category",
-	"version": "3.1.1",
-	"name": "USCoreObservationCategory",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Observation-category",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.120987Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The classification of the type of observation<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "category",
-	"base": [
-		"Observation"
-	],
-	"type": "token",
-	"expression": "Observation.category",
-	"xpath": "f:Observation/f:category",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-observation-category",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-category",
+    "version": "3.1.1",
+    "name": "USCoreObservationCategory",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Observation-category",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.120987Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The classification of the type of observation<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "category",
+    "base": [
+        "Observation"
+    ],
+    "type": "token",
+    "expression": "Observation.category",
+    "xpath": "f:Observation/f:category",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-observation-code.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-observation-code.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-observation-code",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreObservationCode</h2><p><b> description</b> : The code of the observation type<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-observation-code</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-code</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreObservationCode</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-code\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>code</code>\n\t\t\t</p><p><b> base</b> :Observation</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Observation.code</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Observation/f:code</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = SHOULD)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-code",
-	"version": "3.1.1",
-	"name": "USCoreObservationCode",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-code",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.164665Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The code of the observation type<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "code",
-	"base": [
-		"Observation"
-	],
-	"type": "token",
-	"expression": "Observation.code",
-	"xpath": "f:Observation/f:code",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHOULD"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-observation-code",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-code",
+    "version": "3.1.1",
+    "name": "USCoreObservationCode",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-code",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.164665Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The code of the observation type<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "code",
+    "base": [
+        "Observation"
+    ],
+    "type": "token",
+    "expression": "Observation.code",
+    "xpath": "f:Observation/f:code",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHOULD"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-observation-date.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-observation-date.json
@@ -1,149 +1,149 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-observation-date",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreObservationDate</h2><p><b> description</b> : Obtained date/time. If the obtained element is a period, a date that falls in the period<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-observation-date</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-date</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreObservationDate</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-date\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>date</code>\n\t\t\t</p><p><b> base</b> :Observation</p><p><b> type</b> : date</p><p><b> expression</b> : <code>Observation.effective</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Observation/f:effectiveDateTime</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = SHOULD)</p><p><b> comparator</b> : <code>eq</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>ne</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>gt</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>ge</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>lt</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>le</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>sa</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>eb</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>ap</code> ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-date",
-	"version": "3.1.1",
-	"name": "USCoreObservationDate",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-date",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.206613Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Obtained date/time. If the obtained element is a period, a date that falls in the period<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "date",
-	"base": [
-		"Observation"
-	],
-	"type": "date",
-	"expression": "Observation.effective",
-	"xpath": "f:Observation/f:effectiveDateTime",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHOULD"
-			}
-		]
-	},
-	"comparator": [
-		"eq",
-		"ne",
-		"gt",
-		"ge",
-		"lt",
-		"le",
-		"sa",
-		"eb",
-		"ap"
-	],
-	"_comparator": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		}
-	]
+    "resourceType": "SearchParameter",
+    "id": "us-core-observation-date",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-date",
+    "version": "3.1.1",
+    "name": "USCoreObservationDate",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-date",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.206613Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Obtained date/time. If the obtained element is a period, a date that falls in the period<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "date",
+    "base": [
+        "Observation"
+    ],
+    "type": "date",
+    "expression": "Observation.effective",
+    "xpath": "f:Observation/f:effectiveDateTime",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHOULD"
+            }
+        ]
+    },
+    "comparator": [
+        "eq",
+        "ne",
+        "gt",
+        "ge",
+        "lt",
+        "le",
+        "sa",
+        "eb",
+        "ap"
+    ],
+    "_comparator": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-observation-patient.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-observation-patient.json
@@ -1,68 +1,68 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-observation-patient",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreObservationPatient</h2><p><b> description</b> : The subject that the observation is about (if patient)<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-observation-patient</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreObservationPatient</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-patient\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>patient</code>\n\t\t\t</p><p><b> base</b> :Observation</p><p><b> type</b> : reference</p><p><b> expression</b> : <code>Observation.subject.where(resolve() is Patient)</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Observation/f:subject</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient",
-	"version": "3.1.1",
-	"name": "USCoreObservationPatient",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.226469Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The subject that the observation is about (if patient)<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "patient",
-	"base": [
-		"Observation"
-	],
-	"type": "reference",
-	"expression": "Observation.subject.where(resolve() is Patient)",
-	"xpath": "f:Observation/f:subject",
-	"xpathUsage": "normal",
-	"target": [
-		"Patient",
-		"Group"
-	],
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-observation-patient",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient",
+    "version": "3.1.1",
+    "name": "USCoreObservationPatient",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.226469Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The subject that the observation is about (if patient)<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "patient",
+    "base": [
+        "Observation"
+    ],
+    "type": "reference",
+    "expression": "Observation.subject.where(resolve() is Patient)",
+    "xpath": "f:Observation/f:subject",
+    "xpathUsage": "normal",
+    "target": [
+        "Patient",
+        "Group"
+    ],
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-observation-status.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-observation-status.json
@@ -1,70 +1,70 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-observation-status",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreObservationStatus</h2><p><b> description</b> : The status of the observation<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-observation-status</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-status</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreObservationStatus</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Observation-status\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>status</code>\n\t\t\t</p><p><b> base</b> :Observation</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Observation.status</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Observation/f:status</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = SHALL)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"extension": [
-		{
-			"url": "http://ibm.com/fhir/extension/implicit-system",
-			"valueUri": "http://hl7.org/fhir/observation-status"
-		}
-	],
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-status",
-	"version": "3.1.1",
-	"name": "USCoreObservationStatus",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Observation-status",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.107167Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The status of the observation<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "status",
-	"base": [
-		"Observation"
-	],
-	"type": "token",
-	"expression": "Observation.status",
-	"xpath": "f:Observation/f:status",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHALL"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-observation-status",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "extension": [
+        {
+            "url": "http://ibm.com/fhir/extension/implicit-system",
+            "valueUri": "http://hl7.org/fhir/observation-status"
+        }
+    ],
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-status",
+    "version": "3.1.1",
+    "name": "USCoreObservationStatus",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Observation-status",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.107167Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The status of the observation<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "status",
+    "base": [
+        "Observation"
+    ],
+    "type": "token",
+    "expression": "Observation.status",
+    "xpath": "f:Observation/f:status",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHALL"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-organization-address.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-organization-address.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-organization-address",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreOrganizationAddress</h2><p><b> description</b> : A server defined search that may match any of the string fields in the Address, including line, city, district, state, country, postalCode, and/or text<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-organization-address</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-address</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreOrganizationAddress</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Organization-address\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>address</code>\n\t\t\t</p><p><b> base</b> :Organization</p><p><b> type</b> : string</p><p><b> expression</b> : <code>Organization.address</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Organization/f:address</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-address",
-	"version": "3.1.1",
-	"name": "USCoreOrganizationAddress",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Organization-address",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.461362Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "A server defined search that may match any of the string fields in the Address, including line, city, district, state, country, postalCode, and/or text<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "address",
-	"base": [
-		"Organization"
-	],
-	"type": "string",
-	"expression": "Organization.address",
-	"xpath": "f:Organization/f:address",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-organization-address",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-address",
+    "version": "3.1.1",
+    "name": "USCoreOrganizationAddress",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Organization-address",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.461362Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "A server defined search that may match any of the string fields in the Address, including line, city, district, state, country, postalCode, and/or text<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "address",
+    "base": [
+        "Organization"
+    ],
+    "type": "string",
+    "expression": "Organization.address",
+    "xpath": "f:Organization/f:address",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-organization-name.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-organization-name.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-organization-name",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreOrganizationName</h2><p><b> description</b> : A portion of the organization's name or alias<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-organization-name</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-name</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreOrganizationName</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Organization-name\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>name</code>\n\t\t\t</p><p><b> base</b> :Organization</p><p><b> type</b> : string</p><p><b> expression</b> : <code>Organization.name</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Organization/f:name</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-name",
-	"version": "3.1.1",
-	"name": "USCoreOrganizationName",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Organization-name",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.449104Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "A portion of the organization's name or alias<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "name",
-	"base": [
-		"Organization"
-	],
-	"type": "string",
-	"expression": "Organization.name",
-	"xpath": "f:Organization/f:name",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-organization-name",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-name",
+    "version": "3.1.1",
+    "name": "USCoreOrganizationName",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Organization-name",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.449104Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "A portion of the organization's name or alias<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "name",
+    "base": [
+        "Organization"
+    ],
+    "type": "string",
+    "expression": "Organization.name",
+    "xpath": "f:Organization/f:name",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-patient-birthdate.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-patient-birthdate.json
@@ -1,149 +1,149 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-patient-birthdate",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCorePatientBirthdate</h2><p><b> description</b> : The patient's date of birth<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-patient-birthdate</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-birthdate</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCorePatientBirthdate</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/individual-birthdate\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>birthdate</code>\n\t\t\t</p><p><b> base</b> :Patient</p><p><b> type</b> : date</p><p><b> expression</b> : <code>Patient.birthDate</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Patient/f:birthDate</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>eq</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>ne</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>gt</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>ge</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>lt</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>le</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>sa</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>eb</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>ap</code> ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-birthdate",
-	"version": "3.1.1",
-	"name": "USCorePatientBirthdate",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/individual-birthdate",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.536352Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The patient's date of birth<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "birthdate",
-	"base": [
-		"Patient"
-	],
-	"type": "date",
-	"expression": "Patient.birthDate",
-	"xpath": "f:Patient/f:birthDate",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"comparator": [
-		"eq",
-		"ne",
-		"gt",
-		"ge",
-		"lt",
-		"le",
-		"sa",
-		"eb",
-		"ap"
-	],
-	"_comparator": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		}
-	]
+    "resourceType": "SearchParameter",
+    "id": "us-core-patient-birthdate",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-birthdate",
+    "version": "3.1.1",
+    "name": "USCorePatientBirthdate",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/individual-birthdate",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.536352Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The patient's date of birth<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "birthdate",
+    "base": [
+        "Patient"
+    ],
+    "type": "date",
+    "expression": "Patient.birthDate",
+    "xpath": "f:Patient/f:birthDate",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "comparator": [
+        "eq",
+        "ne",
+        "gt",
+        "ge",
+        "lt",
+        "le",
+        "sa",
+        "eb",
+        "ap"
+    ],
+    "_comparator": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-patient-family.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-patient-family.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-patient-family",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCorePatientFamily</h2><p><b> description</b> : A portion of the family name of the patient<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-patient-family</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-family</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCorePatientFamily</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/individual-family\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>family</code>\n\t\t\t</p><p><b> base</b> :Patient</p><p><b> type</b> : string</p><p><b> expression</b> : <code>Patient.name.family</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Patient/f:name/f:family</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-family",
-	"version": "3.1.1",
-	"name": "USCorePatientFamily",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/individual-family",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.548525Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "A portion of the family name of the patient<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "family",
-	"base": [
-		"Patient"
-	],
-	"type": "string",
-	"expression": "Patient.name.family",
-	"xpath": "f:Patient/f:name/f:family",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-patient-family",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-family",
+    "version": "3.1.1",
+    "name": "USCorePatientFamily",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/individual-family",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.548525Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "A portion of the family name of the patient<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "family",
+    "base": [
+        "Patient"
+    ],
+    "type": "string",
+    "expression": "Patient.name.family",
+    "xpath": "f:Patient/f:name/f:family",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-patient-gender.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-patient-gender.json
@@ -1,70 +1,70 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-patient-gender",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCorePatientGender</h2><p><b> description</b> : Gender of the patient<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-patient-gender</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-gender</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCorePatientGender</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/individual-gender\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>gender</code>\n\t\t\t</p><p><b> base</b> :Patient</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Patient.gender</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Patient/f:gender</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"extension": [
-		{
-			"url": "http://ibm.com/fhir/extension/implicit-system",
-			"valueUri": "http://hl7.org/fhir/administrative-gender"
-		}
-	],
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-gender",
-	"version": "3.1.1",
-	"name": "USCorePatientGender",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/individual-gender",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.567529Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Gender of the patient<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "gender",
-	"base": [
-		"Patient"
-	],
-	"type": "token",
-	"expression": "Patient.gender",
-	"xpath": "f:Patient/f:gender",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-patient-gender",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "extension": [
+        {
+            "url": "http://ibm.com/fhir/extension/implicit-system",
+            "valueUri": "http://hl7.org/fhir/administrative-gender"
+        }
+    ],
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-gender",
+    "version": "3.1.1",
+    "name": "USCorePatientGender",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/individual-gender",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.567529Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Gender of the patient<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "gender",
+    "base": [
+        "Patient"
+    ],
+    "type": "token",
+    "expression": "Patient.gender",
+    "xpath": "f:Patient/f:gender",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-patient-given.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-patient-given.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-patient-given",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCorePatientGiven</h2><p><b> description</b> : A portion of the given name of the patient<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-patient-given</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-given</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCorePatientGiven</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/individual-given\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>given</code>\n\t\t\t</p><p><b> base</b> :Patient</p><p><b> type</b> : string</p><p><b> expression</b> : <code>Patient.name.given</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Patient/f:name/f:given</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-given",
-	"version": "3.1.1",
-	"name": "USCorePatientGiven",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/individual-given",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.585406Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "A portion of the given name of the patient<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "given",
-	"base": [
-		"Patient"
-	],
-	"type": "string",
-	"expression": "Patient.name.given",
-	"xpath": "f:Patient/f:name/f:given",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-patient-given",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-given",
+    "version": "3.1.1",
+    "name": "USCorePatientGiven",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/individual-given",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.585406Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "A portion of the given name of the patient<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "given",
+    "base": [
+        "Patient"
+    ],
+    "type": "string",
+    "expression": "Patient.name.given",
+    "xpath": "f:Patient/f:name/f:given",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-patient-id.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-patient-id.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-patient-id",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCorePatientId</h2><p><b> description</b> : Logical id of this artifact<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-patient-id</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-id</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCorePatientId</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Resource-id\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>_id</code>\n\t\t\t</p><p><b> base</b> :Patient</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Patient.id</code>\n\t\t\t</p><p><b> xpath</b> : <code>Patient.id</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-id",
-	"version": "3.1.1",
-	"name": "USCorePatientId",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Resource-id",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.493962Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Logical id of this artifact<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "_id",
-	"base": [
-		"Patient"
-	],
-	"type": "token",
-	"expression": "Patient.id",
-	"xpath": "Patient.id",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-patient-id",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-id",
+    "version": "3.1.1",
+    "name": "USCorePatientId",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Resource-id",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.493962Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Logical id of this artifact<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "_id",
+    "base": [
+        "Patient"
+    ],
+    "type": "token",
+    "expression": "Patient.id",
+    "xpath": "Patient.id",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-patient-identifier.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-patient-identifier.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-patient-identifier",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCorePatientIdentifier</h2><p><b> description</b> : A patient identifier<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-patient-identifier</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-identifier</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCorePatientIdentifier</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Patient-identifier\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>identifier</code>\n\t\t\t</p><p><b> base</b> :Patient</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Patient.identifier</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Patient/f:identifier</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-identifier",
-	"version": "3.1.1",
-	"name": "USCorePatientIdentifier",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Patient-identifier",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.604969Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "A patient identifier<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "identifier",
-	"base": [
-		"Patient"
-	],
-	"type": "token",
-	"expression": "Patient.identifier",
-	"xpath": "f:Patient/f:identifier",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-patient-identifier",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-identifier",
+    "version": "3.1.1",
+    "name": "USCorePatientIdentifier",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Patient-identifier",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.604969Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "A patient identifier<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "identifier",
+    "base": [
+        "Patient"
+    ],
+    "type": "token",
+    "expression": "Patient.identifier",
+    "xpath": "f:Patient/f:identifier",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-patient-name.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-patient-name.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-patient-name",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCorePatientName</h2><p><b> description</b> : A server defined search that may match any of the string fields in the HumanName, including family, give, prefix, suffix, suffix, and/or text<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-patient-name</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-name</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCorePatientName</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Patient-name\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>name</code>\n\t\t\t</p><p><b> base</b> :Patient</p><p><b> type</b> : string</p><p><b> expression</b> : <code>Patient.name</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Patient/f:name</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-name",
-	"version": "3.1.1",
-	"name": "USCorePatientName",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Patient-name",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:57.634221Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "A server defined search that may match any of the string fields in the HumanName, including family, give, prefix, suffix, suffix, and/or text<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "name",
-	"base": [
-		"Patient"
-	],
-	"type": "string",
-	"expression": "Patient.name",
-	"xpath": "f:Patient/f:name",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-patient-name",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-name",
+    "version": "3.1.1",
+    "name": "USCorePatientName",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Patient-name",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:57.634221Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "A server defined search that may match any of the string fields in the HumanName, including family, give, prefix, suffix, suffix, and/or text<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "name",
+    "base": [
+        "Patient"
+    ],
+    "type": "string",
+    "expression": "Patient.name",
+    "xpath": "f:Patient/f:name",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-practitioner-identifier.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-practitioner-identifier.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-practitioner-identifier",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCorePractitionerIdentifier</h2><p><b> description</b> : A practitioner's Identifier<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-practitioner-identifier</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-identifier</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCorePractitionerIdentifier</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Practitioner-identifier\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>identifier</code>\n\t\t\t</p><p><b> base</b> :Practitioner</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Practitioner.identifier</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Practitioner/f:identifier</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-identifier",
-	"version": "3.1.1",
-	"name": "USCorePractitionerIdentifier",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Practitioner-identifier",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.483046Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "A practitioner's Identifier<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "identifier",
-	"base": [
-		"Practitioner"
-	],
-	"type": "token",
-	"expression": "Practitioner.identifier",
-	"xpath": "f:Practitioner/f:identifier",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-practitioner-identifier",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-identifier",
+    "version": "3.1.1",
+    "name": "USCorePractitionerIdentifier",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Practitioner-identifier",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.483046Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "A practitioner's Identifier<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "identifier",
+    "base": [
+        "Practitioner"
+    ],
+    "type": "token",
+    "expression": "Practitioner.identifier",
+    "xpath": "f:Practitioner/f:identifier",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-practitioner-name.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-practitioner-name.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-practitioner-name",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCorePractitionerName</h2><p><b> description</b> : A server defined search that may match any of the string fields in the HumanName, including family, give, prefix, suffix, suffix, and/or text<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-practitioner-name</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-name</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCorePractitionerName</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Practitioner-name\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>name</code>\n\t\t\t</p><p><b> base</b> :Practitioner</p><p><b> type</b> : string</p><p><b> expression</b> : <code>Practitioner.name</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Practitioner/f:name</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-name",
-	"version": "3.1.1",
-	"name": "USCorePractitionerName",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Practitioner-name",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.473510Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "A server defined search that may match any of the string fields in the HumanName, including family, give, prefix, suffix, suffix, and/or text<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "name",
-	"base": [
-		"Practitioner"
-	],
-	"type": "string",
-	"expression": "Practitioner.name",
-	"xpath": "f:Practitioner/f:name",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-practitioner-name",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-name",
+    "version": "3.1.1",
+    "name": "USCorePractitionerName",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Practitioner-name",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.473510Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "A server defined search that may match any of the string fields in the HumanName, including family, give, prefix, suffix, suffix, and/or text<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "name",
+    "base": [
+        "Practitioner"
+    ],
+    "type": "string",
+    "expression": "Practitioner.name",
+    "xpath": "f:Practitioner/f:name",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-practitionerrole-practitioner.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-practitionerrole-practitioner.json
@@ -1,89 +1,89 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-practitionerrole-practitioner",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCorePractitionerrolePractitioner</h2><p><b> description</b> : Practitioner that is able to provide the defined services for the organization<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-practitionerrole-practitioner</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-practitioner</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCorePractitionerrolePractitioner</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/PractitionerRole-practitioner\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>practitioner</code>\n\t\t\t</p><p><b> base</b> :PractitionerRole</p><p><b> type</b> : reference</p><p><b> expression</b> : <code>PractitionerRole.practitioner</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:PractitionerRole/f:practitioner</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p><p><b> chain</b> : <code>identifier</code>  (Conformance Expectation = SHALL)</p><p><b> chain</b> : <code>name</code>  (Conformance Expectation = SHALL)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-practitioner",
-	"version": "3.1.1",
-	"name": "USCorePractitionerrolePractitioner",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/PractitionerRole-practitioner",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.507650Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Practitioner that is able to provide the defined services for the organization<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "practitioner",
-	"base": [
-		"PractitionerRole"
-	],
-	"type": "reference",
-	"expression": "PractitionerRole.practitioner",
-	"xpath": "f:PractitionerRole/f:practitioner",
-	"xpathUsage": "normal",
-	"target": [
-		"Practitioner"
-	],
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"chain": [
-		"identifier",
-		"name"
-	],
-	"_chain": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		}
-	]
+    "resourceType": "SearchParameter",
+    "id": "us-core-practitionerrole-practitioner",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-practitioner",
+    "version": "3.1.1",
+    "name": "USCorePractitionerrolePractitioner",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/PractitionerRole-practitioner",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.507650Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Practitioner that is able to provide the defined services for the organization<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "practitioner",
+    "base": [
+        "PractitionerRole"
+    ],
+    "type": "reference",
+    "expression": "PractitionerRole.practitioner",
+    "xpath": "f:PractitionerRole/f:practitioner",
+    "xpathUsage": "normal",
+    "target": [
+        "Practitioner"
+    ],
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "chain": [
+        "identifier",
+        "name"
+    ],
+    "_chain": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-practitionerrole-specialty.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-practitionerrole-specialty.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-practitionerrole-specialty",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCorePractitionerroleSpecialty</h2><p><b> description</b> : The practitioner has this specialty at an organization<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-practitionerrole-specialty</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-specialty</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCorePractitionerroleSpecialty</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/PractitionerRole-specialty\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>specialty</code>\n\t\t\t</p><p><b> base</b> :PractitionerRole</p><p><b> type</b> : token</p><p><b> expression</b> : <code>PractitionerRole.specialty</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:PractitionerRole/f:specialty</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-specialty",
-	"version": "3.1.1",
-	"name": "USCorePractitionerroleSpecialty",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/PractitionerRole-specialty",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.492949Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The practitioner has this specialty at an organization<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "specialty",
-	"base": [
-		"PractitionerRole"
-	],
-	"type": "token",
-	"expression": "PractitionerRole.specialty",
-	"xpath": "f:PractitionerRole/f:specialty",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-practitionerrole-specialty",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-specialty",
+    "version": "3.1.1",
+    "name": "USCorePractitionerroleSpecialty",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/PractitionerRole-specialty",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.492949Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The practitioner has this specialty at an organization<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "specialty",
+    "base": [
+        "PractitionerRole"
+    ],
+    "type": "token",
+    "expression": "PractitionerRole.specialty",
+    "xpath": "f:PractitionerRole/f:specialty",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-procedure-code.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-procedure-code.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-procedure-code",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreProcedureCode</h2><p><b> description</b> : A code to identify a  procedure<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-procedure-code</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-code</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreProcedureCode</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-code\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>code</code>\n\t\t\t</p><p><b> base</b> :Procedure</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Procedure.code</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Procedure/f:code</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = SHOULD)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-code",
-	"version": "3.1.1",
-	"name": "USCoreProcedureCode",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-code",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.092434Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "A code to identify a  procedure<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "code",
-	"base": [
-		"Procedure"
-	],
-	"type": "token",
-	"expression": "Procedure.code",
-	"xpath": "f:Procedure/f:code",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHOULD"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-procedure-code",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-code",
+    "version": "3.1.1",
+    "name": "USCoreProcedureCode",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-code",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.092434Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "A code to identify a  procedure<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "code",
+    "base": [
+        "Procedure"
+    ],
+    "type": "token",
+    "expression": "Procedure.code",
+    "xpath": "f:Procedure/f:code",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHOULD"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-procedure-date.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-procedure-date.json
@@ -1,149 +1,149 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-procedure-date",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreProcedureDate</h2><p><b> description</b> : When the procedure was performed<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-procedure-date</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-date</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreProcedureDate</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-date\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>date</code>\n\t\t\t</p><p><b> base</b> :Procedure</p><p><b> type</b> : date</p><p><b> expression</b> : <code>Procedure.performed</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Procedure/f:performedDateTime</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = SHOULD)</p><p><b> comparator</b> : <code>eq</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>ne</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>gt</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>ge</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>lt</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>le</code> ( Conformance Expectation = SHALL)</p><p><b> comparator</b> : <code>sa</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>eb</code> ( Conformance Expectation = MAY)</p><p><b> comparator</b> : <code>ap</code> ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-date",
-	"version": "3.1.1",
-	"name": "USCoreProcedureDate",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-date",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.073325Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "When the procedure was performed<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "date",
-	"base": [
-		"Procedure"
-	],
-	"type": "date",
-	"expression": "Procedure.performed",
-	"xpath": "f:Procedure/f:performedDateTime",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHOULD"
-			}
-		]
-	},
-	"comparator": [
-		"eq",
-		"ne",
-		"gt",
-		"ge",
-		"lt",
-		"le",
-		"sa",
-		"eb",
-		"ap"
-	],
-	"_comparator": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		}
-	]
+    "resourceType": "SearchParameter",
+    "id": "us-core-procedure-date",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-date",
+    "version": "3.1.1",
+    "name": "USCoreProcedureDate",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-date",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.073325Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "When the procedure was performed<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "date",
+    "base": [
+        "Procedure"
+    ],
+    "type": "date",
+    "expression": "Procedure.performed",
+    "xpath": "f:Procedure/f:performedDateTime",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHOULD"
+            }
+        ]
+    },
+    "comparator": [
+        "eq",
+        "ne",
+        "gt",
+        "ge",
+        "lt",
+        "le",
+        "sa",
+        "eb",
+        "ap"
+    ],
+    "_comparator": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-procedure-patient.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-procedure-patient.json
@@ -1,68 +1,68 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-procedure-patient",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreProcedurePatient</h2><p><b> description</b> : Search by subject - a patient<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-procedure-patient</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-patient</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreProcedurePatient</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-patient\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>patient</code>\n\t\t\t</p><p><b> base</b> :Procedure</p><p><b> type</b> : reference</p><p><b> expression</b> : <code>Procedure.subject.where(resolve() is Patient)</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Procedure/f:subject</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-patient",
-	"version": "3.1.1",
-	"name": "USCoreProcedurePatient",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.063354Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Search by subject - a patient<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "patient",
-	"base": [
-		"Procedure"
-	],
-	"type": "reference",
-	"expression": "Procedure.subject.where(resolve() is Patient)",
-	"xpath": "f:Procedure/f:subject",
-	"xpathUsage": "normal",
-	"target": [
-		"Patient",
-		"Group"
-	],
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-procedure-patient",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-patient",
+    "version": "3.1.1",
+    "name": "USCoreProcedurePatient",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.063354Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Search by subject - a patient<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "patient",
+    "base": [
+        "Procedure"
+    ],
+    "type": "reference",
+    "expression": "Procedure.subject.where(resolve() is Patient)",
+    "xpath": "f:Procedure/f:subject",
+    "xpathUsage": "normal",
+    "target": [
+        "Patient",
+        "Group"
+    ],
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-procedure-status.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-procedure-status.json
@@ -1,70 +1,70 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-procedure-status",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>SearchParameter: USCoreProcedureStatus</h2><p><b> description</b> : preparation | in-progress | not-done | on-hold | stopped | completed | entered-in-error | unknown<br/>\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br/>\n - multipleAnd<br/>\n - multipleOr<br/>\n - comparator<br/>\n - modifier<br/>\n - chain<br/>\n\n </p><br/><p><b> id</b> us-core-procedure-status</p><p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-status</b>\n\t\t\t</p><p><b> version</b> : 4.0.1</p><p><b> name</b> : USCoreProcedureStatus</p><p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Procedure-status\n\t\t\t</p><p><b> status</b> : active</p><p><b> experimental</b>  False</p><p><b> date</b> : 2020-07-01</p><p><b> publisher</b> : HL7 International - US Realm Steering Committee</p><p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p><p><b> useContext</b> : </p><p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> --><p><b> code</b> : <code>status</code>\n\t\t\t</p><p><b> base</b> :Procedure</p><p><b> type</b> : token</p><p><b> expression</b> : <code>Procedure.status</code>\n\t\t\t</p><p><b> xpath</b> : <code>f:Procedure/f:status</code>\n\t\t\t</p><p><b> xpathUsage</b> : normal</p><p><b> mulitpleOr</b> : True   (Conformance Expectation = SHALL)</p><p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p></div>"
-	},
-	"extension": [
-		{
-			"url": "http://ibm.com/fhir/extension/implicit-system",
-			"valueUri": "http://hl7.org/fhir/event-status"
-		}
-	],
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-status",
-	"version": "3.1.1",
-	"name": "USCoreProcedureStatus",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Procedure-status",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01T21:51:58.057158Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "preparation | in-progress | not-done | on-hold | stopped | completed | entered-in-error | unknown<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "status",
-	"base": [
-		"Procedure"
-	],
-	"type": "token",
-	"expression": "Procedure.status",
-	"xpath": "f:Procedure/f:status",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHALL"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-procedure-status",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "extension": [
+        {
+            "url": "http://ibm.com/fhir/extension/implicit-system",
+            "valueUri": "http://hl7.org/fhir/event-status"
+        }
+    ],
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-status",
+    "version": "3.1.1",
+    "name": "USCoreProcedureStatus",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Procedure-status",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01T21:51:58.057158Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "preparation | in-progress | not-done | on-hold | stopped | completed | entered-in-error | unknown<br />\n<em>NOTE</em>: This US Core SearchParameter definition extends the usage context of\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">capabilitystatement-expectation</a>\n extension to formally express implementer conformance expectations for these elements:<br />\n - multipleAnd<br />\n - multipleOr<br />\n - comparator<br />\n - modifier<br />\n - chain<br />\n\n ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "status",
+    "base": [
+        "Procedure"
+    ],
+    "type": "token",
+    "expression": "Procedure.status",
+    "xpath": "f:Procedure/f:status",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHALL"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-race.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/SearchParameter-us-core-race.json
@@ -1,44 +1,44 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-race",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative</b></p><p><b>id</b>: us-core-race</p><p><b>url</b>: <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-race\">http://hl7.org/fhir/us/core/SearchParameter/us-core-race</a></p><p><b>version</b>: 3.1.1</p><p><b>name</b>: USCoreRace</p><p><b>status</b>: active</p><p><b>date</b>: 2019-05-21</p><p><b>publisher</b>: US Realm Steering Committee</p><p><b>contact</b>: http://www.healthit.gov/</p><p><b>description</b>: Returns patients with a race extension matching the specified code.</p><p><b>jurisdiction</b>: <span title=\"Codes: {urn:iso:std:iso:3166 US}\">United States of America</span></p><p><b>code</b>: race</p><p><b>base</b>: Patient</p><p><b>type</b>: token</p><p><b>expression</b>: Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race').extension.value.code</p><p><b>xpath</b>: f:Patient/f:extension[@url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-race']/f:extension/f:valueCoding/f:code/@value</p><p><b>xpathUsage</b>: normal</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-race",
-	"version": "3.1.1",
-	"name": "USCoreRace",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "other",
-					"value": "http://www.healthit.gov/"
-				}
-			]
-		}
-	],
-	"description": "Returns patients with a race extension matching the specified code.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"code": "race",
-	"base": [
-		"Patient"
-	],
-	"type": "token",
-	"expression": "Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race').extension.value.code",
-	"xpath": "f:Patient/f:extension[@url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-race']/f:extension/f:valueCoding/f:code/@value",
-	"xpathUsage": "normal"
+    "resourceType": "SearchParameter",
+    "id": "us-core-race",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-race",
+    "version": "3.1.1",
+    "name": "USCoreRace",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "other",
+                    "value": "http://www.healthit.gov/"
+                }
+            ]
+        }
+    ],
+    "description": "Returns patients with a race extension matching the specified code.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "code": "race",
+    "base": [
+        "Patient"
+    ],
+    "type": "token",
+    "expression": "Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race').extension.value.code",
+    "xpath": "f:Patient/f:extension[@url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-race']/f:extension/f:valueCoding/f:code/@value",
+    "xpathUsage": "normal"
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-head-occipital-frontal-circumference-percentile.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-head-occipital-frontal-circumference-percentile.json
@@ -1,3823 +1,3823 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "head-occipital-frontal-circumference-percentile",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <span title=\"This profile defines how to represent head occipital-frontal circumference percentile for patients from birth to 36 months of age in FHIR using a standard LOINC code and UCUM units of measure.\">Observation</span><a name=\"Observation\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/vitalsigns.html\">observation-vitalsigns</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">FHIR Vital Signs Profile</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> code<a name=\"Observation.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">1</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Head Occipital-frontal circumference Percentile<br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck101.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#CodeableConcept.coding\">coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Code defined by a terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">(complex)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/loinc.html\">http://loinc.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">8289-1</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> subject<a name=\"Observation.subject\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who and/or what the observation is about</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> valueQuantity<a name=\"Observation.valueQuantity\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Quantity\">Quantity</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> value<a name=\"Observation.valueQuantity.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#decimal\">decimal</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Numerical value (with implicit precision)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> unit<a name=\"Observation.valueQuantity.unit\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Unit representation</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> system<a name=\"Observation.valueQuantity.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">System that defines coded unit form</span><br/><span style=\"font-weight:bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/ucum.html\">http://unitsofmeasure.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> code<a name=\"Observation.valueQuantity.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Coded responses from the common UCUM units for vital signs value set.<br/><span style=\"font-weight:bold\">Fixed Value: </span><span style=\"color: darkgreen\">%</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile",
-	"version": "3.1.1",
-	"name": "UsCorePediatricHeadOccipitalFrontalCircumferencePercentileProfile",
-	"title": "US Core Pediatric Head Occipital-frontal Circumference Percentile Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-01",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.healthit.gov"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the Observation resource for use in querying and retrieving pediatric Pediatric Head Occipital-frontal Circumference Percentile observations.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "sct-concept",
-			"uri": "http://snomed.info/conceptdomain",
-			"name": "SNOMED CT Concept Domain Binding"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "sct-attr",
-			"uri": "http://snomed.org/attributebinding",
-			"name": "SNOMED CT Attribute Binding"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Observation",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/vitalsigns",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "FHIR Vital Signs Profile",
-				"definition": "This profile defines how to represent head occipital-frontal circumference percentile for patients from birth to 36 months of age in FHIR using a standard LOINC code and UCUM units of measure.",
-				"comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
-				"alias": [
-					"Vital Signs",
-					"Measurement",
-					"Results",
-					"Tests"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "obs-6",
-						"severity": "error",
-						"human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
-						"expression": "dataAbsentReason.empty() or value.empty()",
-						"xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "obs-7",
-						"severity": "error",
-						"human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
-						"expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
-						"xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "vs-2",
-						"severity": "error",
-						"human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
-						"expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
-						"xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.id",
-				"path": "Observation.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.meta",
-				"path": "Observation.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.implicitRules",
-				"path": "Observation.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Observation.language",
-				"path": "Observation.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Observation.text",
-				"path": "Observation.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Observation.contained",
-				"path": "Observation.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.extension",
-				"path": "Observation.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.modifierExtension",
-				"path": "Observation.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.identifier",
-				"path": "Observation.identifier",
-				"short": "Business Identifier for observation",
-				"definition": "A unique identifier assigned to this observation.",
-				"requirements": "Allows observations to be distinguished and referenced.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
-					},
-					{
-						"identity": "rim",
-						"map": "id"
-					}
-				]
-			},
-			{
-				"id": "Observation.basedOn",
-				"path": "Observation.basedOn",
-				"short": "Fulfills plan, proposal or order",
-				"definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
-				"requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
-				"alias": [
-					"Fulfills"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan",
-							"http://hl7.org/fhir/StructureDefinition/DeviceRequest",
-							"http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
-							"http://hl7.org/fhir/StructureDefinition/MedicationRequest",
-							"http://hl7.org/fhir/StructureDefinition/NutritionOrder",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.basedOn"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.partOf",
-				"path": "Observation.partOf",
-				"short": "Part of referenced event",
-				"definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
-				"comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
-				"alias": [
-					"Container"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.partOf",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
-							"http://hl7.org/fhir/StructureDefinition/MedicationDispense",
-							"http://hl7.org/fhir/StructureDefinition/MedicationStatement",
-							"http://hl7.org/fhir/StructureDefinition/Procedure",
-							"http://hl7.org/fhir/StructureDefinition/Immunization",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.partOf"
-					},
-					{
-						"identity": "v2",
-						"map": "Varies by domain"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=FLFS].target"
-					}
-				]
-			},
-			{
-				"id": "Observation.status",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
-						"valueString": "default: final"
-					}
-				],
-				"path": "Observation.status",
-				"short": "registered | preliminary | final | amended +",
-				"definition": "The status of the result value.",
-				"comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
-				"requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Status"
-						}
-					],
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 445584004 |Report by finality status|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-11"
-					},
-					{
-						"identity": "rim",
-						"map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
-					}
-				]
-			},
-			{
-				"id": "Observation.category",
-				"path": "Observation.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "coding.code"
-						},
-						{
-							"type": "value",
-							"path": "coding.system"
-						}
-					],
-					"ordered": false,
-					"rules": "open"
-				},
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat",
-				"path": "Observation.category",
-				"sliceName": "VSCat",
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.id",
-				"path": "Observation.category.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.extension",
-				"path": "Observation.category.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding",
-				"path": "Observation.category.coding",
-				"short": "Code defined by a terminology system",
-				"definition": "A reference to a code defined by a terminology system.",
-				"comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
-				"requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "CodeableConcept.coding",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1-8, C*E.10-22"
-					},
-					{
-						"identity": "rim",
-						"map": "union(., ./translation)"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.id",
-				"path": "Observation.category.coding.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.extension",
-				"path": "Observation.category.coding.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.system",
-				"path": "Observation.category.coding.system",
-				"short": "Identity of the terminology system",
-				"definition": "The identification of the code system that defines the meaning of the symbol in the code.",
-				"comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
-				"requirements": "Need to be unambiguous about the source of the definition of the symbol.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.3"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystem"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.version",
-				"path": "Observation.category.coding.version",
-				"short": "Version of the system - if relevant",
-				"definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
-				"comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.version",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.7"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystemVersion"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.code",
-				"path": "Observation.category.coding.code",
-				"short": "Symbol in syntax defined by the system",
-				"definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
-				"requirements": "Need to refer to a particular code in the system.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "vital-signs",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1"
-					},
-					{
-						"identity": "rim",
-						"map": "./code"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.display",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.coding.display",
-				"short": "Representation defined by the system",
-				"definition": "A representation of the meaning of the code in the system, following the rules of the system.",
-				"requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.display",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.2 - but note this is not well followed"
-					},
-					{
-						"identity": "rim",
-						"map": "CV.displayName"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.userSelected",
-				"path": "Observation.category.coding.userSelected",
-				"short": "If this coding was chosen directly by the user",
-				"definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
-				"comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
-				"requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.userSelected",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Sometimes implied by being first"
-					},
-					{
-						"identity": "rim",
-						"map": "CD.codingRationale"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.text",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.text",
-				"short": "Plain text representation of the concept",
-				"definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
-				"comment": "Very often the text is the same as a displayName of one of the codings.",
-				"requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CodeableConcept.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.9. But note many systems use C*E.2 for this"
-					},
-					{
-						"identity": "rim",
-						"map": "./originalText[mediaType/code=\"text/plain\"]/data"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
-					}
-				]
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Head Occipital-frontal circumference Percentile",
-				"definition": "Coded Responses from C-CDA Vital Sign Results.",
-				"comment": "additional codes that translate or map to this code are allowed.  For example a more granular LOINC code or code that is used locally in a system.",
-				"requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
-				"alias": [
-					"Name",
-					"Test"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "8289-1"
-						}
-					]
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "VitalSigns"
-						}
-					],
-					"strength": "extensible",
-					"description": "This identifies the vital sign result type.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-vitalsignresult"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "116680003 |Is a|"
-					}
-				]
-			},
-			{
-				"id": "Observation.subject",
-				"path": "Observation.subject",
-				"short": "Who and/or what the observation is about",
-				"definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
-				"comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
-				"requirements": "Observations have no value if you don't know who or what they're about.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=RTGT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.focus",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
-						"valueCode": "trial-use"
-					}
-				],
-				"path": "Observation.focus",
-				"short": "What the observation is about, when it is not about the subject of record",
-				"definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
-				"comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.focus",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SBJ]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.encounter",
-				"path": "Observation.encounter",
-				"short": "Healthcare event during which this observation is made",
-				"definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
-				"comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
-				"requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
-				"alias": [
-					"Context"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.effective[x]",
-				"path": "Observation.effective[x]",
-				"short": "Often just a dateTime for Vital Signs",
-				"definition": "Often just a dateTime for Vital Signs.",
-				"comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
-				"requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
-				"alias": [
-					"Occurrence"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.effective[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-1",
-						"severity": "error",
-						"human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
-						"expression": "($this as dateTime).toString().length() >= 8",
-						"xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "Observation.issued",
-				"path": "Observation.issued",
-				"short": "Date/Time this version was made available",
-				"definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
-				"comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.issued",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=AUT].time"
-					}
-				]
-			},
-			{
-				"id": "Observation.performer",
-				"path": "Observation.performer",
-				"short": "Who is responsible for the observation",
-				"definition": "Who was responsible for asserting the observed value as \"true\".",
-				"requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.performer",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=PRF]"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]",
-				"path": "Observation.value[x]",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "type",
-							"path": "$this"
-						}
-					],
-					"ordered": false,
-					"rules": "closed"
-				},
-				"short": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
-				"definition": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity",
-				"path": "Observation.value[x]",
-				"sliceName": "valueQuantity",
-				"short": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
-				"definition": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.id",
-				"path": "Observation.value[x].id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.extension",
-				"path": "Observation.value[x].extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.value",
-				"path": "Observation.value[x].value",
-				"short": "Numerical value (with implicit precision)",
-				"definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
-				"comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
-				"requirements": "Precision is handled implicitly in almost all cases of measurement.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.2  / CQ - N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.comparator",
-				"path": "Observation.value[x].comparator",
-				"short": "< | <= | >= | > - how to understand the value",
-				"definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
-				"requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Quantity.comparator",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "QuantityComparator"
-						}
-					],
-					"strength": "required",
-					"description": "How the Quantity should be understood and represented.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.1  / CQ.1"
-					},
-					{
-						"identity": "rim",
-						"map": "IVL properties"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.unit",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.value[x].unit",
-				"short": "Unit representation",
-				"definition": "A human-readable form of the unit.",
-				"requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.unit",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.unit"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.system",
-				"path": "Observation.value[x].system",
-				"short": "System that defines coded unit form",
-				"definition": "The identification of the system that provides the coded form of the unit.",
-				"requirements": "Need to know the system that defines the coded form of the unit.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"condition": [
-					"qty-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "CO.codeSystem, PQ.translation.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.code",
-				"path": "Observation.value[x].code",
-				"short": "Coded responses from the common UCUM units for vital signs value set.",
-				"definition": "A computer processable form of the unit in some unit representation system.",
-				"comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
-				"requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "%",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.code, MO.currency, PQ.translation.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.dataAbsentReason",
-				"path": "Observation.dataAbsentReason",
-				"short": "Why the result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
-				"comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.interpretation",
-				"path": "Observation.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.note",
-				"path": "Observation.note",
-				"short": "Comments about the observation",
-				"definition": "Comments about the observation or the results.",
-				"comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
-				"requirements": "Need to be able to provide free text additional information.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
-					},
-					{
-						"identity": "rim",
-						"map": "subjectOf.observationEvent[code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.bodySite",
-				"path": "Observation.bodySite",
-				"short": "Observed body part",
-				"definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
-				"comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.bodySite",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "BodySite"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing anatomical locations. May include laterality.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/body-site"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123037004 |Body structure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-20"
-					},
-					{
-						"identity": "rim",
-						"map": "targetSiteCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "718497002 |Inherent location|"
-					}
-				]
-			},
-			{
-				"id": "Observation.method",
-				"path": "Observation.method",
-				"short": "How it was done",
-				"definition": "Indicates the mechanism used to perform the observation.",
-				"comment": "Only used if not implicit in code for Observation.code.",
-				"requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.method",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationMethod"
-						}
-					],
-					"strength": "example",
-					"description": "Methods for simple observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-17"
-					},
-					{
-						"identity": "rim",
-						"map": "methodCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.specimen",
-				"path": "Observation.specimen",
-				"short": "Specimen used for this observation",
-				"definition": "The specimen that was used when this observation was made.",
-				"comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.specimen",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Specimen"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123038009 |Specimen|"
-					},
-					{
-						"identity": "v2",
-						"map": "SPM segment"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SPC].specimen"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "704319004 |Inherent in|"
-					}
-				]
-			},
-			{
-				"id": "Observation.device",
-				"path": "Observation.device",
-				"short": "(Measurement) Device",
-				"definition": "The device used to generate the observation data.",
-				"comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.device",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/DeviceMetric"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 49062001 |Device|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-17 / PRT -10"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=DEV]"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "424226004 |Using device|"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange",
-				"path": "Observation.referenceRange",
-				"short": "Provides guide for interpretation",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "obs-3",
-						"severity": "error",
-						"human": "Must have at least a low or a high or text",
-						"expression": "low.exists() or high.exists() or text.exists()",
-						"xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.id",
-				"path": "Observation.referenceRange.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.extension",
-				"path": "Observation.referenceRange.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.modifierExtension",
-				"path": "Observation.referenceRange.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.low",
-				"path": "Observation.referenceRange.low",
-				"short": "Low Range, if relevant",
-				"definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.low",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.low"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.high",
-				"path": "Observation.referenceRange.high",
-				"short": "High Range, if relevant",
-				"definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.high",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.high"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.type",
-				"path": "Observation.referenceRange.type",
-				"short": "Reference range qualifier",
-				"definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
-				"requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeMeaning"
-						}
-					],
-					"strength": "preferred",
-					"description": "Code for the meaning of a reference range.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.appliesTo",
-				"path": "Observation.referenceRange.appliesTo",
-				"short": "Reference range population",
-				"definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
-				"requirements": "Need to be able to identify the target population for proper interpretation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange.appliesTo",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeType"
-						}
-					],
-					"strength": "example",
-					"description": "Codes identifying the population the reference range applies to.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.age",
-				"path": "Observation.referenceRange.age",
-				"short": "Applicable age range, if relevant",
-				"definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
-				"requirements": "Some analytes vary greatly over age.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.age",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Range"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.text",
-				"path": "Observation.referenceRange.text",
-				"short": "Text based reference range in an observation",
-				"definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:ST"
-					}
-				]
-			},
-			{
-				"id": "Observation.hasMember",
-				"path": "Observation.hasMember",
-				"short": "Used when reporting vital signs panel components",
-				"definition": "Used when reporting vital signs panel components.",
-				"comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.hasMember",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship"
-					}
-				]
-			},
-			{
-				"id": "Observation.derivedFrom",
-				"path": "Observation.derivedFrom",
-				"short": "Related measurements the observation is made from",
-				"definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
-				"comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.derivedFrom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/DocumentReference",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy",
-							"http://hl7.org/fhir/StructureDefinition/Media",
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": ".targetObservation"
-					}
-				]
-			},
-			{
-				"id": "Observation.component",
-				"path": "Observation.component",
-				"short": "Used when reporting systolic and diastolic blood pressure.",
-				"definition": "Used when reporting systolic and diastolic blood pressure.",
-				"comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-3",
-						"severity": "error",
-						"human": "If there is no a value a data absent reason must be present",
-						"expression": "value.exists() or dataAbsentReason.exists()",
-						"xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "containment by OBX-4?"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=COMP]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.id",
-				"path": "Observation.component.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.extension",
-				"path": "Observation.component.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.modifierExtension",
-				"path": "Observation.component.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.code",
-				"path": "Observation.component.code",
-				"short": "Type of component observation (code / type)",
-				"definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
-				"comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "VitalSigns"
-						}
-					],
-					"strength": "extensible",
-					"description": "This identifies the vital sign result type.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-vitalsignresult"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.value[x]",
-				"path": "Observation.component.value[x]",
-				"short": "Vital Sign Value recorded with UCUM",
-				"definition": "Vital Sign Value recorded with UCUM.",
-				"comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "VitalSignsUnits"
-						}
-					],
-					"strength": "required",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.dataAbsentReason",
-				"path": "Observation.component.dataAbsentReason",
-				"short": "Why the component result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
-				"comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.interpretation",
-				"path": "Observation.component.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.referenceRange",
-				"path": "Observation.component.referenceRange",
-				"short": "Provides guide for interpretation of component result",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"contentReference": "#Observation.referenceRange",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"definition": "This profile defines how to represent head occipital-frontal circumference percentile for patients from birth to 36 months of age in FHIR using a standard LOINC code and UCUM units of measure.",
-				"mustSupport": false
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Head Occipital-frontal circumference Percentile",
-				"comment": "additional codes that translate or map to this code are allowed.  For example a more granular LOINC code or code that is used locally in a system.",
-				"alias": [
-					"Test",
-					"Name"
-				],
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "8289-1"
-						}
-					]
-				},
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.subject",
-				"path": "Observation.subject",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity",
-				"path": "Observation.valueQuantity",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.value",
-				"path": "Observation.valueQuantity.value",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.unit",
-				"path": "Observation.valueQuantity.unit",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.system",
-				"path": "Observation.valueQuantity.system",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.code",
-				"path": "Observation.valueQuantity.code",
-				"short": "Coded responses from the common UCUM units for vital signs value set.",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "%",
-				"mustSupport": true
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "head-occipital-frontal-circumference-percentile",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile",
+    "version": "3.1.1",
+    "name": "UsCorePediatricHeadOccipitalFrontalCircumferencePercentileProfile",
+    "title": "US Core Pediatric Head Occipital-frontal Circumference Percentile Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-01",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.healthit.gov"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the Observation resource for use in querying and retrieving pediatric Pediatric Head Occipital-frontal Circumference Percentile observations.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "sct-concept",
+            "uri": "http://snomed.info/conceptdomain",
+            "name": "SNOMED CT Concept Domain Binding"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "sct-attr",
+            "uri": "http://snomed.org/attributebinding",
+            "name": "SNOMED CT Attribute Binding"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Observation",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/vitalsigns",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "FHIR Vital Signs Profile",
+                "definition": "This profile defines how to represent head occipital-frontal circumference percentile for patients from birth to 36 months of age in FHIR using a standard LOINC code and UCUM units of measure.",
+                "comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
+                "alias": [
+                    "Vital Signs",
+                    "Measurement",
+                    "Results",
+                    "Tests"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "obs-6",
+                        "severity": "error",
+                        "human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
+                        "expression": "dataAbsentReason.empty() or value.empty()",
+                        "xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "obs-7",
+                        "severity": "error",
+                        "human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
+                        "expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
+                        "xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "vs-2",
+                        "severity": "error",
+                        "human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
+                        "expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
+                        "xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.id",
+                "path": "Observation.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.meta",
+                "path": "Observation.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.implicitRules",
+                "path": "Observation.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Observation.language",
+                "path": "Observation.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Observation.text",
+                "path": "Observation.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.contained",
+                "path": "Observation.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.extension",
+                "path": "Observation.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.modifierExtension",
+                "path": "Observation.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.identifier",
+                "path": "Observation.identifier",
+                "short": "Business Identifier for observation",
+                "definition": "A unique identifier assigned to this observation.",
+                "requirements": "Allows observations to be distinguished and referenced.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "id"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.basedOn",
+                "path": "Observation.basedOn",
+                "short": "Fulfills plan, proposal or order",
+                "definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
+                "requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
+                "alias": [
+                    "Fulfills"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceRequest",
+                            "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+                            "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.basedOn"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.partOf",
+                "path": "Observation.partOf",
+                "short": "Part of referenced event",
+                "definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
+                "comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
+                "alias": [
+                    "Container"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.partOf",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationDispense",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationStatement",
+                            "http://hl7.org/fhir/StructureDefinition/Procedure",
+                            "http://hl7.org/fhir/StructureDefinition/Immunization",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.partOf"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "Varies by domain"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=FLFS].target"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.status",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
+                        "valueString": "default: final"
+                    }
+                ],
+                "path": "Observation.status",
+                "short": "registered | preliminary | final | amended +",
+                "definition": "The status of the result value.",
+                "comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
+                "requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Status"
+                        }
+                    ],
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 445584004 |Report by finality status|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-11"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category",
+                "path": "Observation.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "coding.code"
+                        },
+                        {
+                            "type": "value",
+                            "path": "coding.system"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "open"
+                },
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat",
+                "path": "Observation.category",
+                "sliceName": "VSCat",
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.id",
+                "path": "Observation.category.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.extension",
+                "path": "Observation.category.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding",
+                "path": "Observation.category.coding",
+                "short": "Code defined by a terminology system",
+                "definition": "A reference to a code defined by a terminology system.",
+                "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+                "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "CodeableConcept.coding",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1-8, C*E.10-22"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "union(., ./translation)"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.id",
+                "path": "Observation.category.coding.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.extension",
+                "path": "Observation.category.coding.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.system",
+                "path": "Observation.category.coding.system",
+                "short": "Identity of the terminology system",
+                "definition": "The identification of the code system that defines the meaning of the symbol in the code.",
+                "comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
+                "requirements": "Need to be unambiguous about the source of the definition of the symbol.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystem"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.version",
+                "path": "Observation.category.coding.version",
+                "short": "Version of the system - if relevant",
+                "definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
+                "comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.version",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystemVersion"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.code",
+                "path": "Observation.category.coding.code",
+                "short": "Symbol in syntax defined by the system",
+                "definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
+                "requirements": "Need to refer to a particular code in the system.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "vital-signs",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./code"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.display",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.coding.display",
+                "short": "Representation defined by the system",
+                "definition": "A representation of the meaning of the code in the system, following the rules of the system.",
+                "requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.display",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.2 - but note this is not well followed"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CV.displayName"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.userSelected",
+                "path": "Observation.category.coding.userSelected",
+                "short": "If this coding was chosen directly by the user",
+                "definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
+                "comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
+                "requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.userSelected",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Sometimes implied by being first"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CD.codingRationale"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.text",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.text",
+                "short": "Plain text representation of the concept",
+                "definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
+                "comment": "Very often the text is the same as a displayName of one of the codings.",
+                "requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CodeableConcept.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.9. But note many systems use C*E.2 for this"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./originalText[mediaType/code=\"text/plain\"]/data"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Head Occipital-frontal circumference Percentile",
+                "definition": "Coded Responses from C-CDA Vital Sign Results.",
+                "comment": "additional codes that translate or map to this code are allowed.  For example a more granular LOINC code or code that is used locally in a system.",
+                "requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
+                "alias": [
+                    "Name",
+                    "Test"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "8289-1"
+                        }
+                    ]
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "VitalSigns"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "This identifies the vital sign result type.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-vitalsignresult"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "116680003 |Is a|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.subject",
+                "path": "Observation.subject",
+                "short": "Who and/or what the observation is about",
+                "definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
+                "comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
+                "requirements": "Observations have no value if you don't know who or what they're about.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=RTGT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.focus",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+                        "valueCode": "trial-use"
+                    }
+                ],
+                "path": "Observation.focus",
+                "short": "What the observation is about, when it is not about the subject of record",
+                "definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
+                "comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.focus",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SBJ]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.encounter",
+                "path": "Observation.encounter",
+                "short": "Healthcare event during which this observation is made",
+                "definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
+                "comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
+                "requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
+                "alias": [
+                    "Context"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.effective[x]",
+                "path": "Observation.effective[x]",
+                "short": "Often just a dateTime for Vital Signs",
+                "definition": "Often just a dateTime for Vital Signs.",
+                "comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
+                "requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
+                "alias": [
+                    "Occurrence"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.effective[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-1",
+                        "severity": "error",
+                        "human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
+                        "expression": "($this as dateTime).toString().length() >= 8",
+                        "xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.issued",
+                "path": "Observation.issued",
+                "short": "Date/Time this version was made available",
+                "definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
+                "comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.issued",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.performer",
+                "path": "Observation.performer",
+                "short": "Who is responsible for the observation",
+                "definition": "Who was responsible for asserting the observed value as \"true\".",
+                "requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.performer",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=PRF]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]",
+                "path": "Observation.value[x]",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "type",
+                            "path": "$this"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "closed"
+                },
+                "short": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
+                "definition": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity",
+                "path": "Observation.value[x]",
+                "sliceName": "valueQuantity",
+                "short": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
+                "definition": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.id",
+                "path": "Observation.value[x].id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.extension",
+                "path": "Observation.value[x].extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.value",
+                "path": "Observation.value[x].value",
+                "short": "Numerical value (with implicit precision)",
+                "definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
+                "comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
+                "requirements": "Precision is handled implicitly in almost all cases of measurement.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.2  / CQ - N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.comparator",
+                "path": "Observation.value[x].comparator",
+                "short": "< | <= | >= | > - how to understand the value",
+                "definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
+                "requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.comparator",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "QuantityComparator"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "How the Quantity should be understood and represented.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.1  / CQ.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "IVL properties"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.unit",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.value[x].unit",
+                "short": "Unit representation",
+                "definition": "A human-readable form of the unit.",
+                "requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.unit",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.unit"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.system",
+                "path": "Observation.value[x].system",
+                "short": "System that defines coded unit form",
+                "definition": "The identification of the system that provides the coded form of the unit.",
+                "requirements": "Need to know the system that defines the coded form of the unit.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "condition": [
+                    "qty-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CO.codeSystem, PQ.translation.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.code",
+                "path": "Observation.value[x].code",
+                "short": "Coded responses from the common UCUM units for vital signs value set.",
+                "definition": "A computer processable form of the unit in some unit representation system.",
+                "comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
+                "requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "%",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.code, MO.currency, PQ.translation.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.dataAbsentReason",
+                "path": "Observation.dataAbsentReason",
+                "short": "Why the result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
+                "comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.interpretation",
+                "path": "Observation.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.note",
+                "path": "Observation.note",
+                "short": "Comments about the observation",
+                "definition": "Comments about the observation or the results.",
+                "comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
+                "requirements": "Need to be able to provide free text additional information.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "subjectOf.observationEvent[code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.bodySite",
+                "path": "Observation.bodySite",
+                "short": "Observed body part",
+                "definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
+                "comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.bodySite",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "BodySite"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing anatomical locations. May include laterality.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/body-site"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123037004 |Body structure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-20"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "targetSiteCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "718497002 |Inherent location|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.method",
+                "path": "Observation.method",
+                "short": "How it was done",
+                "definition": "Indicates the mechanism used to perform the observation.",
+                "comment": "Only used if not implicit in code for Observation.code.",
+                "requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.method",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationMethod"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Methods for simple observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "methodCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.specimen",
+                "path": "Observation.specimen",
+                "short": "Specimen used for this observation",
+                "definition": "The specimen that was used when this observation was made.",
+                "comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.specimen",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Specimen"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123038009 |Specimen|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "SPM segment"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SPC].specimen"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "704319004 |Inherent in|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.device",
+                "path": "Observation.device",
+                "short": "(Measurement) Device",
+                "definition": "The device used to generate the observation data.",
+                "comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.device",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceMetric"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 49062001 |Device|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17 / PRT -10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=DEV]"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "424226004 |Using device|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange",
+                "path": "Observation.referenceRange",
+                "short": "Provides guide for interpretation",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "obs-3",
+                        "severity": "error",
+                        "human": "Must have at least a low or a high or text",
+                        "expression": "low.exists() or high.exists() or text.exists()",
+                        "xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.id",
+                "path": "Observation.referenceRange.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.extension",
+                "path": "Observation.referenceRange.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.modifierExtension",
+                "path": "Observation.referenceRange.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.low",
+                "path": "Observation.referenceRange.low",
+                "short": "Low Range, if relevant",
+                "definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.low",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.low"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.high",
+                "path": "Observation.referenceRange.high",
+                "short": "High Range, if relevant",
+                "definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.high",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.high"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.type",
+                "path": "Observation.referenceRange.type",
+                "short": "Reference range qualifier",
+                "definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
+                "requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeMeaning"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Code for the meaning of a reference range.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.appliesTo",
+                "path": "Observation.referenceRange.appliesTo",
+                "short": "Reference range population",
+                "definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
+                "requirements": "Need to be able to identify the target population for proper interpretation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange.appliesTo",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes identifying the population the reference range applies to.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.age",
+                "path": "Observation.referenceRange.age",
+                "short": "Applicable age range, if relevant",
+                "definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
+                "requirements": "Some analytes vary greatly over age.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.age",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Range"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.text",
+                "path": "Observation.referenceRange.text",
+                "short": "Text based reference range in an observation",
+                "definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:ST"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.hasMember",
+                "path": "Observation.hasMember",
+                "short": "Used when reporting vital signs panel components",
+                "definition": "Used when reporting vital signs panel components.",
+                "comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.hasMember",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.derivedFrom",
+                "path": "Observation.derivedFrom",
+                "short": "Related measurements the observation is made from",
+                "definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
+                "comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.derivedFrom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/DocumentReference",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy",
+                            "http://hl7.org/fhir/StructureDefinition/Media",
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".targetObservation"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component",
+                "path": "Observation.component",
+                "short": "Used when reporting systolic and diastolic blood pressure.",
+                "definition": "Used when reporting systolic and diastolic blood pressure.",
+                "comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-3",
+                        "severity": "error",
+                        "human": "If there is no a value a data absent reason must be present",
+                        "expression": "value.exists() or dataAbsentReason.exists()",
+                        "xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "containment by OBX-4?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=COMP]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.id",
+                "path": "Observation.component.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.extension",
+                "path": "Observation.component.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.modifierExtension",
+                "path": "Observation.component.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.code",
+                "path": "Observation.component.code",
+                "short": "Type of component observation (code / type)",
+                "definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
+                "comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "VitalSigns"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "This identifies the vital sign result type.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-vitalsignresult"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.value[x]",
+                "path": "Observation.component.value[x]",
+                "short": "Vital Sign Value recorded with UCUM",
+                "definition": "Vital Sign Value recorded with UCUM.",
+                "comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "VitalSignsUnits"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.dataAbsentReason",
+                "path": "Observation.component.dataAbsentReason",
+                "short": "Why the component result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
+                "comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.interpretation",
+                "path": "Observation.component.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.referenceRange",
+                "path": "Observation.component.referenceRange",
+                "short": "Provides guide for interpretation of component result",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "contentReference": "#Observation.referenceRange",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "definition": "This profile defines how to represent head occipital-frontal circumference percentile for patients from birth to 36 months of age in FHIR using a standard LOINC code and UCUM units of measure.",
+                "mustSupport": false
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Head Occipital-frontal circumference Percentile",
+                "comment": "additional codes that translate or map to this code are allowed.  For example a more granular LOINC code or code that is used locally in a system.",
+                "alias": [
+                    "Test",
+                    "Name"
+                ],
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "8289-1"
+                        }
+                    ]
+                },
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.subject",
+                "path": "Observation.subject",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity",
+                "path": "Observation.valueQuantity",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.value",
+                "path": "Observation.valueQuantity.value",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.unit",
+                "path": "Observation.valueQuantity.unit",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.system",
+                "path": "Observation.valueQuantity.system",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.code",
+                "path": "Observation.valueQuantity.code",
+                "short": "Coded responses from the common UCUM units for vital signs value set.",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "%",
+                "mustSupport": true
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-pediatric-bmi-for-age.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-pediatric-bmi-for-age.json
@@ -1,3821 +1,3821 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "pediatric-bmi-for-age",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-pediatric-bmi-for-age-definitions.html#Observation\" title=\"This profile defines how to represent BMI percentile per age and sex for youth 2-20 observations in FHIR using a standard LOINC code and UCUM units of measure.\">Observation</a><a name=\"Observation\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/vitalsigns.html\">observation-vitalsigns</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">FHIR Vital Signs Profile</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-pediatric-bmi-for-age-definitions.html#Observation.code\">code</a><a name=\"Observation.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">1</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">BMI percentile per age and sex for youth 2-20<br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck101.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#CodeableConcept.coding\">coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Code defined by a terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">(complex)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/loinc.html\">http://loinc.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">59576-9</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-pediatric-bmi-for-age-definitions.html#Observation.subject\">subject</a><a name=\"Observation.subject\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">1</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who and/or what the observation is about</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-pediatric-bmi-for-age-definitions.html#Observation.valueQuantity\">valueQuantity</a><a name=\"Observation.valueQuantity\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Quantity\">Quantity</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-pediatric-bmi-for-age-definitions.html#Observation.valueQuantity.value\">value</a><a name=\"Observation.valueQuantity.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#decimal\">decimal</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Numerical value (with implicit precision)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-pediatric-bmi-for-age-definitions.html#Observation.valueQuantity.unit\">unit</a><a name=\"Observation.valueQuantity.unit\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Unit representation</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-pediatric-bmi-for-age-definitions.html#Observation.valueQuantity.system\">system</a><a name=\"Observation.valueQuantity.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">System that defines coded unit form</span><br/><span style=\"font-weight:bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/ucum.html\">http://unitsofmeasure.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-pediatric-bmi-for-age-definitions.html#Observation.valueQuantity.code\">code</a><a name=\"Observation.valueQuantity.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Coded responses from the common UCUM units for vital signs value set.<br/><span style=\"font-weight:bold\">Fixed Value: </span><span style=\"color: darkgreen\">%</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age",
-	"version": "3.1.1",
-	"name": "USCorePediatricBMIforAgeObservationProfile",
-	"title": "US Core Pediatric BMI for Age Observation Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-06-27",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.healthit.gov"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the Observation resource for use in querying and retrieving pediatric BMI observations.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "sct-concept",
-			"uri": "http://snomed.info/conceptdomain",
-			"name": "SNOMED CT Concept Domain Binding"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "sct-attr",
-			"uri": "http://snomed.org/attributebinding",
-			"name": "SNOMED CT Attribute Binding"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Observation",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/vitalsigns",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "FHIR Vital Signs Profile",
-				"definition": "This profile defines how to represent BMI percentile per age and sex for youth 2-20 observations in FHIR using a standard LOINC code and UCUM units of measure.",
-				"comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
-				"alias": [
-					"Vital Signs",
-					"Measurement",
-					"Results",
-					"Tests"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "obs-6",
-						"severity": "error",
-						"human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
-						"expression": "dataAbsentReason.empty() or value.empty()",
-						"xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "obs-7",
-						"severity": "error",
-						"human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
-						"expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
-						"xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "vs-2",
-						"severity": "error",
-						"human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
-						"expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
-						"xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.id",
-				"path": "Observation.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.meta",
-				"path": "Observation.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.implicitRules",
-				"path": "Observation.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Observation.language",
-				"path": "Observation.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Observation.text",
-				"path": "Observation.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Observation.contained",
-				"path": "Observation.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.extension",
-				"path": "Observation.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.modifierExtension",
-				"path": "Observation.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.identifier",
-				"path": "Observation.identifier",
-				"short": "Business Identifier for observation",
-				"definition": "A unique identifier assigned to this observation.",
-				"requirements": "Allows observations to be distinguished and referenced.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
-					},
-					{
-						"identity": "rim",
-						"map": "id"
-					}
-				]
-			},
-			{
-				"id": "Observation.basedOn",
-				"path": "Observation.basedOn",
-				"short": "Fulfills plan, proposal or order",
-				"definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
-				"requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
-				"alias": [
-					"Fulfills"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan",
-							"http://hl7.org/fhir/StructureDefinition/DeviceRequest",
-							"http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
-							"http://hl7.org/fhir/StructureDefinition/MedicationRequest",
-							"http://hl7.org/fhir/StructureDefinition/NutritionOrder",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.basedOn"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.partOf",
-				"path": "Observation.partOf",
-				"short": "Part of referenced event",
-				"definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
-				"comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
-				"alias": [
-					"Container"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.partOf",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
-							"http://hl7.org/fhir/StructureDefinition/MedicationDispense",
-							"http://hl7.org/fhir/StructureDefinition/MedicationStatement",
-							"http://hl7.org/fhir/StructureDefinition/Procedure",
-							"http://hl7.org/fhir/StructureDefinition/Immunization",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.partOf"
-					},
-					{
-						"identity": "v2",
-						"map": "Varies by domain"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=FLFS].target"
-					}
-				]
-			},
-			{
-				"id": "Observation.status",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
-						"valueString": "default: final"
-					}
-				],
-				"path": "Observation.status",
-				"short": "registered | preliminary | final | amended +",
-				"definition": "The status of the result value.",
-				"comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
-				"requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Status"
-						}
-					],
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 445584004 |Report by finality status|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-11"
-					},
-					{
-						"identity": "rim",
-						"map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
-					}
-				]
-			},
-			{
-				"id": "Observation.category",
-				"path": "Observation.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "coding.code"
-						},
-						{
-							"type": "value",
-							"path": "coding.system"
-						}
-					],
-					"ordered": false,
-					"rules": "open"
-				},
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat",
-				"path": "Observation.category",
-				"sliceName": "VSCat",
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.id",
-				"path": "Observation.category.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.extension",
-				"path": "Observation.category.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding",
-				"path": "Observation.category.coding",
-				"short": "Code defined by a terminology system",
-				"definition": "A reference to a code defined by a terminology system.",
-				"comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
-				"requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "CodeableConcept.coding",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1-8, C*E.10-22"
-					},
-					{
-						"identity": "rim",
-						"map": "union(., ./translation)"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.id",
-				"path": "Observation.category.coding.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.extension",
-				"path": "Observation.category.coding.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.system",
-				"path": "Observation.category.coding.system",
-				"short": "Identity of the terminology system",
-				"definition": "The identification of the code system that defines the meaning of the symbol in the code.",
-				"comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
-				"requirements": "Need to be unambiguous about the source of the definition of the symbol.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.3"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystem"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.version",
-				"path": "Observation.category.coding.version",
-				"short": "Version of the system - if relevant",
-				"definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
-				"comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.version",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.7"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystemVersion"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.code",
-				"path": "Observation.category.coding.code",
-				"short": "Symbol in syntax defined by the system",
-				"definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
-				"requirements": "Need to refer to a particular code in the system.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "vital-signs",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1"
-					},
-					{
-						"identity": "rim",
-						"map": "./code"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.display",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.coding.display",
-				"short": "Representation defined by the system",
-				"definition": "A representation of the meaning of the code in the system, following the rules of the system.",
-				"requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.display",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.2 - but note this is not well followed"
-					},
-					{
-						"identity": "rim",
-						"map": "CV.displayName"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.userSelected",
-				"path": "Observation.category.coding.userSelected",
-				"short": "If this coding was chosen directly by the user",
-				"definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
-				"comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
-				"requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.userSelected",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Sometimes implied by being first"
-					},
-					{
-						"identity": "rim",
-						"map": "CD.codingRationale"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.text",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.text",
-				"short": "Plain text representation of the concept",
-				"definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
-				"comment": "Very often the text is the same as a displayName of one of the codings.",
-				"requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CodeableConcept.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.9. But note many systems use C*E.2 for this"
-					},
-					{
-						"identity": "rim",
-						"map": "./originalText[mediaType/code=\"text/plain\"]/data"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
-					}
-				]
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "BMI percentile per age and sex for youth 2-20",
-				"definition": "Coded Responses from C-CDA Vital Sign Results.",
-				"comment": "additional codes that translate or map to this code are allowed.  For example a more granular LOINC code or code that is used locally in a system.",
-				"requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
-				"alias": [
-					"Name",
-					"Test"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "59576-9"
-						}
-					]
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "VitalSigns"
-						}
-					],
-					"strength": "extensible",
-					"description": "This identifies the vital sign result type.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-vitalsignresult"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "116680003 |Is a|"
-					}
-				]
-			},
-			{
-				"id": "Observation.subject",
-				"path": "Observation.subject",
-				"short": "Who and/or what the observation is about",
-				"definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
-				"comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
-				"requirements": "Observations have no value if you don't know who or what they're about.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=RTGT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.focus",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
-						"valueCode": "trial-use"
-					}
-				],
-				"path": "Observation.focus",
-				"short": "What the observation is about, when it is not about the subject of record",
-				"definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
-				"comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.focus",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SBJ]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.encounter",
-				"path": "Observation.encounter",
-				"short": "Healthcare event during which this observation is made",
-				"definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
-				"comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
-				"requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
-				"alias": [
-					"Context"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.effective[x]",
-				"path": "Observation.effective[x]",
-				"short": "Often just a dateTime for Vital Signs",
-				"definition": "Often just a dateTime for Vital Signs.",
-				"comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
-				"requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
-				"alias": [
-					"Occurrence"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.effective[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-1",
-						"severity": "error",
-						"human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
-						"expression": "($this as dateTime).toString().length() >= 8",
-						"xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "Observation.issued",
-				"path": "Observation.issued",
-				"short": "Date/Time this version was made available",
-				"definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
-				"comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.issued",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=AUT].time"
-					}
-				]
-			},
-			{
-				"id": "Observation.performer",
-				"path": "Observation.performer",
-				"short": "Who is responsible for the observation",
-				"definition": "Who was responsible for asserting the observed value as \"true\".",
-				"requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.performer",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=PRF]"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]",
-				"path": "Observation.value[x]",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "type",
-							"path": "$this"
-						}
-					],
-					"ordered": false,
-					"rules": "closed"
-				},
-				"short": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
-				"definition": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity",
-				"path": "Observation.value[x]",
-				"sliceName": "valueQuantity",
-				"short": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
-				"definition": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.id",
-				"path": "Observation.value[x].id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.extension",
-				"path": "Observation.value[x].extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.value",
-				"path": "Observation.value[x].value",
-				"short": "Numerical value (with implicit precision)",
-				"definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
-				"comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
-				"requirements": "Precision is handled implicitly in almost all cases of measurement.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.2  / CQ - N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.comparator",
-				"path": "Observation.value[x].comparator",
-				"short": "< | <= | >= | > - how to understand the value",
-				"definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
-				"requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Quantity.comparator",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "QuantityComparator"
-						}
-					],
-					"strength": "required",
-					"description": "How the Quantity should be understood and represented.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.1  / CQ.1"
-					},
-					{
-						"identity": "rim",
-						"map": "IVL properties"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.unit",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.value[x].unit",
-				"short": "Unit representation",
-				"definition": "A human-readable form of the unit.",
-				"requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.unit",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.unit"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.system",
-				"path": "Observation.value[x].system",
-				"short": "System that defines coded unit form",
-				"definition": "The identification of the system that provides the coded form of the unit.",
-				"requirements": "Need to know the system that defines the coded form of the unit.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"condition": [
-					"qty-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "CO.codeSystem, PQ.translation.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.code",
-				"path": "Observation.value[x].code",
-				"short": "Coded responses from the common UCUM units for vital signs value set.",
-				"definition": "A computer processable form of the unit in some unit representation system.",
-				"comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
-				"requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "%",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.code, MO.currency, PQ.translation.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.dataAbsentReason",
-				"path": "Observation.dataAbsentReason",
-				"short": "Why the result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
-				"comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.interpretation",
-				"path": "Observation.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.note",
-				"path": "Observation.note",
-				"short": "Comments about the observation",
-				"definition": "Comments about the observation or the results.",
-				"comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
-				"requirements": "Need to be able to provide free text additional information.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
-					},
-					{
-						"identity": "rim",
-						"map": "subjectOf.observationEvent[code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.bodySite",
-				"path": "Observation.bodySite",
-				"short": "Observed body part",
-				"definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
-				"comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.bodySite",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "BodySite"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing anatomical locations. May include laterality.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/body-site"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123037004 |Body structure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-20"
-					},
-					{
-						"identity": "rim",
-						"map": "targetSiteCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "718497002 |Inherent location|"
-					}
-				]
-			},
-			{
-				"id": "Observation.method",
-				"path": "Observation.method",
-				"short": "How it was done",
-				"definition": "Indicates the mechanism used to perform the observation.",
-				"comment": "Only used if not implicit in code for Observation.code.",
-				"requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.method",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationMethod"
-						}
-					],
-					"strength": "example",
-					"description": "Methods for simple observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-17"
-					},
-					{
-						"identity": "rim",
-						"map": "methodCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.specimen",
-				"path": "Observation.specimen",
-				"short": "Specimen used for this observation",
-				"definition": "The specimen that was used when this observation was made.",
-				"comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.specimen",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Specimen"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123038009 |Specimen|"
-					},
-					{
-						"identity": "v2",
-						"map": "SPM segment"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SPC].specimen"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "704319004 |Inherent in|"
-					}
-				]
-			},
-			{
-				"id": "Observation.device",
-				"path": "Observation.device",
-				"short": "(Measurement) Device",
-				"definition": "The device used to generate the observation data.",
-				"comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.device",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/DeviceMetric"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 49062001 |Device|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-17 / PRT -10"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=DEV]"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "424226004 |Using device|"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange",
-				"path": "Observation.referenceRange",
-				"short": "Provides guide for interpretation",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "obs-3",
-						"severity": "error",
-						"human": "Must have at least a low or a high or text",
-						"expression": "low.exists() or high.exists() or text.exists()",
-						"xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.id",
-				"path": "Observation.referenceRange.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.extension",
-				"path": "Observation.referenceRange.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.modifierExtension",
-				"path": "Observation.referenceRange.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.low",
-				"path": "Observation.referenceRange.low",
-				"short": "Low Range, if relevant",
-				"definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.low",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.low"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.high",
-				"path": "Observation.referenceRange.high",
-				"short": "High Range, if relevant",
-				"definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.high",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.high"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.type",
-				"path": "Observation.referenceRange.type",
-				"short": "Reference range qualifier",
-				"definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
-				"requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeMeaning"
-						}
-					],
-					"strength": "preferred",
-					"description": "Code for the meaning of a reference range.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.appliesTo",
-				"path": "Observation.referenceRange.appliesTo",
-				"short": "Reference range population",
-				"definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
-				"requirements": "Need to be able to identify the target population for proper interpretation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange.appliesTo",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeType"
-						}
-					],
-					"strength": "example",
-					"description": "Codes identifying the population the reference range applies to.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.age",
-				"path": "Observation.referenceRange.age",
-				"short": "Applicable age range, if relevant",
-				"definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
-				"requirements": "Some analytes vary greatly over age.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.age",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Range"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.text",
-				"path": "Observation.referenceRange.text",
-				"short": "Text based reference range in an observation",
-				"definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:ST"
-					}
-				]
-			},
-			{
-				"id": "Observation.hasMember",
-				"path": "Observation.hasMember",
-				"short": "Used when reporting vital signs panel components",
-				"definition": "Used when reporting vital signs panel components.",
-				"comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.hasMember",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship"
-					}
-				]
-			},
-			{
-				"id": "Observation.derivedFrom",
-				"path": "Observation.derivedFrom",
-				"short": "Related measurements the observation is made from",
-				"definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
-				"comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.derivedFrom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/DocumentReference",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy",
-							"http://hl7.org/fhir/StructureDefinition/Media",
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": ".targetObservation"
-					}
-				]
-			},
-			{
-				"id": "Observation.component",
-				"path": "Observation.component",
-				"short": "Used when reporting systolic and diastolic blood pressure.",
-				"definition": "Used when reporting systolic and diastolic blood pressure.",
-				"comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-3",
-						"severity": "error",
-						"human": "If there is no a value a data absent reason must be present",
-						"expression": "value.exists() or dataAbsentReason.exists()",
-						"xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "containment by OBX-4?"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=COMP]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.id",
-				"path": "Observation.component.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.extension",
-				"path": "Observation.component.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.modifierExtension",
-				"path": "Observation.component.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.code",
-				"path": "Observation.component.code",
-				"short": "Type of component observation (code / type)",
-				"definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
-				"comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "VitalSigns"
-						}
-					],
-					"strength": "extensible",
-					"description": "This identifies the vital sign result type.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-vitalsignresult"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.value[x]",
-				"path": "Observation.component.value[x]",
-				"short": "Vital Sign Value recorded with UCUM",
-				"definition": "Vital Sign Value recorded with UCUM.",
-				"comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "VitalSignsUnits"
-						}
-					],
-					"strength": "required",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.dataAbsentReason",
-				"path": "Observation.component.dataAbsentReason",
-				"short": "Why the component result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
-				"comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.interpretation",
-				"path": "Observation.component.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.referenceRange",
-				"path": "Observation.component.referenceRange",
-				"short": "Provides guide for interpretation of component result",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"contentReference": "#Observation.referenceRange",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"definition": "This profile defines how to represent BMI percentile per age and sex for youth 2-20 observations in FHIR using a standard LOINC code and UCUM units of measure.",
-				"mustSupport": false
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "BMI percentile per age and sex for youth 2-20",
-				"comment": "additional codes that translate or map to this code are allowed.  For example a more granular LOINC code or code that is used locally in a system.",
-				"alias": [
-					"Test",
-					"Name"
-				],
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "59576-9"
-						}
-					]
-				},
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.subject",
-				"path": "Observation.subject",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity",
-				"path": "Observation.valueQuantity",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.value",
-				"path": "Observation.valueQuantity.value",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.unit",
-				"path": "Observation.valueQuantity.unit",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.system",
-				"path": "Observation.valueQuantity.system",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.code",
-				"path": "Observation.valueQuantity.code",
-				"short": "Coded responses from the common UCUM units for vital signs value set.",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "%",
-				"mustSupport": true
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "pediatric-bmi-for-age",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age",
+    "version": "3.1.1",
+    "name": "USCorePediatricBMIforAgeObservationProfile",
+    "title": "US Core Pediatric BMI for Age Observation Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-06-27",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.healthit.gov"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the Observation resource for use in querying and retrieving pediatric BMI observations.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "sct-concept",
+            "uri": "http://snomed.info/conceptdomain",
+            "name": "SNOMED CT Concept Domain Binding"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "sct-attr",
+            "uri": "http://snomed.org/attributebinding",
+            "name": "SNOMED CT Attribute Binding"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Observation",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/vitalsigns",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "FHIR Vital Signs Profile",
+                "definition": "This profile defines how to represent BMI percentile per age and sex for youth 2-20 observations in FHIR using a standard LOINC code and UCUM units of measure.",
+                "comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
+                "alias": [
+                    "Vital Signs",
+                    "Measurement",
+                    "Results",
+                    "Tests"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "obs-6",
+                        "severity": "error",
+                        "human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
+                        "expression": "dataAbsentReason.empty() or value.empty()",
+                        "xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "obs-7",
+                        "severity": "error",
+                        "human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
+                        "expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
+                        "xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "vs-2",
+                        "severity": "error",
+                        "human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
+                        "expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
+                        "xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.id",
+                "path": "Observation.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.meta",
+                "path": "Observation.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.implicitRules",
+                "path": "Observation.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Observation.language",
+                "path": "Observation.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Observation.text",
+                "path": "Observation.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.contained",
+                "path": "Observation.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.extension",
+                "path": "Observation.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.modifierExtension",
+                "path": "Observation.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.identifier",
+                "path": "Observation.identifier",
+                "short": "Business Identifier for observation",
+                "definition": "A unique identifier assigned to this observation.",
+                "requirements": "Allows observations to be distinguished and referenced.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "id"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.basedOn",
+                "path": "Observation.basedOn",
+                "short": "Fulfills plan, proposal or order",
+                "definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
+                "requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
+                "alias": [
+                    "Fulfills"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceRequest",
+                            "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+                            "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.basedOn"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.partOf",
+                "path": "Observation.partOf",
+                "short": "Part of referenced event",
+                "definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
+                "comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
+                "alias": [
+                    "Container"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.partOf",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationDispense",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationStatement",
+                            "http://hl7.org/fhir/StructureDefinition/Procedure",
+                            "http://hl7.org/fhir/StructureDefinition/Immunization",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.partOf"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "Varies by domain"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=FLFS].target"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.status",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
+                        "valueString": "default: final"
+                    }
+                ],
+                "path": "Observation.status",
+                "short": "registered | preliminary | final | amended +",
+                "definition": "The status of the result value.",
+                "comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
+                "requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Status"
+                        }
+                    ],
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 445584004 |Report by finality status|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-11"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category",
+                "path": "Observation.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "coding.code"
+                        },
+                        {
+                            "type": "value",
+                            "path": "coding.system"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "open"
+                },
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat",
+                "path": "Observation.category",
+                "sliceName": "VSCat",
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.id",
+                "path": "Observation.category.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.extension",
+                "path": "Observation.category.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding",
+                "path": "Observation.category.coding",
+                "short": "Code defined by a terminology system",
+                "definition": "A reference to a code defined by a terminology system.",
+                "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+                "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "CodeableConcept.coding",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1-8, C*E.10-22"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "union(., ./translation)"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.id",
+                "path": "Observation.category.coding.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.extension",
+                "path": "Observation.category.coding.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.system",
+                "path": "Observation.category.coding.system",
+                "short": "Identity of the terminology system",
+                "definition": "The identification of the code system that defines the meaning of the symbol in the code.",
+                "comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
+                "requirements": "Need to be unambiguous about the source of the definition of the symbol.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystem"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.version",
+                "path": "Observation.category.coding.version",
+                "short": "Version of the system - if relevant",
+                "definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
+                "comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.version",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystemVersion"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.code",
+                "path": "Observation.category.coding.code",
+                "short": "Symbol in syntax defined by the system",
+                "definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
+                "requirements": "Need to refer to a particular code in the system.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "vital-signs",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./code"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.display",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.coding.display",
+                "short": "Representation defined by the system",
+                "definition": "A representation of the meaning of the code in the system, following the rules of the system.",
+                "requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.display",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.2 - but note this is not well followed"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CV.displayName"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.userSelected",
+                "path": "Observation.category.coding.userSelected",
+                "short": "If this coding was chosen directly by the user",
+                "definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
+                "comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
+                "requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.userSelected",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Sometimes implied by being first"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CD.codingRationale"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.text",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.text",
+                "short": "Plain text representation of the concept",
+                "definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
+                "comment": "Very often the text is the same as a displayName of one of the codings.",
+                "requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CodeableConcept.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.9. But note many systems use C*E.2 for this"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./originalText[mediaType/code=\"text/plain\"]/data"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "BMI percentile per age and sex for youth 2-20",
+                "definition": "Coded Responses from C-CDA Vital Sign Results.",
+                "comment": "additional codes that translate or map to this code are allowed.  For example a more granular LOINC code or code that is used locally in a system.",
+                "requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
+                "alias": [
+                    "Name",
+                    "Test"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "59576-9"
+                        }
+                    ]
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "VitalSigns"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "This identifies the vital sign result type.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-vitalsignresult"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "116680003 |Is a|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.subject",
+                "path": "Observation.subject",
+                "short": "Who and/or what the observation is about",
+                "definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
+                "comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
+                "requirements": "Observations have no value if you don't know who or what they're about.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=RTGT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.focus",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+                        "valueCode": "trial-use"
+                    }
+                ],
+                "path": "Observation.focus",
+                "short": "What the observation is about, when it is not about the subject of record",
+                "definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
+                "comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.focus",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SBJ]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.encounter",
+                "path": "Observation.encounter",
+                "short": "Healthcare event during which this observation is made",
+                "definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
+                "comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
+                "requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
+                "alias": [
+                    "Context"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.effective[x]",
+                "path": "Observation.effective[x]",
+                "short": "Often just a dateTime for Vital Signs",
+                "definition": "Often just a dateTime for Vital Signs.",
+                "comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
+                "requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
+                "alias": [
+                    "Occurrence"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.effective[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-1",
+                        "severity": "error",
+                        "human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
+                        "expression": "($this as dateTime).toString().length() >= 8",
+                        "xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.issued",
+                "path": "Observation.issued",
+                "short": "Date/Time this version was made available",
+                "definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
+                "comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.issued",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.performer",
+                "path": "Observation.performer",
+                "short": "Who is responsible for the observation",
+                "definition": "Who was responsible for asserting the observed value as \"true\".",
+                "requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.performer",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=PRF]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]",
+                "path": "Observation.value[x]",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "type",
+                            "path": "$this"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "closed"
+                },
+                "short": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
+                "definition": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity",
+                "path": "Observation.value[x]",
+                "sliceName": "valueQuantity",
+                "short": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
+                "definition": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.id",
+                "path": "Observation.value[x].id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.extension",
+                "path": "Observation.value[x].extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.value",
+                "path": "Observation.value[x].value",
+                "short": "Numerical value (with implicit precision)",
+                "definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
+                "comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
+                "requirements": "Precision is handled implicitly in almost all cases of measurement.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.2  / CQ - N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.comparator",
+                "path": "Observation.value[x].comparator",
+                "short": "< | <= | >= | > - how to understand the value",
+                "definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
+                "requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.comparator",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "QuantityComparator"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "How the Quantity should be understood and represented.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.1  / CQ.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "IVL properties"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.unit",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.value[x].unit",
+                "short": "Unit representation",
+                "definition": "A human-readable form of the unit.",
+                "requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.unit",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.unit"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.system",
+                "path": "Observation.value[x].system",
+                "short": "System that defines coded unit form",
+                "definition": "The identification of the system that provides the coded form of the unit.",
+                "requirements": "Need to know the system that defines the coded form of the unit.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "condition": [
+                    "qty-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CO.codeSystem, PQ.translation.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.code",
+                "path": "Observation.value[x].code",
+                "short": "Coded responses from the common UCUM units for vital signs value set.",
+                "definition": "A computer processable form of the unit in some unit representation system.",
+                "comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
+                "requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "%",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.code, MO.currency, PQ.translation.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.dataAbsentReason",
+                "path": "Observation.dataAbsentReason",
+                "short": "Why the result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
+                "comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.interpretation",
+                "path": "Observation.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.note",
+                "path": "Observation.note",
+                "short": "Comments about the observation",
+                "definition": "Comments about the observation or the results.",
+                "comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
+                "requirements": "Need to be able to provide free text additional information.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "subjectOf.observationEvent[code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.bodySite",
+                "path": "Observation.bodySite",
+                "short": "Observed body part",
+                "definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
+                "comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.bodySite",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "BodySite"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing anatomical locations. May include laterality.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/body-site"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123037004 |Body structure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-20"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "targetSiteCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "718497002 |Inherent location|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.method",
+                "path": "Observation.method",
+                "short": "How it was done",
+                "definition": "Indicates the mechanism used to perform the observation.",
+                "comment": "Only used if not implicit in code for Observation.code.",
+                "requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.method",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationMethod"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Methods for simple observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "methodCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.specimen",
+                "path": "Observation.specimen",
+                "short": "Specimen used for this observation",
+                "definition": "The specimen that was used when this observation was made.",
+                "comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.specimen",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Specimen"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123038009 |Specimen|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "SPM segment"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SPC].specimen"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "704319004 |Inherent in|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.device",
+                "path": "Observation.device",
+                "short": "(Measurement) Device",
+                "definition": "The device used to generate the observation data.",
+                "comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.device",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceMetric"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 49062001 |Device|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17 / PRT -10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=DEV]"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "424226004 |Using device|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange",
+                "path": "Observation.referenceRange",
+                "short": "Provides guide for interpretation",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "obs-3",
+                        "severity": "error",
+                        "human": "Must have at least a low or a high or text",
+                        "expression": "low.exists() or high.exists() or text.exists()",
+                        "xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.id",
+                "path": "Observation.referenceRange.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.extension",
+                "path": "Observation.referenceRange.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.modifierExtension",
+                "path": "Observation.referenceRange.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.low",
+                "path": "Observation.referenceRange.low",
+                "short": "Low Range, if relevant",
+                "definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.low",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.low"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.high",
+                "path": "Observation.referenceRange.high",
+                "short": "High Range, if relevant",
+                "definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.high",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.high"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.type",
+                "path": "Observation.referenceRange.type",
+                "short": "Reference range qualifier",
+                "definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
+                "requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeMeaning"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Code for the meaning of a reference range.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.appliesTo",
+                "path": "Observation.referenceRange.appliesTo",
+                "short": "Reference range population",
+                "definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
+                "requirements": "Need to be able to identify the target population for proper interpretation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange.appliesTo",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes identifying the population the reference range applies to.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.age",
+                "path": "Observation.referenceRange.age",
+                "short": "Applicable age range, if relevant",
+                "definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
+                "requirements": "Some analytes vary greatly over age.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.age",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Range"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.text",
+                "path": "Observation.referenceRange.text",
+                "short": "Text based reference range in an observation",
+                "definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:ST"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.hasMember",
+                "path": "Observation.hasMember",
+                "short": "Used when reporting vital signs panel components",
+                "definition": "Used when reporting vital signs panel components.",
+                "comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.hasMember",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.derivedFrom",
+                "path": "Observation.derivedFrom",
+                "short": "Related measurements the observation is made from",
+                "definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
+                "comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.derivedFrom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/DocumentReference",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy",
+                            "http://hl7.org/fhir/StructureDefinition/Media",
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".targetObservation"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component",
+                "path": "Observation.component",
+                "short": "Used when reporting systolic and diastolic blood pressure.",
+                "definition": "Used when reporting systolic and diastolic blood pressure.",
+                "comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-3",
+                        "severity": "error",
+                        "human": "If there is no a value a data absent reason must be present",
+                        "expression": "value.exists() or dataAbsentReason.exists()",
+                        "xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "containment by OBX-4?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=COMP]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.id",
+                "path": "Observation.component.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.extension",
+                "path": "Observation.component.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.modifierExtension",
+                "path": "Observation.component.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.code",
+                "path": "Observation.component.code",
+                "short": "Type of component observation (code / type)",
+                "definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
+                "comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "VitalSigns"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "This identifies the vital sign result type.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-vitalsignresult"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.value[x]",
+                "path": "Observation.component.value[x]",
+                "short": "Vital Sign Value recorded with UCUM",
+                "definition": "Vital Sign Value recorded with UCUM.",
+                "comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "VitalSignsUnits"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.dataAbsentReason",
+                "path": "Observation.component.dataAbsentReason",
+                "short": "Why the component result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
+                "comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.interpretation",
+                "path": "Observation.component.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.referenceRange",
+                "path": "Observation.component.referenceRange",
+                "short": "Provides guide for interpretation of component result",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "contentReference": "#Observation.referenceRange",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "definition": "This profile defines how to represent BMI percentile per age and sex for youth 2-20 observations in FHIR using a standard LOINC code and UCUM units of measure.",
+                "mustSupport": false
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "BMI percentile per age and sex for youth 2-20",
+                "comment": "additional codes that translate or map to this code are allowed.  For example a more granular LOINC code or code that is used locally in a system.",
+                "alias": [
+                    "Test",
+                    "Name"
+                ],
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "59576-9"
+                        }
+                    ]
+                },
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.subject",
+                "path": "Observation.subject",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity",
+                "path": "Observation.valueQuantity",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.value",
+                "path": "Observation.valueQuantity.value",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.unit",
+                "path": "Observation.valueQuantity.unit",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.system",
+                "path": "Observation.valueQuantity.system",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.code",
+                "path": "Observation.valueQuantity.code",
+                "short": "Coded responses from the common UCUM units for vital signs value set.",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "%",
+                "mustSupport": true
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-pediatric-weight-for-height.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-pediatric-weight-for-height.json
@@ -1,3825 +1,3825 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "pediatric-weight-for-height",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-pediatric-weight-for-height-definitions.html#Observation\" title=\"This profile defines how to represent Weight-for-length per age and gender observations in FHIR using a standard LOINC code and UCUM units of measure.\">Observation</a><a name=\"Observation\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/vitalsigns.html\">observation-vitalsigns</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">FHIR Vital Signs Profile</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-pediatric-weight-for-height-definitions.html#Observation.code\">code</a><a name=\"Observation.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Weight-for-length per age and gender<br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck101.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#CodeableConcept.coding\">coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Code defined by a terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">(complex)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/loinc.html\">http://loinc.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">77606-2</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-pediatric-weight-for-height-definitions.html#Observation.subject\">subject</a><a name=\"Observation.subject\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who and/or what the observation is about</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-pediatric-weight-for-height-definitions.html#Observation.valueQuantity\">valueQuantity</a><a name=\"Observation.valueQuantity\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Quantity\">Quantity</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-pediatric-weight-for-height-definitions.html#Observation.valueQuantity.value\">value</a><a name=\"Observation.valueQuantity.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#decimal\">decimal</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Numerical value (with implicit precision)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-pediatric-weight-for-height-definitions.html#Observation.valueQuantity.unit\">unit</a><a name=\"Observation.valueQuantity.unit\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Unit representation</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-pediatric-weight-for-height-definitions.html#Observation.valueQuantity.system\">system</a><a name=\"Observation.valueQuantity.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">System that defines coded unit form</span><br/><span style=\"font-weight:bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/ucum.html\">http://unitsofmeasure.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-pediatric-weight-for-height-definitions.html#Observation.valueQuantity.code\">code</a><a name=\"Observation.valueQuantity.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Coded responses from the common UCUM units for vital signs value set.<br/><span style=\"font-weight:bold\">Fixed Value: </span><span style=\"color: darkgreen\">%</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height",
-	"version": "3.1.1",
-	"name": "USCorePediatricWeightForHeightObservationProfile",
-	"title": "US Core Pediatric Weight for Height Observation Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-06-27",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.healthit.gov"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the Observation resource for use in querying and retrieving pediatric Weight-for-length per age and gender observations.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "sct-concept",
-			"uri": "http://snomed.info/conceptdomain",
-			"name": "SNOMED CT Concept Domain Binding"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "sct-attr",
-			"uri": "http://snomed.org/attributebinding",
-			"name": "SNOMED CT Attribute Binding"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Observation",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/vitalsigns",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "FHIR Vital Signs Profile",
-				"definition": "This profile defines how to represent Weight-for-length per age and gender observations in FHIR using a standard LOINC code and UCUM units of measure.",
-				"comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
-				"alias": [
-					"Vital Signs",
-					"Measurement",
-					"Results",
-					"Tests"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "obs-6",
-						"severity": "error",
-						"human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
-						"expression": "dataAbsentReason.empty() or value.empty()",
-						"xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "obs-7",
-						"severity": "error",
-						"human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
-						"expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
-						"xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "vs-2",
-						"severity": "error",
-						"human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
-						"expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
-						"xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.id",
-				"path": "Observation.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.meta",
-				"path": "Observation.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.implicitRules",
-				"path": "Observation.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Observation.language",
-				"path": "Observation.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Observation.text",
-				"path": "Observation.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Observation.contained",
-				"path": "Observation.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.extension",
-				"path": "Observation.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.modifierExtension",
-				"path": "Observation.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.identifier",
-				"path": "Observation.identifier",
-				"short": "Business Identifier for observation",
-				"definition": "A unique identifier assigned to this observation.",
-				"requirements": "Allows observations to be distinguished and referenced.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
-					},
-					{
-						"identity": "rim",
-						"map": "id"
-					}
-				]
-			},
-			{
-				"id": "Observation.basedOn",
-				"path": "Observation.basedOn",
-				"short": "Fulfills plan, proposal or order",
-				"definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
-				"requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
-				"alias": [
-					"Fulfills"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan",
-							"http://hl7.org/fhir/StructureDefinition/DeviceRequest",
-							"http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
-							"http://hl7.org/fhir/StructureDefinition/MedicationRequest",
-							"http://hl7.org/fhir/StructureDefinition/NutritionOrder",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.basedOn"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.partOf",
-				"path": "Observation.partOf",
-				"short": "Part of referenced event",
-				"definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
-				"comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
-				"alias": [
-					"Container"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.partOf",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
-							"http://hl7.org/fhir/StructureDefinition/MedicationDispense",
-							"http://hl7.org/fhir/StructureDefinition/MedicationStatement",
-							"http://hl7.org/fhir/StructureDefinition/Procedure",
-							"http://hl7.org/fhir/StructureDefinition/Immunization",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.partOf"
-					},
-					{
-						"identity": "v2",
-						"map": "Varies by domain"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=FLFS].target"
-					}
-				]
-			},
-			{
-				"id": "Observation.status",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
-						"valueString": "default: final"
-					}
-				],
-				"path": "Observation.status",
-				"short": "registered | preliminary | final | amended +",
-				"definition": "The status of the result value.",
-				"comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
-				"requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Status"
-						}
-					],
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 445584004 |Report by finality status|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-11"
-					},
-					{
-						"identity": "rim",
-						"map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
-					}
-				]
-			},
-			{
-				"id": "Observation.category",
-				"path": "Observation.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "coding.code"
-						},
-						{
-							"type": "value",
-							"path": "coding.system"
-						}
-					],
-					"ordered": false,
-					"rules": "open"
-				},
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat",
-				"path": "Observation.category",
-				"sliceName": "VSCat",
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.id",
-				"path": "Observation.category.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.extension",
-				"path": "Observation.category.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding",
-				"path": "Observation.category.coding",
-				"short": "Code defined by a terminology system",
-				"definition": "A reference to a code defined by a terminology system.",
-				"comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
-				"requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "CodeableConcept.coding",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1-8, C*E.10-22"
-					},
-					{
-						"identity": "rim",
-						"map": "union(., ./translation)"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.id",
-				"path": "Observation.category.coding.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.extension",
-				"path": "Observation.category.coding.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.system",
-				"path": "Observation.category.coding.system",
-				"short": "Identity of the terminology system",
-				"definition": "The identification of the code system that defines the meaning of the symbol in the code.",
-				"comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
-				"requirements": "Need to be unambiguous about the source of the definition of the symbol.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.3"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystem"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.version",
-				"path": "Observation.category.coding.version",
-				"short": "Version of the system - if relevant",
-				"definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
-				"comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.version",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.7"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystemVersion"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.code",
-				"path": "Observation.category.coding.code",
-				"short": "Symbol in syntax defined by the system",
-				"definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
-				"requirements": "Need to refer to a particular code in the system.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "vital-signs",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1"
-					},
-					{
-						"identity": "rim",
-						"map": "./code"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.display",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.coding.display",
-				"short": "Representation defined by the system",
-				"definition": "A representation of the meaning of the code in the system, following the rules of the system.",
-				"requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.display",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.2 - but note this is not well followed"
-					},
-					{
-						"identity": "rim",
-						"map": "CV.displayName"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.userSelected",
-				"path": "Observation.category.coding.userSelected",
-				"short": "If this coding was chosen directly by the user",
-				"definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
-				"comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
-				"requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.userSelected",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Sometimes implied by being first"
-					},
-					{
-						"identity": "rim",
-						"map": "CD.codingRationale"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.text",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.text",
-				"short": "Plain text representation of the concept",
-				"definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
-				"comment": "Very often the text is the same as a displayName of one of the codings.",
-				"requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CodeableConcept.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.9. But note many systems use C*E.2 for this"
-					},
-					{
-						"identity": "rim",
-						"map": "./originalText[mediaType/code=\"text/plain\"]/data"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
-					}
-				]
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Weight-for-length per age and gender",
-				"definition": "Coded Responses from C-CDA Vital Sign Results.",
-				"comment": "additional codes that translate or map to this code are allowed.  For example a more granular LOINC code or code that is used locally in a system.",
-				"requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
-				"alias": [
-					"Name",
-					"Test"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "77606-2"
-						}
-					]
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "VitalSigns"
-						}
-					],
-					"strength": "extensible",
-					"description": "This identifies the vital sign result type.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-vitalsignresult"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "116680003 |Is a|"
-					}
-				]
-			},
-			{
-				"id": "Observation.subject",
-				"path": "Observation.subject",
-				"short": "Who and/or what the observation is about",
-				"definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
-				"comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
-				"requirements": "Observations have no value if you don't know who or what they're about.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=RTGT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.focus",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
-						"valueCode": "trial-use"
-					}
-				],
-				"path": "Observation.focus",
-				"short": "What the observation is about, when it is not about the subject of record",
-				"definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
-				"comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.focus",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SBJ]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.encounter",
-				"path": "Observation.encounter",
-				"short": "Healthcare event during which this observation is made",
-				"definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
-				"comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
-				"requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
-				"alias": [
-					"Context"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.effective[x]",
-				"path": "Observation.effective[x]",
-				"short": "Often just a dateTime for Vital Signs",
-				"definition": "Often just a dateTime for Vital Signs.",
-				"comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
-				"requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
-				"alias": [
-					"Occurrence"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.effective[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-1",
-						"severity": "error",
-						"human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
-						"expression": "($this as dateTime).toString().length() >= 8",
-						"xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "Observation.issued",
-				"path": "Observation.issued",
-				"short": "Date/Time this version was made available",
-				"definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
-				"comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.issued",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=AUT].time"
-					}
-				]
-			},
-			{
-				"id": "Observation.performer",
-				"path": "Observation.performer",
-				"short": "Who is responsible for the observation",
-				"definition": "Who was responsible for asserting the observed value as \"true\".",
-				"requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.performer",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=PRF]"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]",
-				"path": "Observation.value[x]",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "type",
-							"path": "$this"
-						}
-					],
-					"ordered": false,
-					"rules": "closed"
-				},
-				"short": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
-				"definition": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity",
-				"path": "Observation.value[x]",
-				"sliceName": "valueQuantity",
-				"short": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
-				"definition": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.id",
-				"path": "Observation.value[x].id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.extension",
-				"path": "Observation.value[x].extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.value",
-				"path": "Observation.value[x].value",
-				"short": "Numerical value (with implicit precision)",
-				"definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
-				"comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
-				"requirements": "Precision is handled implicitly in almost all cases of measurement.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.2  / CQ - N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.comparator",
-				"path": "Observation.value[x].comparator",
-				"short": "< | <= | >= | > - how to understand the value",
-				"definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
-				"requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Quantity.comparator",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "QuantityComparator"
-						}
-					],
-					"strength": "required",
-					"description": "How the Quantity should be understood and represented.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.1  / CQ.1"
-					},
-					{
-						"identity": "rim",
-						"map": "IVL properties"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.unit",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.value[x].unit",
-				"short": "Unit representation",
-				"definition": "A human-readable form of the unit.",
-				"requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.unit",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.unit"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.system",
-				"path": "Observation.value[x].system",
-				"short": "System that defines coded unit form",
-				"definition": "The identification of the system that provides the coded form of the unit.",
-				"requirements": "Need to know the system that defines the coded form of the unit.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"condition": [
-					"qty-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "CO.codeSystem, PQ.translation.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.code",
-				"path": "Observation.value[x].code",
-				"short": "Coded responses from the common UCUM units for vital signs value set.",
-				"definition": "A computer processable form of the unit in some unit representation system.",
-				"comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
-				"requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "%",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.code, MO.currency, PQ.translation.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.dataAbsentReason",
-				"path": "Observation.dataAbsentReason",
-				"short": "Why the result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
-				"comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.interpretation",
-				"path": "Observation.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.note",
-				"path": "Observation.note",
-				"short": "Comments about the observation",
-				"definition": "Comments about the observation or the results.",
-				"comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
-				"requirements": "Need to be able to provide free text additional information.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
-					},
-					{
-						"identity": "rim",
-						"map": "subjectOf.observationEvent[code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.bodySite",
-				"path": "Observation.bodySite",
-				"short": "Observed body part",
-				"definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
-				"comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.bodySite",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "BodySite"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing anatomical locations. May include laterality.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/body-site"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123037004 |Body structure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-20"
-					},
-					{
-						"identity": "rim",
-						"map": "targetSiteCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "718497002 |Inherent location|"
-					}
-				]
-			},
-			{
-				"id": "Observation.method",
-				"path": "Observation.method",
-				"short": "How it was done",
-				"definition": "Indicates the mechanism used to perform the observation.",
-				"comment": "Only used if not implicit in code for Observation.code.",
-				"requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.method",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationMethod"
-						}
-					],
-					"strength": "example",
-					"description": "Methods for simple observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-17"
-					},
-					{
-						"identity": "rim",
-						"map": "methodCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.specimen",
-				"path": "Observation.specimen",
-				"short": "Specimen used for this observation",
-				"definition": "The specimen that was used when this observation was made.",
-				"comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.specimen",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Specimen"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123038009 |Specimen|"
-					},
-					{
-						"identity": "v2",
-						"map": "SPM segment"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SPC].specimen"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "704319004 |Inherent in|"
-					}
-				]
-			},
-			{
-				"id": "Observation.device",
-				"path": "Observation.device",
-				"short": "(Measurement) Device",
-				"definition": "The device used to generate the observation data.",
-				"comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.device",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/DeviceMetric"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 49062001 |Device|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-17 / PRT -10"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=DEV]"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "424226004 |Using device|"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange",
-				"path": "Observation.referenceRange",
-				"short": "Provides guide for interpretation",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "obs-3",
-						"severity": "error",
-						"human": "Must have at least a low or a high or text",
-						"expression": "low.exists() or high.exists() or text.exists()",
-						"xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.id",
-				"path": "Observation.referenceRange.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.extension",
-				"path": "Observation.referenceRange.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.modifierExtension",
-				"path": "Observation.referenceRange.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.low",
-				"path": "Observation.referenceRange.low",
-				"short": "Low Range, if relevant",
-				"definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.low",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.low"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.high",
-				"path": "Observation.referenceRange.high",
-				"short": "High Range, if relevant",
-				"definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.high",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.high"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.type",
-				"path": "Observation.referenceRange.type",
-				"short": "Reference range qualifier",
-				"definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
-				"requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeMeaning"
-						}
-					],
-					"strength": "preferred",
-					"description": "Code for the meaning of a reference range.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.appliesTo",
-				"path": "Observation.referenceRange.appliesTo",
-				"short": "Reference range population",
-				"definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
-				"requirements": "Need to be able to identify the target population for proper interpretation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange.appliesTo",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeType"
-						}
-					],
-					"strength": "example",
-					"description": "Codes identifying the population the reference range applies to.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.age",
-				"path": "Observation.referenceRange.age",
-				"short": "Applicable age range, if relevant",
-				"definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
-				"requirements": "Some analytes vary greatly over age.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.age",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Range"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.text",
-				"path": "Observation.referenceRange.text",
-				"short": "Text based reference range in an observation",
-				"definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:ST"
-					}
-				]
-			},
-			{
-				"id": "Observation.hasMember",
-				"path": "Observation.hasMember",
-				"short": "Used when reporting vital signs panel components",
-				"definition": "Used when reporting vital signs panel components.",
-				"comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.hasMember",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship"
-					}
-				]
-			},
-			{
-				"id": "Observation.derivedFrom",
-				"path": "Observation.derivedFrom",
-				"short": "Related measurements the observation is made from",
-				"definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
-				"comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.derivedFrom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/DocumentReference",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy",
-							"http://hl7.org/fhir/StructureDefinition/Media",
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": ".targetObservation"
-					}
-				]
-			},
-			{
-				"id": "Observation.component",
-				"path": "Observation.component",
-				"short": "Used when reporting systolic and diastolic blood pressure.",
-				"definition": "Used when reporting systolic and diastolic blood pressure.",
-				"comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-3",
-						"severity": "error",
-						"human": "If there is no a value a data absent reason must be present",
-						"expression": "value.exists() or dataAbsentReason.exists()",
-						"xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "containment by OBX-4?"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=COMP]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.id",
-				"path": "Observation.component.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.extension",
-				"path": "Observation.component.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.modifierExtension",
-				"path": "Observation.component.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.code",
-				"path": "Observation.component.code",
-				"short": "Type of component observation (code / type)",
-				"definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
-				"comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "VitalSigns"
-						}
-					],
-					"strength": "extensible",
-					"description": "This identifies the vital sign result type.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-vitalsignresult"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.value[x]",
-				"path": "Observation.component.value[x]",
-				"short": "Vital Sign Value recorded with UCUM",
-				"definition": "Vital Sign Value recorded with UCUM.",
-				"comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "VitalSignsUnits"
-						}
-					],
-					"strength": "required",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.dataAbsentReason",
-				"path": "Observation.component.dataAbsentReason",
-				"short": "Why the component result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
-				"comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.interpretation",
-				"path": "Observation.component.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.referenceRange",
-				"path": "Observation.component.referenceRange",
-				"short": "Provides guide for interpretation of component result",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"contentReference": "#Observation.referenceRange",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"definition": "This profile defines how to represent Weight-for-length per age and gender observations in FHIR using a standard LOINC code and UCUM units of measure.",
-				"mustSupport": false
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Weight-for-length per age and gender",
-				"comment": "additional codes that translate or map to this code are allowed.  For example a more granular LOINC code or code that is used locally in a system.",
-				"alias": [
-					"Test",
-					"Name"
-				],
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "77606-2"
-						}
-					]
-				},
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.subject",
-				"path": "Observation.subject",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity",
-				"path": "Observation.valueQuantity",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.value",
-				"path": "Observation.valueQuantity.value",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.unit",
-				"path": "Observation.valueQuantity.unit",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.system",
-				"path": "Observation.valueQuantity.system",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.code",
-				"path": "Observation.valueQuantity.code",
-				"short": "Coded responses from the common UCUM units for vital signs value set.",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "%",
-				"mustSupport": true
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "pediatric-weight-for-height",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height",
+    "version": "3.1.1",
+    "name": "USCorePediatricWeightForHeightObservationProfile",
+    "title": "US Core Pediatric Weight for Height Observation Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-06-27",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.healthit.gov"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the Observation resource for use in querying and retrieving pediatric Weight-for-length per age and gender observations.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "sct-concept",
+            "uri": "http://snomed.info/conceptdomain",
+            "name": "SNOMED CT Concept Domain Binding"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "sct-attr",
+            "uri": "http://snomed.org/attributebinding",
+            "name": "SNOMED CT Attribute Binding"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Observation",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/vitalsigns",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "FHIR Vital Signs Profile",
+                "definition": "This profile defines how to represent Weight-for-length per age and gender observations in FHIR using a standard LOINC code and UCUM units of measure.",
+                "comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
+                "alias": [
+                    "Vital Signs",
+                    "Measurement",
+                    "Results",
+                    "Tests"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "obs-6",
+                        "severity": "error",
+                        "human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
+                        "expression": "dataAbsentReason.empty() or value.empty()",
+                        "xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "obs-7",
+                        "severity": "error",
+                        "human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
+                        "expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
+                        "xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "vs-2",
+                        "severity": "error",
+                        "human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
+                        "expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
+                        "xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.id",
+                "path": "Observation.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.meta",
+                "path": "Observation.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.implicitRules",
+                "path": "Observation.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Observation.language",
+                "path": "Observation.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Observation.text",
+                "path": "Observation.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.contained",
+                "path": "Observation.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.extension",
+                "path": "Observation.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.modifierExtension",
+                "path": "Observation.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.identifier",
+                "path": "Observation.identifier",
+                "short": "Business Identifier for observation",
+                "definition": "A unique identifier assigned to this observation.",
+                "requirements": "Allows observations to be distinguished and referenced.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "id"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.basedOn",
+                "path": "Observation.basedOn",
+                "short": "Fulfills plan, proposal or order",
+                "definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
+                "requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
+                "alias": [
+                    "Fulfills"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceRequest",
+                            "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+                            "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.basedOn"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.partOf",
+                "path": "Observation.partOf",
+                "short": "Part of referenced event",
+                "definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
+                "comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
+                "alias": [
+                    "Container"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.partOf",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationDispense",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationStatement",
+                            "http://hl7.org/fhir/StructureDefinition/Procedure",
+                            "http://hl7.org/fhir/StructureDefinition/Immunization",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.partOf"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "Varies by domain"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=FLFS].target"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.status",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
+                        "valueString": "default: final"
+                    }
+                ],
+                "path": "Observation.status",
+                "short": "registered | preliminary | final | amended +",
+                "definition": "The status of the result value.",
+                "comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
+                "requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Status"
+                        }
+                    ],
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 445584004 |Report by finality status|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-11"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category",
+                "path": "Observation.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "coding.code"
+                        },
+                        {
+                            "type": "value",
+                            "path": "coding.system"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "open"
+                },
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat",
+                "path": "Observation.category",
+                "sliceName": "VSCat",
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.id",
+                "path": "Observation.category.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.extension",
+                "path": "Observation.category.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding",
+                "path": "Observation.category.coding",
+                "short": "Code defined by a terminology system",
+                "definition": "A reference to a code defined by a terminology system.",
+                "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+                "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "CodeableConcept.coding",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1-8, C*E.10-22"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "union(., ./translation)"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.id",
+                "path": "Observation.category.coding.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.extension",
+                "path": "Observation.category.coding.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.system",
+                "path": "Observation.category.coding.system",
+                "short": "Identity of the terminology system",
+                "definition": "The identification of the code system that defines the meaning of the symbol in the code.",
+                "comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
+                "requirements": "Need to be unambiguous about the source of the definition of the symbol.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystem"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.version",
+                "path": "Observation.category.coding.version",
+                "short": "Version of the system - if relevant",
+                "definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
+                "comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.version",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystemVersion"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.code",
+                "path": "Observation.category.coding.code",
+                "short": "Symbol in syntax defined by the system",
+                "definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
+                "requirements": "Need to refer to a particular code in the system.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "vital-signs",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./code"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.display",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.coding.display",
+                "short": "Representation defined by the system",
+                "definition": "A representation of the meaning of the code in the system, following the rules of the system.",
+                "requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.display",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.2 - but note this is not well followed"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CV.displayName"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.userSelected",
+                "path": "Observation.category.coding.userSelected",
+                "short": "If this coding was chosen directly by the user",
+                "definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
+                "comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
+                "requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.userSelected",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Sometimes implied by being first"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CD.codingRationale"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.text",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.text",
+                "short": "Plain text representation of the concept",
+                "definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
+                "comment": "Very often the text is the same as a displayName of one of the codings.",
+                "requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CodeableConcept.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.9. But note many systems use C*E.2 for this"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./originalText[mediaType/code=\"text/plain\"]/data"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Weight-for-length per age and gender",
+                "definition": "Coded Responses from C-CDA Vital Sign Results.",
+                "comment": "additional codes that translate or map to this code are allowed.  For example a more granular LOINC code or code that is used locally in a system.",
+                "requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
+                "alias": [
+                    "Name",
+                    "Test"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "77606-2"
+                        }
+                    ]
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "VitalSigns"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "This identifies the vital sign result type.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-vitalsignresult"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "116680003 |Is a|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.subject",
+                "path": "Observation.subject",
+                "short": "Who and/or what the observation is about",
+                "definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
+                "comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
+                "requirements": "Observations have no value if you don't know who or what they're about.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=RTGT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.focus",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+                        "valueCode": "trial-use"
+                    }
+                ],
+                "path": "Observation.focus",
+                "short": "What the observation is about, when it is not about the subject of record",
+                "definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
+                "comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.focus",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SBJ]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.encounter",
+                "path": "Observation.encounter",
+                "short": "Healthcare event during which this observation is made",
+                "definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
+                "comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
+                "requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
+                "alias": [
+                    "Context"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.effective[x]",
+                "path": "Observation.effective[x]",
+                "short": "Often just a dateTime for Vital Signs",
+                "definition": "Often just a dateTime for Vital Signs.",
+                "comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
+                "requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
+                "alias": [
+                    "Occurrence"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.effective[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-1",
+                        "severity": "error",
+                        "human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
+                        "expression": "($this as dateTime).toString().length() >= 8",
+                        "xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.issued",
+                "path": "Observation.issued",
+                "short": "Date/Time this version was made available",
+                "definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
+                "comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.issued",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.performer",
+                "path": "Observation.performer",
+                "short": "Who is responsible for the observation",
+                "definition": "Who was responsible for asserting the observed value as \"true\".",
+                "requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.performer",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=PRF]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]",
+                "path": "Observation.value[x]",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "type",
+                            "path": "$this"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "closed"
+                },
+                "short": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
+                "definition": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity",
+                "path": "Observation.value[x]",
+                "sliceName": "valueQuantity",
+                "short": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
+                "definition": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.id",
+                "path": "Observation.value[x].id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.extension",
+                "path": "Observation.value[x].extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.value",
+                "path": "Observation.value[x].value",
+                "short": "Numerical value (with implicit precision)",
+                "definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
+                "comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
+                "requirements": "Precision is handled implicitly in almost all cases of measurement.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.2  / CQ - N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.comparator",
+                "path": "Observation.value[x].comparator",
+                "short": "< | <= | >= | > - how to understand the value",
+                "definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
+                "requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.comparator",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "QuantityComparator"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "How the Quantity should be understood and represented.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.1  / CQ.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "IVL properties"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.unit",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.value[x].unit",
+                "short": "Unit representation",
+                "definition": "A human-readable form of the unit.",
+                "requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.unit",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.unit"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.system",
+                "path": "Observation.value[x].system",
+                "short": "System that defines coded unit form",
+                "definition": "The identification of the system that provides the coded form of the unit.",
+                "requirements": "Need to know the system that defines the coded form of the unit.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "condition": [
+                    "qty-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CO.codeSystem, PQ.translation.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.code",
+                "path": "Observation.value[x].code",
+                "short": "Coded responses from the common UCUM units for vital signs value set.",
+                "definition": "A computer processable form of the unit in some unit representation system.",
+                "comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
+                "requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "%",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.code, MO.currency, PQ.translation.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.dataAbsentReason",
+                "path": "Observation.dataAbsentReason",
+                "short": "Why the result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
+                "comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.interpretation",
+                "path": "Observation.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.note",
+                "path": "Observation.note",
+                "short": "Comments about the observation",
+                "definition": "Comments about the observation or the results.",
+                "comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
+                "requirements": "Need to be able to provide free text additional information.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "subjectOf.observationEvent[code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.bodySite",
+                "path": "Observation.bodySite",
+                "short": "Observed body part",
+                "definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
+                "comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.bodySite",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "BodySite"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing anatomical locations. May include laterality.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/body-site"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123037004 |Body structure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-20"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "targetSiteCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "718497002 |Inherent location|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.method",
+                "path": "Observation.method",
+                "short": "How it was done",
+                "definition": "Indicates the mechanism used to perform the observation.",
+                "comment": "Only used if not implicit in code for Observation.code.",
+                "requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.method",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationMethod"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Methods for simple observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "methodCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.specimen",
+                "path": "Observation.specimen",
+                "short": "Specimen used for this observation",
+                "definition": "The specimen that was used when this observation was made.",
+                "comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.specimen",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Specimen"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123038009 |Specimen|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "SPM segment"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SPC].specimen"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "704319004 |Inherent in|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.device",
+                "path": "Observation.device",
+                "short": "(Measurement) Device",
+                "definition": "The device used to generate the observation data.",
+                "comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.device",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceMetric"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 49062001 |Device|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17 / PRT -10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=DEV]"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "424226004 |Using device|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange",
+                "path": "Observation.referenceRange",
+                "short": "Provides guide for interpretation",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "obs-3",
+                        "severity": "error",
+                        "human": "Must have at least a low or a high or text",
+                        "expression": "low.exists() or high.exists() or text.exists()",
+                        "xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.id",
+                "path": "Observation.referenceRange.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.extension",
+                "path": "Observation.referenceRange.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.modifierExtension",
+                "path": "Observation.referenceRange.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.low",
+                "path": "Observation.referenceRange.low",
+                "short": "Low Range, if relevant",
+                "definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.low",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.low"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.high",
+                "path": "Observation.referenceRange.high",
+                "short": "High Range, if relevant",
+                "definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.high",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.high"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.type",
+                "path": "Observation.referenceRange.type",
+                "short": "Reference range qualifier",
+                "definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
+                "requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeMeaning"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Code for the meaning of a reference range.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.appliesTo",
+                "path": "Observation.referenceRange.appliesTo",
+                "short": "Reference range population",
+                "definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
+                "requirements": "Need to be able to identify the target population for proper interpretation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange.appliesTo",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes identifying the population the reference range applies to.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.age",
+                "path": "Observation.referenceRange.age",
+                "short": "Applicable age range, if relevant",
+                "definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
+                "requirements": "Some analytes vary greatly over age.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.age",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Range"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.text",
+                "path": "Observation.referenceRange.text",
+                "short": "Text based reference range in an observation",
+                "definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:ST"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.hasMember",
+                "path": "Observation.hasMember",
+                "short": "Used when reporting vital signs panel components",
+                "definition": "Used when reporting vital signs panel components.",
+                "comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.hasMember",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.derivedFrom",
+                "path": "Observation.derivedFrom",
+                "short": "Related measurements the observation is made from",
+                "definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
+                "comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.derivedFrom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/DocumentReference",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy",
+                            "http://hl7.org/fhir/StructureDefinition/Media",
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".targetObservation"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component",
+                "path": "Observation.component",
+                "short": "Used when reporting systolic and diastolic blood pressure.",
+                "definition": "Used when reporting systolic and diastolic blood pressure.",
+                "comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-3",
+                        "severity": "error",
+                        "human": "If there is no a value a data absent reason must be present",
+                        "expression": "value.exists() or dataAbsentReason.exists()",
+                        "xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "containment by OBX-4?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=COMP]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.id",
+                "path": "Observation.component.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.extension",
+                "path": "Observation.component.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.modifierExtension",
+                "path": "Observation.component.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.code",
+                "path": "Observation.component.code",
+                "short": "Type of component observation (code / type)",
+                "definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
+                "comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "VitalSigns"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "This identifies the vital sign result type.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-vitalsignresult"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.value[x]",
+                "path": "Observation.component.value[x]",
+                "short": "Vital Sign Value recorded with UCUM",
+                "definition": "Vital Sign Value recorded with UCUM.",
+                "comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "VitalSignsUnits"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.dataAbsentReason",
+                "path": "Observation.component.dataAbsentReason",
+                "short": "Why the component result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
+                "comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.interpretation",
+                "path": "Observation.component.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.referenceRange",
+                "path": "Observation.component.referenceRange",
+                "short": "Provides guide for interpretation of component result",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "contentReference": "#Observation.referenceRange",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "definition": "This profile defines how to represent Weight-for-length per age and gender observations in FHIR using a standard LOINC code and UCUM units of measure.",
+                "mustSupport": false
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Weight-for-length per age and gender",
+                "comment": "additional codes that translate or map to this code are allowed.  For example a more granular LOINC code or code that is used locally in a system.",
+                "alias": [
+                    "Test",
+                    "Name"
+                ],
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "77606-2"
+                        }
+                    ]
+                },
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.subject",
+                "path": "Observation.subject",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity",
+                "path": "Observation.valueQuantity",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.value",
+                "path": "Observation.valueQuantity.value",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.unit",
+                "path": "Observation.valueQuantity.unit",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.system",
+                "path": "Observation.valueQuantity.system",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.code",
+                "path": "Observation.valueQuantity.code",
+                "short": "Coded responses from the common UCUM units for vital signs value set.",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "%",
+                "mustSupport": true
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-allergyintolerance.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-allergyintolerance.json
@@ -1,1852 +1,1852 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-allergyintolerance",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-allergyintolerance-definitions.html#AllergyIntolerance\" title=\"The US Core Allergies Profile is based upon the core FHIR AllergyIntolerance Resource and created to meet the 2015 Edition Common Clinical Data Set 'Medical allergies' requirements.\">AllergyIntolerance</a><a name=\"AllergyIntolerance\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/allergyintolerance.html\">AllergyIntolerance</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Allergy or Intolerance (generally: Risk of adverse reaction to a substance)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-allergyintolerance-definitions.html#AllergyIntolerance.clinicalStatus\">clinicalStatus</a><a name=\"AllergyIntolerance.clinicalStatus\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">active | inactive | resolved</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-allergyintolerance-clinical.html\">AllergyIntoleranceClinicalStatusCodes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-allergyintolerance-definitions.html#AllergyIntolerance.verificationStatus\">verificationStatus</a><a name=\"AllergyIntolerance.verificationStatus\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">unconfirmed | confirmed | refuted | entered-in-error</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-allergyintolerance-verification.html\">AllergyIntoleranceVerificationStatusCodes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-allergyintolerance-definitions.html#AllergyIntolerance.code\">code</a><a name=\"AllergyIntolerance.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Code that identifies the allergy or intolerance</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-allergy-substance.html\">US Core Common substances for allergy and intolerance documentation including refutations</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-allergyintolerance-definitions.html#AllergyIntolerance.patient\">patient</a><a name=\"AllergyIntolerance.patient\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who the sensitivity is for</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-allergyintolerance-definitions.html#AllergyIntolerance.reaction\">reaction</a><a name=\"AllergyIntolerance.reaction\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Adverse Reaction Events linked to exposure to substance</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-allergyintolerance-definitions.html#AllergyIntolerance.reaction.manifestation\">manifestation</a><a name=\"AllergyIntolerance.reaction.manifestation\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Clinical symptoms/signs associated with the Event</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-clinical-findings.html\">SNOMEDCTClinicalFindings</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)<br/></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance",
-	"version": "3.1.1",
-	"name": "USCoreAllergyIntolerance",
-	"title": "US  Core AllergyIntolerance Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-06-29",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.healthit.gov"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the AllergyIntolerance resource for the minimal set of data to query and retrieve allergy information.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "argonaut-dq-dstu2",
-			"uri": "http://unknown.org/Argonaut-DQ-DSTU2",
-			"name": "Argonaut-DQ-DSTU2"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "AllergyIntolerance",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/AllergyIntolerance",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "AllergyIntolerance",
-				"path": "AllergyIntolerance",
-				"short": "Allergy or Intolerance (generally: Risk of adverse reaction to a substance)",
-				"definition": "The US Core Allergies Profile is based upon the core FHIR AllergyIntolerance Resource and created to meet the 2015 Edition Common Clinical Data Set 'Medical allergies' requirements.",
-				"comment": "Substances include, but are not limited to: a therapeutic substance administered correctly at an appropriate dosage for the individual; food; material derived from plants or animals; or venom from insect stings.",
-				"alias": [
-					"Allergy",
-					"Intolerance",
-					"Adverse Reaction"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "AllergyIntolerance",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "ait-1",
-						"severity": "error",
-						"human": "AllergyIntolerance.clinicalStatus SHALL be present if verificationStatus is not entered-in-error.",
-						"expression": "verificationStatus.coding.where(system = 'http://terminology.hl7.org/CodeSystem/allergyintolerance-verification' and code = 'entered-in-error').exists() or clinicalStatus.exists()",
-						"xpath": "f:verificationStatus/f:coding/f:code/@value='entered-in-error' or exists(f:clinicalStatus)",
-						"source": "http://hl7.org/fhir/StructureDefinition/AllergyIntolerance"
-					},
-					{
-						"key": "ait-2",
-						"severity": "error",
-						"human": "AllergyIntolerance.clinicalStatus SHALL NOT be present if verification Status is entered-in-error",
-						"expression": "verificationStatus.coding.where(system = 'http://terminology.hl7.org/CodeSystem/allergyintolerance-verification' and code = 'entered-in-error').empty() or clinicalStatus.empty()",
-						"xpath": "not(f:verificationStatus/f:coding/f:code/@value='entered-in-error') or not(exists(f:clinicalStatus))",
-						"source": "http://hl7.org/fhir/StructureDefinition/AllergyIntolerance"
-					},
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation[classCode=OBS, moodCode=EVN]"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "AllergyIntolerance"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.id",
-				"path": "AllergyIntolerance.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "AllergyIntolerance.meta",
-				"path": "AllergyIntolerance.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "AllergyIntolerance.implicitRules",
-				"path": "AllergyIntolerance.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "AllergyIntolerance.language",
-				"path": "AllergyIntolerance.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "AllergyIntolerance.text",
-				"path": "AllergyIntolerance.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.contained",
-				"path": "AllergyIntolerance.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.extension",
-				"path": "AllergyIntolerance.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.modifierExtension",
-				"path": "AllergyIntolerance.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.identifier",
-				"path": "AllergyIntolerance.identifier",
-				"short": "External ids for this item",
-				"definition": "Business identifiers assigned to this AllergyIntolerance by the performer or other systems which remain constant as the resource is updated and propagates from server to server.",
-				"comment": "This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.",
-				"requirements": "Allows identification of the AllergyIntolerance as it is known by various participating systems and in a way that remains consistent across servers.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "AllergyIntolerance.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "IAM-7"
-					},
-					{
-						"identity": "rim",
-						"map": "id"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.clinicalStatus",
-				"path": "AllergyIntolerance.clinicalStatus",
-				"short": "active | inactive | resolved",
-				"definition": "The clinical status of the allergy or intolerance.",
-				"comment": "Refer to [discussion](http://hl7.org/fhir/R4/extensibility.html#Special-Case) if clincalStatus is missing data.\nThe data type is CodeableConcept because clinicalStatus has some clinical judgment involved, such that there might need to be more specificity than the required FHIR value set allows. For example, a SNOMED coding might allow for additional specificity.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.clinicalStatus",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"ait-1",
-					"ait-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the status contains the codes inactive and resolved that mark the AllergyIntolerance as no longer active.",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/allergyintolerance-clinical"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation ACT .inboundRelationship[typeCode=COMP].source[classCode=OBS, code=\"clinicalStatus\", moodCode=EVN].value"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "AllergyIntolerance.status"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.verificationStatus",
-				"path": "AllergyIntolerance.verificationStatus",
-				"short": "unconfirmed | confirmed | refuted | entered-in-error",
-				"definition": "Assertion about certainty associated with the propensity, or potential risk, of a reaction to the identified substance (including pharmaceutical product).",
-				"comment": "The data type is CodeableConcept because verificationStatus has some clinical judgment involved, such that there might need to be more specificity than the required FHIR value set allows. For example, a SNOMED coding might allow for additional specificity.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.verificationStatus",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"ait-1",
-					"ait-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the status contains the codes refuted and entered-in-error that mark the AllergyIntolerance as not currently valid.",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/allergyintolerance-verification"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation ACT .inboundRelationship[typeCode=COMP].source[classCode=OBS, code=\"verificationStatus\", moodCode=EVN].value"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "AllergyIntolerance.status"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.type",
-				"path": "AllergyIntolerance.type",
-				"short": "allergy | intolerance - Underlying mechanism (if known)",
-				"definition": "Identification of the underlying physiological mechanism for the reaction risk.",
-				"comment": "Allergic (typically immune-mediated) reactions have been traditionally regarded as an indicator for potential escalation to significant future risk. Contemporary knowledge suggests that some reactions previously thought to be immune-mediated are, in fact, non-immune, but in some cases can still pose a life threatening risk. It is acknowledged that many clinicians might not be in a position to distinguish the mechanism of a particular reaction. Often the term \"allergy\" is used rather generically and may overlap with the use of \"intolerance\" - in practice the boundaries between these two concepts might not be well-defined or understood. This data element is included nevertheless, because many legacy systems have captured this attribute. Immunologic testing may provide supporting evidence for the basis of the reaction and the causative substance, but no tests are 100% sensitive or specific for sensitivity to a particular substance. If, as is commonly the case, it is unclear whether the reaction is due to an allergy or an intolerance, then the type element should be omitted from the resource.",
-				"alias": [
-					"Category",
-					"Class"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AllergyIntoleranceType"
-						}
-					],
-					"strength": "required",
-					"description": "Identification of the underlying physiological mechanism for a Reaction Risk.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/allergy-intolerance-type|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "v2",
-						"map": "IAM-9"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.category",
-				"path": "AllergyIntolerance.category",
-				"short": "food | medication | environment | biologic",
-				"definition": "Category of the identified substance.",
-				"comment": "This data element has been included because it is currently being captured in some clinical systems. This data can be derived from the substance where coding systems are used, and is effectively redundant in that situation.  When searching on category, consider the implications of AllergyIntolerance resources without a category.  For example, when searching on category = medication, medication allergies that don't have a category valued will not be returned.  Refer to [search](http://hl7.org/fhir/R4/search.html) for more information on how to search category with a :missing modifier to get allergies that don't have a category.  Additionally, category should be used with caution because category can be subjective based on the sender.",
-				"alias": [
-					"Category",
-					"Type",
-					"Reaction Type",
-					"Class"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "AllergyIntolerance.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AllergyIntoleranceCategory"
-						}
-					],
-					"strength": "required",
-					"description": "Category of an identified substance associated with allergies or intolerances.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/allergy-intolerance-category|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "v2",
-						"map": "AL1-2"
-					},
-					{
-						"identity": "rim",
-						"map": "value < IntoleranceValue (Agent)"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.criticality",
-				"path": "AllergyIntolerance.criticality",
-				"short": "low | high | unable-to-assess",
-				"definition": "Estimate of the potential clinical harm, or seriousness, of the reaction to the identified substance.",
-				"comment": "The default criticality value for any propensity to an adverse reaction should be 'Low Risk', indicating at the very least a relative contraindication to deliberate or voluntary exposure to the substance. 'High Risk' is flagged if the clinician has identified a propensity for a more serious or potentially life-threatening reaction, such as anaphylaxis, and implies an absolute contraindication to deliberate or voluntary exposure to the substance. If this element is missing, the criticality is unknown (though it may be known elsewhere).  Systems that capture a severity at the condition level are actually representing the concept of criticality whereas the severity documented at the reaction level is representing the true reaction severity.  Existing systems that are capturing both condition criticality and reaction severity may use the term \"severity\" to represent both.  Criticality is the worst it could be in the future (i.e. situation-agnostic) whereas severity is situation-dependent.",
-				"alias": [
-					"Severity",
-					"Seriousness",
-					"Contra-indication",
-					"Risk"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.criticality",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AllergyIntoleranceCriticality"
-						}
-					],
-					"strength": "required",
-					"description": "Estimate of the potential clinical harm, or seriousness, of a reaction to an identified substance.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/allergy-intolerance-criticality|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.grade"
-					},
-					{
-						"identity": "v2",
-						"map": "AL1-4"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=SEV, value <= SeverityObservation (Severity Level)]"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.code",
-				"path": "AllergyIntolerance.code",
-				"short": "Code that identifies the allergy or intolerance",
-				"definition": "Code for an allergy or intolerance statement (either a positive or a negated/excluded statement).  This may be a code for a substance or pharmaceutical product that is considered to be responsible for the adverse reaction risk (e.g., \"Latex\"), an allergy or intolerance condition (e.g., \"Latex allergy\"), or a negated/excluded code for a specific substance or class (e.g., \"No latex allergy\") or a general or categorical negated statement (e.g.,  \"No known allergy\", \"No known drug allergies\").  Note: the substance for a specific reaction may be different from the substance identified as the cause of the risk, but it must be consistent with it. For instance, it may be a more specific substance (e.g. a brand medication) or a composite product that includes the identified substance. It must be clinically safe to only process the 'code' and ignore the 'reaction.substance'.  If a receiving system is unable to confirm that AllergyIntolerance.reaction.substance falls within the semantic scope of AllergyIntolerance.code, then the receiving system should ignore AllergyIntolerance.reaction.substance.",
-				"comment": "It is strongly recommended that this element be populated using a terminology, where possible. For example, some terminologies used include RxNorm, SNOMED CT, DM+D, NDFRT, ICD-9, IDC-10, UNII, and ATC. Plain text should only be used if there is no appropriate terminology available. Additional details can be specified in the text.\r\rWhen a substance or product code is specified for the 'code' element, the \"default\" semantic context is that this is a positive statement of an allergy or intolerance (depending on the value of the 'type' element, if present) condition to the specified substance/product.  In the corresponding SNOMED CT allergy model, the specified substance/product is the target (destination) of the \"Causative agent\" relationship.\r\rThe 'substanceExposureRisk' extension is available as a structured and more flexible alternative to the 'code' element for making positive or negative allergy or intolerance statements.  This extension provides the capability to make \"no known allergy\" (or \"no risk of adverse reaction\") statements regarding any coded substance/product (including cases when a pre-coordinated \"no allergy to x\" concept for that substance/product does not exist).  If the 'substanceExposureRisk' extension is present, the AllergyIntolerance.code element SHALL be omitted.",
-				"alias": [
-					"Code"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-allergy-substance|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "AL1-3 / IAM-3"
-					},
-					{
-						"identity": "rim",
-						"map": "substance/product:\r\r.participation[typeCode=CAGNT].role[classCode=ADMM].player[classCode=MAT, determinerCode=KIND, code <= ExposureAgentEntityType]\r\rnegated/excluded substance/product:\r\r.participation[typeCode=CAGNT, negationInd=true].role[classCode=ADMM].player[classCode=MAT, determinerCode=KIND, code <= ExposureAgentEntityType]\r\rpositive or negated/excluded condition/situation:\r\rObservation.code=ASSERTION; Observation.value"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "AllergyIntolerance.substance"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.patient",
-				"path": "AllergyIntolerance.patient",
-				"short": "Who the sensitivity is for",
-				"definition": "The patient who has the allergy or intolerance.",
-				"alias": [
-					"Patient"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.patient",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "(PID-3)"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=SBJ].role[classCode=PAT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "AllergyIntolerance.patient"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.encounter",
-				"path": "AllergyIntolerance.encounter",
-				"short": "Encounter when the allergy or intolerance was asserted",
-				"definition": "The encounter when the allergy or intolerance was asserted.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.onset[x]",
-				"path": "AllergyIntolerance.onset[x]",
-				"short": "When allergy or intolerance was identified",
-				"definition": "Estimated or actual date,  date-time, or age when allergy or intolerance was identified.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.onset[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Age"
-					},
-					{
-						"code": "Period"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.init"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime.low"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.recordedDate",
-				"path": "AllergyIntolerance.recordedDate",
-				"short": "Date first version of the resource instance was recorded",
-				"definition": "The recordedDate represents when this particular AllergyIntolerance record was created in the system, which is often a system-generated date.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.recordedDate",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "v2",
-						"map": "IAM-13"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=AUT].time"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.recorder",
-				"path": "AllergyIntolerance.recorder",
-				"short": "Who recorded the sensitivity",
-				"definition": "Individual who recorded the record and takes responsibility for its content.",
-				"alias": [
-					"Author"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.recorder",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.author"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=AUT].role"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.asserter",
-				"path": "AllergyIntolerance.asserter",
-				"short": "Source of the information about the allergy",
-				"definition": "The source of the information about the allergy that is recorded.",
-				"comment": "The recorder takes responsibility for the content, but can reference the source from where they got it.",
-				"alias": [
-					"Source",
-					"Informant"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.asserter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson",
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.source"
-					},
-					{
-						"identity": "v2",
-						"map": "IAM-14 (if patient) / IAM-18 (if practitioner)"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=INF].role"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.lastOccurrence",
-				"path": "AllergyIntolerance.lastOccurrence",
-				"short": "Date(/time) of last known occurrence of a reaction",
-				"definition": "Represents the date and/or time of the last known occurrence of a reaction event.",
-				"comment": "This date may be replicated by one of the Onset of Reaction dates. Where a textual representation of the date of last occurrence is required e.g. 'In Childhood, '10 years ago' the Comment element should be used.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.lastOccurrence",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=SUBJ].target[classCode=OBS, moodCode=EVN, code <= CommonClinicalObservationType, value <= ObservationValue (Reaction Type)].effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.note",
-				"path": "AllergyIntolerance.note",
-				"short": "Additional text not captured in other fields",
-				"definition": "Additional narrative about the propensity for the Adverse Reaction, not captured in other fields.",
-				"comment": "For example: including reason for flagging a seriousness of 'High Risk'; and instructions related to future exposure or administration of the substance, such as administration within an Intensive Care Unit or under corticosteroid cover. The notes should be related to an allergy or intolerance as a condition in general and not related to any particular episode of it. For episode notes and descriptions, use AllergyIntolerance.event.description and  AllergyIntolerance.event.notes.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "AllergyIntolerance.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "subjectOf.observationEvent[code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.reaction",
-				"path": "AllergyIntolerance.reaction",
-				"short": "Adverse Reaction Events linked to exposure to substance",
-				"definition": "Details about each adverse reaction event linked to exposure to the identified substance.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "AllergyIntolerance.reaction",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=SUBJ].target[classCode=OBS, moodCode=EVN, code <= CommonClinicalObservationType, value <= ObservationValue (Reaction Type)]"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.reaction.id",
-				"path": "AllergyIntolerance.reaction.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.reaction.extension",
-				"path": "AllergyIntolerance.reaction.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.reaction.modifierExtension",
-				"path": "AllergyIntolerance.reaction.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.reaction.substance",
-				"path": "AllergyIntolerance.reaction.substance",
-				"short": "Specific substance or pharmaceutical product considered to be responsible for event",
-				"definition": "Identification of the specific substance (or pharmaceutical product) considered to be responsible for the Adverse Reaction event. Note: the substance for a specific reaction may be different from the substance identified as the cause of the risk, but it must be consistent with it. For instance, it may be a more specific substance (e.g. a brand medication) or a composite product that includes the identified substance. It must be clinically safe to only process the 'code' and ignore the 'reaction.substance'.  If a receiving system is unable to confirm that AllergyIntolerance.reaction.substance falls within the semantic scope of AllergyIntolerance.code, then the receiving system should ignore AllergyIntolerance.reaction.substance.",
-				"comment": "Coding of the specific substance (or pharmaceutical product) with a terminology capable of triggering decision support should be used wherever possible.  The 'code' element allows for the use of a specific substance or pharmaceutical product, or a group or class of substances. In the case of an allergy or intolerance to a class of substances, (for example, \"penicillins\"), the 'reaction.substance' element could be used to code the specific substance that was identified as having caused the reaction (for example, \"amoxycillin\"). Duplication of the value in the 'code' and 'reaction.substance' elements is acceptable when a specific substance has been recorded in 'code'.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.reaction.substance",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "SubstanceCode"
-						}
-					],
-					"strength": "example",
-					"description": "Codes defining the type of the substance (including pharmaceutical products).",
-					"valueSet": "http://hl7.org/fhir/ValueSet/substance-code"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=SAS].target[classCode=SBADM, code <= ExposureCode].participation[typeCode=CSM].role[classCode=ADMM].player[classCode=MAT, determinerCode=KIND, code <= ExposureAgentEntityType]"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.reaction.manifestation",
-				"path": "AllergyIntolerance.reaction.manifestation",
-				"short": "Clinical symptoms/signs associated with the Event",
-				"definition": "Clinical symptoms and/or signs that are observed or associated with the adverse reaction event.",
-				"comment": "Manifestation can be expressed as a single word, phrase or brief description. For example: nausea, rash or no reaction. It is preferable that manifestation should be coded with a terminology, where possible. The values entered here may be used to display on an application screen as part of a list of adverse reactions, as recommended in the UK NHS CUI guidelines.  Terminologies commonly used include, but are not limited to, SNOMED CT or ICD10.",
-				"alias": [
-					"Symptoms",
-					"Signs"
-				],
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "AllergyIntolerance.reaction.manifestation",
-					"min": 1,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "AL1-5"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.reaction.description",
-				"path": "AllergyIntolerance.reaction.description",
-				"short": "Description of the event as a whole",
-				"definition": "Text description about the reaction as a whole, including details of the manifestation if required.",
-				"comment": "Use the description to provide any details of a particular event of the occurred reaction such as circumstances, reaction specifics, what happened before/after. Information, related to the event, but not describing a particular care should be captured in the comment field. For example: at the age of four, the patient was given penicillin for strep throat and subsequently developed severe hives.",
-				"alias": [
-					"Narrative",
-					"Text"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.reaction.description",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "text"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.reaction.onset",
-				"path": "AllergyIntolerance.reaction.onset",
-				"short": "Date(/time) when manifestations showed",
-				"definition": "Record of the date and/or time of the onset of the Reaction.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.reaction.onset",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "AL1-6"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime.low"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.reaction.severity",
-				"path": "AllergyIntolerance.reaction.severity",
-				"short": "mild | moderate | severe (of event as a whole)",
-				"definition": "Clinical assessment of the severity of the reaction event as a whole, potentially considering multiple different manifestations.",
-				"comment": "It is acknowledged that this assessment is very subjective. There may be some specific practice domains where objective scales have been applied. Objective scales can be included in this model as extensions.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.reaction.severity",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AllergyIntoleranceSeverity"
-						}
-					],
-					"strength": "required",
-					"description": "Clinical assessment of the severity of a reaction event as a whole, potentially considering multiple different manifestations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/reaction-event-severity|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=SEV, value <= SeverityObservation (Severity Level)]"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.reaction.exposureRoute",
-				"path": "AllergyIntolerance.reaction.exposureRoute",
-				"short": "How the subject was exposed to the substance",
-				"definition": "Identification of the route by which the subject was exposed to the substance.",
-				"comment": "Coding of the route of exposure with a terminology should be used wherever possible.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.reaction.exposureRoute",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "RouteOfAdministration"
-						}
-					],
-					"strength": "example",
-					"description": "A coded concept describing the route or physiological path of administration of a therapeutic agent into or onto the body of a subject.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/route-codes"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=SAS].target[classCode=SBADM, code <= ExposureCode].routeCode"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.reaction.note",
-				"path": "AllergyIntolerance.reaction.note",
-				"short": "Text about event not captured in other fields",
-				"definition": "Additional text about the adverse reaction event not captured in other fields.",
-				"comment": "Use this field to record information indirectly related to a particular event and not captured in the description. For example: Clinical records are no longer available, recorded based on information provided to the patient by her mother and her mother is deceased.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "AllergyIntolerance.reaction.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "subjectOf.observationEvent[code=\"annotation\"].value"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "AllergyIntolerance",
-				"path": "AllergyIntolerance",
-				"definition": "The US Core Allergies Profile is based upon the core FHIR AllergyIntolerance Resource and created to meet the 2015 Edition Common Clinical Data Set 'Medical allergies' requirements.",
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "AllergyIntolerance"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.clinicalStatus",
-				"path": "AllergyIntolerance.clinicalStatus",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/allergyintolerance-clinical"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "AllergyIntolerance.status"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.verificationStatus",
-				"path": "AllergyIntolerance.verificationStatus",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/allergyintolerance-verification"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "AllergyIntolerance.status"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.code",
-				"path": "AllergyIntolerance.code",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-allergy-substance|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "AllergyIntolerance.substance"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.patient",
-				"path": "AllergyIntolerance.patient",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "AllergyIntolerance.patient"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.reaction",
-				"path": "AllergyIntolerance.reaction",
-				"min": 0,
-				"max": "*",
-				"mustSupport": true
-			},
-			{
-				"id": "AllergyIntolerance.reaction.manifestation",
-				"path": "AllergyIntolerance.reaction.manifestation",
-				"min": 1,
-				"max": "*",
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
-				}
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-allergyintolerance",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance",
+    "version": "3.1.1",
+    "name": "USCoreAllergyIntolerance",
+    "title": "US  Core AllergyIntolerance Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-06-29",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.healthit.gov"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the AllergyIntolerance resource for the minimal set of data to query and retrieve allergy information.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "argonaut-dq-dstu2",
+            "uri": "http://unknown.org/Argonaut-DQ-DSTU2",
+            "name": "Argonaut-DQ-DSTU2"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "AllergyIntolerance",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/AllergyIntolerance",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "AllergyIntolerance",
+                "path": "AllergyIntolerance",
+                "short": "Allergy or Intolerance (generally: Risk of adverse reaction to a substance)",
+                "definition": "The US Core Allergies Profile is based upon the core FHIR AllergyIntolerance Resource and created to meet the 2015 Edition Common Clinical Data Set 'Medical allergies' requirements.",
+                "comment": "Substances include, but are not limited to: a therapeutic substance administered correctly at an appropriate dosage for the individual; food; material derived from plants or animals; or venom from insect stings.",
+                "alias": [
+                    "Allergy",
+                    "Intolerance",
+                    "Adverse Reaction"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "AllergyIntolerance",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "ait-1",
+                        "severity": "error",
+                        "human": "AllergyIntolerance.clinicalStatus SHALL be present if verificationStatus is not entered-in-error.",
+                        "expression": "verificationStatus.coding.where(system = 'http://terminology.hl7.org/CodeSystem/allergyintolerance-verification' and code = 'entered-in-error').exists() or clinicalStatus.exists()",
+                        "xpath": "f:verificationStatus/f:coding/f:code/@value='entered-in-error' or exists(f:clinicalStatus)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/AllergyIntolerance"
+                    },
+                    {
+                        "key": "ait-2",
+                        "severity": "error",
+                        "human": "AllergyIntolerance.clinicalStatus SHALL NOT be present if verification Status is entered-in-error",
+                        "expression": "verificationStatus.coding.where(system = 'http://terminology.hl7.org/CodeSystem/allergyintolerance-verification' and code = 'entered-in-error').empty() or clinicalStatus.empty()",
+                        "xpath": "not(f:verificationStatus/f:coding/f:code/@value='entered-in-error') or not(exists(f:clinicalStatus))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/AllergyIntolerance"
+                    },
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation[classCode=OBS, moodCode=EVN]"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "AllergyIntolerance"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.id",
+                "path": "AllergyIntolerance.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "AllergyIntolerance.meta",
+                "path": "AllergyIntolerance.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "AllergyIntolerance.implicitRules",
+                "path": "AllergyIntolerance.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "AllergyIntolerance.language",
+                "path": "AllergyIntolerance.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "AllergyIntolerance.text",
+                "path": "AllergyIntolerance.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.contained",
+                "path": "AllergyIntolerance.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.extension",
+                "path": "AllergyIntolerance.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.modifierExtension",
+                "path": "AllergyIntolerance.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.identifier",
+                "path": "AllergyIntolerance.identifier",
+                "short": "External ids for this item",
+                "definition": "Business identifiers assigned to this AllergyIntolerance by the performer or other systems which remain constant as the resource is updated and propagates from server to server.",
+                "comment": "This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.",
+                "requirements": "Allows identification of the AllergyIntolerance as it is known by various participating systems and in a way that remains consistent across servers.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "AllergyIntolerance.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "IAM-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "id"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.clinicalStatus",
+                "path": "AllergyIntolerance.clinicalStatus",
+                "short": "active | inactive | resolved",
+                "definition": "The clinical status of the allergy or intolerance.",
+                "comment": "Refer to [discussion](http://hl7.org/fhir/R4/extensibility.html#Special-Case) if clincalStatus is missing data.\nThe data type is CodeableConcept because clinicalStatus has some clinical judgment involved, such that there might need to be more specificity than the required FHIR value set allows. For example, a SNOMED coding might allow for additional specificity.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.clinicalStatus",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "ait-1",
+                    "ait-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the status contains the codes inactive and resolved that mark the AllergyIntolerance as no longer active.",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/allergyintolerance-clinical"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation ACT .inboundRelationship[typeCode=COMP].source[classCode=OBS, code=\"clinicalStatus\", moodCode=EVN].value"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "AllergyIntolerance.status"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.verificationStatus",
+                "path": "AllergyIntolerance.verificationStatus",
+                "short": "unconfirmed | confirmed | refuted | entered-in-error",
+                "definition": "Assertion about certainty associated with the propensity, or potential risk, of a reaction to the identified substance (including pharmaceutical product).",
+                "comment": "The data type is CodeableConcept because verificationStatus has some clinical judgment involved, such that there might need to be more specificity than the required FHIR value set allows. For example, a SNOMED coding might allow for additional specificity.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.verificationStatus",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "ait-1",
+                    "ait-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the status contains the codes refuted and entered-in-error that mark the AllergyIntolerance as not currently valid.",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/allergyintolerance-verification"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation ACT .inboundRelationship[typeCode=COMP].source[classCode=OBS, code=\"verificationStatus\", moodCode=EVN].value"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "AllergyIntolerance.status"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.type",
+                "path": "AllergyIntolerance.type",
+                "short": "allergy | intolerance - Underlying mechanism (if known)",
+                "definition": "Identification of the underlying physiological mechanism for the reaction risk.",
+                "comment": "Allergic (typically immune-mediated) reactions have been traditionally regarded as an indicator for potential escalation to significant future risk. Contemporary knowledge suggests that some reactions previously thought to be immune-mediated are, in fact, non-immune, but in some cases can still pose a life threatening risk. It is acknowledged that many clinicians might not be in a position to distinguish the mechanism of a particular reaction. Often the term \"allergy\" is used rather generically and may overlap with the use of \"intolerance\" - in practice the boundaries between these two concepts might not be well-defined or understood. This data element is included nevertheless, because many legacy systems have captured this attribute. Immunologic testing may provide supporting evidence for the basis of the reaction and the causative substance, but no tests are 100% sensitive or specific for sensitivity to a particular substance. If, as is commonly the case, it is unclear whether the reaction is due to an allergy or an intolerance, then the type element should be omitted from the resource.",
+                "alias": [
+                    "Category",
+                    "Class"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AllergyIntoleranceType"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Identification of the underlying physiological mechanism for a Reaction Risk.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/allergy-intolerance-type|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "IAM-9"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.category",
+                "path": "AllergyIntolerance.category",
+                "short": "food | medication | environment | biologic",
+                "definition": "Category of the identified substance.",
+                "comment": "This data element has been included because it is currently being captured in some clinical systems. This data can be derived from the substance where coding systems are used, and is effectively redundant in that situation.  When searching on category, consider the implications of AllergyIntolerance resources without a category.  For example, when searching on category = medication, medication allergies that don't have a category valued will not be returned.  Refer to [search](http://hl7.org/fhir/R4/search.html) for more information on how to search category with a :missing modifier to get allergies that don't have a category.  Additionally, category should be used with caution because category can be subjective based on the sender.",
+                "alias": [
+                    "Category",
+                    "Type",
+                    "Reaction Type",
+                    "Class"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "AllergyIntolerance.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AllergyIntoleranceCategory"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Category of an identified substance associated with allergies or intolerances.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/allergy-intolerance-category|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "AL1-2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value < IntoleranceValue (Agent)"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.criticality",
+                "path": "AllergyIntolerance.criticality",
+                "short": "low | high | unable-to-assess",
+                "definition": "Estimate of the potential clinical harm, or seriousness, of the reaction to the identified substance.",
+                "comment": "The default criticality value for any propensity to an adverse reaction should be 'Low Risk', indicating at the very least a relative contraindication to deliberate or voluntary exposure to the substance. 'High Risk' is flagged if the clinician has identified a propensity for a more serious or potentially life-threatening reaction, such as anaphylaxis, and implies an absolute contraindication to deliberate or voluntary exposure to the substance. If this element is missing, the criticality is unknown (though it may be known elsewhere).  Systems that capture a severity at the condition level are actually representing the concept of criticality whereas the severity documented at the reaction level is representing the true reaction severity.  Existing systems that are capturing both condition criticality and reaction severity may use the term \"severity\" to represent both.  Criticality is the worst it could be in the future (i.e. situation-agnostic) whereas severity is situation-dependent.",
+                "alias": [
+                    "Severity",
+                    "Seriousness",
+                    "Contra-indication",
+                    "Risk"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.criticality",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AllergyIntoleranceCriticality"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Estimate of the potential clinical harm, or seriousness, of a reaction to an identified substance.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/allergy-intolerance-criticality|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.grade"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "AL1-4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=SEV, value <= SeverityObservation (Severity Level)]"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.code",
+                "path": "AllergyIntolerance.code",
+                "short": "Code that identifies the allergy or intolerance",
+                "definition": "Code for an allergy or intolerance statement (either a positive or a negated/excluded statement).  This may be a code for a substance or pharmaceutical product that is considered to be responsible for the adverse reaction risk (e.g., \"Latex\"), an allergy or intolerance condition (e.g., \"Latex allergy\"), or a negated/excluded code for a specific substance or class (e.g., \"No latex allergy\") or a general or categorical negated statement (e.g.,  \"No known allergy\", \"No known drug allergies\").  Note: the substance for a specific reaction may be different from the substance identified as the cause of the risk, but it must be consistent with it. For instance, it may be a more specific substance (e.g. a brand medication) or a composite product that includes the identified substance. It must be clinically safe to only process the 'code' and ignore the 'reaction.substance'.  If a receiving system is unable to confirm that AllergyIntolerance.reaction.substance falls within the semantic scope of AllergyIntolerance.code, then the receiving system should ignore AllergyIntolerance.reaction.substance.",
+                "comment": "It is strongly recommended that this element be populated using a terminology, where possible. For example, some terminologies used include RxNorm, SNOMED CT, DM+D, NDFRT, ICD-9, IDC-10, UNII, and ATC. Plain text should only be used if there is no appropriate terminology available. Additional details can be specified in the text.\r\rWhen a substance or product code is specified for the 'code' element, the \"default\" semantic context is that this is a positive statement of an allergy or intolerance (depending on the value of the 'type' element, if present) condition to the specified substance/product.  In the corresponding SNOMED CT allergy model, the specified substance/product is the target (destination) of the \"Causative agent\" relationship.\r\rThe 'substanceExposureRisk' extension is available as a structured and more flexible alternative to the 'code' element for making positive or negative allergy or intolerance statements.  This extension provides the capability to make \"no known allergy\" (or \"no risk of adverse reaction\") statements regarding any coded substance/product (including cases when a pre-coordinated \"no allergy to x\" concept for that substance/product does not exist).  If the 'substanceExposureRisk' extension is present, the AllergyIntolerance.code element SHALL be omitted.",
+                "alias": [
+                    "Code"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-allergy-substance|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "AL1-3 / IAM-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "substance/product:\r\r.participation[typeCode=CAGNT].role[classCode=ADMM].player[classCode=MAT, determinerCode=KIND, code <= ExposureAgentEntityType]\r\rnegated/excluded substance/product:\r\r.participation[typeCode=CAGNT, negationInd=true].role[classCode=ADMM].player[classCode=MAT, determinerCode=KIND, code <= ExposureAgentEntityType]\r\rpositive or negated/excluded condition/situation:\r\rObservation.code=ASSERTION; Observation.value"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "AllergyIntolerance.substance"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.patient",
+                "path": "AllergyIntolerance.patient",
+                "short": "Who the sensitivity is for",
+                "definition": "The patient who has the allergy or intolerance.",
+                "alias": [
+                    "Patient"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.patient",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "(PID-3)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=SBJ].role[classCode=PAT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "AllergyIntolerance.patient"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.encounter",
+                "path": "AllergyIntolerance.encounter",
+                "short": "Encounter when the allergy or intolerance was asserted",
+                "definition": "The encounter when the allergy or intolerance was asserted.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.onset[x]",
+                "path": "AllergyIntolerance.onset[x]",
+                "short": "When allergy or intolerance was identified",
+                "definition": "Estimated or actual date,  date-time, or age when allergy or intolerance was identified.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.onset[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Age"
+                    },
+                    {
+                        "code": "Period"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.init"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime.low"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.recordedDate",
+                "path": "AllergyIntolerance.recordedDate",
+                "short": "Date first version of the resource instance was recorded",
+                "definition": "The recordedDate represents when this particular AllergyIntolerance record was created in the system, which is often a system-generated date.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.recordedDate",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "IAM-13"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.recorder",
+                "path": "AllergyIntolerance.recorder",
+                "short": "Who recorded the sensitivity",
+                "definition": "Individual who recorded the record and takes responsibility for its content.",
+                "alias": [
+                    "Author"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.recorder",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.author"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=AUT].role"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.asserter",
+                "path": "AllergyIntolerance.asserter",
+                "short": "Source of the information about the allergy",
+                "definition": "The source of the information about the allergy that is recorded.",
+                "comment": "The recorder takes responsibility for the content, but can reference the source from where they got it.",
+                "alias": [
+                    "Source",
+                    "Informant"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.asserter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.source"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "IAM-14 (if patient) / IAM-18 (if practitioner)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=INF].role"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.lastOccurrence",
+                "path": "AllergyIntolerance.lastOccurrence",
+                "short": "Date(/time) of last known occurrence of a reaction",
+                "definition": "Represents the date and/or time of the last known occurrence of a reaction event.",
+                "comment": "This date may be replicated by one of the Onset of Reaction dates. Where a textual representation of the date of last occurrence is required e.g. 'In Childhood, '10 years ago' the Comment element should be used.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.lastOccurrence",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=SUBJ].target[classCode=OBS, moodCode=EVN, code <= CommonClinicalObservationType, value <= ObservationValue (Reaction Type)].effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.note",
+                "path": "AllergyIntolerance.note",
+                "short": "Additional text not captured in other fields",
+                "definition": "Additional narrative about the propensity for the Adverse Reaction, not captured in other fields.",
+                "comment": "For example: including reason for flagging a seriousness of 'High Risk'; and instructions related to future exposure or administration of the substance, such as administration within an Intensive Care Unit or under corticosteroid cover. The notes should be related to an allergy or intolerance as a condition in general and not related to any particular episode of it. For episode notes and descriptions, use AllergyIntolerance.event.description and  AllergyIntolerance.event.notes.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "AllergyIntolerance.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "subjectOf.observationEvent[code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.reaction",
+                "path": "AllergyIntolerance.reaction",
+                "short": "Adverse Reaction Events linked to exposure to substance",
+                "definition": "Details about each adverse reaction event linked to exposure to the identified substance.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "AllergyIntolerance.reaction",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=SUBJ].target[classCode=OBS, moodCode=EVN, code <= CommonClinicalObservationType, value <= ObservationValue (Reaction Type)]"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.reaction.id",
+                "path": "AllergyIntolerance.reaction.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.reaction.extension",
+                "path": "AllergyIntolerance.reaction.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.reaction.modifierExtension",
+                "path": "AllergyIntolerance.reaction.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.reaction.substance",
+                "path": "AllergyIntolerance.reaction.substance",
+                "short": "Specific substance or pharmaceutical product considered to be responsible for event",
+                "definition": "Identification of the specific substance (or pharmaceutical product) considered to be responsible for the Adverse Reaction event. Note: the substance for a specific reaction may be different from the substance identified as the cause of the risk, but it must be consistent with it. For instance, it may be a more specific substance (e.g. a brand medication) or a composite product that includes the identified substance. It must be clinically safe to only process the 'code' and ignore the 'reaction.substance'.  If a receiving system is unable to confirm that AllergyIntolerance.reaction.substance falls within the semantic scope of AllergyIntolerance.code, then the receiving system should ignore AllergyIntolerance.reaction.substance.",
+                "comment": "Coding of the specific substance (or pharmaceutical product) with a terminology capable of triggering decision support should be used wherever possible.  The 'code' element allows for the use of a specific substance or pharmaceutical product, or a group or class of substances. In the case of an allergy or intolerance to a class of substances, (for example, \"penicillins\"), the 'reaction.substance' element could be used to code the specific substance that was identified as having caused the reaction (for example, \"amoxycillin\"). Duplication of the value in the 'code' and 'reaction.substance' elements is acceptable when a specific substance has been recorded in 'code'.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.reaction.substance",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "SubstanceCode"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes defining the type of the substance (including pharmaceutical products).",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/substance-code"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=SAS].target[classCode=SBADM, code <= ExposureCode].participation[typeCode=CSM].role[classCode=ADMM].player[classCode=MAT, determinerCode=KIND, code <= ExposureAgentEntityType]"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.reaction.manifestation",
+                "path": "AllergyIntolerance.reaction.manifestation",
+                "short": "Clinical symptoms/signs associated with the Event",
+                "definition": "Clinical symptoms and/or signs that are observed or associated with the adverse reaction event.",
+                "comment": "Manifestation can be expressed as a single word, phrase or brief description. For example: nausea, rash or no reaction. It is preferable that manifestation should be coded with a terminology, where possible. The values entered here may be used to display on an application screen as part of a list of adverse reactions, as recommended in the UK NHS CUI guidelines.  Terminologies commonly used include, but are not limited to, SNOMED CT or ICD10.",
+                "alias": [
+                    "Symptoms",
+                    "Signs"
+                ],
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "AllergyIntolerance.reaction.manifestation",
+                    "min": 1,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "AL1-5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.reaction.description",
+                "path": "AllergyIntolerance.reaction.description",
+                "short": "Description of the event as a whole",
+                "definition": "Text description about the reaction as a whole, including details of the manifestation if required.",
+                "comment": "Use the description to provide any details of a particular event of the occurred reaction such as circumstances, reaction specifics, what happened before/after. Information, related to the event, but not describing a particular care should be captured in the comment field. For example: at the age of four, the patient was given penicillin for strep throat and subsequently developed severe hives.",
+                "alias": [
+                    "Narrative",
+                    "Text"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.reaction.description",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "text"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.reaction.onset",
+                "path": "AllergyIntolerance.reaction.onset",
+                "short": "Date(/time) when manifestations showed",
+                "definition": "Record of the date and/or time of the onset of the Reaction.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.reaction.onset",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "AL1-6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime.low"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.reaction.severity",
+                "path": "AllergyIntolerance.reaction.severity",
+                "short": "mild | moderate | severe (of event as a whole)",
+                "definition": "Clinical assessment of the severity of the reaction event as a whole, potentially considering multiple different manifestations.",
+                "comment": "It is acknowledged that this assessment is very subjective. There may be some specific practice domains where objective scales have been applied. Objective scales can be included in this model as extensions.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.reaction.severity",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AllergyIntoleranceSeverity"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Clinical assessment of the severity of a reaction event as a whole, potentially considering multiple different manifestations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/reaction-event-severity|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=SEV, value <= SeverityObservation (Severity Level)]"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.reaction.exposureRoute",
+                "path": "AllergyIntolerance.reaction.exposureRoute",
+                "short": "How the subject was exposed to the substance",
+                "definition": "Identification of the route by which the subject was exposed to the substance.",
+                "comment": "Coding of the route of exposure with a terminology should be used wherever possible.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.reaction.exposureRoute",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "RouteOfAdministration"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "A coded concept describing the route or physiological path of administration of a therapeutic agent into or onto the body of a subject.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/route-codes"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=SAS].target[classCode=SBADM, code <= ExposureCode].routeCode"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.reaction.note",
+                "path": "AllergyIntolerance.reaction.note",
+                "short": "Text about event not captured in other fields",
+                "definition": "Additional text about the adverse reaction event not captured in other fields.",
+                "comment": "Use this field to record information indirectly related to a particular event and not captured in the description. For example: Clinical records are no longer available, recorded based on information provided to the patient by her mother and her mother is deceased.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "AllergyIntolerance.reaction.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "subjectOf.observationEvent[code=\"annotation\"].value"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "AllergyIntolerance",
+                "path": "AllergyIntolerance",
+                "definition": "The US Core Allergies Profile is based upon the core FHIR AllergyIntolerance Resource and created to meet the 2015 Edition Common Clinical Data Set 'Medical allergies' requirements.",
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "AllergyIntolerance"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.clinicalStatus",
+                "path": "AllergyIntolerance.clinicalStatus",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/allergyintolerance-clinical"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "AllergyIntolerance.status"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.verificationStatus",
+                "path": "AllergyIntolerance.verificationStatus",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/allergyintolerance-verification"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "AllergyIntolerance.status"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.code",
+                "path": "AllergyIntolerance.code",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-allergy-substance|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "AllergyIntolerance.substance"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.patient",
+                "path": "AllergyIntolerance.patient",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "AllergyIntolerance.patient"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.reaction",
+                "path": "AllergyIntolerance.reaction",
+                "min": 0,
+                "max": "*",
+                "mustSupport": true
+            },
+            {
+                "id": "AllergyIntolerance.reaction.manifestation",
+                "path": "AllergyIntolerance.reaction.manifestation",
+                "min": 1,
+                "max": "*",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
+                }
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-birthsex.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-birthsex.json
@@ -1,369 +1,369 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-birthsex",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-birthsex-definitions.html#Extension\" title=\"A code classifying the person's sex assigned at birth  as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc).\">Extension</a><a name=\"Extension\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/extensibility.html#Extension\">Extension</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Extension</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-birthsex-definitions.html#Extension.url\">url</a><a name=\"Extension.url\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">1</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"color: darkgreen\">&quot;http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex&quot;</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck00.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-birthsex-definitions.html#Extension.valueCode\">valueCode</a><a name=\"Extension.valueCode\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Value of extension</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-birthsex.html\">Birth Sex</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
-	"version": "3.1.1",
-	"name": "USCoreBirthSexExtension",
-	"title": "US Core Birth Sex Extension",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.healthit.gov"
-				}
-			]
-		}
-	],
-	"description": "A code classifying the person's sex assigned at birth  as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc). This extension aligns with the C-CDA Birth Sex Observation (LOINC 76689-9).",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		}
-	],
-	"kind": "complex-type",
-	"abstract": false,
-	"context": [
-		{
-			"type": "element",
-			"expression": "Patient"
-		}
-	],
-	"type": "Extension",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Extension",
-				"path": "Extension",
-				"short": "Extension",
-				"definition": "A code classifying the person's sex assigned at birth  as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc).",
-				"comment": "The codes required are intended to present birth sex (i.e., the sex recorded on the patient’s birth certificate) and not gender identity or reassigned sex.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Extension",
-					"min": 0,
-					"max": "*"
-				},
-				"condition": [
-					"ele-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender"
-					},
-					{
-						"identity": "iso11179",
-						"map": ".patient.administrativeGenderCode"
-					}
-				]
-			},
-			{
-				"id": "Extension.id",
-				"path": "Extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension",
-				"path": "Extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.url",
-				"path": "Extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "uri"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.value[x]",
-				"path": "Extension.value[x]",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "type",
-							"path": "$this"
-						}
-					],
-					"ordered": false,
-					"rules": "closed"
-				},
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.value[x]:valueCode",
-				"path": "Extension.value[x]",
-				"sliceName": "valueCode",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"strength": "required",
-					"description": "Code for sex assigned at birth",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/birthsex|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Extension",
-				"path": "Extension",
-				"definition": "A code classifying the person's sex assigned at birth  as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc).",
-				"comment": "The codes required are intended to present birth sex (i.e., the sex recorded on the patient’s birth certificate) and not gender identity or reassigned sex.",
-				"min": 0,
-				"max": "1",
-				"isModifier": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender"
-					},
-					{
-						"identity": "iso11179",
-						"map": ".patient.administrativeGenderCode"
-					}
-				]
-			},
-			{
-				"id": "Extension.url",
-				"path": "Extension.url",
-				"fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex"
-			},
-			{
-				"id": "Extension.valueCode",
-				"path": "Extension.valueCode",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"binding": {
-					"strength": "required",
-					"description": "Code for sex assigned at birth",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/birthsex|3.1.1"
-				}
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-birthsex",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+    "version": "3.1.1",
+    "name": "USCoreBirthSexExtension",
+    "title": "US Core Birth Sex Extension",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.healthit.gov"
+                }
+            ]
+        }
+    ],
+    "description": "A code classifying the person's sex assigned at birth  as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc). This extension aligns with the C-CDA Birth Sex Observation (LOINC 76689-9).",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        }
+    ],
+    "kind": "complex-type",
+    "abstract": false,
+    "context": [
+        {
+            "type": "element",
+            "expression": "Patient"
+        }
+    ],
+    "type": "Extension",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Extension",
+                "path": "Extension",
+                "short": "Extension",
+                "definition": "A code classifying the person's sex assigned at birth  as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc).",
+                "comment": "The codes required are intended to present birth sex (i.e., the sex recorded on the patient’s birth certificate) and not gender identity or reassigned sex.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "condition": [
+                    "ele-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender"
+                    },
+                    {
+                        "identity": "iso11179",
+                        "map": ".patient.administrativeGenderCode"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.id",
+                "path": "Extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension",
+                "path": "Extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.url",
+                "path": "Extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "uri"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.value[x]",
+                "path": "Extension.value[x]",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "type",
+                            "path": "$this"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "closed"
+                },
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.value[x]:valueCode",
+                "path": "Extension.value[x]",
+                "sliceName": "valueCode",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "strength": "required",
+                    "description": "Code for sex assigned at birth",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/birthsex|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Extension",
+                "path": "Extension",
+                "definition": "A code classifying the person's sex assigned at birth  as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc).",
+                "comment": "The codes required are intended to present birth sex (i.e., the sex recorded on the patient’s birth certificate) and not gender identity or reassigned sex.",
+                "min": 0,
+                "max": "1",
+                "isModifier": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender"
+                    },
+                    {
+                        "identity": "iso11179",
+                        "map": ".patient.administrativeGenderCode"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.url",
+                "path": "Extension.url",
+                "fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex"
+            },
+            {
+                "id": "Extension.valueCode",
+                "path": "Extension.valueCode",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "binding": {
+                    "strength": "required",
+                    "description": "Code for sex assigned at birth",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/birthsex|3.1.1"
+                }
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-careplan.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-careplan.json
@@ -1,3322 +1,3322 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-careplan",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-careplan-definitions.html#CarePlan\" title=\"The US Core CarePlan Profile is based upon the core FHIR CarePlan Resource and created to meet the 2015 Edition Common Clinical Data Set 'Assessment and Plan of Treatment requirements.\">CarePlan</a><a name=\"CarePlan\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/careplan.html\">CarePlan</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Healthcare plan for patient or group</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-careplan-definitions.html#CarePlan.text\">text</a><a name=\"CarePlan.text\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Narrative\">Narrative</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Text summary of the resource, for human interpretation</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-careplan-definitions.html#CarePlan.text.status\" title=\"generated | additional.\">status</a><a name=\"CarePlan.text.status\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">1</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">generated | extensions | additional | empty</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-narrative-status.html\">US Core Narrative Status</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-careplan-definitions.html#CarePlan.status\">status</a><a name=\"CarePlan.status\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">draft | active | on-hold | revoked | completed | entered-in-error | unknown</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-request-status.html\">RequestStatus</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-careplan-definitions.html#CarePlan.intent\">intent</a><a name=\"CarePlan.intent\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">proposal | plan | order | option</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-care-plan-intent.html\">CarePlanIntent</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck13.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Definition\" class=\"hierarchy\"/> <a style=\"font-style: italic\" href=\"StructureDefinition-us-core-careplan-definitions.html#CarePlan.category\" title=\"Type of plan.\">category</a><a name=\"CarePlan.category\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red; font-style: italic\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"font-style: italic\"/><span style=\"font-style: italic\">1</span><span style=\"font-style: italic\">..</span><span style=\"font-style: italic\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"font-style: italic\" href=\"http://hl7.org/fhir/R4/profiling.html#slicing\">(Slice Definition)</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5; font-style: italic\">Type of plan</span><br style=\"font-style: italic\"/><span style=\"font-weight:bold; font-style: italic\">Slice: </span><span style=\"font-style: italic\">Unordered, Open by pattern:$this</span><br style=\"font-style: italic\"/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck125.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-careplan-definitions.html#CarePlan.category:AssessPlan\" title=\"Slice AssessPlan: Type of plan.\">category:AssessPlan</a><a name=\"CarePlan.category\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Type of plan</span><br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1241.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#CodeableConcept.coding\">coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Code defined by a terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">(complex)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck12410.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"CodeSystem-careplan-category.html\">http://hl7.org/fhir/us/core/CodeSystem/careplan-category</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck12400.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">assess-plan</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck00.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-careplan-definitions.html#CarePlan.subject\" title=\"Who care plan is for.\">subject</a><a name=\"CarePlan.subject\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who the care plan is for</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan",
-	"version": "3.1.1",
-	"name": "USCoreCarePlanProfile",
-	"title": "US Core CarePlan Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2019-08-29",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.healthit.gov"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the CarePlan resource for the minimal set of data to query and retrieve a patient's Care Plan.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "argonaut-dq-dstu2",
-			"uri": "http://unknown.org/Argonaut-DQ-DSTU2",
-			"name": "Argonaut-DQ-DSTU2"
-		},
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "CarePlan",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/CarePlan",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "CarePlan",
-				"path": "CarePlan",
-				"short": "Healthcare plan for patient or group",
-				"definition": "The US Core CarePlan Profile is based upon the core FHIR CarePlan Resource and created to meet the 2015 Edition Common Clinical Data Set 'Assessment and Plan of Treatment requirements.",
-				"alias": [
-					"Care Team"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Request"
-					},
-					{
-						"identity": "rim",
-						"map": "Act[classCode=PCPR, moodCode=INT]"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.id",
-				"path": "CarePlan.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "CarePlan.meta",
-				"path": "CarePlan.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "CarePlan.implicitRules",
-				"path": "CarePlan.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "CarePlan.language",
-				"path": "CarePlan.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "CarePlan.text",
-				"path": "CarePlan.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.text"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.text.id",
-				"path": "CarePlan.text.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.text.extension",
-				"path": "CarePlan.text.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.text.status",
-				"path": "CarePlan.text.status",
-				"short": "generated | extensions | additional | empty",
-				"definition": "generated | additional.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Narrative.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"strength": "required",
-					"description": "Constrained value set of narrative statuses.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-narrative-status|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.text.status"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.text.div",
-				"path": "CarePlan.text.div",
-				"short": "Limited xhtml content",
-				"definition": "The actual narrative content, a stripped down version of XHTML.",
-				"comment": "The contents of the html element are an XHTML fragment containing only the basic html formatting elements described in chapters 7-11 and 15 of the HTML 4.0 standard, <a> elements (either name or href), images and internally contained stylesheets. The XHTML content SHALL NOT contain a head, a body, external stylesheet references, scripts, forms, base/link/xlink, frames, iframes and objects.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Narrative.div",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "xhtml"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "txt-1",
-						"severity": "error",
-						"human": "The narrative SHALL contain only the basic html formatting elements and attributes described in chapters 7-11 (except section 4 of chapter 9) and 15 of the HTML 4.0 standard, <a> elements (either name or href), images and internally contained style attributes",
-						"expression": "htmlChecks()",
-						"xpath": "not(descendant-or-self::*[not(local-name(.)=('a', 'abbr', 'acronym', 'b', 'big', 'blockquote', 'br', 'caption', 'cite', 'code', 'col', 'colgroup', 'dd', 'dfn', 'div', 'dl', 'dt', 'em', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'i', 'img', 'li', 'ol', 'p', 'pre', 'q', 'samp', 'small', 'span', 'strong', 'sub', 'sup', 'table', 'tbody', 'td', 'tfoot', 'th', 'thead', 'tr', 'tt', 'ul', 'var'))]) and not(descendant-or-self::*/@*[not(name(.)=('abbr', 'accesskey', 'align', 'alt', 'axis', 'bgcolor', 'border', 'cellhalign', 'cellpadding', 'cellspacing', 'cellvalign', 'char', 'charoff', 'charset', 'cite', 'class', 'colspan', 'compact', 'coords', 'dir', 'frame', 'headers', 'height', 'href', 'hreflang', 'hspace', 'id', 'lang', 'longdesc', 'name', 'nowrap', 'rel', 'rev', 'rowspan', 'rules', 'scope', 'shape', 'span', 'src', 'start', 'style', 'summary', 'tabindex', 'title', 'type', 'valign', 'value', 'vspace', 'width'))])"
-					},
-					{
-						"key": "txt-2",
-						"severity": "error",
-						"human": "The narrative SHALL have some non-whitespace content",
-						"expression": "htmlChecks()",
-						"xpath": "descendant::text()[normalize-space(.)!=''] or descendant::h:img[@src]"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.contained",
-				"path": "CarePlan.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.extension",
-				"path": "CarePlan.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.modifierExtension",
-				"path": "CarePlan.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.identifier",
-				"path": "CarePlan.identifier",
-				"short": "External Ids for this plan",
-				"definition": "Business identifiers assigned to this care plan by the performer or other systems which remain constant as the resource is updated and propagates from server to server.",
-				"comment": "This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.",
-				"requirements": "Allows identification of the care plan as it is known by various participating systems and in a way that remains consistent across servers.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "PTH-3"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.instantiatesCanonical",
-				"path": "CarePlan.instantiatesCanonical",
-				"short": "Instantiates FHIR protocol or definition",
-				"definition": "The URL pointing to a FHIR-defined protocol, guideline, questionnaire or other definition that is adhered to in whole or in part by this CarePlan.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.instantiatesCanonical",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "canonical",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/PlanDefinition",
-							"http://hl7.org/fhir/StructureDefinition/Questionnaire",
-							"http://hl7.org/fhir/StructureDefinition/Measure",
-							"http://hl7.org/fhir/StructureDefinition/ActivityDefinition",
-							"http://hl7.org/fhir/StructureDefinition/OperationDefinition"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.instantiatesCanonical"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=DEFN].target"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.instantiatesUri",
-				"path": "CarePlan.instantiatesUri",
-				"short": "Instantiates external protocol or definition",
-				"definition": "The URL pointing to an externally maintained protocol, guideline, questionnaire or other definition that is adhered to in whole or in part by this CarePlan.",
-				"comment": "This might be an HTML page, PDF, etc. or could just be a non-resolvable URI identifier.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.instantiatesUri",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.instantiatesUri"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=DEFN].target"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.basedOn",
-				"path": "CarePlan.basedOn",
-				"short": "Fulfills CarePlan",
-				"definition": "A care plan that is fulfilled in whole or in part by this care plan.",
-				"requirements": "Allows tracing of the care plan and tracking whether proposals/recommendations were acted upon.",
-				"alias": [
-					"fulfills"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-hierarchy",
-								"valueBoolean": true
-							}
-						],
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.basedOn"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.replaces",
-				"path": "CarePlan.replaces",
-				"short": "CarePlan replaced by this CarePlan",
-				"definition": "Completed or terminated care plan whose function is taken by this new care plan.",
-				"comment": "The replacement could be because the initial care plan was immediately rejected (due to an issue) or because the previous care plan was completed, but the need for the action described by the care plan remains ongoing.",
-				"requirements": "Allows tracing the continuation of a therapy or administrative process instantiated through multiple care plans.",
-				"alias": [
-					"supersedes"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.replaces",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-hierarchy",
-								"valueBoolean": true
-							}
-						],
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.replaces"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.partOf",
-				"path": "CarePlan.partOf",
-				"short": "Part of referenced CarePlan",
-				"definition": "A larger care plan of which this particular care plan is a component or step.",
-				"comment": "Each care plan is an independent request, such that having a care plan be part of another care plan can cause issues with cascading statuses.  As such, this element is still being discussed.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.partOf",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-hierarchy",
-								"valueBoolean": true
-							}
-						],
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "CarePlan.status",
-				"path": "CarePlan.status",
-				"short": "draft | active | on-hold | revoked | completed | entered-in-error | unknown",
-				"definition": "Indicates whether the plan is currently being acted upon, represents future intentions or is now a historical record.",
-				"comment": "The unknown code is not to be used to convey other statuses.  The unknown code should be used when one of the statuses applies, but the authoring system doesn't know the current state of the care plan.\n\nThis element is labeled as a modifier because the status contains the code entered-in-error that marks the plan as not currently valid.",
-				"requirements": "Indicates whether the plan is currently being acted upon, represents future intentions or is now a historical record.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"description": "Indicates whether the plan is currently being acted upon, represents future intentions or is now a historical record.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/request-status"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.status {uses different ValueSet}"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "v2",
-						"map": "PTH-5"
-					},
-					{
-						"identity": "rim",
-						"map": ".statusCode planned = new active = active completed = completed"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.status"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.intent",
-				"path": "CarePlan.intent",
-				"short": "proposal | plan | order | option",
-				"definition": "Indicates the level of authority/intentionality associated with the care plan and where the care plan fits into the workflow chain.",
-				"comment": "This element is labeled as a modifier because the intent alters when and how the resource is actually applicable.",
-				"requirements": "Proposals/recommendations, plans and orders all use the same structure and can exist in the same fulfillment chain.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.intent",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element changes the interpretation of all descriptive attributes. For example \"the time the request is recommended to occur\" vs. \"the time the request is authorized to occur\" or \"who is recommended to perform the request\" vs. \"who is authorized to perform the request\"",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"description": "Codes indicating the degree of authority/intentionality associated with a care plan",
-					"valueSet": "http://hl7.org/fhir/ValueSet/care-plan-intent"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.intent"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA (new element in STU3)"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.category",
-				"path": "CarePlan.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "$this"
-						}
-					],
-					"rules": "open"
-				},
-				"short": "Type of plan",
-				"definition": "Type of plan.",
-				"comment": "There may be multiple axes of categorization and one plan may serve multiple purposes.  In some cases, this may be redundant with references to CarePlan.concern.",
-				"requirements": "Identifies what \"kind\" of plan this is to support differentiation between multiple co-existing plans; e.g. \"Home health\", \"psychiatric\", \"asthma\", \"disease management\", \"wellness plan\", etc.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "CarePlanCategory"
-						}
-					],
-					"strength": "example",
-					"description": "Identifies what \"kind\" of plan this is to support differentiation between multiple co-existing plans; e.g. \"Home health\", \"psychiatric\", \"asthma\", \"disease management\", etc.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/care-plan-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.category"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.category:AssessPlan",
-				"path": "CarePlan.category",
-				"sliceName": "AssessPlan",
-				"short": "Type of plan",
-				"definition": "Type of plan.",
-				"comment": "There may be multiple axes of categorization and one plan may serve multiple purposes.  In some cases, this may be redundant with references to CarePlan.concern.",
-				"requirements": "Identifies what \"kind\" of plan this is to support differentiation between multiple co-existing plans; e.g. \"Home health\", \"psychiatric\", \"asthma\", \"disease management\", \"wellness plan\", etc.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://hl7.org/fhir/us/core/CodeSystem/careplan-category",
-							"code": "assess-plan"
-						}
-					]
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "CarePlanCategory"
-						}
-					],
-					"strength": "example",
-					"description": "Identifies what \"kind\" of plan this is to support differentiation between multiple co-existing plans; e.g. \"Home health\", \"psychiatric\", \"asthma\", \"disease management\", etc.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/care-plan-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.category"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.title",
-				"path": "CarePlan.title",
-				"short": "Human-friendly name for the care plan",
-				"definition": "Human-friendly name for the care plan.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.title",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "CarePlan.description",
-				"path": "CarePlan.description",
-				"short": "Summary of nature of plan",
-				"definition": "A description of the scope and nature of the plan.",
-				"requirements": "Provides more detail than conveyed by category.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.description",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.subject",
-				"path": "CarePlan.subject",
-				"short": "Who the care plan is for",
-				"definition": "Who care plan is for.",
-				"requirements": "Identifies the patient or group whose intended care is described by the plan.",
-				"alias": [
-					"patient"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.subject",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=PAT].role[classCode=PAT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.subject"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.encounter",
-				"path": "CarePlan.encounter",
-				"short": "Encounter created as part of",
-				"definition": "The Encounter during which this CarePlan was created or to which the creation of this record is tightly associated.",
-				"comment": "This will typically be the encounter the event occurred within, but some activities may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter. CarePlan activities conducted as a result of the care plan may well occur as part of other encounters.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "Associated PV1"
-					},
-					{
-						"identity": "rim",
-						"map": "."
-					}
-				]
-			},
-			{
-				"id": "CarePlan.period",
-				"path": "CarePlan.period",
-				"short": "Time period plan covers",
-				"definition": "Indicates when the plan did (or is intended to) come into effect and end.",
-				"comment": "Any activities scheduled as part of the plan should be constrained to the specified period regardless of whether the activities are planned within a single encounter/episode or across multiple encounters/episodes (e.g. the longitudinal management of a chronic condition).",
-				"requirements": "Allows tracking what plan(s) are in effect at a particular time.",
-				"alias": [
-					"timing"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.planned"
-					},
-					{
-						"identity": "v2",
-						"map": "GOL-7 / GOL-8"
-					},
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.created",
-				"path": "CarePlan.created",
-				"short": "Date record was first recorded",
-				"definition": "Represents when this particular CarePlan record was created in the system, which is often a system-generated date.",
-				"alias": [
-					"authoredOn"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.created",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.authoredOn"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=AUT].time"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.author",
-				"path": "CarePlan.author",
-				"short": "Who is the designated responsible party",
-				"definition": "When populated, the author is responsible for the care plan.  The care plan is attributed to the author.",
-				"comment": "The author may also be a contributor.  For example, an organization can be an author, but not listed as a contributor.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.author",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.requester"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.author"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.contributor",
-				"path": "CarePlan.contributor",
-				"short": "Who provided the content of the care plan",
-				"definition": "Identifies the individual(s) or organization who provided the contents of the care plan.",
-				"comment": "Collaborative care plans may have multiple contributors.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.contributor",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "CarePlan.careTeam",
-				"path": "CarePlan.careTeam",
-				"short": "Who's involved in plan?",
-				"definition": "Identifies all people and organizations who are expected to be involved in the care envisioned by this plan.",
-				"requirements": "Allows representation of care teams, helps scope care plan.  In some cases may be a determiner of access permissions.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.careTeam",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CareTeam"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.performer {similar but does not entail CareTeam}"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.addresses",
-				"path": "CarePlan.addresses",
-				"short": "Health issues this plan addresses",
-				"definition": "Identifies the conditions/problems/concerns/diagnoses/etc. whose management and/or mitigation are handled by this plan.",
-				"comment": "When the diagnosis is related to an allergy or intolerance, the Condition and AllergyIntolerance resources can both be used. However, to be actionable for decision support, using Condition alone is not sufficient as the allergy or intolerance condition needs to be represented as an AllergyIntolerance.",
-				"requirements": "Links plan to the conditions it manages.  The element can identify risks addressed by the plan as well as active conditions.  (The Condition resource can include things like \"at risk for hypertension\" or \"fall risk\".)  Also scopes plans - multiple plans may exist addressing different concerns.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.addresses",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Condition"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.reasonReference"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.why[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PRB-4"
-					},
-					{
-						"identity": "rim",
-						"map": ".actRelationship[typeCode=SUBJ].target[classCode=CONC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.supportingInfo",
-				"path": "CarePlan.supportingInfo",
-				"short": "Information considered as part of plan",
-				"definition": "Identifies portions of the patient's record that specifically influenced the formation of the plan.  These might include comorbidities, recent procedures, limitations, recent assessments, etc.",
-				"comment": "Use \"concern\" to identify specific conditions addressed by the care plan.",
-				"requirements": "Identifies barriers and other considerations associated with the care plan.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.supportingInfo",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.supportingInfo"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.goal",
-				"path": "CarePlan.goal",
-				"short": "Desired outcome of plan",
-				"definition": "Describes the intended objective(s) of carrying out the care plan.",
-				"comment": "Goal can be achieving a particular change or merely maintaining a current state or even slowing a decline.",
-				"requirements": "Provides context for plan.  Allows plan effectiveness to be evaluated by clinicians.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.goal",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Goal"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "GOL.1"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode<=OBJ]."
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity",
-				"path": "CarePlan.activity",
-				"short": "Action to occur as part of plan",
-				"definition": "Identifies a planned action to occur as part of the plan.  For example, a medication to be used, lab tests to perform, self-monitoring, education, etc.",
-				"requirements": "Allows systems to prompt for performance of planned activities, and validate plans against best practice.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.activity",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "cpl-3",
-						"severity": "error",
-						"human": "Provide a reference or detail, not both",
-						"expression": "detail.empty() or reference.empty()",
-						"xpath": "not(exists(f:detail)) or not(exists(f:reference))"
-					},
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "{no mapping\nNOTE: This is a list of contained Request-Event tuples!}"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=COMP].target"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.id",
-				"path": "CarePlan.activity.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.extension",
-				"path": "CarePlan.activity.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.modifierExtension",
-				"path": "CarePlan.activity.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.outcomeCodeableConcept",
-				"path": "CarePlan.activity.outcomeCodeableConcept",
-				"short": "Results of the activity",
-				"definition": "Identifies the outcome at the point when the status of the activity is assessed.  For example, the outcome of an education activity could be patient understands (or not).",
-				"comment": "Note that this should not duplicate the activity status (e.g. completed or in progress).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.activity.outcomeCodeableConcept",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "CarePlanActivityOutcome"
-						}
-					],
-					"strength": "example",
-					"description": "Identifies the results of the activity.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/care-plan-activity-outcome"
-				}
-			},
-			{
-				"id": "CarePlan.activity.outcomeReference",
-				"path": "CarePlan.activity.outcomeReference",
-				"short": "Appointment, Encounter, Procedure, etc.",
-				"definition": "Details of the outcome or action resulting from the activity.  The reference to an \"event\" resource, such as Procedure or Encounter or Observation, is the result/outcome of the activity itself.  The activity can be conveyed using CarePlan.activity.detail OR using the CarePlan.activity.reference (a reference to a “request” resource).",
-				"comment": "The activity outcome is independent of the outcome of the related goal(s).  For example, if the goal is to achieve a target body weight of 150 lbs and an activity is defined to diet, then the activity outcome could be calories consumed whereas the goal outcome is an observation for the actual body weight measured.",
-				"requirements": "Links plan to resulting actions.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.activity.outcomeReference",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "{Event that is outcome of Request in activity.reference}"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=FLFS].source"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.progress",
-				"path": "CarePlan.activity.progress",
-				"short": "Comments about the activity status/progress",
-				"definition": "Notes about the adherence/status/progress of the activity.",
-				"comment": "This element should NOT be used to describe the activity to be performed - that occurs either within the resource pointed to by activity.detail.reference or in activity.detail.description.",
-				"requirements": "Can be used to capture information about adherence, progress, concerns, etc.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.activity.progress",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NTE?"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.reference",
-				"path": "CarePlan.activity.reference",
-				"short": "Activity details defined in specific resource",
-				"definition": "The details of the proposed activity represented in a specific resource.",
-				"comment": "Standard extension exists ([resource-pertainsToGoal](http://hl7.org/fhir/R4/extension-resource-pertainstogoal.html)) that allows goals to be referenced from any of the referenced resources in CarePlan.activity.reference.  \rThe goal should be visible when the resource referenced by CarePlan.activity.reference is viewed independently from the CarePlan.  Requests that are pointed to by a CarePlan using this element should *not* point to this CarePlan using the \"basedOn\" element.  i.e. Requests that are part of a CarePlan are not \"based on\" the CarePlan.",
-				"requirements": "Details in a form consistent with other applications and contexts of use.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.activity.reference",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Appointment",
-							"http://hl7.org/fhir/StructureDefinition/CommunicationRequest",
-							"http://hl7.org/fhir/StructureDefinition/DeviceRequest",
-							"http://hl7.org/fhir/StructureDefinition/MedicationRequest",
-							"http://hl7.org/fhir/StructureDefinition/NutritionOrder",
-							"http://hl7.org/fhir/StructureDefinition/Task",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest",
-							"http://hl7.org/fhir/StructureDefinition/VisionPrescription",
-							"http://hl7.org/fhir/StructureDefinition/RequestGroup"
-						]
-					}
-				],
-				"condition": [
-					"cpl-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "{Request that resulted in Event in activity.actionResulting}"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=COMP].target"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail",
-				"path": "CarePlan.activity.detail",
-				"short": "In-line definition of activity",
-				"definition": "A simple summary of a planned activity suitable for a general care plan system (e.g. form driven) that doesn't know about specific resources such as procedure etc.",
-				"requirements": "Details in a simple form for generic care plan systems.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.activity.detail",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"condition": [
-					"cpl-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=COMP, subsetCode=SUMM].target"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.id",
-				"path": "CarePlan.activity.detail.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.extension",
-				"path": "CarePlan.activity.detail.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.modifierExtension",
-				"path": "CarePlan.activity.detail.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.kind",
-				"path": "CarePlan.activity.detail.kind",
-				"short": "Appointment | CommunicationRequest | DeviceRequest | MedicationRequest | NutritionOrder | Task | ServiceRequest | VisionPrescription",
-				"definition": "A description of the kind of resource the in-line definition of a care plan activity is representing.  The CarePlan.activity.detail is an in-line definition when a resource is not referenced using CarePlan.activity.reference.  For example, a MedicationRequest, a ServiceRequest, or a CommunicationRequest.",
-				"requirements": "May determine what types of extensions are permitted.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.activity.detail.kind",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "CarePlanActivityKind"
-						}
-					],
-					"strength": "required",
-					"description": "Resource types defined as part of FHIR that can be represented as in-line definitions of a care plan activity.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/care-plan-activity-kind|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[classCode=LIST].code"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.instantiatesCanonical",
-				"path": "CarePlan.activity.detail.instantiatesCanonical",
-				"short": "Instantiates FHIR protocol or definition",
-				"definition": "The URL pointing to a FHIR-defined protocol, guideline, questionnaire or other definition that is adhered to in whole or in part by this CarePlan activity.",
-				"requirements": "Allows Questionnaires that the patient (or practitioner) should fill in to fulfill the care plan activity.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.activity.detail.instantiatesCanonical",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "canonical",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/PlanDefinition",
-							"http://hl7.org/fhir/StructureDefinition/ActivityDefinition",
-							"http://hl7.org/fhir/StructureDefinition/Questionnaire",
-							"http://hl7.org/fhir/StructureDefinition/Measure",
-							"http://hl7.org/fhir/StructureDefinition/OperationDefinition"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.instantiatesCanonical"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=DEFN].target"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.instantiatesUri",
-				"path": "CarePlan.activity.detail.instantiatesUri",
-				"short": "Instantiates external protocol or definition",
-				"definition": "The URL pointing to an externally maintained protocol, guideline, questionnaire or other definition that is adhered to in whole or in part by this CarePlan activity.",
-				"comment": "This might be an HTML page, PDF, etc. or could just be a non-resolvable URI identifier.",
-				"requirements": "Allows Questionnaires that the patient (or practitioner) should fill in to fulfill the care plan activity.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.activity.detail.instantiatesUri",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.instantiatesUri"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=DEFN].target"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.code",
-				"path": "CarePlan.activity.detail.code",
-				"short": "Detail type of activity",
-				"definition": "Detailed description of the type of planned activity; e.g. what lab test, what procedure, what kind of encounter.",
-				"comment": "Tends to be less relevant for activities involving particular products.  Codes should not convey negation - use \"prohibited\" instead.",
-				"requirements": "Allows matching performed to planned as well as validation against protocols.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.activity.detail.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "CarePlanActivityType"
-						}
-					],
-					"strength": "example",
-					"description": "Detailed description of the type of activity; e.g. What lab test, what procedure, what kind of encounter.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/procedure-code"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.code"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-4 / RXE-2 / RXO-1 / RXD-2"
-					},
-					{
-						"identity": "rim",
-						"map": ".code"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.reasonCode",
-				"path": "CarePlan.activity.detail.reasonCode",
-				"short": "Why activity should be done or why activity was prohibited",
-				"definition": "Provides the rationale that drove the inclusion of this particular activity as part of the plan or the reason why the activity was prohibited.",
-				"comment": "This could be a diagnosis code.  If a full condition record exists or additional detail is needed, use reasonCondition instead.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.activity.detail.reasonCode",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "CarePlanActivityReason"
-						}
-					],
-					"strength": "example",
-					"description": "Identifies why a care plan activity is needed.  Can include any health condition codes as well as such concepts as \"general wellness\", prophylaxis, surgical preparation, etc.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.reasonCode"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.reasonReference",
-				"path": "CarePlan.activity.detail.reasonReference",
-				"short": "Why activity is needed",
-				"definition": "Indicates another resource, such as the health condition(s), whose existence justifies this request and drove the inclusion of this particular activity as part of the plan.",
-				"comment": "Conditions can be identified at the activity level that are not identified as reasons for the overall plan.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.activity.detail.reasonReference",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Condition",
-							"http://hl7.org/fhir/StructureDefinition/Observation",
-							"http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
-							"http://hl7.org/fhir/StructureDefinition/DocumentReference"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.reasonReference"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.goal",
-				"path": "CarePlan.activity.detail.goal",
-				"short": "Goals this activity relates to",
-				"definition": "Internal reference that identifies the goals that this activity is intended to contribute towards meeting.",
-				"requirements": "So that participants know the link explicitly.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.activity.detail.goal",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Goal"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode<=OBJ]."
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.status",
-				"path": "CarePlan.activity.detail.status",
-				"short": "not-started | scheduled | in-progress | on-hold | completed | cancelled | stopped | unknown | entered-in-error",
-				"definition": "Identifies what progress is being made for the specific activity.",
-				"comment": "Some aspects of status can be inferred based on the resources linked in actionTaken.  Note that \"status\" is only as current as the plan was most recently updated.  \nThe unknown code is not to be used to convey other statuses.  The unknown code should be used when one of the statuses applies, but the authoring system doesn't know the current state of the activity.",
-				"requirements": "Indicates progress against the plan, whether the activity is still relevant for the plan.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.activity.detail.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labelled as a modifier because it is a status element that contains status entered-in-error which means that the activity should not be treated as valid",
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "CarePlanActivityStatus"
-						}
-					],
-					"strength": "required",
-					"description": "Codes that reflect the current state of a care plan activity within its overall life cycle.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/care-plan-activity-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.status"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC-5?"
-					},
-					{
-						"identity": "rim",
-						"map": ".statusCode not-started = new scheduled = not-started (and fulfillment relationship to appointent) in-progress = active on-hold = suspended completed = completed cancelled = aborted"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.statusReason",
-				"path": "CarePlan.activity.detail.statusReason",
-				"short": "Reason for current status",
-				"definition": "Provides reason why the activity isn't yet started, is on hold, was cancelled, etc.",
-				"comment": "Will generally not be present if status is \"complete\".  Be sure to prompt to update this (or at least remove the existing value) if the status is changed.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.activity.detail.statusReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.statusReason"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.doNotPerform",
-				"path": "CarePlan.activity.detail.doNotPerform",
-				"short": "If true, activity is prohibiting action",
-				"definition": "If true, indicates that the described activity is one that must NOT be engaged in when following the plan.  If false, or missing, indicates that the described activity is one that should be engaged in when following the plan.",
-				"comment": "This element is labeled as a modifier because it marks an activity as an activity that is not to be performed.",
-				"requirements": "Captures intention to not do something that may have been previously typical.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.activity.detail.doNotPerform",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"meaningWhenMissing": "If missing indicates that the described activity is one that should be engaged in when following the plan.",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "If true this element negates the specified action. For example, instead of a request for a procedure, it is a request for the procedure to not occur.",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.doNotPerform"
-					},
-					{
-						"identity": "rim",
-						"map": "actionNegationInd"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.scheduled[x]",
-				"path": "CarePlan.activity.detail.scheduled[x]",
-				"short": "When activity is to occur",
-				"definition": "The period, timing or frequency upon which the described activity is to occur.",
-				"requirements": "Allows prompting for activities and detection of missed planned activities.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.activity.detail.scheduled[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Timing"
-					},
-					{
-						"code": "Period"
-					},
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.occurrence[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "TQ1"
-					},
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.location",
-				"path": "CarePlan.activity.detail.location",
-				"short": "Where it should happen",
-				"definition": "Identifies the facility where the activity will occur; e.g. home, hospital, specific clinic, etc.",
-				"comment": "May reference a specific clinical location or may identify a type of location.",
-				"requirements": "Helps in planning of activity.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.activity.detail.location",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Location"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBR-24(???!!)"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=LOC].role"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.performer",
-				"path": "CarePlan.activity.detail.performer",
-				"short": "Who will be responsible?",
-				"definition": "Identifies who's expected to be involved in the activity.",
-				"comment": "A performer MAY also be a participant in the care plan.",
-				"requirements": "Helps in planning of activity.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.activity.detail.performer",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam",
-							"http://hl7.org/fhir/StructureDefinition/HealthcareService",
-							"http://hl7.org/fhir/StructureDefinition/Device"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.performer"
-					},
-					{
-						"identity": "v2",
-						"map": "PRT-5 : ( PRV-4 = (provider participations)); PRT-5 : ( PRV-4 = (non-provider person participations )) ; PRT-5 : ( PRV-4 = (patient non-subject of care) ) ; PRT-8"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=PFM]"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.product[x]",
-				"path": "CarePlan.activity.detail.product[x]",
-				"short": "What is to be administered/supplied",
-				"definition": "Identifies the food, drug or other product to be consumed or supplied in the activity.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.activity.detail.product[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Medication",
-							"http://hl7.org/fhir/StructureDefinition/Substance"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "CarePlanProduct"
-						}
-					],
-					"strength": "example",
-					"description": "A product supplied or administered as part of a care plan activity.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/medication-codes"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXE-2 / RXO-1 / RXD-2"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=PRD].role"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.dailyAmount",
-				"path": "CarePlan.activity.detail.dailyAmount",
-				"short": "How to consume/day?",
-				"definition": "Identifies the quantity expected to be consumed in a given day.",
-				"requirements": "Allows rough dose checking.",
-				"alias": [
-					"daily dose"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.activity.detail.dailyAmount",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXO-23 / RXE-19 / RXD-12"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=COMP][classCode=SBADM].doseQuantity"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.quantity",
-				"path": "CarePlan.activity.detail.quantity",
-				"short": "How much to administer/supply/consume",
-				"definition": "Identifies the quantity expected to be supplied, administered or consumed by the subject.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.activity.detail.quantity",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXO-11 / RXE-10 / RXD-4 / RXG-5 / RXA-6 /  TQ1-2.1  *and*  RXO-12 /  RXE-11 / RXD-5 / RXG-7 / RXA-7 / TQ1-2.2"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=COMP][classCode=SPLY].quantity"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.description",
-				"path": "CarePlan.activity.detail.description",
-				"short": "Extra info describing activity to perform",
-				"definition": "This provides a textual description of constraints on the intended activity occurrence, including relation to other activities.  It may also include objectives, pre-conditions and end-conditions.  Finally, it may convey specifics about the activity such as body site, method, route, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.activity.detail.description",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NTE?"
-					},
-					{
-						"identity": "rim",
-						"map": ".text"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.note",
-				"path": "CarePlan.note",
-				"short": "Comments about the plan",
-				"definition": "General notes about the care plan not covered elsewhere.",
-				"requirements": "Used to capture information that applies to the plan as a whole that doesn't fit into discrete elements.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.note"
-					},
-					{
-						"identity": "v2",
-						"map": "NTE?"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"annotation\"].value"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "CarePlan",
-				"path": "CarePlan",
-				"definition": "The US Core CarePlan Profile is based upon the core FHIR CarePlan Resource and created to meet the 2015 Edition Common Clinical Data Set 'Assessment and Plan of Treatment requirements.",
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.text",
-				"path": "CarePlan.text",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.text"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.text.status",
-				"path": "CarePlan.text.status",
-				"definition": "generated | additional.",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"description": "Constrained value set of narrative statuses.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-narrative-status|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.text.status"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.status",
-				"path": "CarePlan.status",
-				"requirements": "Indicates whether the plan is currently being acted upon, represents future intentions or is now a historical record.",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"description": "Indicates whether the plan is currently being acted upon, represents future intentions or is now a historical record.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/request-status"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.status"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.intent",
-				"path": "CarePlan.intent",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"description": "Codes indicating the degree of authority/intentionality associated with a care plan",
-					"valueSet": "http://hl7.org/fhir/ValueSet/care-plan-intent"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA (new element in STU3)"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.category",
-				"path": "CarePlan.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "$this"
-						}
-					],
-					"rules": "open"
-				},
-				"definition": "Type of plan.",
-				"requirements": "Identifies what \"kind\" of plan this is to support differentiation between multiple co-existing plans; e.g. \"Home health\", \"psychiatric\", \"asthma\", \"disease management\", \"wellness plan\", etc.",
-				"min": 1,
-				"max": "*",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.category"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.category:AssessPlan",
-				"path": "CarePlan.category",
-				"sliceName": "AssessPlan",
-				"definition": "Type of plan.",
-				"requirements": "Identifies what \"kind\" of plan this is to support differentiation between multiple co-existing plans; e.g. \"Home health\", \"psychiatric\", \"asthma\", \"disease management\", \"wellness plan\", etc.",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://hl7.org/fhir/us/core/CodeSystem/careplan-category",
-							"code": "assess-plan"
-						}
-					]
-				},
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.category"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.subject",
-				"path": "CarePlan.subject",
-				"definition": "Who care plan is for.",
-				"requirements": "Identifies the patient or group whose intended care is described by the plan.",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.subject"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-careplan",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan",
+    "version": "3.1.1",
+    "name": "USCoreCarePlanProfile",
+    "title": "US Core CarePlan Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2019-08-29",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.healthit.gov"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the CarePlan resource for the minimal set of data to query and retrieve a patient's Care Plan.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "argonaut-dq-dstu2",
+            "uri": "http://unknown.org/Argonaut-DQ-DSTU2",
+            "name": "Argonaut-DQ-DSTU2"
+        },
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "CarePlan",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/CarePlan",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "CarePlan",
+                "path": "CarePlan",
+                "short": "Healthcare plan for patient or group",
+                "definition": "The US Core CarePlan Profile is based upon the core FHIR CarePlan Resource and created to meet the 2015 Edition Common Clinical Data Set 'Assessment and Plan of Treatment requirements.",
+                "alias": [
+                    "Care Team"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Request"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Act[classCode=PCPR, moodCode=INT]"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.id",
+                "path": "CarePlan.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "CarePlan.meta",
+                "path": "CarePlan.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "CarePlan.implicitRules",
+                "path": "CarePlan.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "CarePlan.language",
+                "path": "CarePlan.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "CarePlan.text",
+                "path": "CarePlan.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.text"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.text.id",
+                "path": "CarePlan.text.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.text.extension",
+                "path": "CarePlan.text.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.text.status",
+                "path": "CarePlan.text.status",
+                "short": "generated | extensions | additional | empty",
+                "definition": "generated | additional.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Narrative.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "strength": "required",
+                    "description": "Constrained value set of narrative statuses.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-narrative-status|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.text.status"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.text.div",
+                "path": "CarePlan.text.div",
+                "short": "Limited xhtml content",
+                "definition": "The actual narrative content, a stripped down version of XHTML.",
+                "comment": "The contents of the html element are an XHTML fragment containing only the basic html formatting elements described in chapters 7-11 and 15 of the HTML 4.0 standard, <a> elements (either name or href), images and internally contained stylesheets. The XHTML content SHALL NOT contain a head, a body, external stylesheet references, scripts, forms, base/link/xlink, frames, iframes and objects.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Narrative.div",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "xhtml"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "txt-1",
+                        "severity": "error",
+                        "human": "The narrative SHALL contain only the basic html formatting elements and attributes described in chapters 7-11 (except section 4 of chapter 9) and 15 of the HTML 4.0 standard, <a> elements (either name or href), images and internally contained style attributes",
+                        "expression": "htmlChecks()",
+                        "xpath": "not(descendant-or-self::*[not(local-name(.)=('a', 'abbr', 'acronym', 'b', 'big', 'blockquote', 'br', 'caption', 'cite', 'code', 'col', 'colgroup', 'dd', 'dfn', 'div', 'dl', 'dt', 'em', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'i', 'img', 'li', 'ol', 'p', 'pre', 'q', 'samp', 'small', 'span', 'strong', 'sub', 'sup', 'table', 'tbody', 'td', 'tfoot', 'th', 'thead', 'tr', 'tt', 'ul', 'var'))]) and not(descendant-or-self::*/@*[not(name(.)=('abbr', 'accesskey', 'align', 'alt', 'axis', 'bgcolor', 'border', 'cellhalign', 'cellpadding', 'cellspacing', 'cellvalign', 'char', 'charoff', 'charset', 'cite', 'class', 'colspan', 'compact', 'coords', 'dir', 'frame', 'headers', 'height', 'href', 'hreflang', 'hspace', 'id', 'lang', 'longdesc', 'name', 'nowrap', 'rel', 'rev', 'rowspan', 'rules', 'scope', 'shape', 'span', 'src', 'start', 'style', 'summary', 'tabindex', 'title', 'type', 'valign', 'value', 'vspace', 'width'))])"
+                    },
+                    {
+                        "key": "txt-2",
+                        "severity": "error",
+                        "human": "The narrative SHALL have some non-whitespace content",
+                        "expression": "htmlChecks()",
+                        "xpath": "descendant::text()[normalize-space(.)!=''] or descendant::h:img[@src]"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.contained",
+                "path": "CarePlan.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.extension",
+                "path": "CarePlan.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.modifierExtension",
+                "path": "CarePlan.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.identifier",
+                "path": "CarePlan.identifier",
+                "short": "External Ids for this plan",
+                "definition": "Business identifiers assigned to this care plan by the performer or other systems which remain constant as the resource is updated and propagates from server to server.",
+                "comment": "This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.",
+                "requirements": "Allows identification of the care plan as it is known by various participating systems and in a way that remains consistent across servers.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PTH-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.instantiatesCanonical",
+                "path": "CarePlan.instantiatesCanonical",
+                "short": "Instantiates FHIR protocol or definition",
+                "definition": "The URL pointing to a FHIR-defined protocol, guideline, questionnaire or other definition that is adhered to in whole or in part by this CarePlan.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.instantiatesCanonical",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "canonical",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/PlanDefinition",
+                            "http://hl7.org/fhir/StructureDefinition/Questionnaire",
+                            "http://hl7.org/fhir/StructureDefinition/Measure",
+                            "http://hl7.org/fhir/StructureDefinition/ActivityDefinition",
+                            "http://hl7.org/fhir/StructureDefinition/OperationDefinition"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.instantiatesCanonical"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=DEFN].target"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.instantiatesUri",
+                "path": "CarePlan.instantiatesUri",
+                "short": "Instantiates external protocol or definition",
+                "definition": "The URL pointing to an externally maintained protocol, guideline, questionnaire or other definition that is adhered to in whole or in part by this CarePlan.",
+                "comment": "This might be an HTML page, PDF, etc. or could just be a non-resolvable URI identifier.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.instantiatesUri",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.instantiatesUri"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=DEFN].target"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.basedOn",
+                "path": "CarePlan.basedOn",
+                "short": "Fulfills CarePlan",
+                "definition": "A care plan that is fulfilled in whole or in part by this care plan.",
+                "requirements": "Allows tracing of the care plan and tracking whether proposals/recommendations were acted upon.",
+                "alias": [
+                    "fulfills"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-hierarchy",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.basedOn"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.replaces",
+                "path": "CarePlan.replaces",
+                "short": "CarePlan replaced by this CarePlan",
+                "definition": "Completed or terminated care plan whose function is taken by this new care plan.",
+                "comment": "The replacement could be because the initial care plan was immediately rejected (due to an issue) or because the previous care plan was completed, but the need for the action described by the care plan remains ongoing.",
+                "requirements": "Allows tracing the continuation of a therapy or administrative process instantiated through multiple care plans.",
+                "alias": [
+                    "supersedes"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.replaces",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-hierarchy",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.replaces"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.partOf",
+                "path": "CarePlan.partOf",
+                "short": "Part of referenced CarePlan",
+                "definition": "A larger care plan of which this particular care plan is a component or step.",
+                "comment": "Each care plan is an independent request, such that having a care plan be part of another care plan can cause issues with cascading statuses.  As such, this element is still being discussed.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.partOf",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-hierarchy",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "CarePlan.status",
+                "path": "CarePlan.status",
+                "short": "draft | active | on-hold | revoked | completed | entered-in-error | unknown",
+                "definition": "Indicates whether the plan is currently being acted upon, represents future intentions or is now a historical record.",
+                "comment": "The unknown code is not to be used to convey other statuses.  The unknown code should be used when one of the statuses applies, but the authoring system doesn't know the current state of the care plan.\n\nThis element is labeled as a modifier because the status contains the code entered-in-error that marks the plan as not currently valid.",
+                "requirements": "Indicates whether the plan is currently being acted upon, represents future intentions or is now a historical record.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "description": "Indicates whether the plan is currently being acted upon, represents future intentions or is now a historical record.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/request-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.status {uses different ValueSet}"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PTH-5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".statusCode planned = new active = active completed = completed"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.status"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.intent",
+                "path": "CarePlan.intent",
+                "short": "proposal | plan | order | option",
+                "definition": "Indicates the level of authority/intentionality associated with the care plan and where the care plan fits into the workflow chain.",
+                "comment": "This element is labeled as a modifier because the intent alters when and how the resource is actually applicable.",
+                "requirements": "Proposals/recommendations, plans and orders all use the same structure and can exist in the same fulfillment chain.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.intent",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element changes the interpretation of all descriptive attributes. For example \"the time the request is recommended to occur\" vs. \"the time the request is authorized to occur\" or \"who is recommended to perform the request\" vs. \"who is authorized to perform the request\"",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "description": "Codes indicating the degree of authority/intentionality associated with a care plan",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/care-plan-intent"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.intent"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA (new element in STU3)"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.category",
+                "path": "CarePlan.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "$this"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "short": "Type of plan",
+                "definition": "Type of plan.",
+                "comment": "There may be multiple axes of categorization and one plan may serve multiple purposes.  In some cases, this may be redundant with references to CarePlan.concern.",
+                "requirements": "Identifies what \"kind\" of plan this is to support differentiation between multiple co-existing plans; e.g. \"Home health\", \"psychiatric\", \"asthma\", \"disease management\", \"wellness plan\", etc.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "CarePlanCategory"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Identifies what \"kind\" of plan this is to support differentiation between multiple co-existing plans; e.g. \"Home health\", \"psychiatric\", \"asthma\", \"disease management\", etc.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/care-plan-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.category"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.category:AssessPlan",
+                "path": "CarePlan.category",
+                "sliceName": "AssessPlan",
+                "short": "Type of plan",
+                "definition": "Type of plan.",
+                "comment": "There may be multiple axes of categorization and one plan may serve multiple purposes.  In some cases, this may be redundant with references to CarePlan.concern.",
+                "requirements": "Identifies what \"kind\" of plan this is to support differentiation between multiple co-existing plans; e.g. \"Home health\", \"psychiatric\", \"asthma\", \"disease management\", \"wellness plan\", etc.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/us/core/CodeSystem/careplan-category",
+                            "code": "assess-plan"
+                        }
+                    ]
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "CarePlanCategory"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Identifies what \"kind\" of plan this is to support differentiation between multiple co-existing plans; e.g. \"Home health\", \"psychiatric\", \"asthma\", \"disease management\", etc.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/care-plan-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.category"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.title",
+                "path": "CarePlan.title",
+                "short": "Human-friendly name for the care plan",
+                "definition": "Human-friendly name for the care plan.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.title",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "CarePlan.description",
+                "path": "CarePlan.description",
+                "short": "Summary of nature of plan",
+                "definition": "A description of the scope and nature of the plan.",
+                "requirements": "Provides more detail than conveyed by category.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.description",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.subject",
+                "path": "CarePlan.subject",
+                "short": "Who the care plan is for",
+                "definition": "Who care plan is for.",
+                "requirements": "Identifies the patient or group whose intended care is described by the plan.",
+                "alias": [
+                    "patient"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.subject",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=PAT].role[classCode=PAT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.subject"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.encounter",
+                "path": "CarePlan.encounter",
+                "short": "Encounter created as part of",
+                "definition": "The Encounter during which this CarePlan was created or to which the creation of this record is tightly associated.",
+                "comment": "This will typically be the encounter the event occurred within, but some activities may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter. CarePlan activities conducted as a result of the care plan may well occur as part of other encounters.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "Associated PV1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "."
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.period",
+                "path": "CarePlan.period",
+                "short": "Time period plan covers",
+                "definition": "Indicates when the plan did (or is intended to) come into effect and end.",
+                "comment": "Any activities scheduled as part of the plan should be constrained to the specified period regardless of whether the activities are planned within a single encounter/episode or across multiple encounters/episodes (e.g. the longitudinal management of a chronic condition).",
+                "requirements": "Allows tracking what plan(s) are in effect at a particular time.",
+                "alias": [
+                    "timing"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.planned"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "GOL-7 / GOL-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.created",
+                "path": "CarePlan.created",
+                "short": "Date record was first recorded",
+                "definition": "Represents when this particular CarePlan record was created in the system, which is often a system-generated date.",
+                "alias": [
+                    "authoredOn"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.created",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.authoredOn"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.author",
+                "path": "CarePlan.author",
+                "short": "Who is the designated responsible party",
+                "definition": "When populated, the author is responsible for the care plan.  The care plan is attributed to the author.",
+                "comment": "The author may also be a contributor.  For example, an organization can be an author, but not listed as a contributor.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.author",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.requester"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.author"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.contributor",
+                "path": "CarePlan.contributor",
+                "short": "Who provided the content of the care plan",
+                "definition": "Identifies the individual(s) or organization who provided the contents of the care plan.",
+                "comment": "Collaborative care plans may have multiple contributors.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.contributor",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "CarePlan.careTeam",
+                "path": "CarePlan.careTeam",
+                "short": "Who's involved in plan?",
+                "definition": "Identifies all people and organizations who are expected to be involved in the care envisioned by this plan.",
+                "requirements": "Allows representation of care teams, helps scope care plan.  In some cases may be a determiner of access permissions.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.careTeam",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.performer {similar but does not entail CareTeam}"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.addresses",
+                "path": "CarePlan.addresses",
+                "short": "Health issues this plan addresses",
+                "definition": "Identifies the conditions/problems/concerns/diagnoses/etc. whose management and/or mitigation are handled by this plan.",
+                "comment": "When the diagnosis is related to an allergy or intolerance, the Condition and AllergyIntolerance resources can both be used. However, to be actionable for decision support, using Condition alone is not sufficient as the allergy or intolerance condition needs to be represented as an AllergyIntolerance.",
+                "requirements": "Links plan to the conditions it manages.  The element can identify risks addressed by the plan as well as active conditions.  (The Condition resource can include things like \"at risk for hypertension\" or \"fall risk\".)  Also scopes plans - multiple plans may exist addressing different concerns.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.addresses",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Condition"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.reasonReference"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.why[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRB-4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".actRelationship[typeCode=SUBJ].target[classCode=CONC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.supportingInfo",
+                "path": "CarePlan.supportingInfo",
+                "short": "Information considered as part of plan",
+                "definition": "Identifies portions of the patient's record that specifically influenced the formation of the plan.  These might include comorbidities, recent procedures, limitations, recent assessments, etc.",
+                "comment": "Use \"concern\" to identify specific conditions addressed by the care plan.",
+                "requirements": "Identifies barriers and other considerations associated with the care plan.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.supportingInfo",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.supportingInfo"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.goal",
+                "path": "CarePlan.goal",
+                "short": "Desired outcome of plan",
+                "definition": "Describes the intended objective(s) of carrying out the care plan.",
+                "comment": "Goal can be achieving a particular change or merely maintaining a current state or even slowing a decline.",
+                "requirements": "Provides context for plan.  Allows plan effectiveness to be evaluated by clinicians.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.goal",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Goal"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "GOL.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode<=OBJ]."
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity",
+                "path": "CarePlan.activity",
+                "short": "Action to occur as part of plan",
+                "definition": "Identifies a planned action to occur as part of the plan.  For example, a medication to be used, lab tests to perform, self-monitoring, education, etc.",
+                "requirements": "Allows systems to prompt for performance of planned activities, and validate plans against best practice.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.activity",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "cpl-3",
+                        "severity": "error",
+                        "human": "Provide a reference or detail, not both",
+                        "expression": "detail.empty() or reference.empty()",
+                        "xpath": "not(exists(f:detail)) or not(exists(f:reference))"
+                    },
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "{no mapping\nNOTE: This is a list of contained Request-Event tuples!}"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=COMP].target"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.id",
+                "path": "CarePlan.activity.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.extension",
+                "path": "CarePlan.activity.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.modifierExtension",
+                "path": "CarePlan.activity.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.outcomeCodeableConcept",
+                "path": "CarePlan.activity.outcomeCodeableConcept",
+                "short": "Results of the activity",
+                "definition": "Identifies the outcome at the point when the status of the activity is assessed.  For example, the outcome of an education activity could be patient understands (or not).",
+                "comment": "Note that this should not duplicate the activity status (e.g. completed or in progress).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.activity.outcomeCodeableConcept",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "CarePlanActivityOutcome"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Identifies the results of the activity.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/care-plan-activity-outcome"
+                }
+            },
+            {
+                "id": "CarePlan.activity.outcomeReference",
+                "path": "CarePlan.activity.outcomeReference",
+                "short": "Appointment, Encounter, Procedure, etc.",
+                "definition": "Details of the outcome or action resulting from the activity.  The reference to an \"event\" resource, such as Procedure or Encounter or Observation, is the result/outcome of the activity itself.  The activity can be conveyed using CarePlan.activity.detail OR using the CarePlan.activity.reference (a reference to a “request” resource).",
+                "comment": "The activity outcome is independent of the outcome of the related goal(s).  For example, if the goal is to achieve a target body weight of 150 lbs and an activity is defined to diet, then the activity outcome could be calories consumed whereas the goal outcome is an observation for the actual body weight measured.",
+                "requirements": "Links plan to resulting actions.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.activity.outcomeReference",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "{Event that is outcome of Request in activity.reference}"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=FLFS].source"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.progress",
+                "path": "CarePlan.activity.progress",
+                "short": "Comments about the activity status/progress",
+                "definition": "Notes about the adherence/status/progress of the activity.",
+                "comment": "This element should NOT be used to describe the activity to be performed - that occurs either within the resource pointed to by activity.detail.reference or in activity.detail.description.",
+                "requirements": "Can be used to capture information about adherence, progress, concerns, etc.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.activity.progress",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NTE?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.reference",
+                "path": "CarePlan.activity.reference",
+                "short": "Activity details defined in specific resource",
+                "definition": "The details of the proposed activity represented in a specific resource.",
+                "comment": "Standard extension exists ([resource-pertainsToGoal](http://hl7.org/fhir/R4/extension-resource-pertainstogoal.html)) that allows goals to be referenced from any of the referenced resources in CarePlan.activity.reference.  \rThe goal should be visible when the resource referenced by CarePlan.activity.reference is viewed independently from the CarePlan.  Requests that are pointed to by a CarePlan using this element should *not* point to this CarePlan using the \"basedOn\" element.  i.e. Requests that are part of a CarePlan are not \"based on\" the CarePlan.",
+                "requirements": "Details in a form consistent with other applications and contexts of use.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.activity.reference",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Appointment",
+                            "http://hl7.org/fhir/StructureDefinition/CommunicationRequest",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceRequest",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+                            "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+                            "http://hl7.org/fhir/StructureDefinition/Task",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest",
+                            "http://hl7.org/fhir/StructureDefinition/VisionPrescription",
+                            "http://hl7.org/fhir/StructureDefinition/RequestGroup"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "cpl-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "{Request that resulted in Event in activity.actionResulting}"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=COMP].target"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail",
+                "path": "CarePlan.activity.detail",
+                "short": "In-line definition of activity",
+                "definition": "A simple summary of a planned activity suitable for a general care plan system (e.g. form driven) that doesn't know about specific resources such as procedure etc.",
+                "requirements": "Details in a simple form for generic care plan systems.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.activity.detail",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "condition": [
+                    "cpl-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=COMP, subsetCode=SUMM].target"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.id",
+                "path": "CarePlan.activity.detail.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.extension",
+                "path": "CarePlan.activity.detail.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.modifierExtension",
+                "path": "CarePlan.activity.detail.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.kind",
+                "path": "CarePlan.activity.detail.kind",
+                "short": "Appointment | CommunicationRequest | DeviceRequest | MedicationRequest | NutritionOrder | Task | ServiceRequest | VisionPrescription",
+                "definition": "A description of the kind of resource the in-line definition of a care plan activity is representing.  The CarePlan.activity.detail is an in-line definition when a resource is not referenced using CarePlan.activity.reference.  For example, a MedicationRequest, a ServiceRequest, or a CommunicationRequest.",
+                "requirements": "May determine what types of extensions are permitted.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.activity.detail.kind",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "CarePlanActivityKind"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Resource types defined as part of FHIR that can be represented as in-line definitions of a care plan activity.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/care-plan-activity-kind|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[classCode=LIST].code"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.instantiatesCanonical",
+                "path": "CarePlan.activity.detail.instantiatesCanonical",
+                "short": "Instantiates FHIR protocol or definition",
+                "definition": "The URL pointing to a FHIR-defined protocol, guideline, questionnaire or other definition that is adhered to in whole or in part by this CarePlan activity.",
+                "requirements": "Allows Questionnaires that the patient (or practitioner) should fill in to fulfill the care plan activity.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.activity.detail.instantiatesCanonical",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "canonical",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/PlanDefinition",
+                            "http://hl7.org/fhir/StructureDefinition/ActivityDefinition",
+                            "http://hl7.org/fhir/StructureDefinition/Questionnaire",
+                            "http://hl7.org/fhir/StructureDefinition/Measure",
+                            "http://hl7.org/fhir/StructureDefinition/OperationDefinition"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.instantiatesCanonical"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=DEFN].target"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.instantiatesUri",
+                "path": "CarePlan.activity.detail.instantiatesUri",
+                "short": "Instantiates external protocol or definition",
+                "definition": "The URL pointing to an externally maintained protocol, guideline, questionnaire or other definition that is adhered to in whole or in part by this CarePlan activity.",
+                "comment": "This might be an HTML page, PDF, etc. or could just be a non-resolvable URI identifier.",
+                "requirements": "Allows Questionnaires that the patient (or practitioner) should fill in to fulfill the care plan activity.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.activity.detail.instantiatesUri",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.instantiatesUri"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=DEFN].target"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.code",
+                "path": "CarePlan.activity.detail.code",
+                "short": "Detail type of activity",
+                "definition": "Detailed description of the type of planned activity; e.g. what lab test, what procedure, what kind of encounter.",
+                "comment": "Tends to be less relevant for activities involving particular products.  Codes should not convey negation - use \"prohibited\" instead.",
+                "requirements": "Allows matching performed to planned as well as validation against protocols.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.activity.detail.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "CarePlanActivityType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Detailed description of the type of activity; e.g. What lab test, what procedure, what kind of encounter.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/procedure-code"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.code"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-4 / RXE-2 / RXO-1 / RXD-2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".code"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.reasonCode",
+                "path": "CarePlan.activity.detail.reasonCode",
+                "short": "Why activity should be done or why activity was prohibited",
+                "definition": "Provides the rationale that drove the inclusion of this particular activity as part of the plan or the reason why the activity was prohibited.",
+                "comment": "This could be a diagnosis code.  If a full condition record exists or additional detail is needed, use reasonCondition instead.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.activity.detail.reasonCode",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "CarePlanActivityReason"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Identifies why a care plan activity is needed.  Can include any health condition codes as well as such concepts as \"general wellness\", prophylaxis, surgical preparation, etc.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.reasonCode"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.reasonReference",
+                "path": "CarePlan.activity.detail.reasonReference",
+                "short": "Why activity is needed",
+                "definition": "Indicates another resource, such as the health condition(s), whose existence justifies this request and drove the inclusion of this particular activity as part of the plan.",
+                "comment": "Conditions can be identified at the activity level that are not identified as reasons for the overall plan.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.activity.detail.reasonReference",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Condition",
+                            "http://hl7.org/fhir/StructureDefinition/Observation",
+                            "http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
+                            "http://hl7.org/fhir/StructureDefinition/DocumentReference"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.reasonReference"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.goal",
+                "path": "CarePlan.activity.detail.goal",
+                "short": "Goals this activity relates to",
+                "definition": "Internal reference that identifies the goals that this activity is intended to contribute towards meeting.",
+                "requirements": "So that participants know the link explicitly.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.activity.detail.goal",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Goal"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode<=OBJ]."
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.status",
+                "path": "CarePlan.activity.detail.status",
+                "short": "not-started | scheduled | in-progress | on-hold | completed | cancelled | stopped | unknown | entered-in-error",
+                "definition": "Identifies what progress is being made for the specific activity.",
+                "comment": "Some aspects of status can be inferred based on the resources linked in actionTaken.  Note that \"status\" is only as current as the plan was most recently updated.  \nThe unknown code is not to be used to convey other statuses.  The unknown code should be used when one of the statuses applies, but the authoring system doesn't know the current state of the activity.",
+                "requirements": "Indicates progress against the plan, whether the activity is still relevant for the plan.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.activity.detail.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labelled as a modifier because it is a status element that contains status entered-in-error which means that the activity should not be treated as valid",
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "CarePlanActivityStatus"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Codes that reflect the current state of a care plan activity within its overall life cycle.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/care-plan-activity-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.status"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC-5?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".statusCode not-started = new scheduled = not-started (and fulfillment relationship to appointent) in-progress = active on-hold = suspended completed = completed cancelled = aborted"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.statusReason",
+                "path": "CarePlan.activity.detail.statusReason",
+                "short": "Reason for current status",
+                "definition": "Provides reason why the activity isn't yet started, is on hold, was cancelled, etc.",
+                "comment": "Will generally not be present if status is \"complete\".  Be sure to prompt to update this (or at least remove the existing value) if the status is changed.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.activity.detail.statusReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.statusReason"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.doNotPerform",
+                "path": "CarePlan.activity.detail.doNotPerform",
+                "short": "If true, activity is prohibiting action",
+                "definition": "If true, indicates that the described activity is one that must NOT be engaged in when following the plan.  If false, or missing, indicates that the described activity is one that should be engaged in when following the plan.",
+                "comment": "This element is labeled as a modifier because it marks an activity as an activity that is not to be performed.",
+                "requirements": "Captures intention to not do something that may have been previously typical.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.activity.detail.doNotPerform",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "meaningWhenMissing": "If missing indicates that the described activity is one that should be engaged in when following the plan.",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "If true this element negates the specified action. For example, instead of a request for a procedure, it is a request for the procedure to not occur.",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.doNotPerform"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "actionNegationInd"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.scheduled[x]",
+                "path": "CarePlan.activity.detail.scheduled[x]",
+                "short": "When activity is to occur",
+                "definition": "The period, timing or frequency upon which the described activity is to occur.",
+                "requirements": "Allows prompting for activities and detection of missed planned activities.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.activity.detail.scheduled[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Timing"
+                    },
+                    {
+                        "code": "Period"
+                    },
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.occurrence[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "TQ1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.location",
+                "path": "CarePlan.activity.detail.location",
+                "short": "Where it should happen",
+                "definition": "Identifies the facility where the activity will occur; e.g. home, hospital, specific clinic, etc.",
+                "comment": "May reference a specific clinical location or may identify a type of location.",
+                "requirements": "Helps in planning of activity.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.activity.detail.location",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Location"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBR-24(???!!)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=LOC].role"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.performer",
+                "path": "CarePlan.activity.detail.performer",
+                "short": "Who will be responsible?",
+                "definition": "Identifies who's expected to be involved in the activity.",
+                "comment": "A performer MAY also be a participant in the care plan.",
+                "requirements": "Helps in planning of activity.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.activity.detail.performer",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam",
+                            "http://hl7.org/fhir/StructureDefinition/HealthcareService",
+                            "http://hl7.org/fhir/StructureDefinition/Device"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.performer"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRT-5 : ( PRV-4 = (provider participations)); PRT-5 : ( PRV-4 = (non-provider person participations )) ; PRT-5 : ( PRV-4 = (patient non-subject of care) ) ; PRT-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=PFM]"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.product[x]",
+                "path": "CarePlan.activity.detail.product[x]",
+                "short": "What is to be administered/supplied",
+                "definition": "Identifies the food, drug or other product to be consumed or supplied in the activity.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.activity.detail.product[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Medication",
+                            "http://hl7.org/fhir/StructureDefinition/Substance"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "CarePlanProduct"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "A product supplied or administered as part of a care plan activity.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/medication-codes"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXE-2 / RXO-1 / RXD-2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=PRD].role"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.dailyAmount",
+                "path": "CarePlan.activity.detail.dailyAmount",
+                "short": "How to consume/day?",
+                "definition": "Identifies the quantity expected to be consumed in a given day.",
+                "requirements": "Allows rough dose checking.",
+                "alias": [
+                    "daily dose"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.activity.detail.dailyAmount",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXO-23 / RXE-19 / RXD-12"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=COMP][classCode=SBADM].doseQuantity"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.quantity",
+                "path": "CarePlan.activity.detail.quantity",
+                "short": "How much to administer/supply/consume",
+                "definition": "Identifies the quantity expected to be supplied, administered or consumed by the subject.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.activity.detail.quantity",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXO-11 / RXE-10 / RXD-4 / RXG-5 / RXA-6 /  TQ1-2.1  *and*  RXO-12 /  RXE-11 / RXD-5 / RXG-7 / RXA-7 / TQ1-2.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=COMP][classCode=SPLY].quantity"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.description",
+                "path": "CarePlan.activity.detail.description",
+                "short": "Extra info describing activity to perform",
+                "definition": "This provides a textual description of constraints on the intended activity occurrence, including relation to other activities.  It may also include objectives, pre-conditions and end-conditions.  Finally, it may convey specifics about the activity such as body site, method, route, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.activity.detail.description",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NTE?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".text"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.note",
+                "path": "CarePlan.note",
+                "short": "Comments about the plan",
+                "definition": "General notes about the care plan not covered elsewhere.",
+                "requirements": "Used to capture information that applies to the plan as a whole that doesn't fit into discrete elements.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.note"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "NTE?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"annotation\"].value"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "CarePlan",
+                "path": "CarePlan",
+                "definition": "The US Core CarePlan Profile is based upon the core FHIR CarePlan Resource and created to meet the 2015 Edition Common Clinical Data Set 'Assessment and Plan of Treatment requirements.",
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.text",
+                "path": "CarePlan.text",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.text"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.text.status",
+                "path": "CarePlan.text.status",
+                "definition": "generated | additional.",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "description": "Constrained value set of narrative statuses.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-narrative-status|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.text.status"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.status",
+                "path": "CarePlan.status",
+                "requirements": "Indicates whether the plan is currently being acted upon, represents future intentions or is now a historical record.",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "description": "Indicates whether the plan is currently being acted upon, represents future intentions or is now a historical record.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/request-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.status"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.intent",
+                "path": "CarePlan.intent",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "description": "Codes indicating the degree of authority/intentionality associated with a care plan",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/care-plan-intent"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA (new element in STU3)"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.category",
+                "path": "CarePlan.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "$this"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "definition": "Type of plan.",
+                "requirements": "Identifies what \"kind\" of plan this is to support differentiation between multiple co-existing plans; e.g. \"Home health\", \"psychiatric\", \"asthma\", \"disease management\", \"wellness plan\", etc.",
+                "min": 1,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.category"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.category:AssessPlan",
+                "path": "CarePlan.category",
+                "sliceName": "AssessPlan",
+                "definition": "Type of plan.",
+                "requirements": "Identifies what \"kind\" of plan this is to support differentiation between multiple co-existing plans; e.g. \"Home health\", \"psychiatric\", \"asthma\", \"disease management\", \"wellness plan\", etc.",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/us/core/CodeSystem/careplan-category",
+                            "code": "assess-plan"
+                        }
+                    ]
+                },
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.category"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.subject",
+                "path": "CarePlan.subject",
+                "definition": "Who care plan is for.",
+                "requirements": "Identifies the patient or group whose intended care is described by the plan.",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.subject"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-careteam.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-careteam.json
@@ -1,1419 +1,1419 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-careteam",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-careteam-definitions.html#CareTeam\" title=\"The US Core CareTeam Profile is based upon the core FHIR CareTeam Resource and created to meet the 2015 Edition Common Clinical Data Set 'Care team member(s)' requirements.\">CareTeam</a><a name=\"CareTeam\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/careteam.html\">CareTeam</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Planned participants in the coordination and delivery of care for a patient or group</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-careteam-definitions.html#CareTeam.status\">status</a><a name=\"CareTeam.status\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">proposed | active | suspended | inactive | entered-in-error</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-care-team-status.html\">CareTeamStatus</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-careteam-definitions.html#CareTeam.subject\">subject</a><a name=\"CareTeam.subject\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who care team is for</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-careteam-definitions.html#CareTeam.participant\">participant</a><a name=\"CareTeam.participant\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Members of the team</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-careteam-definitions.html#CareTeam.participant.role\">role</a><a name=\"CareTeam.participant.role\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Type of involvement</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-careteam-provider-roles.html\">US Core CareTeam Provider Roles</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-careteam-definitions.html#CareTeam.participant.member\">member</a><a name=\"CareTeam.participant.member\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a> | <a href=\"StructureDefinition-us-core-practitioner.html\">US Core Practitioner Profile</a> | <a href=\"StructureDefinition-us-core-organization.html\">US Core Organization Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who is involved</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam",
-	"version": "3.1.1",
-	"name": "USCoreCareTeam",
-	"title": "US Core CareTeam Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-06-26",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.healthit.gov"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the CareTeam resource for the minimal set of data to query and retrieve a patient's Care Team.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "argonaut-dq-dstu2",
-			"uri": "http://unknown.org/Argonaut-DQ-DSTU2",
-			"name": "Argonaut-DQ-DSTU2"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "CareTeam",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/CareTeam",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "CareTeam",
-				"path": "CareTeam",
-				"short": "Planned participants in the coordination and delivery of care for a patient or group",
-				"definition": "The US Core CareTeam Profile is based upon the core FHIR CareTeam Resource and created to meet the 2015 Edition Common Clinical Data Set 'Care team member(s)' requirements.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CareTeam",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.id",
-				"path": "CareTeam.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "CareTeam.meta",
-				"path": "CareTeam.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "CareTeam.implicitRules",
-				"path": "CareTeam.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "CareTeam.language",
-				"path": "CareTeam.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "CareTeam.text",
-				"path": "CareTeam.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.contained",
-				"path": "CareTeam.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.extension",
-				"path": "CareTeam.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.modifierExtension",
-				"path": "CareTeam.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.identifier",
-				"path": "CareTeam.identifier",
-				"short": "External Ids for this team",
-				"definition": "Business identifiers assigned to this care team by the performer or other systems which remain constant as the resource is updated and propagates from server to server.",
-				"comment": "This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.",
-				"requirements": "Allows identification of the care team as it is known by various participating systems and in a way that remains consistent across servers.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CareTeam.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.status",
-				"path": "CareTeam.status",
-				"short": "proposed | active | suspended | inactive | entered-in-error",
-				"definition": "Indicates the current state of the care team.",
-				"comment": "This element is labeled as a modifier because the status contains the code entered-in-error that marks the care team as not currently valid.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CareTeam.status",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labelled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"description": "Indicates whether the team is current , represents future intentions or is now a historical record.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/care-team-status"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.status"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.category",
-				"path": "CareTeam.category",
-				"short": "Type of team",
-				"definition": "Identifies what kind of team.  This is to support differentiation between multiple co-existing teams, such as care plan team, episode of care team, longitudinal care team.",
-				"comment": "There may be multiple axis of categorization and one team may serve multiple purposes.",
-				"requirements": "Used for filtering what teams(s) are retrieved and displayed to different types of users.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CareTeam.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "CareTeamCategory"
-						}
-					],
-					"strength": "example",
-					"description": "Indicates the type of care team.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/care-team-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.name",
-				"path": "CareTeam.name",
-				"short": "Name of the team, such as crisis assessment team",
-				"definition": "A label for human use intended to distinguish like teams.  E.g. the \"red\" vs. \"green\" trauma teams.",
-				"comment": "The meaning/purpose of the team is conveyed in CareTeam.category.  This element may also convey semantics of the team (e.g. \"Red trauma team\"), but its primary purpose is to distinguish between identical teams in a human-friendly way.  (\"Team 18735\" isn't as friendly.).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CareTeam.name",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "CareTeam.subject",
-				"path": "CareTeam.subject",
-				"short": "Who care team is for",
-				"definition": "Identifies the patient or group whose intended care is handled by the team.",
-				"requirements": "Allows the team to care for a group (e.g. marriage) therapy. \nAllows for an organization to designate a team such as the PICC line team.",
-				"alias": [
-					"patient"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "CareTeam.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.subject"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.encounter",
-				"path": "CareTeam.encounter",
-				"short": "Encounter created as part of",
-				"definition": "The Encounter during which this CareTeam was created or to which the creation of this record is tightly associated.",
-				"comment": "This will typically be the encounter the event occurred within, but some activities may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CareTeam.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.period",
-				"path": "CareTeam.period",
-				"short": "Time period team covers",
-				"definition": "Indicates when the team did (or is intended to) come into effect and end.",
-				"requirements": "Allows tracking what team(s) are in effect at a particular time.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CareTeam.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.init"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.participant",
-				"path": "CareTeam.participant",
-				"short": "Members of the team",
-				"definition": "Identifies all people and organizations who are expected to be involved in the care team.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "CareTeam.participant",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"condition": [
-					"ctm-1"
-				],
-				"constraint": [
-					{
-						"key": "ctm-1",
-						"severity": "error",
-						"human": "CareTeam.participant.onBehalfOf can only be populated when CareTeam.participant.member is a Practitioner",
-						"expression": "onBehalfOf.exists() implies (member.resolve().iif(empty(), true, ofType(Practitioner).exists()))",
-						"xpath": "starts-with(f:member/f:reference/@value, 'Practitioner/') or contains(f:member/f:reference/@value, '/Practitioner/') or exists(ancestor::*/f:contains/f:Practitioner/f:id[@value=substring-after(current()/f:member/f:reference/@value, '#')]) or not(exists(f:onBehalfOf))",
-						"source": "http://hl7.org/fhir/StructureDefinition/CareTeam"
-					},
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "REL (REL.4 is always the Patient) ( or PRT?)"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=PRF]"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.participant"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.participant.id",
-				"path": "CareTeam.participant.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.participant.extension",
-				"path": "CareTeam.participant.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.participant.modifierExtension",
-				"path": "CareTeam.participant.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.participant.role",
-				"path": "CareTeam.participant.role",
-				"short": "Type of involvement",
-				"definition": "Indicates specific responsibility of an individual within the care team, such as \"Primary care physician\", \"Trained social worker counselor\", \"Caregiver\", etc.",
-				"comment": "Roles may sometimes be inferred by type of Practitioner.  These are relationships that hold only within the context of the care team.  General relationships should be handled as properties of the Patient resource directly.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "CareTeam.participant.role",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Indicates specific responsibility of an individual within the care team, such as Primary physician, Team coordinator, Caregiver, etc.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-careteam-provider-roles|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "REL.2 (or PRT-4?)"
-					},
-					{
-						"identity": "rim",
-						"map": ".functionCode"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.participant.role"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.participant.member",
-				"path": "CareTeam.participant.member",
-				"short": "Who is involved",
-				"definition": "The specific person or organization who is participating/expected to participate in the care team.",
-				"comment": "Patient only needs to be listed if they have a role other than \"subject of care\".\n\nMember is optional because some participants may be known only by their role, particularly in draft plans.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "CareTeam.participant.member",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "REL.5 (or PRT-5 : ( PRV-4 {provider participations} ) / PRT-5 : ( PRV-4  {non-provider person participations} ) / PRT-5 : ( PRV-4 = (patient non-subject of care) ) / PRT-8?)"
-					},
-					{
-						"identity": "rim",
-						"map": ".role"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.participant.member"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.participant.onBehalfOf",
-				"path": "CareTeam.participant.onBehalfOf",
-				"short": "Organization of the practitioner",
-				"definition": "The organization of the practitioner.",
-				"requirements": "Practitioners can be associated with multiple organizations.  This element indicates which organization they were acting on behalf of.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CareTeam.participant.onBehalfOf",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "CareTeam.participant.period",
-				"path": "CareTeam.participant.period",
-				"short": "Time period of participant",
-				"definition": "Indicates when the specific member or organization did (or is intended to) come into effect and end.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CareTeam.participant.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "CareTeam.reasonCode",
-				"path": "CareTeam.reasonCode",
-				"short": "Why the care team exists",
-				"definition": "Describes why the care team exists.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CareTeam.reasonCode",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "CareTeamReason"
-						}
-					],
-					"strength": "example",
-					"description": "Indicates the reason for the care team.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.why[x]"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.reasonReference",
-				"path": "CareTeam.reasonReference",
-				"short": "Why the care team exists",
-				"definition": "Condition(s) that this care team addresses.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CareTeam.reasonReference",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Condition"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.why[x]"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.managingOrganization",
-				"path": "CareTeam.managingOrganization",
-				"short": "Organization responsible for the care team",
-				"definition": "The organization responsible for the care team.",
-				"requirements": "Allows for multiple organizations to collaboratively manage cross-organizational, longitudinal care plan.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CareTeam.managingOrganization",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "CareTeam.telecom",
-				"path": "CareTeam.telecom",
-				"short": "A contact detail for the care team (that applies to all members)",
-				"definition": "A central contact detail for the care team (that applies to all members).",
-				"comment": "The ContactPoint.use code of home is not appropriate to use. These contacts are not the contact details of individual care team members.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CareTeam.telecom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "ContactPoint"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "CareTeam.note",
-				"path": "CareTeam.note",
-				"short": "Comments made about the CareTeam",
-				"definition": "Comments made about the CareTeam.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CareTeam.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "CareTeam",
-				"path": "CareTeam",
-				"definition": "The US Core CareTeam Profile is based upon the core FHIR CareTeam Resource and created to meet the 2015 Edition Common Clinical Data Set 'Care team member(s)' requirements.",
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.status",
-				"path": "CareTeam.status",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"description": "Indicates whether the team is current , represents future intentions or is now a historical record.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/care-team-status"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.status"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.subject",
-				"path": "CareTeam.subject",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.subject"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.participant",
-				"path": "CareTeam.participant",
-				"min": 1,
-				"max": "*",
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.participant"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.participant.role",
-				"path": "CareTeam.participant.role",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Indicates specific responsibility of an individual within the care team, such as Primary physician, Team coordinator, Caregiver, etc.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-careteam-provider-roles|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.participant.role"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.participant.member",
-				"path": "CareTeam.participant.member",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.participant.member"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-careteam",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam",
+    "version": "3.1.1",
+    "name": "USCoreCareTeam",
+    "title": "US Core CareTeam Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-06-26",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.healthit.gov"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the CareTeam resource for the minimal set of data to query and retrieve a patient's Care Team.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "argonaut-dq-dstu2",
+            "uri": "http://unknown.org/Argonaut-DQ-DSTU2",
+            "name": "Argonaut-DQ-DSTU2"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "CareTeam",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/CareTeam",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "CareTeam",
+                "path": "CareTeam",
+                "short": "Planned participants in the coordination and delivery of care for a patient or group",
+                "definition": "The US Core CareTeam Profile is based upon the core FHIR CareTeam Resource and created to meet the 2015 Edition Common Clinical Data Set 'Care team member(s)' requirements.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CareTeam",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.id",
+                "path": "CareTeam.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "CareTeam.meta",
+                "path": "CareTeam.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "CareTeam.implicitRules",
+                "path": "CareTeam.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "CareTeam.language",
+                "path": "CareTeam.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "CareTeam.text",
+                "path": "CareTeam.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.contained",
+                "path": "CareTeam.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.extension",
+                "path": "CareTeam.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.modifierExtension",
+                "path": "CareTeam.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.identifier",
+                "path": "CareTeam.identifier",
+                "short": "External Ids for this team",
+                "definition": "Business identifiers assigned to this care team by the performer or other systems which remain constant as the resource is updated and propagates from server to server.",
+                "comment": "This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.",
+                "requirements": "Allows identification of the care team as it is known by various participating systems and in a way that remains consistent across servers.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CareTeam.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.status",
+                "path": "CareTeam.status",
+                "short": "proposed | active | suspended | inactive | entered-in-error",
+                "definition": "Indicates the current state of the care team.",
+                "comment": "This element is labeled as a modifier because the status contains the code entered-in-error that marks the care team as not currently valid.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CareTeam.status",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labelled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "description": "Indicates whether the team is current , represents future intentions or is now a historical record.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/care-team-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.status"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.category",
+                "path": "CareTeam.category",
+                "short": "Type of team",
+                "definition": "Identifies what kind of team.  This is to support differentiation between multiple co-existing teams, such as care plan team, episode of care team, longitudinal care team.",
+                "comment": "There may be multiple axis of categorization and one team may serve multiple purposes.",
+                "requirements": "Used for filtering what teams(s) are retrieved and displayed to different types of users.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CareTeam.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "CareTeamCategory"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Indicates the type of care team.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/care-team-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.name",
+                "path": "CareTeam.name",
+                "short": "Name of the team, such as crisis assessment team",
+                "definition": "A label for human use intended to distinguish like teams.  E.g. the \"red\" vs. \"green\" trauma teams.",
+                "comment": "The meaning/purpose of the team is conveyed in CareTeam.category.  This element may also convey semantics of the team (e.g. \"Red trauma team\"), but its primary purpose is to distinguish between identical teams in a human-friendly way.  (\"Team 18735\" isn't as friendly.).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CareTeam.name",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "CareTeam.subject",
+                "path": "CareTeam.subject",
+                "short": "Who care team is for",
+                "definition": "Identifies the patient or group whose intended care is handled by the team.",
+                "requirements": "Allows the team to care for a group (e.g. marriage) therapy. \nAllows for an organization to designate a team such as the PICC line team.",
+                "alias": [
+                    "patient"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "CareTeam.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.subject"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.encounter",
+                "path": "CareTeam.encounter",
+                "short": "Encounter created as part of",
+                "definition": "The Encounter during which this CareTeam was created or to which the creation of this record is tightly associated.",
+                "comment": "This will typically be the encounter the event occurred within, but some activities may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CareTeam.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.period",
+                "path": "CareTeam.period",
+                "short": "Time period team covers",
+                "definition": "Indicates when the team did (or is intended to) come into effect and end.",
+                "requirements": "Allows tracking what team(s) are in effect at a particular time.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CareTeam.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.init"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.participant",
+                "path": "CareTeam.participant",
+                "short": "Members of the team",
+                "definition": "Identifies all people and organizations who are expected to be involved in the care team.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "CareTeam.participant",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "condition": [
+                    "ctm-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ctm-1",
+                        "severity": "error",
+                        "human": "CareTeam.participant.onBehalfOf can only be populated when CareTeam.participant.member is a Practitioner",
+                        "expression": "onBehalfOf.exists() implies (member.resolve().iif(empty(), true, ofType(Practitioner).exists()))",
+                        "xpath": "starts-with(f:member/f:reference/@value, 'Practitioner/') or contains(f:member/f:reference/@value, '/Practitioner/') or exists(ancestor::*/f:contains/f:Practitioner/f:id[@value=substring-after(current()/f:member/f:reference/@value, '#')]) or not(exists(f:onBehalfOf))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/CareTeam"
+                    },
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "REL (REL.4 is always the Patient) ( or PRT?)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=PRF]"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.participant"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.participant.id",
+                "path": "CareTeam.participant.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.participant.extension",
+                "path": "CareTeam.participant.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.participant.modifierExtension",
+                "path": "CareTeam.participant.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.participant.role",
+                "path": "CareTeam.participant.role",
+                "short": "Type of involvement",
+                "definition": "Indicates specific responsibility of an individual within the care team, such as \"Primary care physician\", \"Trained social worker counselor\", \"Caregiver\", etc.",
+                "comment": "Roles may sometimes be inferred by type of Practitioner.  These are relationships that hold only within the context of the care team.  General relationships should be handled as properties of the Patient resource directly.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "CareTeam.participant.role",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Indicates specific responsibility of an individual within the care team, such as Primary physician, Team coordinator, Caregiver, etc.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-careteam-provider-roles|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "REL.2 (or PRT-4?)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".functionCode"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.participant.role"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.participant.member",
+                "path": "CareTeam.participant.member",
+                "short": "Who is involved",
+                "definition": "The specific person or organization who is participating/expected to participate in the care team.",
+                "comment": "Patient only needs to be listed if they have a role other than \"subject of care\".\n\nMember is optional because some participants may be known only by their role, particularly in draft plans.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "CareTeam.participant.member",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "REL.5 (or PRT-5 : ( PRV-4 {provider participations} ) / PRT-5 : ( PRV-4  {non-provider person participations} ) / PRT-5 : ( PRV-4 = (patient non-subject of care) ) / PRT-8?)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".role"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.participant.member"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.participant.onBehalfOf",
+                "path": "CareTeam.participant.onBehalfOf",
+                "short": "Organization of the practitioner",
+                "definition": "The organization of the practitioner.",
+                "requirements": "Practitioners can be associated with multiple organizations.  This element indicates which organization they were acting on behalf of.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CareTeam.participant.onBehalfOf",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "CareTeam.participant.period",
+                "path": "CareTeam.participant.period",
+                "short": "Time period of participant",
+                "definition": "Indicates when the specific member or organization did (or is intended to) come into effect and end.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CareTeam.participant.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "CareTeam.reasonCode",
+                "path": "CareTeam.reasonCode",
+                "short": "Why the care team exists",
+                "definition": "Describes why the care team exists.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CareTeam.reasonCode",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "CareTeamReason"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Indicates the reason for the care team.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.why[x]"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.reasonReference",
+                "path": "CareTeam.reasonReference",
+                "short": "Why the care team exists",
+                "definition": "Condition(s) that this care team addresses.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CareTeam.reasonReference",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Condition"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.why[x]"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.managingOrganization",
+                "path": "CareTeam.managingOrganization",
+                "short": "Organization responsible for the care team",
+                "definition": "The organization responsible for the care team.",
+                "requirements": "Allows for multiple organizations to collaboratively manage cross-organizational, longitudinal care plan.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CareTeam.managingOrganization",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "CareTeam.telecom",
+                "path": "CareTeam.telecom",
+                "short": "A contact detail for the care team (that applies to all members)",
+                "definition": "A central contact detail for the care team (that applies to all members).",
+                "comment": "The ContactPoint.use code of home is not appropriate to use. These contacts are not the contact details of individual care team members.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CareTeam.telecom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "ContactPoint"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "CareTeam.note",
+                "path": "CareTeam.note",
+                "short": "Comments made about the CareTeam",
+                "definition": "Comments made about the CareTeam.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CareTeam.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "CareTeam",
+                "path": "CareTeam",
+                "definition": "The US Core CareTeam Profile is based upon the core FHIR CareTeam Resource and created to meet the 2015 Edition Common Clinical Data Set 'Care team member(s)' requirements.",
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.status",
+                "path": "CareTeam.status",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "description": "Indicates whether the team is current , represents future intentions or is now a historical record.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/care-team-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.status"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.subject",
+                "path": "CareTeam.subject",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.subject"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.participant",
+                "path": "CareTeam.participant",
+                "min": 1,
+                "max": "*",
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.participant"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.participant.role",
+                "path": "CareTeam.participant.role",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Indicates specific responsibility of an individual within the care team, such as Primary physician, Team coordinator, Caregiver, etc.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-careteam-provider-roles|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.participant.role"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.participant.member",
+                "path": "CareTeam.participant.member",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.participant.member"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-condition.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-condition.json
@@ -1,2154 +1,2154 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-condition",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-condition-definitions.html#Condition\" title=\"The US Core Condition Profile is based upon the core FHIR Condition Resource and created to meet the 2015 Edition Common Clinical Data Set 'Problems' and 'Health Concerns' requirements.\">Condition</a><a name=\"Condition\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-1)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/condition.html\">Condition</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Detailed information about conditions, problems or diagnoses</span><br/><span style=\"font-weight:bold\">us-core-1: </span>A code in Condition.category SHOULD be from US Core Condition Category Codes value set.</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-condition-definitions.html#Condition.clinicalStatus\">clinicalStatus</a><a name=\"Condition.clinicalStatus\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">active | recurrence | relapse | inactive | remission | resolved</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-condition-clinical.html\">ConditionClinicalStatusCodes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-condition-definitions.html#Condition.verificationStatus\">verificationStatus</a><a name=\"Condition.verificationStatus\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">unconfirmed | provisional | differential | confirmed | refuted | entered-in-error</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-condition-ver-status.html\">ConditionVerificationStatus</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-condition-definitions.html#Condition.category\">category</a><a name=\"Condition.category\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-1)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">problem-list-item | encounter-diagnosis | health-concern<br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-condition-category.html\">US Core Condition Category Codes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)<br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-condition-definitions.html#Condition.code\">code</a><a name=\"Condition.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Identification of the condition, problem or diagnosis</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-condition-code.html\">US Core Condition Code</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck00.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-condition-definitions.html#Condition.subject\">subject</a><a name=\"Condition.subject\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who has the condition?</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition",
-	"version": "3.1.1",
-	"name": "USCoreCondition",
-	"title": "US Core Condition Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-06-27",
-	"publisher": "Health Level Seven International (Infrastructure and Messaging - Data Access Framework)",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.healthit.gov"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the Condition resource for the minimal set of data to query and retrieve problems and health concerns information.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "argonaut-dq-dstu2",
-			"uri": "http://unknown.org/Argonaut-DQ-DSTU2",
-			"name": "Argonaut-DQ-DSTU2"
-		},
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "sct-concept",
-			"uri": "http://snomed.info/conceptdomain",
-			"name": "SNOMED CT Concept Domain Binding"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "sct-attr",
-			"uri": "http://snomed.org/attributebinding",
-			"name": "SNOMED CT Attribute Binding"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Condition",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Condition",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Condition",
-				"path": "Condition",
-				"short": "Detailed information about conditions, problems or diagnoses",
-				"definition": "The US Core Condition Profile is based upon the core FHIR Condition Resource and created to meet the 2015 Edition Common Clinical Data Set 'Problems' and 'Health Concerns' requirements.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Condition",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "Most systems will expect a clinicalStatus to be valued for problem-list-items that are managed over time, but might not need a clinicalStatus for point in time encounter-diagnosis."
-							}
-						],
-						"key": "con-3",
-						"severity": "warning",
-						"human": "Condition.clinicalStatus SHALL be present if verificationStatus is not entered-in-error and category is problem-list-item",
-						"expression": "clinicalStatus.exists() or verificationStatus.coding.where(system='http://terminology.hl7.org/CodeSystem/condition-ver-status' and code = 'entered-in-error').exists() or category.select($this='problem-list-item').empty()",
-						"xpath": "exists(f:clinicalStatus) or exists(f:verificationStatus/f:coding/f:code/@value='entered-in-error') or not(exists(category[@value='problem-list-item']))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Condition"
-					},
-					{
-						"key": "con-4",
-						"severity": "error",
-						"human": "If condition is abated, then clinicalStatus must be either inactive, resolved, or remission",
-						"expression": "abatement.empty() or clinicalStatus.coding.where(system='http://terminology.hl7.org/CodeSystem/condition-clinical' and (code='resolved' or code='remission' or code='inactive')).exists()",
-						"xpath": "not(exists(*[starts-with(local-name(.), 'abatement')])) or exists(f:clinicalStatus/f:coding[f:system/@value='http://terminology.hl7.org/CodeSystem/condition-clinical' and f:code/@value=('resolved', 'remission', 'inactive')])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Condition"
-					},
-					{
-						"key": "con-5",
-						"severity": "error",
-						"human": "Condition.clinicalStatus SHALL NOT be present if verification Status is entered-in-error",
-						"expression": "verificationStatus.coding.where(system='http://terminology.hl7.org/CodeSystem/condition-ver-status' and code='entered-in-error').empty() or clinicalStatus.empty()",
-						"xpath": "not(exists(f:verificationStatus/f:coding[f:system/@value='http://terminology.hl7.org/CodeSystem/condition-ver-status' and f:code/@value='entered-in-error'])) or not(exists(f:clinicalStatus))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Condition"
-					},
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							}
-						],
-						"key": "us-core-1",
-						"severity": "warning",
-						"human": "A code in Condition.category SHOULD be from US Core Condition Category Codes value set.",
-						"expression": "where(category.memberOf('http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category|3.1.1')).exists()",
-						"xpath": "(no xpath equivalent)"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 243796009 |Situation with explicit context| : 246090004 |Associated finding| = ( ( < 404684003 |Clinical finding| MINUS ( << 420134006 |Propensity to adverse reactions| OR << 473010000 |Hypersensitivity condition| OR << 79899007 |Drug interaction| OR << 69449002 |Drug action| OR << 441742003 |Evaluation finding| OR << 307824009 |Administrative status| OR << 385356007 |Tumor stage finding|)) OR < 272379006 |Event|)"
-					},
-					{
-						"identity": "v2",
-						"map": "PPR message"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation[classCode=OBS, moodCode=EVN, code=ASSERTION, value<Diagnosis]"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Condition"
-					}
-				]
-			},
-			{
-				"id": "Condition.id",
-				"path": "Condition.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Condition.meta",
-				"path": "Condition.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Condition.implicitRules",
-				"path": "Condition.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Condition.language",
-				"path": "Condition.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Condition.text",
-				"path": "Condition.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Condition.contained",
-				"path": "Condition.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Condition.extension",
-				"path": "Condition.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Condition.modifierExtension",
-				"path": "Condition.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Condition.identifier",
-				"path": "Condition.identifier",
-				"short": "External Ids for this condition",
-				"definition": "Business identifiers assigned to this condition by the performer or other systems which remain constant as the resource is updated and propagates from server to server.",
-				"comment": "This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.",
-				"requirements": "Allows identification of the condition as it is known by various participating systems and in a way that remains consistent across servers.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Condition.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					}
-				]
-			},
-			{
-				"id": "Condition.clinicalStatus",
-				"path": "Condition.clinicalStatus",
-				"short": "active | recurrence | relapse | inactive | remission | resolved",
-				"definition": "The clinical status of the condition.",
-				"comment": "The data type is CodeableConcept because clinicalStatus has some clinical judgment involved, such that there might need to be more specificity than the required FHIR value set allows. For example, a SNOMED coding might allow for additional specificity.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Condition.clinicalStatus",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"con-3",
-					"con-4",
-					"con-5"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the status contains codes that mark the condition as no longer active.",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/condition-clinical"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 303105007 |Disease phases|"
-					},
-					{
-						"identity": "v2",
-						"map": "PRB-14"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation ACT\n.inboundRelationship[typeCode=COMP].source[classCode=OBS, code=\"clinicalStatus\", moodCode=EVN].value"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Condition.clinicalStatus"
-					}
-				]
-			},
-			{
-				"id": "Condition.verificationStatus",
-				"path": "Condition.verificationStatus",
-				"short": "unconfirmed | provisional | differential | confirmed | refuted | entered-in-error",
-				"definition": "The verification status to support the clinical status of the condition.",
-				"comment": "verificationStatus is not required.  For example, when a patient has abdominal pain in the ED, there is not likely going to be a verification status.\nThe data type is CodeableConcept because verificationStatus has some clinical judgment involved, such that there might need to be more specificity than the required FHIR value set allows. For example, a SNOMED coding might allow for additional specificity.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Condition.verificationStatus",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"con-3",
-					"con-5"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the status contains the code refuted and entered-in-error that mark the Condition as not currently valid.",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/condition-ver-status"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 410514004 |Finding context value|"
-					},
-					{
-						"identity": "v2",
-						"map": "PRB-13"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation ACT\n.inboundRelationship[typeCode=COMP].source[classCode=OBS, code=\"verificationStatus\", moodCode=EVN].value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "408729009"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Condition.verificationStatus"
-					}
-				]
-			},
-			{
-				"id": "Condition.category",
-				"path": "Condition.category",
-				"short": "problem-list-item | encounter-diagnosis | health-concern",
-				"definition": "A category assigned to the condition.",
-				"comment": "The categorization is often highly contextual and may appear poorly differentiated or not very useful in other contexts.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Condition.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"us-core-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 404684003 |Clinical finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "'problem' if from PRB-3. 'diagnosis' if from DG1 segment in PV1 message"
-					},
-					{
-						"identity": "rim",
-						"map": ".code"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Condition.category"
-					}
-				]
-			},
-			{
-				"id": "Condition.severity",
-				"path": "Condition.severity",
-				"short": "Subjective severity of condition",
-				"definition": "A subjective assessment of the severity of the condition as evaluated by the clinician.",
-				"comment": "Coding of the severity with a terminology is preferred, where possible.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Condition.severity",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ConditionSeverity"
-						}
-					],
-					"strength": "preferred",
-					"description": "A subjective assessment of the severity of the condition as evaluated by the clinician.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/condition-severity"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.grade"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 272141005 |Severities|"
-					},
-					{
-						"identity": "v2",
-						"map": "PRB-26 / ABS-3"
-					},
-					{
-						"identity": "rim",
-						"map": "Can be pre/post-coordinated into value.  Or ./inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"severity\"].value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "246112005"
-					}
-				]
-			},
-			{
-				"id": "Condition.code",
-				"path": "Condition.code",
-				"short": "Identification of the condition, problem or diagnosis",
-				"definition": "Identification of the condition, problem or diagnosis.",
-				"requirements": "0..1 to account for primarily narrative only resources.",
-				"alias": [
-					"type"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Condition.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Valueset to describe the actual problem experienced by the patient",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-code|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "code 246090004 |Associated finding| (< 404684003 |Clinical finding| MINUS\n<< 420134006 |Propensity to adverse reactions| MINUS \n<< 473010000 |Hypersensitivity condition| MINUS \n<< 79899007 |Drug interaction| MINUS\n<< 69449002 |Drug action| MINUS \n<< 441742003 |Evaluation finding| MINUS \n<< 307824009 |Administrative status| MINUS \n<< 385356007 |Tumor stage finding|) \nOR < 413350009 |Finding with explicit context|\nOR < 272379006 |Event|"
-					},
-					{
-						"identity": "v2",
-						"map": "PRB-3"
-					},
-					{
-						"identity": "rim",
-						"map": ".value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "246090004"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Condition.code"
-					}
-				]
-			},
-			{
-				"id": "Condition.bodySite",
-				"path": "Condition.bodySite",
-				"short": "Anatomical location, if relevant",
-				"definition": "The anatomical location where this condition manifests itself.",
-				"comment": "Only used if not implicit in code found in Condition.code. If the use case requires attributes from the BodySite resource (e.g. to identify and track separately) then use the standard extension [bodySite](http://hl7.org/fhir/R4/extension-bodysite.html).  May be a summary code, or a reference to a very precise definition of the location, or both.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Condition.bodySite",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "BodySite"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing anatomical locations. May include laterality.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/body-site"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 442083009  |Anatomical or acquired body structure|"
-					},
-					{
-						"identity": "rim",
-						"map": ".targetBodySiteCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363698007"
-					}
-				]
-			},
-			{
-				"id": "Condition.subject",
-				"path": "Condition.subject",
-				"short": "Who has the condition?",
-				"definition": "Indicates the patient or group who the condition record is associated with.",
-				"requirements": "Group is typically used for veterinary or public health use cases.",
-				"alias": [
-					"patient"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Condition.subject",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=SBJ].role[classCode=PAT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Condition.patient"
-					}
-				]
-			},
-			{
-				"id": "Condition.encounter",
-				"path": "Condition.encounter",
-				"short": "Encounter created as part of",
-				"definition": "The Encounter during which this Condition was created or to which the creation of this record is tightly associated.",
-				"comment": "This will typically be the encounter the event occurred within, but some activities may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter. This record indicates the encounter this particular record is associated with.  In the case of a \"new\" diagnosis reflecting ongoing/revised information about the condition, this might be distinct from the first encounter in which the underlying condition was first \"known\".",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Condition.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1-19 (+PV1-54)"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Condition.onset[x]",
-				"path": "Condition.onset[x]",
-				"short": "Estimated or actual date,  date-time, or age",
-				"definition": "Estimated or actual date or date-time  the condition began, in the opinion of the clinician.",
-				"comment": "Age is generally used when the patient reports an age at which the Condition began to occur.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Condition.onset[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Age"
-					},
-					{
-						"code": "Period"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.init"
-					},
-					{
-						"identity": "v2",
-						"map": "PRB-16"
-					},
-					{
-						"identity": "rim",
-						"map": ".effectiveTime.low or .inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"age at onset\"].value"
-					}
-				]
-			},
-			{
-				"id": "Condition.abatement[x]",
-				"path": "Condition.abatement[x]",
-				"short": "When in resolution/remission",
-				"definition": "The date or estimated date that the condition resolved or went into remission. This is called \"abatement\" because of the many overloaded connotations associated with \"remission\" or \"resolution\" - Conditions are never really resolved, but they can abate.",
-				"comment": "There is no explicit distinction between resolution and remission because in many cases the distinction is not clear. Age is generally used when the patient reports an age at which the Condition abated.  If there is no abatement element, it is unknown whether the condition has resolved or entered remission; applications and users should generally assume that the condition is still valid.  When abatementString exists, it implies the condition is abated.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Condition.abatement[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Age"
-					},
-					{
-						"code": "Period"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "string"
-					}
-				],
-				"condition": [
-					"con-4"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".effectiveTime.high or .inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"age at remission\"].value or .inboundRelationship[typeCode=SUBJ]source[classCode=CONC, moodCode=EVN].status=completed"
-					}
-				]
-			},
-			{
-				"id": "Condition.recordedDate",
-				"path": "Condition.recordedDate",
-				"short": "Date record was first recorded",
-				"definition": "The recordedDate represents when this particular Condition record was created in the system, which is often a system-generated date.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Condition.recordedDate",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "v2",
-						"map": "REL-11"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=AUT].time"
-					}
-				]
-			},
-			{
-				"id": "Condition.recorder",
-				"path": "Condition.recorder",
-				"short": "Who recorded the condition",
-				"definition": "Individual who recorded the record and takes responsibility for its content.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Condition.recorder",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.author"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=AUT].role"
-					}
-				]
-			},
-			{
-				"id": "Condition.asserter",
-				"path": "Condition.asserter",
-				"short": "Person who asserts this condition",
-				"definition": "Individual who is making the condition statement.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Condition.asserter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.source"
-					},
-					{
-						"identity": "v2",
-						"map": "REL-7.1 identifier + REL-7.12 type code"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=INF].role"
-					}
-				]
-			},
-			{
-				"id": "Condition.stage",
-				"path": "Condition.stage",
-				"short": "Stage/grade, usually assessed formally",
-				"definition": "Clinical stage or grade of a condition. May include formal severity assessments.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Condition.stage",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "con-1",
-						"severity": "error",
-						"human": "Stage SHALL have summary or assessment",
-						"expression": "summary.exists() or assessment.exists()",
-						"xpath": "exists(f:summary) or exists(f:assessment)"
-					},
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "./inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"stage/grade\"]"
-					}
-				]
-			},
-			{
-				"id": "Condition.stage.id",
-				"path": "Condition.stage.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Condition.stage.extension",
-				"path": "Condition.stage.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Condition.stage.modifierExtension",
-				"path": "Condition.stage.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Condition.stage.summary",
-				"path": "Condition.stage.summary",
-				"short": "Simple summary (disease specific)",
-				"definition": "A simple summary of the stage such as \"Stage 3\". The determination of the stage is disease-specific.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Condition.stage.summary",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"con-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ConditionStage"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing condition stages (e.g. Cancer stages).",
-					"valueSet": "http://hl7.org/fhir/ValueSet/condition-stage"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 254291000 |Staging and scales|"
-					},
-					{
-						"identity": "v2",
-						"map": "PRB-14"
-					},
-					{
-						"identity": "rim",
-						"map": ".value"
-					}
-				]
-			},
-			{
-				"id": "Condition.stage.assessment",
-				"path": "Condition.stage.assessment",
-				"short": "Formal record of assessment",
-				"definition": "Reference to a formal record of the evidence on which the staging assessment is based.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Condition.stage.assessment",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/ClinicalImpression",
-							"http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
-							"http://hl7.org/fhir/StructureDefinition/Observation"
-						]
-					}
-				],
-				"condition": [
-					"con-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".self"
-					}
-				]
-			},
-			{
-				"id": "Condition.stage.type",
-				"path": "Condition.stage.type",
-				"short": "Kind of staging",
-				"definition": "The kind of staging, such as pathological or clinical staging.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Condition.stage.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ConditionStageType"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing the kind of condition staging (e.g. clinical or pathological).",
-					"valueSet": "http://hl7.org/fhir/ValueSet/condition-stage-type"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "./inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"stage type\"]"
-					}
-				]
-			},
-			{
-				"id": "Condition.evidence",
-				"path": "Condition.evidence",
-				"short": "Supporting evidence",
-				"definition": "Supporting evidence / manifestations that are the basis of the Condition's verification status, such as evidence that confirmed or refuted the condition.",
-				"comment": "The evidence may be a simple list of coded symptoms/manifestations, or references to observations or formal assessments, or both.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Condition.evidence",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "con-2",
-						"severity": "error",
-						"human": "evidence SHALL have code or details",
-						"expression": "code.exists() or detail.exists()",
-						"xpath": "exists(f:code) or exists(f:detail)"
-					},
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=SPRT].target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Condition.evidence.id",
-				"path": "Condition.evidence.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Condition.evidence.extension",
-				"path": "Condition.evidence.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Condition.evidence.modifierExtension",
-				"path": "Condition.evidence.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Condition.evidence.code",
-				"path": "Condition.evidence.code",
-				"short": "Manifestation/symptom",
-				"definition": "A manifestation or symptom that led to the recording of this condition.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Condition.evidence.code",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"con-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ManifestationOrSymptom"
-						}
-					],
-					"strength": "example",
-					"description": "Codes that describe the manifestation or symptoms of a condition.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/manifestation-or-symptom"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.reasonCode"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.why[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 404684003 |Clinical finding|"
-					},
-					{
-						"identity": "rim",
-						"map": "[code=\"diagnosis\"].value"
-					}
-				]
-			},
-			{
-				"id": "Condition.evidence.detail",
-				"path": "Condition.evidence.detail",
-				"short": "Supporting information found elsewhere",
-				"definition": "Links to other relevant information, including pathology reports.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Condition.evidence.detail",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"condition": [
-					"con-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.why[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".self"
-					}
-				]
-			},
-			{
-				"id": "Condition.note",
-				"path": "Condition.note",
-				"short": "Additional information about the Condition",
-				"definition": "Additional information about the Condition. This is a general notes/comments entry  for description of the Condition, its diagnosis and prognosis.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Condition.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.note"
-					},
-					{
-						"identity": "v2",
-						"map": "NTE child of PRB"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"annotation\"].value"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Condition",
-				"path": "Condition",
-				"definition": "The US Core Condition Profile is based upon the core FHIR Condition Resource and created to meet the 2015 Edition Common Clinical Data Set 'Problems' and 'Health Concerns' requirements.",
-				"constraint": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							}
-						],
-						"key": "us-core-1",
-						"severity": "warning",
-						"human": "A code in Condition.category SHOULD be from US Core Condition Category Codes value set.",
-						"expression": "where(category.memberOf('http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category|3.1.1')).exists()",
-						"xpath": "(no xpath equivalent)"
-					}
-				],
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Condition"
-					}
-				]
-			},
-			{
-				"id": "Condition.clinicalStatus",
-				"path": "Condition.clinicalStatus",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/condition-clinical"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Condition.clinicalStatus"
-					}
-				]
-			},
-			{
-				"id": "Condition.verificationStatus",
-				"path": "Condition.verificationStatus",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/condition-ver-status"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Condition.verificationStatus"
-					}
-				]
-			},
-			{
-				"id": "Condition.category",
-				"path": "Condition.category",
-				"short": "problem-list-item | encounter-diagnosis | health-concern",
-				"min": 1,
-				"max": "*",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"us-core-1"
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Condition.category"
-					}
-				]
-			},
-			{
-				"id": "Condition.code",
-				"path": "Condition.code",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Valueset to describe the actual problem experienced by the patient",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-code|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Condition.code"
-					}
-				]
-			},
-			{
-				"id": "Condition.subject",
-				"path": "Condition.subject",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Condition.patient"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-condition",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition",
+    "version": "3.1.1",
+    "name": "USCoreCondition",
+    "title": "US Core Condition Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-06-27",
+    "publisher": "Health Level Seven International (Infrastructure and Messaging - Data Access Framework)",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.healthit.gov"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the Condition resource for the minimal set of data to query and retrieve problems and health concerns information.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "argonaut-dq-dstu2",
+            "uri": "http://unknown.org/Argonaut-DQ-DSTU2",
+            "name": "Argonaut-DQ-DSTU2"
+        },
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "sct-concept",
+            "uri": "http://snomed.info/conceptdomain",
+            "name": "SNOMED CT Concept Domain Binding"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "sct-attr",
+            "uri": "http://snomed.org/attributebinding",
+            "name": "SNOMED CT Attribute Binding"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Condition",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Condition",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Condition",
+                "path": "Condition",
+                "short": "Detailed information about conditions, problems or diagnoses",
+                "definition": "The US Core Condition Profile is based upon the core FHIR Condition Resource and created to meet the 2015 Edition Common Clinical Data Set 'Problems' and 'Health Concerns' requirements.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Condition",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "Most systems will expect a clinicalStatus to be valued for problem-list-items that are managed over time, but might not need a clinicalStatus for point in time encounter-diagnosis."
+                            }
+                        ],
+                        "key": "con-3",
+                        "severity": "warning",
+                        "human": "Condition.clinicalStatus SHALL be present if verificationStatus is not entered-in-error and category is problem-list-item",
+                        "expression": "clinicalStatus.exists() or verificationStatus.coding.where(system='http://terminology.hl7.org/CodeSystem/condition-ver-status' and code = 'entered-in-error').exists() or category.select($this='problem-list-item').empty()",
+                        "xpath": "exists(f:clinicalStatus) or exists(f:verificationStatus/f:coding/f:code/@value='entered-in-error') or not(exists(category[@value='problem-list-item']))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Condition"
+                    },
+                    {
+                        "key": "con-4",
+                        "severity": "error",
+                        "human": "If condition is abated, then clinicalStatus must be either inactive, resolved, or remission",
+                        "expression": "abatement.empty() or clinicalStatus.coding.where(system='http://terminology.hl7.org/CodeSystem/condition-clinical' and (code='resolved' or code='remission' or code='inactive')).exists()",
+                        "xpath": "not(exists(*[starts-with(local-name(.), 'abatement')])) or exists(f:clinicalStatus/f:coding[f:system/@value='http://terminology.hl7.org/CodeSystem/condition-clinical' and f:code/@value=('resolved', 'remission', 'inactive')])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Condition"
+                    },
+                    {
+                        "key": "con-5",
+                        "severity": "error",
+                        "human": "Condition.clinicalStatus SHALL NOT be present if verification Status is entered-in-error",
+                        "expression": "verificationStatus.coding.where(system='http://terminology.hl7.org/CodeSystem/condition-ver-status' and code='entered-in-error').empty() or clinicalStatus.empty()",
+                        "xpath": "not(exists(f:verificationStatus/f:coding[f:system/@value='http://terminology.hl7.org/CodeSystem/condition-ver-status' and f:code/@value='entered-in-error'])) or not(exists(f:clinicalStatus))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Condition"
+                    },
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "key": "us-core-1",
+                        "severity": "warning",
+                        "human": "A code in Condition.category SHOULD be from US Core Condition Category Codes value set.",
+                        "expression": "where(category.memberOf('http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category|3.1.1')).exists()",
+                        "xpath": "(no xpath equivalent)"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 243796009 |Situation with explicit context| : 246090004 |Associated finding| = ( ( < 404684003 |Clinical finding| MINUS ( << 420134006 |Propensity to adverse reactions| OR << 473010000 |Hypersensitivity condition| OR << 79899007 |Drug interaction| OR << 69449002 |Drug action| OR << 441742003 |Evaluation finding| OR << 307824009 |Administrative status| OR << 385356007 |Tumor stage finding|)) OR < 272379006 |Event|)"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PPR message"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation[classCode=OBS, moodCode=EVN, code=ASSERTION, value<Diagnosis]"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Condition"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.id",
+                "path": "Condition.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Condition.meta",
+                "path": "Condition.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Condition.implicitRules",
+                "path": "Condition.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Condition.language",
+                "path": "Condition.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Condition.text",
+                "path": "Condition.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.contained",
+                "path": "Condition.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.extension",
+                "path": "Condition.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.modifierExtension",
+                "path": "Condition.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.identifier",
+                "path": "Condition.identifier",
+                "short": "External Ids for this condition",
+                "definition": "Business identifiers assigned to this condition by the performer or other systems which remain constant as the resource is updated and propagates from server to server.",
+                "comment": "This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.",
+                "requirements": "Allows identification of the condition as it is known by various participating systems and in a way that remains consistent across servers.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Condition.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.clinicalStatus",
+                "path": "Condition.clinicalStatus",
+                "short": "active | recurrence | relapse | inactive | remission | resolved",
+                "definition": "The clinical status of the condition.",
+                "comment": "The data type is CodeableConcept because clinicalStatus has some clinical judgment involved, such that there might need to be more specificity than the required FHIR value set allows. For example, a SNOMED coding might allow for additional specificity.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Condition.clinicalStatus",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "con-3",
+                    "con-4",
+                    "con-5"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the status contains codes that mark the condition as no longer active.",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/condition-clinical"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 303105007 |Disease phases|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRB-14"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation ACT\n.inboundRelationship[typeCode=COMP].source[classCode=OBS, code=\"clinicalStatus\", moodCode=EVN].value"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Condition.clinicalStatus"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.verificationStatus",
+                "path": "Condition.verificationStatus",
+                "short": "unconfirmed | provisional | differential | confirmed | refuted | entered-in-error",
+                "definition": "The verification status to support the clinical status of the condition.",
+                "comment": "verificationStatus is not required.  For example, when a patient has abdominal pain in the ED, there is not likely going to be a verification status.\nThe data type is CodeableConcept because verificationStatus has some clinical judgment involved, such that there might need to be more specificity than the required FHIR value set allows. For example, a SNOMED coding might allow for additional specificity.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Condition.verificationStatus",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "con-3",
+                    "con-5"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the status contains the code refuted and entered-in-error that mark the Condition as not currently valid.",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/condition-ver-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 410514004 |Finding context value|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRB-13"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation ACT\n.inboundRelationship[typeCode=COMP].source[classCode=OBS, code=\"verificationStatus\", moodCode=EVN].value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "408729009"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Condition.verificationStatus"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.category",
+                "path": "Condition.category",
+                "short": "problem-list-item | encounter-diagnosis | health-concern",
+                "definition": "A category assigned to the condition.",
+                "comment": "The categorization is often highly contextual and may appear poorly differentiated or not very useful in other contexts.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Condition.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "us-core-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 404684003 |Clinical finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "'problem' if from PRB-3. 'diagnosis' if from DG1 segment in PV1 message"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".code"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Condition.category"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.severity",
+                "path": "Condition.severity",
+                "short": "Subjective severity of condition",
+                "definition": "A subjective assessment of the severity of the condition as evaluated by the clinician.",
+                "comment": "Coding of the severity with a terminology is preferred, where possible.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Condition.severity",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ConditionSeverity"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A subjective assessment of the severity of the condition as evaluated by the clinician.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/condition-severity"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.grade"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 272141005 |Severities|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRB-26 / ABS-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Can be pre/post-coordinated into value.  Or ./inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"severity\"].value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "246112005"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.code",
+                "path": "Condition.code",
+                "short": "Identification of the condition, problem or diagnosis",
+                "definition": "Identification of the condition, problem or diagnosis.",
+                "requirements": "0..1 to account for primarily narrative only resources.",
+                "alias": [
+                    "type"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Condition.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Valueset to describe the actual problem experienced by the patient",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-code|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "code 246090004 |Associated finding| (< 404684003 |Clinical finding| MINUS\n<< 420134006 |Propensity to adverse reactions| MINUS \n<< 473010000 |Hypersensitivity condition| MINUS \n<< 79899007 |Drug interaction| MINUS\n<< 69449002 |Drug action| MINUS \n<< 441742003 |Evaluation finding| MINUS \n<< 307824009 |Administrative status| MINUS \n<< 385356007 |Tumor stage finding|) \nOR < 413350009 |Finding with explicit context|\nOR < 272379006 |Event|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRB-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "246090004"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Condition.code"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.bodySite",
+                "path": "Condition.bodySite",
+                "short": "Anatomical location, if relevant",
+                "definition": "The anatomical location where this condition manifests itself.",
+                "comment": "Only used if not implicit in code found in Condition.code. If the use case requires attributes from the BodySite resource (e.g. to identify and track separately) then use the standard extension [bodySite](http://hl7.org/fhir/R4/extension-bodysite.html).  May be a summary code, or a reference to a very precise definition of the location, or both.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Condition.bodySite",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "BodySite"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing anatomical locations. May include laterality.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/body-site"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 442083009  |Anatomical or acquired body structure|"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".targetBodySiteCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363698007"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.subject",
+                "path": "Condition.subject",
+                "short": "Who has the condition?",
+                "definition": "Indicates the patient or group who the condition record is associated with.",
+                "requirements": "Group is typically used for veterinary or public health use cases.",
+                "alias": [
+                    "patient"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Condition.subject",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=SBJ].role[classCode=PAT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Condition.patient"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.encounter",
+                "path": "Condition.encounter",
+                "short": "Encounter created as part of",
+                "definition": "The Encounter during which this Condition was created or to which the creation of this record is tightly associated.",
+                "comment": "This will typically be the encounter the event occurred within, but some activities may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter. This record indicates the encounter this particular record is associated with.  In the case of a \"new\" diagnosis reflecting ongoing/revised information about the condition, this might be distinct from the first encounter in which the underlying condition was first \"known\".",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Condition.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1-19 (+PV1-54)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.onset[x]",
+                "path": "Condition.onset[x]",
+                "short": "Estimated or actual date,  date-time, or age",
+                "definition": "Estimated or actual date or date-time  the condition began, in the opinion of the clinician.",
+                "comment": "Age is generally used when the patient reports an age at which the Condition began to occur.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Condition.onset[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Age"
+                    },
+                    {
+                        "code": "Period"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.init"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRB-16"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime.low or .inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"age at onset\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.abatement[x]",
+                "path": "Condition.abatement[x]",
+                "short": "When in resolution/remission",
+                "definition": "The date or estimated date that the condition resolved or went into remission. This is called \"abatement\" because of the many overloaded connotations associated with \"remission\" or \"resolution\" - Conditions are never really resolved, but they can abate.",
+                "comment": "There is no explicit distinction between resolution and remission because in many cases the distinction is not clear. Age is generally used when the patient reports an age at which the Condition abated.  If there is no abatement element, it is unknown whether the condition has resolved or entered remission; applications and users should generally assume that the condition is still valid.  When abatementString exists, it implies the condition is abated.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Condition.abatement[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Age"
+                    },
+                    {
+                        "code": "Period"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "string"
+                    }
+                ],
+                "condition": [
+                    "con-4"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime.high or .inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"age at remission\"].value or .inboundRelationship[typeCode=SUBJ]source[classCode=CONC, moodCode=EVN].status=completed"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.recordedDate",
+                "path": "Condition.recordedDate",
+                "short": "Date record was first recorded",
+                "definition": "The recordedDate represents when this particular Condition record was created in the system, which is often a system-generated date.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Condition.recordedDate",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "REL-11"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.recorder",
+                "path": "Condition.recorder",
+                "short": "Who recorded the condition",
+                "definition": "Individual who recorded the record and takes responsibility for its content.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Condition.recorder",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.author"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=AUT].role"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.asserter",
+                "path": "Condition.asserter",
+                "short": "Person who asserts this condition",
+                "definition": "Individual who is making the condition statement.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Condition.asserter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.source"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "REL-7.1 identifier + REL-7.12 type code"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=INF].role"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.stage",
+                "path": "Condition.stage",
+                "short": "Stage/grade, usually assessed formally",
+                "definition": "Clinical stage or grade of a condition. May include formal severity assessments.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Condition.stage",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "con-1",
+                        "severity": "error",
+                        "human": "Stage SHALL have summary or assessment",
+                        "expression": "summary.exists() or assessment.exists()",
+                        "xpath": "exists(f:summary) or exists(f:assessment)"
+                    },
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "./inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"stage/grade\"]"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.stage.id",
+                "path": "Condition.stage.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.stage.extension",
+                "path": "Condition.stage.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.stage.modifierExtension",
+                "path": "Condition.stage.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.stage.summary",
+                "path": "Condition.stage.summary",
+                "short": "Simple summary (disease specific)",
+                "definition": "A simple summary of the stage such as \"Stage 3\". The determination of the stage is disease-specific.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Condition.stage.summary",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "con-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ConditionStage"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing condition stages (e.g. Cancer stages).",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/condition-stage"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 254291000 |Staging and scales|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRB-14"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".value"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.stage.assessment",
+                "path": "Condition.stage.assessment",
+                "short": "Formal record of assessment",
+                "definition": "Reference to a formal record of the evidence on which the staging assessment is based.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Condition.stage.assessment",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/ClinicalImpression",
+                            "http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
+                            "http://hl7.org/fhir/StructureDefinition/Observation"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "con-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".self"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.stage.type",
+                "path": "Condition.stage.type",
+                "short": "Kind of staging",
+                "definition": "The kind of staging, such as pathological or clinical staging.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Condition.stage.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ConditionStageType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing the kind of condition staging (e.g. clinical or pathological).",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/condition-stage-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "./inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"stage type\"]"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.evidence",
+                "path": "Condition.evidence",
+                "short": "Supporting evidence",
+                "definition": "Supporting evidence / manifestations that are the basis of the Condition's verification status, such as evidence that confirmed or refuted the condition.",
+                "comment": "The evidence may be a simple list of coded symptoms/manifestations, or references to observations or formal assessments, or both.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Condition.evidence",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "con-2",
+                        "severity": "error",
+                        "human": "evidence SHALL have code or details",
+                        "expression": "code.exists() or detail.exists()",
+                        "xpath": "exists(f:code) or exists(f:detail)"
+                    },
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=SPRT].target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.evidence.id",
+                "path": "Condition.evidence.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.evidence.extension",
+                "path": "Condition.evidence.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.evidence.modifierExtension",
+                "path": "Condition.evidence.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.evidence.code",
+                "path": "Condition.evidence.code",
+                "short": "Manifestation/symptom",
+                "definition": "A manifestation or symptom that led to the recording of this condition.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Condition.evidence.code",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "con-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ManifestationOrSymptom"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes that describe the manifestation or symptoms of a condition.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/manifestation-or-symptom"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.reasonCode"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.why[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 404684003 |Clinical finding|"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "[code=\"diagnosis\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.evidence.detail",
+                "path": "Condition.evidence.detail",
+                "short": "Supporting information found elsewhere",
+                "definition": "Links to other relevant information, including pathology reports.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Condition.evidence.detail",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "con-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.why[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".self"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.note",
+                "path": "Condition.note",
+                "short": "Additional information about the Condition",
+                "definition": "Additional information about the Condition. This is a general notes/comments entry  for description of the Condition, its diagnosis and prognosis.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Condition.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.note"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "NTE child of PRB"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"annotation\"].value"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Condition",
+                "path": "Condition",
+                "definition": "The US Core Condition Profile is based upon the core FHIR Condition Resource and created to meet the 2015 Edition Common Clinical Data Set 'Problems' and 'Health Concerns' requirements.",
+                "constraint": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "key": "us-core-1",
+                        "severity": "warning",
+                        "human": "A code in Condition.category SHOULD be from US Core Condition Category Codes value set.",
+                        "expression": "where(category.memberOf('http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category|3.1.1')).exists()",
+                        "xpath": "(no xpath equivalent)"
+                    }
+                ],
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Condition"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.clinicalStatus",
+                "path": "Condition.clinicalStatus",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/condition-clinical"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Condition.clinicalStatus"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.verificationStatus",
+                "path": "Condition.verificationStatus",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/condition-ver-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Condition.verificationStatus"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.category",
+                "path": "Condition.category",
+                "short": "problem-list-item | encounter-diagnosis | health-concern",
+                "min": 1,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "us-core-1"
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Condition.category"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.code",
+                "path": "Condition.code",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Valueset to describe the actual problem experienced by the patient",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-code|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Condition.code"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.subject",
+                "path": "Condition.subject",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Condition.patient"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-diagnosticreport-lab.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-diagnosticreport-lab.json
@@ -1,1915 +1,1915 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-diagnosticreport-lab",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-lab-definitions.html#DiagnosticReport\" title=\"The US Core Diagnostic Report Profile is based upon the core FHIR DiagnosticReport Resource and created to meet the 2015 Edition Common Clinical Data Set 'Laboratory test(s) and Laboratory value(s)/result(s)' requirements.\">DiagnosticReport</a><a name=\"DiagnosticReport\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/diagnosticreport.html\">DiagnosticReport</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">A Diagnostic report - a combination of request information, atomic results, images, interpretation, as well as formatted reports</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-lab-definitions.html#DiagnosticReport.status\">status</a><a name=\"DiagnosticReport.status\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">registered | partial | preliminary | final +</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-diagnostic-report-status.html\">DiagnosticReportStatus</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck13.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Slice Definition\" class=\"hierarchy\"/> <a style=\"font-style: italic\" href=\"StructureDefinition-us-core-diagnosticreport-lab-definitions.html#DiagnosticReport.category\">category</a><a name=\"DiagnosticReport.category\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red; font-style: italic\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"font-style: italic\"/><span style=\"font-style: italic\">1</span><span style=\"font-style: italic\">..</span><span style=\"font-style: italic\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"font-style: italic\" href=\"http://hl7.org/fhir/R4/profiling.html#slicing\">(Slice Definition)</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5; font-style: italic\">Service category</span><br style=\"font-style: italic\"/><span style=\"font-weight:bold; font-style: italic\">Slice: </span><span style=\"font-style: italic\">Unordered, Open by pattern:$this</span><br style=\"font-style: italic\"/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck125.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-lab-definitions.html#DiagnosticReport.category:LaboratorySlice\" title=\"Slice LaboratorySlice\">category:LaboratorySlice</a><a name=\"DiagnosticReport.category\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Service category</span><br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1241.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#CodeableConcept.coding\">coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Code defined by a terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">(complex)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck12410.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"https://terminology.hl7.org/1.0.0//CodeSystem-v2-0074.html\">http://terminology.hl7.org/CodeSystem/v2-0074</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck12400.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">LAB</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-lab-definitions.html#DiagnosticReport.code\" title=\"The test, panel or battery that was ordered.\">code</a><a name=\"DiagnosticReport.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">US Core Laboratory Report Order Code<br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-diagnosticreport-lab-codes.html\">US Core Diagnostic Report Laboratory Codes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-lab-definitions.html#DiagnosticReport.subject\">subject</a><a name=\"DiagnosticReport.subject\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The subject of the report - usually, but not always, the patient</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_choice.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Choice of Types\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-lab-definitions.html#DiagnosticReport.effective[x]\" title=\"This is the Specimen Collection Datetime or Period which is the physically relevent dateTime for laboratory tests.\">effective[x]</a><a name=\"DiagnosticReport.effective_x_\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Specimen Collection Datetime or Period</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for dateTime Type: A date, date-time or partial date (e.g. just year or year + month).  If hours and minutes are specified, a time zone SHALL be populated. The format is a union of the schema types gYear, gYearMonth, date and dateTime. Seconds must be provided due to schema type constraints but may be zero-filled and may be ignored.                 Dates SHALL be valid dates.\">effectiveDateTime</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#dateTime\">dateTime</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for Period Type: A time period defined by a start and end date and optionally time.\">effectivePeriod</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Period\">Period</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-lab-definitions.html#DiagnosticReport.issued\">issued</a><a name=\"DiagnosticReport.issued\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#instant\">instant</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">DateTime this version was made</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-lab-definitions.html#DiagnosticReport.performer\">performer</a><a name=\"DiagnosticReport.performer\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-practitioner.html\">US Core Practitioner Profile</a> | <a href=\"StructureDefinition-us-core-organization.html\">US Core Organization Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Responsible Diagnostic Service</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck00.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-lab-definitions.html#DiagnosticReport.result\">result</a><a name=\"DiagnosticReport.result\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-observation-lab.html\">US Core Laboratory Result Observation Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Observations</span><br/></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab",
-	"version": "3.1.1",
-	"name": "USCoreDiagnosticReportProfileLaboratoryReporting",
-	"title": "US Core DiagnosticReport Profile for Laboratory Results Reporting",
-	"status": "active",
-	"experimental": false,
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.healthit.gov"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the DiagnosticReport resource  for the minimal set of data to query and retrieve diagnostic reports associated with laboratory results for a patient",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "DiagnosticReport",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "DiagnosticReport",
-				"path": "DiagnosticReport",
-				"short": "A Diagnostic report - a combination of request information, atomic results, images, interpretation, as well as formatted reports",
-				"definition": "The US Core Diagnostic Report Profile is based upon the core FHIR DiagnosticReport Resource and created to meet the 2015 Edition Common Clinical Data Set 'Laboratory test(s) and Laboratory value(s)/result(s)' requirements.",
-				"comment": "This is intended to capture a single report and is not suitable for use in displaying summary information that covers multiple reports.  For example, this resource has not been designed for laboratory cumulative reporting formats nor detailed structured reports for sequencing.",
-				"alias": [
-					"Report",
-					"Test",
-					"Result",
-					"Results",
-					"Labs",
-					"Laboratory",
-					"Lab Result",
-					"Lab Report"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "v2",
-						"map": "ORU -> OBR"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.id",
-				"path": "DiagnosticReport.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "DiagnosticReport.meta",
-				"path": "DiagnosticReport.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "DiagnosticReport.implicitRules",
-				"path": "DiagnosticReport.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "DiagnosticReport.language",
-				"path": "DiagnosticReport.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "DiagnosticReport.text",
-				"path": "DiagnosticReport.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.contained",
-				"path": "DiagnosticReport.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.extension",
-				"path": "DiagnosticReport.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.modifierExtension",
-				"path": "DiagnosticReport.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.identifier",
-				"path": "DiagnosticReport.identifier",
-				"short": "Business identifier for report",
-				"definition": "Identifiers assigned to this report by the performer or other systems.",
-				"comment": "Usually assigned by the Information System of the diagnostic service provider (filler id).",
-				"requirements": "Need to know what identifier to use when making queries about this report from the source laboratory, and for linking to the report outside FHIR context.",
-				"alias": [
-					"ReportID",
-					"Filler ID",
-					"Placer ID"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-51/ for globally unique filler ID  - OBR-3 , For non-globally unique filler-id the flller/placer number must be combined with the universal service Id -  OBR-2(if present)+OBR-3+OBR-4"
-					},
-					{
-						"identity": "rim",
-						"map": "id"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.basedOn",
-				"path": "DiagnosticReport.basedOn",
-				"short": "What was requested",
-				"definition": "Details concerning a service requested.",
-				"comment": "Note: Usually there is one test request for each result, however in some circumstances multiple test requests may be represented using a single test result resource. Note that there are also cases where one request leads to multiple reports.",
-				"requirements": "This allows tracing of authorization for the report and tracking whether proposals/recommendations were acted upon.",
-				"alias": [
-					"Request"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan",
-							"http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
-							"http://hl7.org/fhir/StructureDefinition/MedicationRequest",
-							"http://hl7.org/fhir/StructureDefinition/NutritionOrder",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.basedOn"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC? OBR-2/3?"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=FLFS].target"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.status",
-				"path": "DiagnosticReport.status",
-				"short": "registered | partial | preliminary | final +",
-				"definition": "The status of the diagnostic report.",
-				"requirements": "Diagnostic services routinely issue provisional/incomplete reports, and sometimes withdraw previously released reports.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/diagnostic-report-status"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-25 (not 1:1 mapping)"
-					},
-					{
-						"identity": "rim",
-						"map": "statusCode  Note: final and amended are distinguished by whether observation is the subject of a ControlAct event of type \"revise\""
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.category",
-				"path": "DiagnosticReport.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "$this"
-						}
-					],
-					"rules": "open"
-				},
-				"short": "Service category",
-				"definition": "A code that classifies the clinical discipline, department or diagnostic service that created the report (e.g. cardiology, biochemistry, hematology, MRI). This is used for searching, sorting and display purposes.",
-				"comment": "Multiple categories are allowed using various categorization schemes.   The level of granularity is defined by the category concepts in the value set. More fine-grained filtering can be performed using the metadata and/or terminology hierarchy in DiagnosticReport.code.",
-				"alias": [
-					"Department",
-					"Sub-department",
-					"Service",
-					"Discipline"
-				],
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "DiagnosticServiceSection"
-						}
-					],
-					"strength": "example",
-					"description": "Codes for diagnostic service sections.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/diagnostic-service-sections"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-24"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=COMP].source[classCode=LIST, moodCode=EVN, code < LabService].code"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.category:LaboratorySlice",
-				"path": "DiagnosticReport.category",
-				"sliceName": "LaboratorySlice",
-				"short": "Service category",
-				"definition": "A code that classifies the clinical discipline, department or diagnostic service that created the report (e.g. cardiology, biochemistry, hematology, MRI). This is used for searching, sorting and display purposes.",
-				"comment": "Multiple categories are allowed using various categorization schemes.   The level of granularity is defined by the category concepts in the value set. More fine-grained filtering can be performed using the metadata and/or terminology hierarchy in DiagnosticReport.code.",
-				"alias": [
-					"Department",
-					"Sub-department",
-					"Service",
-					"Discipline"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://terminology.hl7.org/CodeSystem/v2-0074",
-							"code": "LAB"
-						}
-					]
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "DiagnosticServiceSection"
-						}
-					],
-					"strength": "example",
-					"description": "Codes for diagnostic service sections.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/diagnostic-service-sections"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-24"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=COMP].source[classCode=LIST, moodCode=EVN, code < LabService].code"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.code",
-				"path": "DiagnosticReport.code",
-				"short": "US Core Laboratory Report Order Code",
-				"definition": "The test, panel or battery that was ordered.",
-				"comment": "UsageNote= The typical patterns for codes are:  1)  a LOINC code either as a  translation from a \"local\" code or as a primary code, or 2)  a local code only if no suitable LOINC exists,  or 3)  both the local and the LOINC translation.   Systems SHALL be capable of sending the local code if one exists.",
-				"alias": [
-					"Type"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "LOINC codes",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-lab-codes|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-4 (HL7 v2 doesn't provide an easy way to indicate both the ordered test and the performed panel)"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.subject",
-				"path": "DiagnosticReport.subject",
-				"short": "The subject of the report - usually, but not always, the patient",
-				"definition": "The subject of the report. Usually, but not always, this is a patient. However, diagnostic services also perform analyses on specimens collected from a variety of other sources.",
-				"requirements": "SHALL know the subject context.",
-				"alias": [
-					"Patient"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3 (no HL7 v2 mapping for Group or Device)"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SBJ]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.encounter",
-				"path": "DiagnosticReport.encounter",
-				"short": "Health care event when test ordered",
-				"definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) which this DiagnosticReport is about.",
-				"comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter  but still be tied to the context of the encounter  (e.g. pre-admission laboratory tests).",
-				"requirements": "Links the request to the Encounter context.",
-				"alias": [
-					"Context"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.encounter"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1-19"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.effective[x]",
-				"path": "DiagnosticReport.effective[x]",
-				"short": "Specimen Collection Datetime or Period",
-				"definition": "This is the Specimen Collection Datetime or Period which is the physically relevent dateTime for laboratory tests.",
-				"comment": "If the diagnostic procedure was performed on the patient, this is the time it was performed. If there are specimens, the diagnostically relevant time can be derived from the specimen collection times, but the specimen information is not always available, and the exact relationship between the specimens and the diagnostically relevant time is not always automatic.",
-				"requirements": "Need to know where in the patient history to file/present this report.",
-				"alias": [
-					"Observation time",
-					"Effective Time",
-					"Occurrence"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.effective[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-7"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.issued",
-				"path": "DiagnosticReport.issued",
-				"short": "DateTime this version was made",
-				"definition": "The date and time that this version of the report was made available to providers, typically after the report was reviewed and verified.",
-				"comment": "May be different from the update time of the resource itself, because that is the status of the record (potentially a secondary copy), not the actual release time of the report.",
-				"requirements": "Clinicians need to be able to check the date that the report was released.",
-				"alias": [
-					"Date published",
-					"Date Issued",
-					"Date Verified"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.issued",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-22"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=VRF or AUT].time"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.performer",
-				"path": "DiagnosticReport.performer",
-				"short": "Responsible Diagnostic Service",
-				"definition": "The diagnostic service that is responsible for issuing the report.",
-				"comment": "This is not necessarily the source of the atomic data items or the entity that interpreted the results. It is the entity that takes responsibility for the clinical report.",
-				"requirements": "Need to know whom to contact if there are queries about the results. Also may need to track the source of reports for secondary data analysis.",
-				"alias": [
-					"Laboratory",
-					"Service",
-					"Practitioner",
-					"Department",
-					"Company",
-					"Authorized by",
-					"Director"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.performer",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "PRT-8 (where this PRT-4-Participation = \"PO\")"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=PRF]"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.resultsInterpreter",
-				"path": "DiagnosticReport.resultsInterpreter",
-				"short": "Primary result interpreter",
-				"definition": "The practitioner or organization that is responsible for the report's conclusions and interpretations.",
-				"comment": "Might not be the same entity that takes responsibility for the clinical report.",
-				"requirements": "Need to know whom to contact if there are queries about the results. Also may need to track the source of reports for secondary data analysis.",
-				"alias": [
-					"Analyzed by",
-					"Reported by"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.resultsInterpreter",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-32, PRT-8 (where this PRT-4-Participation = \"PI\")"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=PRF]"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.specimen",
-				"path": "DiagnosticReport.specimen",
-				"short": "Specimens this report is based on",
-				"definition": "Details about the specimens on which this diagnostic report is based.",
-				"comment": "If the specimen is sufficiently specified with a code in the test result name, then this additional data may be redundant. If there are multiple specimens, these may be represented per observation or group.",
-				"requirements": "Need to be able to report information about the collected specimens on which the report is based.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.specimen",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Specimen"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SPM"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SBJ]"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.result",
-				"path": "DiagnosticReport.result",
-				"short": "Observations",
-				"definition": "[Observations](http://hl7.org/fhir/R4/observation.html)  that are part of this diagnostic report.",
-				"comment": "Observations can contain observations.",
-				"requirements": "Need to support individual results, or  groups of results, where the result grouping is arbitrary, but meaningful.",
-				"alias": [
-					"Data",
-					"Atomic Value",
-					"Result",
-					"Atomic result",
-					"Data",
-					"Test",
-					"Analyte",
-					"Battery",
-					"Organizer"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.result",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBXs"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=COMP].target"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.imagingStudy",
-				"path": "DiagnosticReport.imagingStudy",
-				"short": "Reference to full details of imaging associated with the diagnostic report",
-				"definition": "One or more links to full details of any imaging performed during the diagnostic investigation. Typically, this is imaging performed by DICOM enabled modalities, but this is not required. A fully enabled PACS viewer can use this information to provide views of the source images.",
-				"comment": "ImagingStudy and the image element are somewhat overlapping - typically, the list of image references in the image element will also be found in one of the imaging study resources. However, each caters to different types of displays for different types of purposes. Neither, either, or both may be provided.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.imagingStudy",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=COMP].target[classsCode=DGIMG, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.media",
-				"path": "DiagnosticReport.media",
-				"short": "Key images associated with this report",
-				"definition": "A list of key images associated with this report. The images are generally created during the diagnostic process, and may be directly of the patient, or of treated specimens (i.e. slides of interest).",
-				"requirements": "Many diagnostic services include images in the report as part of their service.",
-				"alias": [
-					"DICOM",
-					"Slides",
-					"Scans"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.media",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX?"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=COMP].target"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.media.id",
-				"path": "DiagnosticReport.media.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.media.extension",
-				"path": "DiagnosticReport.media.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.media.modifierExtension",
-				"path": "DiagnosticReport.media.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.media.comment",
-				"path": "DiagnosticReport.media.comment",
-				"short": "Comment about the image (e.g. explanation)",
-				"definition": "A comment about the image. Typically, this is used to provide an explanation for why the image is included, or to draw the viewer's attention to important features.",
-				"comment": "The comment should be displayed with the image. It would be common for the report to include additional discussion of the image contents in other sections such as the conclusion.",
-				"requirements": "The provider of the report should make a comment about each image included in the report.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.media.comment",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[classCode=OBS, moodCode=EVN, code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.media.link",
-				"path": "DiagnosticReport.media.link",
-				"short": "Reference to the image source",
-				"definition": "Reference to the image source.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.media.link",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Media"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".value.reference"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.conclusion",
-				"path": "DiagnosticReport.conclusion",
-				"short": "Clinical conclusion (interpretation) of test results",
-				"definition": "Concise and clinically contextualized summary conclusion (interpretation/impression) of the diagnostic report.",
-				"requirements": "Need to be able to provide a conclusion that is not lost among the basic result data.",
-				"alias": [
-					"Report"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.conclusion",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=\"SPRT\"].source[classCode=OBS, moodCode=EVN, code=LOINC:48767-8].value (type=ST)"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.conclusionCode",
-				"path": "DiagnosticReport.conclusionCode",
-				"short": "Codes for the clinical conclusion of test results",
-				"definition": "One or more codes that represent the summary conclusion (interpretation/impression) of the diagnostic report.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.conclusionCode",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AdjunctDiagnosis"
-						}
-					],
-					"strength": "example",
-					"description": "Diagnosis codes provided as adjuncts to the report.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=SPRT].source[classCode=OBS, moodCode=EVN, code=LOINC:54531-9].value (type=CD)"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.presentedForm",
-				"path": "DiagnosticReport.presentedForm",
-				"short": "Entire report as issued",
-				"definition": "Rich text representation of the entire result as issued by the diagnostic service. Multiple formats are allowed but they SHALL be semantically equivalent.",
-				"comment": "\"application/pdf\" is recommended as the most reliable and interoperable in this context.",
-				"requirements": "Gives laboratory the ability to provide its own fully formatted report for clinical fidelity.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.presentedForm",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Attachment"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "text (type=ED)"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "DiagnosticReport",
-				"path": "DiagnosticReport",
-				"definition": "The US Core Diagnostic Report Profile is based upon the core FHIR DiagnosticReport Resource and created to meet the 2015 Edition Common Clinical Data Set 'Laboratory test(s) and Laboratory value(s)/result(s)' requirements.",
-				"alias": [
-					"Lab Result",
-					"Lab Report"
-				],
-				"mustSupport": false,
-				"isModifier": false
-			},
-			{
-				"id": "DiagnosticReport.status",
-				"path": "DiagnosticReport.status",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/diagnostic-report-status"
-				}
-			},
-			{
-				"id": "DiagnosticReport.category",
-				"path": "DiagnosticReport.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "$this"
-						}
-					],
-					"rules": "open"
-				},
-				"min": 1,
-				"max": "*",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "DiagnosticReport.category:LaboratorySlice",
-				"path": "DiagnosticReport.category",
-				"sliceName": "LaboratorySlice",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://terminology.hl7.org/CodeSystem/v2-0074",
-							"code": "LAB"
-						}
-					]
-				},
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "DiagnosticReport.code",
-				"path": "DiagnosticReport.code",
-				"short": "US Core Laboratory Report Order Code",
-				"definition": "The test, panel or battery that was ordered.",
-				"comment": "UsageNote= The typical patterns for codes are:  1)  a LOINC code either as a  translation from a \"local\" code or as a primary code, or 2)  a local code only if no suitable LOINC exists,  or 3)  both the local and the LOINC translation.   Systems SHALL be capable of sending the local code if one exists.",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"binding": {
-					"strength": "extensible",
-					"description": "LOINC codes",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-lab-codes|3.1.1"
-				}
-			},
-			{
-				"id": "DiagnosticReport.subject",
-				"path": "DiagnosticReport.subject",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "DiagnosticReport.effective[x]",
-				"path": "DiagnosticReport.effective[x]",
-				"short": "Specimen Collection Datetime or Period",
-				"definition": "This is the Specimen Collection Datetime or Period which is the physically relevent dateTime for laboratory tests.",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "DiagnosticReport.issued",
-				"path": "DiagnosticReport.issued",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "DiagnosticReport.performer",
-				"path": "DiagnosticReport.performer",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "DiagnosticReport.result",
-				"path": "DiagnosticReport.result",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-diagnosticreport-lab",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab",
+    "version": "3.1.1",
+    "name": "USCoreDiagnosticReportProfileLaboratoryReporting",
+    "title": "US Core DiagnosticReport Profile for Laboratory Results Reporting",
+    "status": "active",
+    "experimental": false,
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.healthit.gov"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the DiagnosticReport resource  for the minimal set of data to query and retrieve diagnostic reports associated with laboratory results for a patient",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "DiagnosticReport",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "DiagnosticReport",
+                "path": "DiagnosticReport",
+                "short": "A Diagnostic report - a combination of request information, atomic results, images, interpretation, as well as formatted reports",
+                "definition": "The US Core Diagnostic Report Profile is based upon the core FHIR DiagnosticReport Resource and created to meet the 2015 Edition Common Clinical Data Set 'Laboratory test(s) and Laboratory value(s)/result(s)' requirements.",
+                "comment": "This is intended to capture a single report and is not suitable for use in displaying summary information that covers multiple reports.  For example, this resource has not been designed for laboratory cumulative reporting formats nor detailed structured reports for sequencing.",
+                "alias": [
+                    "Report",
+                    "Test",
+                    "Result",
+                    "Results",
+                    "Labs",
+                    "Laboratory",
+                    "Lab Result",
+                    "Lab Report"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORU -> OBR"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.id",
+                "path": "DiagnosticReport.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "DiagnosticReport.meta",
+                "path": "DiagnosticReport.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "DiagnosticReport.implicitRules",
+                "path": "DiagnosticReport.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "DiagnosticReport.language",
+                "path": "DiagnosticReport.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "DiagnosticReport.text",
+                "path": "DiagnosticReport.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.contained",
+                "path": "DiagnosticReport.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.extension",
+                "path": "DiagnosticReport.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.modifierExtension",
+                "path": "DiagnosticReport.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.identifier",
+                "path": "DiagnosticReport.identifier",
+                "short": "Business identifier for report",
+                "definition": "Identifiers assigned to this report by the performer or other systems.",
+                "comment": "Usually assigned by the Information System of the diagnostic service provider (filler id).",
+                "requirements": "Need to know what identifier to use when making queries about this report from the source laboratory, and for linking to the report outside FHIR context.",
+                "alias": [
+                    "ReportID",
+                    "Filler ID",
+                    "Placer ID"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-51/ for globally unique filler ID  - OBR-3 , For non-globally unique filler-id the flller/placer number must be combined with the universal service Id -  OBR-2(if present)+OBR-3+OBR-4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "id"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.basedOn",
+                "path": "DiagnosticReport.basedOn",
+                "short": "What was requested",
+                "definition": "Details concerning a service requested.",
+                "comment": "Note: Usually there is one test request for each result, however in some circumstances multiple test requests may be represented using a single test result resource. Note that there are also cases where one request leads to multiple reports.",
+                "requirements": "This allows tracing of authorization for the report and tracking whether proposals/recommendations were acted upon.",
+                "alias": [
+                    "Request"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan",
+                            "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+                            "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.basedOn"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC? OBR-2/3?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=FLFS].target"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.status",
+                "path": "DiagnosticReport.status",
+                "short": "registered | partial | preliminary | final +",
+                "definition": "The status of the diagnostic report.",
+                "requirements": "Diagnostic services routinely issue provisional/incomplete reports, and sometimes withdraw previously released reports.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/diagnostic-report-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-25 (not 1:1 mapping)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "statusCode  Note: final and amended are distinguished by whether observation is the subject of a ControlAct event of type \"revise\""
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.category",
+                "path": "DiagnosticReport.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "$this"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "short": "Service category",
+                "definition": "A code that classifies the clinical discipline, department or diagnostic service that created the report (e.g. cardiology, biochemistry, hematology, MRI). This is used for searching, sorting and display purposes.",
+                "comment": "Multiple categories are allowed using various categorization schemes.   The level of granularity is defined by the category concepts in the value set. More fine-grained filtering can be performed using the metadata and/or terminology hierarchy in DiagnosticReport.code.",
+                "alias": [
+                    "Department",
+                    "Sub-department",
+                    "Service",
+                    "Discipline"
+                ],
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "DiagnosticServiceSection"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes for diagnostic service sections.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/diagnostic-service-sections"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-24"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=COMP].source[classCode=LIST, moodCode=EVN, code < LabService].code"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.category:LaboratorySlice",
+                "path": "DiagnosticReport.category",
+                "sliceName": "LaboratorySlice",
+                "short": "Service category",
+                "definition": "A code that classifies the clinical discipline, department or diagnostic service that created the report (e.g. cardiology, biochemistry, hematology, MRI). This is used for searching, sorting and display purposes.",
+                "comment": "Multiple categories are allowed using various categorization schemes.   The level of granularity is defined by the category concepts in the value set. More fine-grained filtering can be performed using the metadata and/or terminology hierarchy in DiagnosticReport.code.",
+                "alias": [
+                    "Department",
+                    "Sub-department",
+                    "Service",
+                    "Discipline"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                            "code": "LAB"
+                        }
+                    ]
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "DiagnosticServiceSection"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes for diagnostic service sections.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/diagnostic-service-sections"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-24"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=COMP].source[classCode=LIST, moodCode=EVN, code < LabService].code"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.code",
+                "path": "DiagnosticReport.code",
+                "short": "US Core Laboratory Report Order Code",
+                "definition": "The test, panel or battery that was ordered.",
+                "comment": "UsageNote= The typical patterns for codes are:  1)  a LOINC code either as a  translation from a \"local\" code or as a primary code, or 2)  a local code only if no suitable LOINC exists,  or 3)  both the local and the LOINC translation.   Systems SHALL be capable of sending the local code if one exists.",
+                "alias": [
+                    "Type"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "LOINC codes",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-lab-codes|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-4 (HL7 v2 doesn't provide an easy way to indicate both the ordered test and the performed panel)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.subject",
+                "path": "DiagnosticReport.subject",
+                "short": "The subject of the report - usually, but not always, the patient",
+                "definition": "The subject of the report. Usually, but not always, this is a patient. However, diagnostic services also perform analyses on specimens collected from a variety of other sources.",
+                "requirements": "SHALL know the subject context.",
+                "alias": [
+                    "Patient"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3 (no HL7 v2 mapping for Group or Device)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SBJ]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.encounter",
+                "path": "DiagnosticReport.encounter",
+                "short": "Health care event when test ordered",
+                "definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) which this DiagnosticReport is about.",
+                "comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter  but still be tied to the context of the encounter  (e.g. pre-admission laboratory tests).",
+                "requirements": "Links the request to the Encounter context.",
+                "alias": [
+                    "Context"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.encounter"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1-19"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.effective[x]",
+                "path": "DiagnosticReport.effective[x]",
+                "short": "Specimen Collection Datetime or Period",
+                "definition": "This is the Specimen Collection Datetime or Period which is the physically relevent dateTime for laboratory tests.",
+                "comment": "If the diagnostic procedure was performed on the patient, this is the time it was performed. If there are specimens, the diagnostically relevant time can be derived from the specimen collection times, but the specimen information is not always available, and the exact relationship between the specimens and the diagnostically relevant time is not always automatic.",
+                "requirements": "Need to know where in the patient history to file/present this report.",
+                "alias": [
+                    "Observation time",
+                    "Effective Time",
+                    "Occurrence"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.effective[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.issued",
+                "path": "DiagnosticReport.issued",
+                "short": "DateTime this version was made",
+                "definition": "The date and time that this version of the report was made available to providers, typically after the report was reviewed and verified.",
+                "comment": "May be different from the update time of the resource itself, because that is the status of the record (potentially a secondary copy), not the actual release time of the report.",
+                "requirements": "Clinicians need to be able to check the date that the report was released.",
+                "alias": [
+                    "Date published",
+                    "Date Issued",
+                    "Date Verified"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.issued",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-22"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=VRF or AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.performer",
+                "path": "DiagnosticReport.performer",
+                "short": "Responsible Diagnostic Service",
+                "definition": "The diagnostic service that is responsible for issuing the report.",
+                "comment": "This is not necessarily the source of the atomic data items or the entity that interpreted the results. It is the entity that takes responsibility for the clinical report.",
+                "requirements": "Need to know whom to contact if there are queries about the results. Also may need to track the source of reports for secondary data analysis.",
+                "alias": [
+                    "Laboratory",
+                    "Service",
+                    "Practitioner",
+                    "Department",
+                    "Company",
+                    "Authorized by",
+                    "Director"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.performer",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRT-8 (where this PRT-4-Participation = \"PO\")"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=PRF]"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.resultsInterpreter",
+                "path": "DiagnosticReport.resultsInterpreter",
+                "short": "Primary result interpreter",
+                "definition": "The practitioner or organization that is responsible for the report's conclusions and interpretations.",
+                "comment": "Might not be the same entity that takes responsibility for the clinical report.",
+                "requirements": "Need to know whom to contact if there are queries about the results. Also may need to track the source of reports for secondary data analysis.",
+                "alias": [
+                    "Analyzed by",
+                    "Reported by"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.resultsInterpreter",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-32, PRT-8 (where this PRT-4-Participation = \"PI\")"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=PRF]"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.specimen",
+                "path": "DiagnosticReport.specimen",
+                "short": "Specimens this report is based on",
+                "definition": "Details about the specimens on which this diagnostic report is based.",
+                "comment": "If the specimen is sufficiently specified with a code in the test result name, then this additional data may be redundant. If there are multiple specimens, these may be represented per observation or group.",
+                "requirements": "Need to be able to report information about the collected specimens on which the report is based.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.specimen",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Specimen"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SPM"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SBJ]"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.result",
+                "path": "DiagnosticReport.result",
+                "short": "Observations",
+                "definition": "[Observations](http://hl7.org/fhir/R4/observation.html)  that are part of this diagnostic report.",
+                "comment": "Observations can contain observations.",
+                "requirements": "Need to support individual results, or  groups of results, where the result grouping is arbitrary, but meaningful.",
+                "alias": [
+                    "Data",
+                    "Atomic Value",
+                    "Result",
+                    "Atomic result",
+                    "Data",
+                    "Test",
+                    "Analyte",
+                    "Battery",
+                    "Organizer"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.result",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBXs"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=COMP].target"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.imagingStudy",
+                "path": "DiagnosticReport.imagingStudy",
+                "short": "Reference to full details of imaging associated with the diagnostic report",
+                "definition": "One or more links to full details of any imaging performed during the diagnostic investigation. Typically, this is imaging performed by DICOM enabled modalities, but this is not required. A fully enabled PACS viewer can use this information to provide views of the source images.",
+                "comment": "ImagingStudy and the image element are somewhat overlapping - typically, the list of image references in the image element will also be found in one of the imaging study resources. However, each caters to different types of displays for different types of purposes. Neither, either, or both may be provided.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.imagingStudy",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=COMP].target[classsCode=DGIMG, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.media",
+                "path": "DiagnosticReport.media",
+                "short": "Key images associated with this report",
+                "definition": "A list of key images associated with this report. The images are generally created during the diagnostic process, and may be directly of the patient, or of treated specimens (i.e. slides of interest).",
+                "requirements": "Many diagnostic services include images in the report as part of their service.",
+                "alias": [
+                    "DICOM",
+                    "Slides",
+                    "Scans"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.media",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=COMP].target"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.media.id",
+                "path": "DiagnosticReport.media.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.media.extension",
+                "path": "DiagnosticReport.media.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.media.modifierExtension",
+                "path": "DiagnosticReport.media.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.media.comment",
+                "path": "DiagnosticReport.media.comment",
+                "short": "Comment about the image (e.g. explanation)",
+                "definition": "A comment about the image. Typically, this is used to provide an explanation for why the image is included, or to draw the viewer's attention to important features.",
+                "comment": "The comment should be displayed with the image. It would be common for the report to include additional discussion of the image contents in other sections such as the conclusion.",
+                "requirements": "The provider of the report should make a comment about each image included in the report.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.media.comment",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[classCode=OBS, moodCode=EVN, code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.media.link",
+                "path": "DiagnosticReport.media.link",
+                "short": "Reference to the image source",
+                "definition": "Reference to the image source.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.media.link",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Media"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".value.reference"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.conclusion",
+                "path": "DiagnosticReport.conclusion",
+                "short": "Clinical conclusion (interpretation) of test results",
+                "definition": "Concise and clinically contextualized summary conclusion (interpretation/impression) of the diagnostic report.",
+                "requirements": "Need to be able to provide a conclusion that is not lost among the basic result data.",
+                "alias": [
+                    "Report"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.conclusion",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=\"SPRT\"].source[classCode=OBS, moodCode=EVN, code=LOINC:48767-8].value (type=ST)"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.conclusionCode",
+                "path": "DiagnosticReport.conclusionCode",
+                "short": "Codes for the clinical conclusion of test results",
+                "definition": "One or more codes that represent the summary conclusion (interpretation/impression) of the diagnostic report.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.conclusionCode",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AdjunctDiagnosis"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Diagnosis codes provided as adjuncts to the report.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=SPRT].source[classCode=OBS, moodCode=EVN, code=LOINC:54531-9].value (type=CD)"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.presentedForm",
+                "path": "DiagnosticReport.presentedForm",
+                "short": "Entire report as issued",
+                "definition": "Rich text representation of the entire result as issued by the diagnostic service. Multiple formats are allowed but they SHALL be semantically equivalent.",
+                "comment": "\"application/pdf\" is recommended as the most reliable and interoperable in this context.",
+                "requirements": "Gives laboratory the ability to provide its own fully formatted report for clinical fidelity.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.presentedForm",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Attachment"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "text (type=ED)"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "DiagnosticReport",
+                "path": "DiagnosticReport",
+                "definition": "The US Core Diagnostic Report Profile is based upon the core FHIR DiagnosticReport Resource and created to meet the 2015 Edition Common Clinical Data Set 'Laboratory test(s) and Laboratory value(s)/result(s)' requirements.",
+                "alias": [
+                    "Lab Result",
+                    "Lab Report"
+                ],
+                "mustSupport": false,
+                "isModifier": false
+            },
+            {
+                "id": "DiagnosticReport.status",
+                "path": "DiagnosticReport.status",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/diagnostic-report-status"
+                }
+            },
+            {
+                "id": "DiagnosticReport.category",
+                "path": "DiagnosticReport.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "$this"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "min": 1,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "DiagnosticReport.category:LaboratorySlice",
+                "path": "DiagnosticReport.category",
+                "sliceName": "LaboratorySlice",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                            "code": "LAB"
+                        }
+                    ]
+                },
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "DiagnosticReport.code",
+                "path": "DiagnosticReport.code",
+                "short": "US Core Laboratory Report Order Code",
+                "definition": "The test, panel or battery that was ordered.",
+                "comment": "UsageNote= The typical patterns for codes are:  1)  a LOINC code either as a  translation from a \"local\" code or as a primary code, or 2)  a local code only if no suitable LOINC exists,  or 3)  both the local and the LOINC translation.   Systems SHALL be capable of sending the local code if one exists.",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "LOINC codes",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-lab-codes|3.1.1"
+                }
+            },
+            {
+                "id": "DiagnosticReport.subject",
+                "path": "DiagnosticReport.subject",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "DiagnosticReport.effective[x]",
+                "path": "DiagnosticReport.effective[x]",
+                "short": "Specimen Collection Datetime or Period",
+                "definition": "This is the Specimen Collection Datetime or Period which is the physically relevent dateTime for laboratory tests.",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "DiagnosticReport.issued",
+                "path": "DiagnosticReport.issued",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "DiagnosticReport.performer",
+                "path": "DiagnosticReport.performer",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "DiagnosticReport.result",
+                "path": "DiagnosticReport.result",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-diagnosticreport-note.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-diagnosticreport-note.json
@@ -1,1831 +1,1831 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-diagnosticreport-note",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-note-definitions.html#DiagnosticReport\" title=\"The US Core Diagnostic Report Profile for Report and Note exchange is based upon the requirements of the Argonauts to exchang imaginge reports.\">DiagnosticReport</a><a name=\"DiagnosticReport\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/diagnosticreport.html\">DiagnosticReport</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">US Core Diagnostic Report Profile for Report and Note exchange</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-note-definitions.html#DiagnosticReport.status\">status</a><a name=\"DiagnosticReport.status\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">registered | partial | preliminary | final +</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-diagnostic-report-status.html\">DiagnosticReportStatus</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-note-definitions.html#DiagnosticReport.category\">category</a><a name=\"DiagnosticReport.category\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..<span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Service category</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-diagnosticreport-category.html\">US Core DiagnosticReport Category</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-note-definitions.html#DiagnosticReport.code\" title=\"The test, panel, report, or note that was ordered.\">code</a><a name=\"DiagnosticReport.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">US Core Report Code<br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-diagnosticreport-report-and-note-codes.html\">US Core Diagnosticreport Report And Note Codes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-note-definitions.html#DiagnosticReport.subject\" title=\"The subject of the report. Usually, but not always, this is a patient. However diagnostic services also perform analyses on specimens collected from a variety of other sources.\">subject</a><a name=\"DiagnosticReport.subject\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element is included in summaries\">Σ</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">The subject of the report - usually, but not always, the patient</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-note-definitions.html#DiagnosticReport.encounter\">encounter</a><a name=\"DiagnosticReport.encounter\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-encounter.html\">US Core Encounter Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Health care event when test ordered</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_choice.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Choice of Types\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-note-definitions.html#DiagnosticReport.effective[x]\" title=\"This is the Datetime or Period when the report or note was written.\">effective[x]</a><a name=\"DiagnosticReport.effective_x_\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Time of the report or note</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for dateTime Type: A date, date-time or partial date (e.g. just year or year + month).  If hours and minutes are specified, a time zone SHALL be populated. The format is a union of the schema types gYear, gYearMonth, date and dateTime. Seconds must be provided due to schema type constraints but may be zero-filled and may be ignored.                 Dates SHALL be valid dates.\">effectiveDateTime</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#dateTime\">dateTime</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for Period Type: A time period defined by a start and end date and optionally time.\">effectivePeriod</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Period\">Period</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-note-definitions.html#DiagnosticReport.issued\">issued</a><a name=\"DiagnosticReport.issued\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#instant\">instant</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">DateTime this version was made</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-note-definitions.html#DiagnosticReport.performer\">performer</a><a name=\"DiagnosticReport.performer\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-practitioner.html\">US Core Practitioner Profile</a> | <a href=\"StructureDefinition-us-core-organization.html\">US Core Organization Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Responsible Diagnostic Service</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck00.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-note-definitions.html#DiagnosticReport.presentedForm\">presentedForm</a><a name=\"DiagnosticReport.presentedForm\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Attachment\">Attachment</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Entire report as issued</span><br/></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note",
-	"version": "3.1.1",
-	"name": "USCoreDiagnosticReportProfileNoteExchange",
-	"title": "US Core DiagnosticReport Profile for Report and Note exchange",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.healthit.gov"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the DiagnosticReport resource  for the minimal set of data to query and retrieve diagnostic reports associated with clinical notes for a patient",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "DiagnosticReport",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "DiagnosticReport",
-				"path": "DiagnosticReport",
-				"short": "US Core Diagnostic Report Profile for Report and Note exchange",
-				"definition": "The US Core Diagnostic Report Profile for Report and Note exchange is based upon the requirements of the Argonauts to exchang imaginge reports.",
-				"comment": "This is intended to capture a single report and is not suitable for use in displaying summary information that covers multiple reports.  For example, this resource has not been designed for laboratory cumulative reporting formats nor detailed structured reports for sequencing.",
-				"alias": [
-					"Report",
-					"Test",
-					"Result",
-					"Results",
-					"Labs",
-					"Laboratory",
-					"Imaging Report",
-					"Radiology Report"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "v2",
-						"map": "ORU -> OBR"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.id",
-				"path": "DiagnosticReport.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "DiagnosticReport.meta",
-				"path": "DiagnosticReport.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "DiagnosticReport.implicitRules",
-				"path": "DiagnosticReport.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "DiagnosticReport.language",
-				"path": "DiagnosticReport.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "DiagnosticReport.text",
-				"path": "DiagnosticReport.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.contained",
-				"path": "DiagnosticReport.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.extension",
-				"path": "DiagnosticReport.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.modifierExtension",
-				"path": "DiagnosticReport.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.identifier",
-				"path": "DiagnosticReport.identifier",
-				"short": "Business identifier for report",
-				"definition": "Identifiers assigned to this report by the performer or other systems.",
-				"comment": "Usually assigned by the Information System of the diagnostic service provider (filler id).",
-				"requirements": "Need to know what identifier to use when making queries about this report from the source laboratory, and for linking to the report outside FHIR context.",
-				"alias": [
-					"ReportID",
-					"Filler ID",
-					"Placer ID"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-51/ for globally unique filler ID  - OBR-3 , For non-globally unique filler-id the flller/placer number must be combined with the universal service Id -  OBR-2(if present)+OBR-3+OBR-4"
-					},
-					{
-						"identity": "rim",
-						"map": "id"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.basedOn",
-				"path": "DiagnosticReport.basedOn",
-				"short": "What was requested",
-				"definition": "Details concerning a service requested.",
-				"comment": "Note: Usually there is one test request for each result, however in some circumstances multiple test requests may be represented using a single test result resource. Note that there are also cases where one request leads to multiple reports.",
-				"requirements": "This allows tracing of authorization for the report and tracking whether proposals/recommendations were acted upon.",
-				"alias": [
-					"Request"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan",
-							"http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
-							"http://hl7.org/fhir/StructureDefinition/MedicationRequest",
-							"http://hl7.org/fhir/StructureDefinition/NutritionOrder",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.basedOn"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC? OBR-2/3?"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=FLFS].target"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.status",
-				"path": "DiagnosticReport.status",
-				"short": "registered | partial | preliminary | final +",
-				"definition": "The status of the diagnostic report.",
-				"requirements": "Diagnostic services routinely issue provisional/incomplete reports, and sometimes withdraw previously released reports.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/diagnostic-report-status"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-25 (not 1:1 mapping)"
-					},
-					{
-						"identity": "rim",
-						"map": "statusCode  Note: final and amended are distinguished by whether observation is the subject of a ControlAct event of type \"revise\""
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.category",
-				"path": "DiagnosticReport.category",
-				"short": "Service category",
-				"definition": "A code that classifies the clinical discipline, department or diagnostic service that created the report (e.g. cardiology, biochemistry, hematology, MRI). This is used for searching, sorting and display purposes.",
-				"comment": "Multiple categories are allowed using various categorization schemes.   The level of granularity is defined by the category concepts in the value set. More fine-grained filtering can be performed using the metadata and/or terminology hierarchy in DiagnosticReport.code.",
-				"alias": [
-					"Department",
-					"Sub-department",
-					"Service",
-					"Discipline",
-					"service",
-					"discipline"
-				],
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-category|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-24"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=COMP].source[classCode=LIST, moodCode=EVN, code < LabService].code"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.code",
-				"path": "DiagnosticReport.code",
-				"short": "US Core Report Code",
-				"definition": "The test, panel, report, or note that was ordered.",
-				"comment": "UsageNote= The typical patterns for codes are:  1)  a LOINC code either as a  translation from a \"local\" code or as a primary code, or 2)  a local code only if no suitable LOINC exists,  or 3)  both the local and the LOINC translation.   Systems SHALL be capable of sending the local code if one exists.",
-				"alias": [
-					"Type"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "LOINC codes",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-report-and-note-codes|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-4 (HL7 v2 doesn't provide an easy way to indicate both the ordered test and the performed panel)"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.subject",
-				"path": "DiagnosticReport.subject",
-				"short": "The subject of the report - usually, but not always, the patient",
-				"definition": "The subject of the report. Usually, but not always, this is a patient. However diagnostic services also perform analyses on specimens collected from a variety of other sources.",
-				"requirements": "SHALL know the subject context.",
-				"alias": [
-					"Patient"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3 (no HL7 v2 mapping for Group or Device)"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SBJ]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.encounter",
-				"path": "DiagnosticReport.encounter",
-				"short": "Health care event when test ordered",
-				"definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) which this DiagnosticReport is about.",
-				"comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter  but still be tied to the context of the encounter  (e.g. pre-admission laboratory tests).",
-				"requirements": "Links the request to the Encounter context.",
-				"alias": [
-					"Context"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.encounter"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1-19"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.effective[x]",
-				"path": "DiagnosticReport.effective[x]",
-				"short": "Time of the report or note",
-				"definition": "This is the Datetime or Period when the report or note was written.",
-				"comment": "If the diagnostic procedure was performed on the patient, this is the time it was performed. If there are specimens, the diagnostically relevant time can be derived from the specimen collection times, but the specimen information is not always available, and the exact relationship between the specimens and the diagnostically relevant time is not always automatic.",
-				"requirements": "Need to know where in the patient history to file/present this report.",
-				"alias": [
-					"Observation time",
-					"Effective Time",
-					"Occurrence"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.effective[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-7"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.issued",
-				"path": "DiagnosticReport.issued",
-				"short": "DateTime this version was made",
-				"definition": "The date and time that this version of the report was made available to providers, typically after the report was reviewed and verified.",
-				"comment": "May be different from the update time of the resource itself, because that is the status of the record (potentially a secondary copy), not the actual release time of the report.",
-				"requirements": "Clinicians need to be able to check the date that the report was released.",
-				"alias": [
-					"Date published",
-					"Date Issued",
-					"Date Verified"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.issued",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-22"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=VRF or AUT].time"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.performer",
-				"path": "DiagnosticReport.performer",
-				"short": "Responsible Diagnostic Service",
-				"definition": "The diagnostic service that is responsible for issuing the report.",
-				"comment": "This is not necessarily the source of the atomic data items or the entity that interpreted the results. It is the entity that takes responsibility for the clinical report.",
-				"requirements": "Need to know whom to contact if there are queries about the results. Also may need to track the source of reports for secondary data analysis.",
-				"alias": [
-					"Laboratory",
-					"Service",
-					"Practitioner",
-					"Department",
-					"Company",
-					"Authorized by",
-					"Director"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.performer",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "PRT-8 (where this PRT-4-Participation = \"PO\")"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=PRF]"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.resultsInterpreter",
-				"path": "DiagnosticReport.resultsInterpreter",
-				"short": "Primary result interpreter",
-				"definition": "The practitioner or organization that is responsible for the report's conclusions and interpretations.",
-				"comment": "Might not be the same entity that takes responsibility for the clinical report.",
-				"requirements": "Need to know whom to contact if there are queries about the results. Also may need to track the source of reports for secondary data analysis.",
-				"alias": [
-					"Analyzed by",
-					"Reported by"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.resultsInterpreter",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-32, PRT-8 (where this PRT-4-Participation = \"PI\")"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=PRF]"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.specimen",
-				"path": "DiagnosticReport.specimen",
-				"short": "Specimens this report is based on",
-				"definition": "Details about the specimens on which this diagnostic report is based.",
-				"comment": "If the specimen is sufficiently specified with a code in the test result name, then this additional data may be redundant. If there are multiple specimens, these may be represented per observation or group.",
-				"requirements": "Need to be able to report information about the collected specimens on which the report is based.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.specimen",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Specimen"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SPM"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SBJ]"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.result",
-				"path": "DiagnosticReport.result",
-				"short": "Observations",
-				"definition": "[Observations](http://hl7.org/fhir/R4/observation.html)  that are part of this diagnostic report.",
-				"comment": "Observations can contain observations.",
-				"requirements": "Need to support individual results, or  groups of results, where the result grouping is arbitrary, but meaningful.",
-				"alias": [
-					"Data",
-					"Atomic Value",
-					"Result",
-					"Atomic result",
-					"Data",
-					"Test",
-					"Analyte",
-					"Battery",
-					"Organizer"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.result",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Observation"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBXs"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=COMP].target"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.imagingStudy",
-				"path": "DiagnosticReport.imagingStudy",
-				"short": "Reference to full details of imaging associated with the diagnostic report",
-				"definition": "One or more links to full details of any imaging performed during the diagnostic investigation. Typically, this is imaging performed by DICOM enabled modalities, but this is not required. A fully enabled PACS viewer can use this information to provide views of the source images.",
-				"comment": "ImagingStudy and the image element are somewhat overlapping - typically, the list of image references in the image element will also be found in one of the imaging study resources. However, each caters to different types of displays for different types of purposes. Neither, either, or both may be provided.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.imagingStudy",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=COMP].target[classsCode=DGIMG, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.media",
-				"path": "DiagnosticReport.media",
-				"short": "Key images associated with this report",
-				"definition": "A list of key images associated with this report. The images are generally created during the diagnostic process, and may be directly of the patient, or of treated specimens (i.e. slides of interest).",
-				"requirements": "Many diagnostic services include images in the report as part of their service.",
-				"alias": [
-					"DICOM",
-					"Slides",
-					"Scans"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.media",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX?"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=COMP].target"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.media.id",
-				"path": "DiagnosticReport.media.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.media.extension",
-				"path": "DiagnosticReport.media.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.media.modifierExtension",
-				"path": "DiagnosticReport.media.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.media.comment",
-				"path": "DiagnosticReport.media.comment",
-				"short": "Comment about the image (e.g. explanation)",
-				"definition": "A comment about the image. Typically, this is used to provide an explanation for why the image is included, or to draw the viewer's attention to important features.",
-				"comment": "The comment should be displayed with the image. It would be common for the report to include additional discussion of the image contents in other sections such as the conclusion.",
-				"requirements": "The provider of the report should make a comment about each image included in the report.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.media.comment",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[classCode=OBS, moodCode=EVN, code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.media.link",
-				"path": "DiagnosticReport.media.link",
-				"short": "Reference to the image source",
-				"definition": "Reference to the image source.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.media.link",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Media"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".value.reference"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.conclusion",
-				"path": "DiagnosticReport.conclusion",
-				"short": "Clinical conclusion (interpretation) of test results",
-				"definition": "Concise and clinically contextualized summary conclusion (interpretation/impression) of the diagnostic report.",
-				"requirements": "Need to be able to provide a conclusion that is not lost among the basic result data.",
-				"alias": [
-					"Report"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.conclusion",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=\"SPRT\"].source[classCode=OBS, moodCode=EVN, code=LOINC:48767-8].value (type=ST)"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.conclusionCode",
-				"path": "DiagnosticReport.conclusionCode",
-				"short": "Codes for the clinical conclusion of test results",
-				"definition": "One or more codes that represent the summary conclusion (interpretation/impression) of the diagnostic report.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.conclusionCode",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AdjunctDiagnosis"
-						}
-					],
-					"strength": "example",
-					"description": "Diagnosis codes provided as adjuncts to the report.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=SPRT].source[classCode=OBS, moodCode=EVN, code=LOINC:54531-9].value (type=CD)"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.presentedForm",
-				"path": "DiagnosticReport.presentedForm",
-				"short": "Entire report as issued",
-				"definition": "Rich text representation of the entire result as issued by the diagnostic service. Multiple formats are allowed but they SHALL be semantically equivalent.",
-				"comment": "\"application/pdf\" is recommended as the most reliable and interoperable in this context.",
-				"requirements": "Gives laboratory the ability to provide its own fully formatted report for clinical fidelity.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.presentedForm",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Attachment"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "text (type=ED)"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "DiagnosticReport",
-				"path": "DiagnosticReport",
-				"short": "US Core Diagnostic Report Profile for Report and Note exchange",
-				"definition": "The US Core Diagnostic Report Profile for Report and Note exchange is based upon the requirements of the Argonauts to exchang imaginge reports.",
-				"alias": [
-					"Imaging Report",
-					"Radiology Report"
-				],
-				"mustSupport": false,
-				"isModifier": false
-			},
-			{
-				"id": "DiagnosticReport.status",
-				"path": "DiagnosticReport.status",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/diagnostic-report-status"
-				}
-			},
-			{
-				"id": "DiagnosticReport.category",
-				"path": "DiagnosticReport.category",
-				"alias": [
-					"Department",
-					"Sub-department",
-					"service",
-					"discipline"
-				],
-				"min": 1,
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-category|3.1.1"
-				}
-			},
-			{
-				"id": "DiagnosticReport.code",
-				"path": "DiagnosticReport.code",
-				"short": "US Core Report Code",
-				"definition": "The test, panel, report, or note that was ordered.",
-				"comment": "UsageNote= The typical patterns for codes are:  1)  a LOINC code either as a  translation from a \"local\" code or as a primary code, or 2)  a local code only if no suitable LOINC exists,  or 3)  both the local and the LOINC translation.   Systems SHALL be capable of sending the local code if one exists.",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"binding": {
-					"strength": "extensible",
-					"description": "LOINC codes",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-report-and-note-codes|3.1.1"
-				}
-			},
-			{
-				"id": "DiagnosticReport.subject",
-				"path": "DiagnosticReport.subject",
-				"short": "The subject of the report - usually, but not always, the patient",
-				"definition": "The subject of the report. Usually, but not always, this is a patient. However diagnostic services also perform analyses on specimens collected from a variety of other sources.",
-				"requirements": "SHALL know the subject context.",
-				"alias": [
-					"Patient"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "DiagnosticReport.encounter",
-				"path": "DiagnosticReport.encounter",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "DiagnosticReport.effective[x]",
-				"path": "DiagnosticReport.effective[x]",
-				"short": "Time of the report or note",
-				"definition": "This is the Datetime or Period when the report or note was written.",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "DiagnosticReport.issued",
-				"path": "DiagnosticReport.issued",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "DiagnosticReport.performer",
-				"path": "DiagnosticReport.performer",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "DiagnosticReport.presentedForm",
-				"path": "DiagnosticReport.presentedForm",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "Attachment"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-diagnosticreport-note",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note",
+    "version": "3.1.1",
+    "name": "USCoreDiagnosticReportProfileNoteExchange",
+    "title": "US Core DiagnosticReport Profile for Report and Note exchange",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.healthit.gov"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the DiagnosticReport resource  for the minimal set of data to query and retrieve diagnostic reports associated with clinical notes for a patient",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "DiagnosticReport",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "DiagnosticReport",
+                "path": "DiagnosticReport",
+                "short": "US Core Diagnostic Report Profile for Report and Note exchange",
+                "definition": "The US Core Diagnostic Report Profile for Report and Note exchange is based upon the requirements of the Argonauts to exchang imaginge reports.",
+                "comment": "This is intended to capture a single report and is not suitable for use in displaying summary information that covers multiple reports.  For example, this resource has not been designed for laboratory cumulative reporting formats nor detailed structured reports for sequencing.",
+                "alias": [
+                    "Report",
+                    "Test",
+                    "Result",
+                    "Results",
+                    "Labs",
+                    "Laboratory",
+                    "Imaging Report",
+                    "Radiology Report"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORU -> OBR"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.id",
+                "path": "DiagnosticReport.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "DiagnosticReport.meta",
+                "path": "DiagnosticReport.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "DiagnosticReport.implicitRules",
+                "path": "DiagnosticReport.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "DiagnosticReport.language",
+                "path": "DiagnosticReport.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "DiagnosticReport.text",
+                "path": "DiagnosticReport.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.contained",
+                "path": "DiagnosticReport.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.extension",
+                "path": "DiagnosticReport.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.modifierExtension",
+                "path": "DiagnosticReport.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.identifier",
+                "path": "DiagnosticReport.identifier",
+                "short": "Business identifier for report",
+                "definition": "Identifiers assigned to this report by the performer or other systems.",
+                "comment": "Usually assigned by the Information System of the diagnostic service provider (filler id).",
+                "requirements": "Need to know what identifier to use when making queries about this report from the source laboratory, and for linking to the report outside FHIR context.",
+                "alias": [
+                    "ReportID",
+                    "Filler ID",
+                    "Placer ID"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-51/ for globally unique filler ID  - OBR-3 , For non-globally unique filler-id the flller/placer number must be combined with the universal service Id -  OBR-2(if present)+OBR-3+OBR-4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "id"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.basedOn",
+                "path": "DiagnosticReport.basedOn",
+                "short": "What was requested",
+                "definition": "Details concerning a service requested.",
+                "comment": "Note: Usually there is one test request for each result, however in some circumstances multiple test requests may be represented using a single test result resource. Note that there are also cases where one request leads to multiple reports.",
+                "requirements": "This allows tracing of authorization for the report and tracking whether proposals/recommendations were acted upon.",
+                "alias": [
+                    "Request"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan",
+                            "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+                            "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.basedOn"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC? OBR-2/3?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=FLFS].target"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.status",
+                "path": "DiagnosticReport.status",
+                "short": "registered | partial | preliminary | final +",
+                "definition": "The status of the diagnostic report.",
+                "requirements": "Diagnostic services routinely issue provisional/incomplete reports, and sometimes withdraw previously released reports.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/diagnostic-report-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-25 (not 1:1 mapping)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "statusCode  Note: final and amended are distinguished by whether observation is the subject of a ControlAct event of type \"revise\""
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.category",
+                "path": "DiagnosticReport.category",
+                "short": "Service category",
+                "definition": "A code that classifies the clinical discipline, department or diagnostic service that created the report (e.g. cardiology, biochemistry, hematology, MRI). This is used for searching, sorting and display purposes.",
+                "comment": "Multiple categories are allowed using various categorization schemes.   The level of granularity is defined by the category concepts in the value set. More fine-grained filtering can be performed using the metadata and/or terminology hierarchy in DiagnosticReport.code.",
+                "alias": [
+                    "Department",
+                    "Sub-department",
+                    "Service",
+                    "Discipline",
+                    "service",
+                    "discipline"
+                ],
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-category|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-24"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=COMP].source[classCode=LIST, moodCode=EVN, code < LabService].code"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.code",
+                "path": "DiagnosticReport.code",
+                "short": "US Core Report Code",
+                "definition": "The test, panel, report, or note that was ordered.",
+                "comment": "UsageNote= The typical patterns for codes are:  1)  a LOINC code either as a  translation from a \"local\" code or as a primary code, or 2)  a local code only if no suitable LOINC exists,  or 3)  both the local and the LOINC translation.   Systems SHALL be capable of sending the local code if one exists.",
+                "alias": [
+                    "Type"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "LOINC codes",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-report-and-note-codes|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-4 (HL7 v2 doesn't provide an easy way to indicate both the ordered test and the performed panel)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.subject",
+                "path": "DiagnosticReport.subject",
+                "short": "The subject of the report - usually, but not always, the patient",
+                "definition": "The subject of the report. Usually, but not always, this is a patient. However diagnostic services also perform analyses on specimens collected from a variety of other sources.",
+                "requirements": "SHALL know the subject context.",
+                "alias": [
+                    "Patient"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3 (no HL7 v2 mapping for Group or Device)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SBJ]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.encounter",
+                "path": "DiagnosticReport.encounter",
+                "short": "Health care event when test ordered",
+                "definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) which this DiagnosticReport is about.",
+                "comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter  but still be tied to the context of the encounter  (e.g. pre-admission laboratory tests).",
+                "requirements": "Links the request to the Encounter context.",
+                "alias": [
+                    "Context"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.encounter"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1-19"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.effective[x]",
+                "path": "DiagnosticReport.effective[x]",
+                "short": "Time of the report or note",
+                "definition": "This is the Datetime or Period when the report or note was written.",
+                "comment": "If the diagnostic procedure was performed on the patient, this is the time it was performed. If there are specimens, the diagnostically relevant time can be derived from the specimen collection times, but the specimen information is not always available, and the exact relationship between the specimens and the diagnostically relevant time is not always automatic.",
+                "requirements": "Need to know where in the patient history to file/present this report.",
+                "alias": [
+                    "Observation time",
+                    "Effective Time",
+                    "Occurrence"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.effective[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.issued",
+                "path": "DiagnosticReport.issued",
+                "short": "DateTime this version was made",
+                "definition": "The date and time that this version of the report was made available to providers, typically after the report was reviewed and verified.",
+                "comment": "May be different from the update time of the resource itself, because that is the status of the record (potentially a secondary copy), not the actual release time of the report.",
+                "requirements": "Clinicians need to be able to check the date that the report was released.",
+                "alias": [
+                    "Date published",
+                    "Date Issued",
+                    "Date Verified"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.issued",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-22"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=VRF or AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.performer",
+                "path": "DiagnosticReport.performer",
+                "short": "Responsible Diagnostic Service",
+                "definition": "The diagnostic service that is responsible for issuing the report.",
+                "comment": "This is not necessarily the source of the atomic data items or the entity that interpreted the results. It is the entity that takes responsibility for the clinical report.",
+                "requirements": "Need to know whom to contact if there are queries about the results. Also may need to track the source of reports for secondary data analysis.",
+                "alias": [
+                    "Laboratory",
+                    "Service",
+                    "Practitioner",
+                    "Department",
+                    "Company",
+                    "Authorized by",
+                    "Director"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.performer",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRT-8 (where this PRT-4-Participation = \"PO\")"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=PRF]"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.resultsInterpreter",
+                "path": "DiagnosticReport.resultsInterpreter",
+                "short": "Primary result interpreter",
+                "definition": "The practitioner or organization that is responsible for the report's conclusions and interpretations.",
+                "comment": "Might not be the same entity that takes responsibility for the clinical report.",
+                "requirements": "Need to know whom to contact if there are queries about the results. Also may need to track the source of reports for secondary data analysis.",
+                "alias": [
+                    "Analyzed by",
+                    "Reported by"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.resultsInterpreter",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-32, PRT-8 (where this PRT-4-Participation = \"PI\")"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=PRF]"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.specimen",
+                "path": "DiagnosticReport.specimen",
+                "short": "Specimens this report is based on",
+                "definition": "Details about the specimens on which this diagnostic report is based.",
+                "comment": "If the specimen is sufficiently specified with a code in the test result name, then this additional data may be redundant. If there are multiple specimens, these may be represented per observation or group.",
+                "requirements": "Need to be able to report information about the collected specimens on which the report is based.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.specimen",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Specimen"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SPM"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SBJ]"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.result",
+                "path": "DiagnosticReport.result",
+                "short": "Observations",
+                "definition": "[Observations](http://hl7.org/fhir/R4/observation.html)  that are part of this diagnostic report.",
+                "comment": "Observations can contain observations.",
+                "requirements": "Need to support individual results, or  groups of results, where the result grouping is arbitrary, but meaningful.",
+                "alias": [
+                    "Data",
+                    "Atomic Value",
+                    "Result",
+                    "Atomic result",
+                    "Data",
+                    "Test",
+                    "Analyte",
+                    "Battery",
+                    "Organizer"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.result",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Observation"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBXs"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=COMP].target"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.imagingStudy",
+                "path": "DiagnosticReport.imagingStudy",
+                "short": "Reference to full details of imaging associated with the diagnostic report",
+                "definition": "One or more links to full details of any imaging performed during the diagnostic investigation. Typically, this is imaging performed by DICOM enabled modalities, but this is not required. A fully enabled PACS viewer can use this information to provide views of the source images.",
+                "comment": "ImagingStudy and the image element are somewhat overlapping - typically, the list of image references in the image element will also be found in one of the imaging study resources. However, each caters to different types of displays for different types of purposes. Neither, either, or both may be provided.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.imagingStudy",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=COMP].target[classsCode=DGIMG, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.media",
+                "path": "DiagnosticReport.media",
+                "short": "Key images associated with this report",
+                "definition": "A list of key images associated with this report. The images are generally created during the diagnostic process, and may be directly of the patient, or of treated specimens (i.e. slides of interest).",
+                "requirements": "Many diagnostic services include images in the report as part of their service.",
+                "alias": [
+                    "DICOM",
+                    "Slides",
+                    "Scans"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.media",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=COMP].target"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.media.id",
+                "path": "DiagnosticReport.media.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.media.extension",
+                "path": "DiagnosticReport.media.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.media.modifierExtension",
+                "path": "DiagnosticReport.media.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.media.comment",
+                "path": "DiagnosticReport.media.comment",
+                "short": "Comment about the image (e.g. explanation)",
+                "definition": "A comment about the image. Typically, this is used to provide an explanation for why the image is included, or to draw the viewer's attention to important features.",
+                "comment": "The comment should be displayed with the image. It would be common for the report to include additional discussion of the image contents in other sections such as the conclusion.",
+                "requirements": "The provider of the report should make a comment about each image included in the report.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.media.comment",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[classCode=OBS, moodCode=EVN, code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.media.link",
+                "path": "DiagnosticReport.media.link",
+                "short": "Reference to the image source",
+                "definition": "Reference to the image source.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.media.link",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Media"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".value.reference"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.conclusion",
+                "path": "DiagnosticReport.conclusion",
+                "short": "Clinical conclusion (interpretation) of test results",
+                "definition": "Concise and clinically contextualized summary conclusion (interpretation/impression) of the diagnostic report.",
+                "requirements": "Need to be able to provide a conclusion that is not lost among the basic result data.",
+                "alias": [
+                    "Report"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.conclusion",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=\"SPRT\"].source[classCode=OBS, moodCode=EVN, code=LOINC:48767-8].value (type=ST)"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.conclusionCode",
+                "path": "DiagnosticReport.conclusionCode",
+                "short": "Codes for the clinical conclusion of test results",
+                "definition": "One or more codes that represent the summary conclusion (interpretation/impression) of the diagnostic report.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.conclusionCode",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AdjunctDiagnosis"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Diagnosis codes provided as adjuncts to the report.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=SPRT].source[classCode=OBS, moodCode=EVN, code=LOINC:54531-9].value (type=CD)"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.presentedForm",
+                "path": "DiagnosticReport.presentedForm",
+                "short": "Entire report as issued",
+                "definition": "Rich text representation of the entire result as issued by the diagnostic service. Multiple formats are allowed but they SHALL be semantically equivalent.",
+                "comment": "\"application/pdf\" is recommended as the most reliable and interoperable in this context.",
+                "requirements": "Gives laboratory the ability to provide its own fully formatted report for clinical fidelity.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.presentedForm",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Attachment"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "text (type=ED)"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "DiagnosticReport",
+                "path": "DiagnosticReport",
+                "short": "US Core Diagnostic Report Profile for Report and Note exchange",
+                "definition": "The US Core Diagnostic Report Profile for Report and Note exchange is based upon the requirements of the Argonauts to exchang imaginge reports.",
+                "alias": [
+                    "Imaging Report",
+                    "Radiology Report"
+                ],
+                "mustSupport": false,
+                "isModifier": false
+            },
+            {
+                "id": "DiagnosticReport.status",
+                "path": "DiagnosticReport.status",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/diagnostic-report-status"
+                }
+            },
+            {
+                "id": "DiagnosticReport.category",
+                "path": "DiagnosticReport.category",
+                "alias": [
+                    "Department",
+                    "Sub-department",
+                    "service",
+                    "discipline"
+                ],
+                "min": 1,
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-category|3.1.1"
+                }
+            },
+            {
+                "id": "DiagnosticReport.code",
+                "path": "DiagnosticReport.code",
+                "short": "US Core Report Code",
+                "definition": "The test, panel, report, or note that was ordered.",
+                "comment": "UsageNote= The typical patterns for codes are:  1)  a LOINC code either as a  translation from a \"local\" code or as a primary code, or 2)  a local code only if no suitable LOINC exists,  or 3)  both the local and the LOINC translation.   Systems SHALL be capable of sending the local code if one exists.",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "LOINC codes",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-report-and-note-codes|3.1.1"
+                }
+            },
+            {
+                "id": "DiagnosticReport.subject",
+                "path": "DiagnosticReport.subject",
+                "short": "The subject of the report - usually, but not always, the patient",
+                "definition": "The subject of the report. Usually, but not always, this is a patient. However diagnostic services also perform analyses on specimens collected from a variety of other sources.",
+                "requirements": "SHALL know the subject context.",
+                "alias": [
+                    "Patient"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "DiagnosticReport.encounter",
+                "path": "DiagnosticReport.encounter",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "DiagnosticReport.effective[x]",
+                "path": "DiagnosticReport.effective[x]",
+                "short": "Time of the report or note",
+                "definition": "This is the Datetime or Period when the report or note was written.",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "DiagnosticReport.issued",
+                "path": "DiagnosticReport.issued",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "DiagnosticReport.performer",
+                "path": "DiagnosticReport.performer",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "DiagnosticReport.presentedForm",
+                "path": "DiagnosticReport.presentedForm",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "Attachment"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-direct.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-direct.json
@@ -1,360 +1,360 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-direct",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-direct-definitions.html#Extension\" title=\"This email address is associated with a &quot;direct&quot; service - e.g. http://wiki.directproject.org/Addressing+Specification. This extension can only be used on contact points where the system = 'email'\">Extension</a><a name=\"Extension\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/extensibility.html#Extension\">Extension</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Email is a &quot;direct&quot; email</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-direct-definitions.html#Extension.url\">url</a><a name=\"Extension.url\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">1</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"color: darkgreen\">&quot;http://hl7.org/fhir/us/core/StructureDefinition/us-core-direct&quot;</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck00.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-direct-definitions.html#Extension.valueBoolean\">valueBoolean</a><a name=\"Extension.valueBoolean\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#boolean\">boolean</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Value of extension</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-direct",
-	"version": "3.1.1",
-	"name": "USCoreDirectEmailExtension",
-	"title": "US Core Direct email Extension",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.healthit.gov"
-				}
-			]
-		}
-	],
-	"description": "This email address is associated with a [direct](http://wiki.directproject.org/Addressing+Specification) service.  This extension can only be used on contact points where the system = 'email'",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		}
-	],
-	"kind": "complex-type",
-	"abstract": false,
-	"context": [
-		{
-			"type": "element",
-			"expression": "ContactPoint"
-		}
-	],
-	"type": "Extension",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Extension",
-				"path": "Extension",
-				"short": "Email is a \"direct\" email",
-				"definition": "This email address is associated with a \"direct\" service - e.g. http://wiki.directproject.org/Addressing+Specification. This extension can only be used on contact points where the system = 'email'",
-				"comment": "This extension can only be used on contact points where the system = 'email'.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Extension",
-					"min": 0,
-					"max": "*"
-				},
-				"condition": [
-					"ele-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "No v2 equivalent"
-					},
-					{
-						"identity": "rim",
-						"map": "No RIM equivalent"
-					}
-				]
-			},
-			{
-				"id": "Extension.id",
-				"path": "Extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension",
-				"path": "Extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.url",
-				"path": "Extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "uri"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-direct",
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.value[x]",
-				"path": "Extension.value[x]",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "type",
-							"path": "$this"
-						}
-					],
-					"ordered": false,
-					"rules": "closed"
-				},
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.value[x]:valueBoolean",
-				"path": "Extension.value[x]",
-				"sliceName": "valueBoolean",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Extension",
-				"path": "Extension",
-				"short": "Email is a \"direct\" email",
-				"definition": "This email address is associated with a \"direct\" service - e.g. http://wiki.directproject.org/Addressing+Specification. This extension can only be used on contact points where the system = 'email'",
-				"comment": "This extension can only be used on contact points where the system = 'email'.",
-				"min": 0,
-				"max": "1",
-				"isModifier": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "No v2 equivalent"
-					},
-					{
-						"identity": "rim",
-						"map": "No RIM equivalent"
-					}
-				]
-			},
-			{
-				"id": "Extension.url",
-				"path": "Extension.url",
-				"fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-direct"
-			},
-			{
-				"id": "Extension.valueBoolean",
-				"path": "Extension.valueBoolean",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "boolean"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-direct",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-direct",
+    "version": "3.1.1",
+    "name": "USCoreDirectEmailExtension",
+    "title": "US Core Direct email Extension",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.healthit.gov"
+                }
+            ]
+        }
+    ],
+    "description": "This email address is associated with a [direct](http://wiki.directproject.org/Addressing+Specification) service.  This extension can only be used on contact points where the system = 'email'",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        }
+    ],
+    "kind": "complex-type",
+    "abstract": false,
+    "context": [
+        {
+            "type": "element",
+            "expression": "ContactPoint"
+        }
+    ],
+    "type": "Extension",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Extension",
+                "path": "Extension",
+                "short": "Email is a \"direct\" email",
+                "definition": "This email address is associated with a \"direct\" service - e.g. http://wiki.directproject.org/Addressing+Specification. This extension can only be used on contact points where the system = 'email'",
+                "comment": "This extension can only be used on contact points where the system = 'email'.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "condition": [
+                    "ele-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "No v2 equivalent"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "No RIM equivalent"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.id",
+                "path": "Extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension",
+                "path": "Extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.url",
+                "path": "Extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "uri"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-direct",
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.value[x]",
+                "path": "Extension.value[x]",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "type",
+                            "path": "$this"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "closed"
+                },
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.value[x]:valueBoolean",
+                "path": "Extension.value[x]",
+                "sliceName": "valueBoolean",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Extension",
+                "path": "Extension",
+                "short": "Email is a \"direct\" email",
+                "definition": "This email address is associated with a \"direct\" service - e.g. http://wiki.directproject.org/Addressing+Specification. This extension can only be used on contact points where the system = 'email'",
+                "comment": "This extension can only be used on contact points where the system = 'email'.",
+                "min": 0,
+                "max": "1",
+                "isModifier": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "No v2 equivalent"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "No RIM equivalent"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.url",
+                "path": "Extension.url",
+                "fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-direct"
+            },
+            {
+                "id": "Extension.valueBoolean",
+                "path": "Extension.valueBoolean",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-documentreference.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-documentreference.json
@@ -1,3079 +1,3079 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-documentreference",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference\" title=\"This is a basic constraint on DocumentRefernce for use in the US Core IG.\">DocumentReference</a><a name=\"DocumentReference\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/documentreference.html\">DocumentReference</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">A reference to a document</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.identifier\">identifier</a><a name=\"DocumentReference.identifier\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Identifier\">Identifier</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Other identifiers for the document</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.status\">status</a><a name=\"DocumentReference.status\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">current | superseded | entered-in-error</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-document-reference-status.html\">DocumentReferenceStatus</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.type\">type</a><a name=\"DocumentReference.type\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Kind of document (LOINC if possible)</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-documentreference-type.html\">US Core DocumentReference Type</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)<br/><a style=\"font-weight:bold\" href=\"http://hl7.org/fhir/R4/extension-elementdefinition-minvalueset.html\" title=\"Min Value Set Extension\">Min Binding: </a><a href=\"ValueSet-us-core-clinical-note-type.html\">US Core Clinical Note Type</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.category\">category</a><a name=\"DocumentReference.category\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Categorization of document</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-documentreference-category.html\">US Core DocumentReference Category</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)<br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.subject\">subject</a><a name=\"DocumentReference.subject\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who/what is the subject of the document</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.date\">date</a><a name=\"DocumentReference.date\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#instant\">instant</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">When this document reference was created</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.author\">author</a><a name=\"DocumentReference.author\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-practitioner.html\">US Core Practitioner Profile</a> | <a href=\"StructureDefinition-us-core-organization.html\">US Core Organization Profile</a> | <a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who and/or what authored the document</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.custodian\">custodian</a><a name=\"DocumentReference.custodian\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-organization.html\">US Core Organization Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Organization which maintains the document</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.content\">content</a><a name=\"DocumentReference.content\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Document referenced</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck111.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.content.attachment\">attachment</a><a name=\"DocumentReference.content.attachment\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-6)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Attachment\">Attachment</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Where to access the document</span><br/><span style=\"font-weight:bold\">us-core-6: </span>DocumentReference.content.attachment.url or  DocumentReference.content.attachment.data or both SHALL be present.</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.content.attachment.contentType\">contentType</a><a name=\"DocumentReference.content.attachment.contentType\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Mime type of the content, with charset etc.</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.content.attachment.data\">data</a><a name=\"DocumentReference.content.attachment.data\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-6)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#base64Binary\">base64Binary</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Data inline, base64ed</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.content.attachment.url\">url</a><a name=\"DocumentReference.content.attachment.url\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-6)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#url\">url</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Uri where the data can be found</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.content.format\">format</a><a name=\"DocumentReference.content.format\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Format/content rules for the document</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-formatcodes.html\">DocumentReferenceFormatCodeSet</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.context\">context</a><a name=\"DocumentReference.context\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Clinical context of document</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.context.encounter\">encounter</a><a name=\"DocumentReference.context.encounter\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-encounter.html\">US Core Encounter Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Context of the document  content</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.context.period\">period</a><a name=\"DocumentReference.context.period\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Period\">Period</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Time of service that is being documented</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference",
-	"version": "3.1.1",
-	"name": "USCoreDocumentReferenceProfile",
-	"title": "US Core DocumentReference Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-02",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.healthit.gov"
-				}
-			]
-		}
-	],
-	"description": "The document reference profile used in US Core.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "fhircomposition",
-			"uri": "http://hl7.org/fhir/composition",
-			"name": "FHIR Composition"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "cda",
-			"uri": "http://hl7.org/v3/cda",
-			"name": "CDA (R2)"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "xds",
-			"uri": "http://ihe.net/xds",
-			"name": "XDS metadata equivalent"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "DocumentReference",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/DocumentReference",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "DocumentReference",
-				"path": "DocumentReference",
-				"short": "A reference to a document",
-				"definition": "This is a basic constraint on DocumentRefernce for use in the US Core IG.",
-				"comment": "Usually, this is used for documents other than those defined by FHIR.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DocumentReference",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "fhircomposition",
-						"map": "when describing a Composition"
-					},
-					{
-						"identity": "rim",
-						"map": "Document[classCode=\"DOC\" and moodCode=\"EVN\"]"
-					},
-					{
-						"identity": "cda",
-						"map": "when describing a CDA"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.id",
-				"path": "DocumentReference.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "DocumentReference.meta",
-				"path": "DocumentReference.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "DocumentReference.implicitRules",
-				"path": "DocumentReference.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "DocumentReference.language",
-				"path": "DocumentReference.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "DocumentReference.text",
-				"path": "DocumentReference.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.contained",
-				"path": "DocumentReference.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.extension",
-				"path": "DocumentReference.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.modifierExtension",
-				"path": "DocumentReference.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.masterIdentifier",
-				"path": "DocumentReference.masterIdentifier",
-				"short": "Master Version Specific Identifier",
-				"definition": "Document identifier as assigned by the source of the document. This identifier is specific to this version of the document. This unique identifier may be used elsewhere to identify this version of the document.",
-				"comment": "CDA Document Id extension and root.",
-				"requirements": "The structure and format of this Id shall be consistent with the specification corresponding to the formatCode attribute. (e.g. for a DICOM standard document a 64-character numeric UID, for an HL7 CDA format a serialization of the CDA Document Id extension and root in the form \"oid^extension\", where OID is a 64 digits max, and the Id is a 16 UTF-8 char max. If the OID is coded without the extension then the '^' character shall not be included.).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.masterIdentifier",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "TXA-12"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.uniqueId"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/id"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.identifier",
-				"path": "DocumentReference.identifier",
-				"short": "Other identifiers for the document",
-				"definition": "Other identifiers associated with the document, including version independent identifiers.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DocumentReference.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "TXA-16?"
-					},
-					{
-						"identity": "rim",
-						"map": ".id / .setId"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.entryUUID"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.status",
-				"path": "DocumentReference.status",
-				"short": "current | superseded | entered-in-error",
-				"definition": "The status of this document reference.",
-				"comment": "This is the status of the DocumentReference object, which might be independent from the docStatus element.\n\nThis element is labeled as a modifier because the status contains the codes that mark the document or reference as not currently valid.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labelled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/document-reference-status"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "v2",
-						"map": "TXA-19"
-					},
-					{
-						"identity": "rim",
-						"map": "interim: .completionCode=\"IN\" & ./statusCode[isNormalDatatype()]=\"active\";  final: .completionCode=\"AU\" &&  ./statusCode[isNormalDatatype()]=\"complete\" and not(./inboundRelationship[typeCode=\"SUBJ\" and isNormalActRelationship()]/source[subsumesCode(\"ActClass#CACT\") and moodCode=\"EVN\" and domainMember(\"ReviseDocument\", code) and isNormalAct()]);  amended: .completionCode=\"AU\" &&  ./statusCode[isNormalDatatype()]=\"complete\" and ./inboundRelationship[typeCode=\"SUBJ\" and isNormalActRelationship()]/source[subsumesCode(\"ActClass#CACT\") and moodCode=\"EVN\" and domainMember(\"ReviseDocument\", code) and isNormalAct() and statusCode=\"completed\"];  withdrawn : .completionCode=NI &&  ./statusCode[isNormalDatatype()]=\"obsolete\""
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.availabilityStatus"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.docStatus",
-				"path": "DocumentReference.docStatus",
-				"short": "preliminary | final | amended | entered-in-error",
-				"definition": "The status of the underlying document.",
-				"comment": "The document that is pointed to might be in various lifecycle states.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.docStatus",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ReferredDocumentStatus"
-						}
-					],
-					"strength": "required",
-					"description": "Status of the underlying document.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/composition-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.status"
-					},
-					{
-						"identity": "v2",
-						"map": "TXA-17"
-					},
-					{
-						"identity": "rim",
-						"map": ".statusCode"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.type",
-				"path": "DocumentReference.type",
-				"short": "Kind of document (LOINC if possible)",
-				"definition": "Specifies the particular kind of document referenced  (e.g. History and Physical, Discharge Summary, Progress Note). This usually equates to the purpose of making the document referenced.",
-				"comment": "Key metadata element describing the document that describes he exact type of document. Helps humans to assess whether the document is of interest when viewing a list of documents.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-minValueSet",
-							"valueCanonical": "http://hl7.org/fhir/us/core/ValueSet/us-core-clinical-note-type|3.1.1"
-						}
-					],
-					"strength": "required",
-					"description": "All LOINC  values whose SCALE is DOC in the LOINC database and the HL7 v3 Code System NullFlavor concept 'unknown'",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-type|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.type"
-					},
-					{
-						"identity": "v2",
-						"map": "TXA-2"
-					},
-					{
-						"identity": "rim",
-						"map": "./code"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.type"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/code/@code \n\nThe typeCode should be mapped from the ClinicalDocument/code element to a set of document type codes configured in the affinity domain. One suggested coding system to use for typeCode is LOINC, in which case the mapping step can be omitted."
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.category",
-				"path": "DocumentReference.category",
-				"short": "Categorization of document",
-				"definition": "A categorization for the type of document referenced - helps for indexing and searching. This may be implied by or derived from the code specified in the DocumentReference.type.",
-				"comment": "Key metadata element describing the the category or classification of the document. This is a broader perspective that groups similar documents based on how they would be used. This is a primary key used in searching.",
-				"alias": [
-					"claxs"
-				],
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "DocumentReference.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The US Core DocumentReferences Type Value Set is a &#39;starter set&#39; of categories supported for fetching and storing clinical notes.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-category|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.class"
-					},
-					{
-						"identity": "cda",
-						"map": "Derived from a mapping of /ClinicalDocument/code/@code to an Affinity Domain specified coded value to use and coding system. Affinity Domains are encouraged to use the appropriate value for Type of Service, based on the LOINC Type of Service (see Page 53 of the LOINC User's Manual). Must be consistent with /ClinicalDocument/code/@code"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.subject",
-				"path": "DocumentReference.subject",
-				"short": "Who/what is the subject of the document",
-				"definition": "Who or what the document is about. The document can be about a person, (patient or healthcare practitioner), a device (e.g. a machine) or even a group of subjects (such as a document about a herd of farm animals, or a set of patients that share a common exposure).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.subject"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3 (No standard way to define a Practitioner or Group subject in HL7 v2 MDM message)"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=\"SBJ\"].role[typeCode=\"PAT\"]"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.patientId"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/recordTarget/"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.date",
-				"path": "DocumentReference.date",
-				"short": "When this document reference was created",
-				"definition": "When the document reference was created.",
-				"comment": "Referencing/indexing time is used for tracking, organizing versions and searching.",
-				"alias": [
-					"indexed"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.date",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.date"
-					},
-					{
-						"identity": "rim",
-						"map": ".availabilityTime[type=\"TS\"]"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.author",
-				"path": "DocumentReference.author",
-				"short": "Who and/or what authored the document",
-				"definition": "Identifies who is responsible for adding the information to the document.",
-				"comment": "Not necessarily who did the actual data entry (i.e. typist) or who was the source (informant).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DocumentReference.author",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.author"
-					},
-					{
-						"identity": "v2",
-						"map": "TXA-9 (No standard way to indicate a Device in HL7 v2 MDM message)"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=\"AUT\"].role[classCode=\"ASSIGNED\"]"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.author"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/author"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.authenticator",
-				"path": "DocumentReference.authenticator",
-				"short": "Who/what authenticated the document",
-				"definition": "Which person or organization authenticates that this document is valid.",
-				"comment": "Represents a participant within the author institution who has legally authenticated or attested the document. Legal authentication implies that a document has been signed manually or electronically by the legal Authenticator.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.authenticator",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.witness"
-					},
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.attester"
-					},
-					{
-						"identity": "v2",
-						"map": "TXA-10"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=\"AUTHEN\"].role[classCode=\"ASSIGNED\"]"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.legalAuthenticator"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/legalAuthenticator"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.custodian",
-				"path": "DocumentReference.custodian",
-				"short": "Organization which maintains the document",
-				"definition": "Identifies the organization or group who is responsible for ongoing maintenance of and access to the document.",
-				"comment": "Identifies the logical organization (software system, vendor, or department) to go to find the current version, where to report issues, etc. This is different from the physical location (URL, disk drive, or server) of the document, which is the technical location of the document, which host may be delegated to the management of some other organization.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.custodian",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.custodian"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=\"RCV\"].role[classCode=\"CUST\"].scoper[classCode=\"ORG\" and determinerCode=\"INST\"]"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.relatesTo",
-				"path": "DocumentReference.relatesTo",
-				"short": "Relationships to other documents",
-				"definition": "Relationships that this document has with other document references that already exist.",
-				"comment": "This element is labeled as a modifier because documents that append to other documents are incomplete on their own.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DocumentReference.relatesTo",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.relatesTo"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry Associations"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.relatesTo.id",
-				"path": "DocumentReference.relatesTo.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.relatesTo.extension",
-				"path": "DocumentReference.relatesTo.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.relatesTo.modifierExtension",
-				"path": "DocumentReference.relatesTo.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.relatesTo.code",
-				"path": "DocumentReference.relatesTo.code",
-				"short": "replaces | transforms | signs | appends",
-				"definition": "The type of relationship that this document has with anther document.",
-				"comment": "If this document appends another document, then the document cannot be fully understood without also accessing the referenced document.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.relatesTo.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "DocumentRelationshipType"
-						}
-					],
-					"strength": "required",
-					"description": "The type of relationship between documents.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/document-relationship-type|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.relatesTo.code"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship.typeCode"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry Associations type"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.relatesTo.target",
-				"path": "DocumentReference.relatesTo.target",
-				"short": "Target of the relationship",
-				"definition": "The target document of this relationship.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.relatesTo.target",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/DocumentReference"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.relatesTo.target"
-					},
-					{
-						"identity": "rim",
-						"map": ".target[classCode=\"DOC\", moodCode=\"EVN\"].id"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry Associations reference"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.description",
-				"path": "DocumentReference.description",
-				"short": "Human-readable description",
-				"definition": "Human-readable description of the source document.",
-				"comment": "What the document is about,  a terse summary of the document.",
-				"requirements": "Helps humans to assess whether the document is of interest.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.description",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "TXA-25"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"SUBJ\"].target.text"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.comments"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.securityLabel",
-				"path": "DocumentReference.securityLabel",
-				"short": "Document security-tags",
-				"definition": "A set of Security-Tag codes specifying the level of privacy/security of the Document. Note that DocumentReference.meta.security contains the security labels of the \"reference\" to the document, while DocumentReference.securityLabel contains a snapshot of the security labels on the document the reference refers to.",
-				"comment": "The confidentiality codes can carry multiple vocabulary items. HL7 has developed an understanding of security and privacy tags that might be desirable in a Document Sharing environment, called HL7 Healthcare Privacy and Security Classification System (HCS). The following specification is recommended but not mandated, as the vocabulary bindings are an administrative domain responsibility. The use of this method is up to the policy domain such as the XDS Affinity Domain or other Trust Domain where all parties including sender and recipients are trusted to appropriately tag and enforce.   \n\nIn the HL7 Healthcare Privacy and Security Classification (HCS) there are code systems specific to Confidentiality, Sensitivity, Integrity, and Handling Caveats. Some values would come from a local vocabulary as they are related to workflow roles and special projects.",
-				"requirements": "Use of the Health Care Privacy/Security Classification (HCS) system of security-tag use is recommended.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DocumentReference.securityLabel",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "SecurityLabels"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "extensible",
-					"description": "Security Labels from the Healthcare Privacy and Security Classification System.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/security-labels"
-				},
-				"mapping": [
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.confidentiality, Composition.meta.security"
-					},
-					{
-						"identity": "v2",
-						"map": "TXA-18"
-					},
-					{
-						"identity": "rim",
-						"map": ".confidentialityCode"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.confidentialityCode"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/confidentialityCode/@code"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content",
-				"path": "DocumentReference.content",
-				"short": "Document referenced",
-				"definition": "The document and format referenced. There may be multiple content element repetitions, each with a different format.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "DocumentReference.content",
-					"min": 1,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "fhircomposition",
-						"map": "Bundle(Composition+*)"
-					},
-					{
-						"identity": "rim",
-						"map": "document.text"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content.id",
-				"path": "DocumentReference.content.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content.extension",
-				"path": "DocumentReference.content.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content.modifierExtension",
-				"path": "DocumentReference.content.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content.attachment",
-				"path": "DocumentReference.content.attachment",
-				"short": "Where to access the document",
-				"definition": "The document or URL of the document along with critical metadata to prove content has integrity.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.content.attachment",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Attachment"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "us-core-6",
-						"severity": "error",
-						"human": "DocumentReference.content.attachment.url or  DocumentReference.content.attachment.data or both SHALL be present.",
-						"expression": "url.exists() or data.exists()",
-						"xpath": "f:url or f:content"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.language, \nComposition.title, \nComposition.date"
-					},
-					{
-						"identity": "v2",
-						"map": "TXA-3 for mime type"
-					},
-					{
-						"identity": "rim",
-						"map": "document.text"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.mimeType, DocumentEntry.languageCode, DocumentEntry.URI, DocumentEntry.size, DocumentEntry.hash, DocumentEntry.title, DocumentEntry.creationTime"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/languageCode, ClinicalDocument/title, ClinicalDocument/date"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content.attachment.id",
-				"path": "DocumentReference.content.attachment.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content.attachment.extension",
-				"path": "DocumentReference.content.attachment.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content.attachment.contentType",
-				"path": "DocumentReference.content.attachment.contentType",
-				"short": "Mime type of the content, with charset etc.",
-				"definition": "Identifies the type of the data in the attachment and allows a method to be chosen to interpret or render the data. Includes mime type parameters such as charset where appropriate.",
-				"requirements": "Processors of the data need to be able to know how to interpret the data.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Attachment.contentType",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueCode": "text/plain; charset=UTF-8, image/png"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "MimeType"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "required",
-					"description": "The mime type of an attachment. Any valid mime type is allowed.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/mimetypes|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "ED.2+ED.3/RP.2+RP.3. Note conversion may be needed if old style values are being used"
-					},
-					{
-						"identity": "rim",
-						"map": "./mediaType, ./charset"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content.attachment.language",
-				"path": "DocumentReference.content.attachment.language",
-				"short": "Human language of the content (BCP-47)",
-				"definition": "The human language of the content. The value can be any valid value according to BCP 47.",
-				"requirements": "Users need to be able to choose between the languages in a set of attachments.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Attachment.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueCode": "en-AU"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "./language"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content.attachment.data",
-				"path": "DocumentReference.content.attachment.data",
-				"short": "Data inline, base64ed",
-				"definition": "The actual data of the attachment - a sequence of bytes, base64 encoded.",
-				"comment": "The base64-encoded data SHALL be expressed in the same character set as the base resource XML or JSON.",
-				"requirements": "The data needs to able to be transmitted inline.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Attachment.data",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "base64Binary"
-					}
-				],
-				"condition": [
-					"us-core-6"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "ED.5"
-					},
-					{
-						"identity": "rim",
-						"map": "./data"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content.attachment.url",
-				"path": "DocumentReference.content.attachment.url",
-				"short": "Uri where the data can be found",
-				"definition": "A location where the data can be accessed.",
-				"comment": "If both data and url are provided, the url SHALL point to the same content as the data contains. Urls may be relative references or may reference transient locations such as a wrapping envelope using cid: though this has ramifications for using signatures. Relative URLs are interpreted relative to the service url, like a resource reference, rather than relative to the resource itself. If a URL is provided, it SHALL resolve to actual data.",
-				"requirements": "The data needs to be transmitted by reference.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Attachment.url",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "url"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueUrl": "http://www.acme.com/logo-small.png"
-					}
-				],
-				"condition": [
-					"us-core-6"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RP.1+RP.2 - if they refer to a URL (see v2.6)"
-					},
-					{
-						"identity": "rim",
-						"map": "./reference/literal"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content.attachment.size",
-				"path": "DocumentReference.content.attachment.size",
-				"short": "Number of bytes of content (if url provided)",
-				"definition": "The number of bytes of data that make up this attachment (before base64 encoding, if that is done).",
-				"comment": "The number of bytes is redundant if the data is provided as a base64binary, but is useful if the data is provided as a url reference.",
-				"requirements": "Representing the size allows applications to determine whether they should fetch the content automatically in advance, or refuse to fetch it at all.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Attachment.size",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "unsignedInt"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A (needs data type R3 proposal)"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content.attachment.hash",
-				"path": "DocumentReference.content.attachment.hash",
-				"short": "Hash of the data (sha-1, base64ed)",
-				"definition": "The calculated hash of the data using SHA-1. Represented using base64.",
-				"comment": "The hash is calculated on the data prior to base64 encoding, if the data is based64 encoded. The hash is not intended to support digital signatures. Where protection against malicious threats a digital signature should be considered, see [Provenance.signature](http://hl7.org/fhir/R4/provenance-definitions.html#Provenance.signature) for mechanism to protect a resource with a digital signature.",
-				"requirements": "Included so that applications can verify that the contents of a location have not changed due to technical failures (e.g., storage rot, transport glitch, incorrect version).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Attachment.hash",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "base64Binary"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".integrityCheck[parent::ED/integrityCheckAlgorithm=\"SHA-1\"]"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content.attachment.title",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "DocumentReference.content.attachment.title",
-				"short": "Label to display in place of the data",
-				"definition": "A label or set of text to display in place of the data.",
-				"requirements": "Applications need a label to display to a human user in place of the actual data if the data cannot be rendered or perceived by the viewer.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Attachment.title",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "Official Corporate Logo"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "./title/data"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content.attachment.creation",
-				"path": "DocumentReference.content.attachment.creation",
-				"short": "Date attachment was first created",
-				"definition": "The date that the attachment was first created.",
-				"requirements": "This is often tracked as an integrity issue for use of the attachment.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Attachment.creation",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A (needs data type R3 proposal)"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content.format",
-				"path": "DocumentReference.content.format",
-				"short": "Format/content rules for the document",
-				"definition": "An identifier of the document encoding, structure, and template that the document conforms to beyond the base format indicated in the mimeType.",
-				"comment": "Note that while IHE mostly issues URNs for format types, not all documents can be identified by a URI.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.content.format",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/ValueSet/formatcodes"
-				},
-				"mapping": [
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.meta.profile"
-					},
-					{
-						"identity": "rim",
-						"map": "document.text"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.formatCode"
-					},
-					{
-						"identity": "cda",
-						"map": "derived from the IHE Profile or Implementation Guide templateID"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.context",
-				"path": "DocumentReference.context",
-				"short": "Clinical context of document",
-				"definition": "The clinical context in which the document was prepared.",
-				"comment": "These values are primarily added to help with searching for interesting/relevant documents.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.context",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=\"SUBJ\"].target[classCode<'ACT']"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.context.id",
-				"path": "DocumentReference.context.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.context.extension",
-				"path": "DocumentReference.context.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.context.modifierExtension",
-				"path": "DocumentReference.context.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.context.encounter",
-				"path": "DocumentReference.context.encounter",
-				"short": "Context of the document  content",
-				"definition": "Describes the clinical encounter or type of care that the document content is associated with.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.context.encounter",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.encounter"
-					},
-					{
-						"identity": "rim",
-						"map": "unique(highest(./outboundRelationship[typeCode=\"SUBJ\" and isNormalActRelationship()], priorityNumber)/target[moodCode=\"EVN\" and classCode=(\"ENC\", \"PCPR\") and isNormalAct])"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.context.event",
-				"path": "DocumentReference.context.event",
-				"short": "Main clinical acts documented",
-				"definition": "This list of codes represents the main clinical acts, such as a colonoscopy or an appendectomy, being documented. In some cases, the event is inherent in the type Code, such as a \"History and Physical Report\" in which the procedure being documented is necessarily a \"History and Physical\" act.",
-				"comment": "An event can further specialize the act inherent in the type, such as  where it is simply \"Procedure Report\" and the procedure was a \"colonoscopy\". If one or more event codes are included, they shall not conflict with the values inherent in the class or type elements as such a conflict would create an ambiguous situation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DocumentReference.context.event",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "DocumentEventType"
-						}
-					],
-					"strength": "example",
-					"description": "This list of codes represents the main clinical acts being documented.",
-					"valueSet": "http://terminology.hl7.org/ValueSet/v3-ActCode"
-				},
-				"mapping": [
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.event.code"
-					},
-					{
-						"identity": "rim",
-						"map": ".code"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.eventCodeList"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.context.period",
-				"path": "DocumentReference.context.period",
-				"short": "Time of service that is being documented",
-				"definition": "The time period over which the service that is described by the document was provided.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.context.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.event.period"
-					},
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.serviceStartTime, DocumentEntry.serviceStopTime"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/documentationOf/\nserviceEvent/effectiveTime/low/\n@value --> ClinicalDocument/documentationOf/\nserviceEvent/effectiveTime/high/\n@value"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.context.facilityType",
-				"path": "DocumentReference.context.facilityType",
-				"short": "Kind of facility where patient was seen",
-				"definition": "The kind of facility where the patient was seen.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.context.facilityType",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "DocumentC80FacilityType"
-						}
-					],
-					"strength": "example",
-					"description": "XDS Facility Type.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/c80-facilitycodes"
-				},
-				"mapping": [
-					{
-						"identity": "fhircomposition",
-						"map": "usually from a mapping to a local ValueSet"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=\"LOC\"].role[classCode=\"DSDLOC\"].code"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.healthcareFacilityTypeCode"
-					},
-					{
-						"identity": "cda",
-						"map": "usually a mapping to a local ValueSet. Must be consistent with /clinicalDocument/code"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.context.practiceSetting",
-				"path": "DocumentReference.context.practiceSetting",
-				"short": "Additional details about where the content was created (e.g. clinical specialty)",
-				"definition": "This property may convey specifics about the practice setting where the content was created, often reflecting the clinical specialty.",
-				"comment": "This element should be based on a coarse classification system for the class of specialty practice. Recommend the use of the classification system for Practice Setting, such as that described by the Subject Matter Domain in LOINC.",
-				"requirements": "This is an important piece of metadata that providers often rely upon to quickly sort and/or filter out to find specific content.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.context.practiceSetting",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "DocumentC80PracticeSetting"
-						}
-					],
-					"strength": "example",
-					"description": "Additional details about where the content was created (e.g. clinical specialty).",
-					"valueSet": "http://hl7.org/fhir/ValueSet/c80-practice-codes"
-				},
-				"mapping": [
-					{
-						"identity": "fhircomposition",
-						"map": "usually from a mapping to a local ValueSet"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=\"LOC\"].role[classCode=\"DSDLOC\"].code"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.practiceSettingCode"
-					},
-					{
-						"identity": "cda",
-						"map": "usually from a mapping to a local ValueSet"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.context.sourcePatientInfo",
-				"path": "DocumentReference.context.sourcePatientInfo",
-				"short": "Patient demographics from source",
-				"definition": "The Patient Information as known when the document was published. May be a reference to a version specific, or contained.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.context.sourcePatientInfo",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Patient"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.subject"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=\"SBJ\"].role[typeCode=\"PAT\"]"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.sourcePatientInfo, DocumentEntry.sourcePatientId"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/recordTarget/"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.context.related",
-				"path": "DocumentReference.context.related",
-				"short": "Related identifiers or resources",
-				"definition": "Related identifiers or resources associated with the DocumentReference.",
-				"comment": "May be identifiers or resources that caused the DocumentReference or referenced Document to be created.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DocumentReference.context.related",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.event.detail"
-					},
-					{
-						"identity": "rim",
-						"map": "./outboundRelationship[typeCode=\"PERT\" and isNormalActRelationship()] / target[isNormalAct]"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.referenceIdList"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/relatedDocument"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "DocumentReference",
-				"path": "DocumentReference",
-				"definition": "This is a basic constraint on DocumentRefernce for use in the US Core IG.",
-				"mustSupport": false
-			},
-			{
-				"id": "DocumentReference.identifier",
-				"path": "DocumentReference.identifier",
-				"min": 0,
-				"max": "*",
-				"mustSupport": true
-			},
-			{
-				"id": "DocumentReference.status",
-				"path": "DocumentReference.status",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/document-reference-status"
-				}
-			},
-			{
-				"id": "DocumentReference.type",
-				"path": "DocumentReference.type",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-minValueSet",
-							"valueCanonical": "http://hl7.org/fhir/us/core/ValueSet/us-core-clinical-note-type|3.1.1"
-						}
-					],
-					"strength": "required",
-					"description": "All LOINC  values whose SCALE is DOC in the LOINC database and the HL7 v3 Code System NullFlavor concept 'unknown'",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-type|3.1.1"
-				}
-			},
-			{
-				"id": "DocumentReference.category",
-				"path": "DocumentReference.category",
-				"min": 1,
-				"max": "*",
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The US Core DocumentReferences Type Value Set is a &#39;starter set&#39; of categories supported for fetching and storing clinical notes.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-category|3.1.1"
-				}
-			},
-			{
-				"id": "DocumentReference.subject",
-				"path": "DocumentReference.subject",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "DocumentReference.date",
-				"path": "DocumentReference.date",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "DocumentReference.author",
-				"path": "DocumentReference.author",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "DocumentReference.custodian",
-				"path": "DocumentReference.custodian",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "DocumentReference.content",
-				"path": "DocumentReference.content",
-				"min": 1,
-				"max": "*",
-				"mustSupport": true
-			},
-			{
-				"id": "DocumentReference.content.attachment",
-				"path": "DocumentReference.content.attachment",
-				"min": 1,
-				"max": "1",
-				"constraint": [
-					{
-						"key": "us-core-6",
-						"severity": "error",
-						"human": "DocumentReference.content.attachment.url or  DocumentReference.content.attachment.data or both SHALL be present.",
-						"expression": "url.exists() or data.exists()",
-						"xpath": "f:url or f:content"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "DocumentReference.content.attachment.contentType",
-				"path": "DocumentReference.content.attachment.contentType",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "DocumentReference.content.attachment.data",
-				"path": "DocumentReference.content.attachment.data",
-				"min": 0,
-				"max": "1",
-				"condition": [
-					"us-core-6"
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "DocumentReference.content.attachment.url",
-				"path": "DocumentReference.content.attachment.url",
-				"min": 0,
-				"max": "1",
-				"condition": [
-					"us-core-6"
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "DocumentReference.content.format",
-				"path": "DocumentReference.content.format",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/ValueSet/formatcodes"
-				}
-			},
-			{
-				"id": "DocumentReference.context",
-				"path": "DocumentReference.context",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "DocumentReference.context.encounter",
-				"path": "DocumentReference.context.encounter",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "DocumentReference.context.period",
-				"path": "DocumentReference.context.period",
-				"mustSupport": true
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-documentreference",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference",
+    "version": "3.1.1",
+    "name": "USCoreDocumentReferenceProfile",
+    "title": "US Core DocumentReference Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-02",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.healthit.gov"
+                }
+            ]
+        }
+    ],
+    "description": "The document reference profile used in US Core.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "fhircomposition",
+            "uri": "http://hl7.org/fhir/composition",
+            "name": "FHIR Composition"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "cda",
+            "uri": "http://hl7.org/v3/cda",
+            "name": "CDA (R2)"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "xds",
+            "uri": "http://ihe.net/xds",
+            "name": "XDS metadata equivalent"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "DocumentReference",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/DocumentReference",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "DocumentReference",
+                "path": "DocumentReference",
+                "short": "A reference to a document",
+                "definition": "This is a basic constraint on DocumentRefernce for use in the US Core IG.",
+                "comment": "Usually, this is used for documents other than those defined by FHIR.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DocumentReference",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "fhircomposition",
+                        "map": "when describing a Composition"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Document[classCode=\"DOC\" and moodCode=\"EVN\"]"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "when describing a CDA"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.id",
+                "path": "DocumentReference.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "DocumentReference.meta",
+                "path": "DocumentReference.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "DocumentReference.implicitRules",
+                "path": "DocumentReference.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "DocumentReference.language",
+                "path": "DocumentReference.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "DocumentReference.text",
+                "path": "DocumentReference.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.contained",
+                "path": "DocumentReference.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.extension",
+                "path": "DocumentReference.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.modifierExtension",
+                "path": "DocumentReference.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.masterIdentifier",
+                "path": "DocumentReference.masterIdentifier",
+                "short": "Master Version Specific Identifier",
+                "definition": "Document identifier as assigned by the source of the document. This identifier is specific to this version of the document. This unique identifier may be used elsewhere to identify this version of the document.",
+                "comment": "CDA Document Id extension and root.",
+                "requirements": "The structure and format of this Id shall be consistent with the specification corresponding to the formatCode attribute. (e.g. for a DICOM standard document a 64-character numeric UID, for an HL7 CDA format a serialization of the CDA Document Id extension and root in the form \"oid^extension\", where OID is a 64 digits max, and the Id is a 16 UTF-8 char max. If the OID is coded without the extension then the '^' character shall not be included.).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.masterIdentifier",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "TXA-12"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.uniqueId"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/id"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.identifier",
+                "path": "DocumentReference.identifier",
+                "short": "Other identifiers for the document",
+                "definition": "Other identifiers associated with the document, including version independent identifiers.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DocumentReference.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "TXA-16?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id / .setId"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.entryUUID"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.status",
+                "path": "DocumentReference.status",
+                "short": "current | superseded | entered-in-error",
+                "definition": "The status of this document reference.",
+                "comment": "This is the status of the DocumentReference object, which might be independent from the docStatus element.\n\nThis element is labeled as a modifier because the status contains the codes that mark the document or reference as not currently valid.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labelled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/document-reference-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "TXA-19"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interim: .completionCode=\"IN\" & ./statusCode[isNormalDatatype()]=\"active\";  final: .completionCode=\"AU\" &&  ./statusCode[isNormalDatatype()]=\"complete\" and not(./inboundRelationship[typeCode=\"SUBJ\" and isNormalActRelationship()]/source[subsumesCode(\"ActClass#CACT\") and moodCode=\"EVN\" and domainMember(\"ReviseDocument\", code) and isNormalAct()]);  amended: .completionCode=\"AU\" &&  ./statusCode[isNormalDatatype()]=\"complete\" and ./inboundRelationship[typeCode=\"SUBJ\" and isNormalActRelationship()]/source[subsumesCode(\"ActClass#CACT\") and moodCode=\"EVN\" and domainMember(\"ReviseDocument\", code) and isNormalAct() and statusCode=\"completed\"];  withdrawn : .completionCode=NI &&  ./statusCode[isNormalDatatype()]=\"obsolete\""
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.availabilityStatus"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.docStatus",
+                "path": "DocumentReference.docStatus",
+                "short": "preliminary | final | amended | entered-in-error",
+                "definition": "The status of the underlying document.",
+                "comment": "The document that is pointed to might be in various lifecycle states.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.docStatus",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ReferredDocumentStatus"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Status of the underlying document.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/composition-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.status"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "TXA-17"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".statusCode"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.type",
+                "path": "DocumentReference.type",
+                "short": "Kind of document (LOINC if possible)",
+                "definition": "Specifies the particular kind of document referenced  (e.g. History and Physical, Discharge Summary, Progress Note). This usually equates to the purpose of making the document referenced.",
+                "comment": "Key metadata element describing the document that describes he exact type of document. Helps humans to assess whether the document is of interest when viewing a list of documents.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-minValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/us/core/ValueSet/us-core-clinical-note-type|3.1.1"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "All LOINC  values whose SCALE is DOC in the LOINC database and the HL7 v3 Code System NullFlavor concept 'unknown'",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-type|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.type"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "TXA-2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./code"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.type"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/code/@code \n\nThe typeCode should be mapped from the ClinicalDocument/code element to a set of document type codes configured in the affinity domain. One suggested coding system to use for typeCode is LOINC, in which case the mapping step can be omitted."
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.category",
+                "path": "DocumentReference.category",
+                "short": "Categorization of document",
+                "definition": "A categorization for the type of document referenced - helps for indexing and searching. This may be implied by or derived from the code specified in the DocumentReference.type.",
+                "comment": "Key metadata element describing the the category or classification of the document. This is a broader perspective that groups similar documents based on how they would be used. This is a primary key used in searching.",
+                "alias": [
+                    "claxs"
+                ],
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "DocumentReference.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The US Core DocumentReferences Type Value Set is a &#39;starter set&#39; of categories supported for fetching and storing clinical notes.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-category|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.class"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "Derived from a mapping of /ClinicalDocument/code/@code to an Affinity Domain specified coded value to use and coding system. Affinity Domains are encouraged to use the appropriate value for Type of Service, based on the LOINC Type of Service (see Page 53 of the LOINC User's Manual). Must be consistent with /ClinicalDocument/code/@code"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.subject",
+                "path": "DocumentReference.subject",
+                "short": "Who/what is the subject of the document",
+                "definition": "Who or what the document is about. The document can be about a person, (patient or healthcare practitioner), a device (e.g. a machine) or even a group of subjects (such as a document about a herd of farm animals, or a set of patients that share a common exposure).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.subject"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3 (No standard way to define a Practitioner or Group subject in HL7 v2 MDM message)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=\"SBJ\"].role[typeCode=\"PAT\"]"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.patientId"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/recordTarget/"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.date",
+                "path": "DocumentReference.date",
+                "short": "When this document reference was created",
+                "definition": "When the document reference was created.",
+                "comment": "Referencing/indexing time is used for tracking, organizing versions and searching.",
+                "alias": [
+                    "indexed"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.date",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.date"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".availabilityTime[type=\"TS\"]"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.author",
+                "path": "DocumentReference.author",
+                "short": "Who and/or what authored the document",
+                "definition": "Identifies who is responsible for adding the information to the document.",
+                "comment": "Not necessarily who did the actual data entry (i.e. typist) or who was the source (informant).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DocumentReference.author",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.author"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "TXA-9 (No standard way to indicate a Device in HL7 v2 MDM message)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=\"AUT\"].role[classCode=\"ASSIGNED\"]"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.author"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/author"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.authenticator",
+                "path": "DocumentReference.authenticator",
+                "short": "Who/what authenticated the document",
+                "definition": "Which person or organization authenticates that this document is valid.",
+                "comment": "Represents a participant within the author institution who has legally authenticated or attested the document. Legal authentication implies that a document has been signed manually or electronically by the legal Authenticator.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.authenticator",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.witness"
+                    },
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.attester"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "TXA-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=\"AUTHEN\"].role[classCode=\"ASSIGNED\"]"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.legalAuthenticator"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/legalAuthenticator"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.custodian",
+                "path": "DocumentReference.custodian",
+                "short": "Organization which maintains the document",
+                "definition": "Identifies the organization or group who is responsible for ongoing maintenance of and access to the document.",
+                "comment": "Identifies the logical organization (software system, vendor, or department) to go to find the current version, where to report issues, etc. This is different from the physical location (URL, disk drive, or server) of the document, which is the technical location of the document, which host may be delegated to the management of some other organization.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.custodian",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.custodian"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=\"RCV\"].role[classCode=\"CUST\"].scoper[classCode=\"ORG\" and determinerCode=\"INST\"]"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.relatesTo",
+                "path": "DocumentReference.relatesTo",
+                "short": "Relationships to other documents",
+                "definition": "Relationships that this document has with other document references that already exist.",
+                "comment": "This element is labeled as a modifier because documents that append to other documents are incomplete on their own.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DocumentReference.relatesTo",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.relatesTo"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry Associations"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.relatesTo.id",
+                "path": "DocumentReference.relatesTo.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.relatesTo.extension",
+                "path": "DocumentReference.relatesTo.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.relatesTo.modifierExtension",
+                "path": "DocumentReference.relatesTo.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.relatesTo.code",
+                "path": "DocumentReference.relatesTo.code",
+                "short": "replaces | transforms | signs | appends",
+                "definition": "The type of relationship that this document has with anther document.",
+                "comment": "If this document appends another document, then the document cannot be fully understood without also accessing the referenced document.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.relatesTo.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "DocumentRelationshipType"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The type of relationship between documents.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/document-relationship-type|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.relatesTo.code"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship.typeCode"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry Associations type"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.relatesTo.target",
+                "path": "DocumentReference.relatesTo.target",
+                "short": "Target of the relationship",
+                "definition": "The target document of this relationship.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.relatesTo.target",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/DocumentReference"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.relatesTo.target"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".target[classCode=\"DOC\", moodCode=\"EVN\"].id"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry Associations reference"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.description",
+                "path": "DocumentReference.description",
+                "short": "Human-readable description",
+                "definition": "Human-readable description of the source document.",
+                "comment": "What the document is about,  a terse summary of the document.",
+                "requirements": "Helps humans to assess whether the document is of interest.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.description",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "TXA-25"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"SUBJ\"].target.text"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.comments"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.securityLabel",
+                "path": "DocumentReference.securityLabel",
+                "short": "Document security-tags",
+                "definition": "A set of Security-Tag codes specifying the level of privacy/security of the Document. Note that DocumentReference.meta.security contains the security labels of the \"reference\" to the document, while DocumentReference.securityLabel contains a snapshot of the security labels on the document the reference refers to.",
+                "comment": "The confidentiality codes can carry multiple vocabulary items. HL7 has developed an understanding of security and privacy tags that might be desirable in a Document Sharing environment, called HL7 Healthcare Privacy and Security Classification System (HCS). The following specification is recommended but not mandated, as the vocabulary bindings are an administrative domain responsibility. The use of this method is up to the policy domain such as the XDS Affinity Domain or other Trust Domain where all parties including sender and recipients are trusted to appropriately tag and enforce.   \n\nIn the HL7 Healthcare Privacy and Security Classification (HCS) there are code systems specific to Confidentiality, Sensitivity, Integrity, and Handling Caveats. Some values would come from a local vocabulary as they are related to workflow roles and special projects.",
+                "requirements": "Use of the Health Care Privacy/Security Classification (HCS) system of security-tag use is recommended.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DocumentReference.securityLabel",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "SecurityLabels"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Security Labels from the Healthcare Privacy and Security Classification System.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/security-labels"
+                },
+                "mapping": [
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.confidentiality, Composition.meta.security"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "TXA-18"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".confidentialityCode"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.confidentialityCode"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/confidentialityCode/@code"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content",
+                "path": "DocumentReference.content",
+                "short": "Document referenced",
+                "definition": "The document and format referenced. There may be multiple content element repetitions, each with a different format.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "DocumentReference.content",
+                    "min": 1,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Bundle(Composition+*)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "document.text"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content.id",
+                "path": "DocumentReference.content.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content.extension",
+                "path": "DocumentReference.content.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content.modifierExtension",
+                "path": "DocumentReference.content.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content.attachment",
+                "path": "DocumentReference.content.attachment",
+                "short": "Where to access the document",
+                "definition": "The document or URL of the document along with critical metadata to prove content has integrity.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.content.attachment",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Attachment"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "us-core-6",
+                        "severity": "error",
+                        "human": "DocumentReference.content.attachment.url or  DocumentReference.content.attachment.data or both SHALL be present.",
+                        "expression": "url.exists() or data.exists()",
+                        "xpath": "f:url or f:content"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.language, \nComposition.title, \nComposition.date"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "TXA-3 for mime type"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "document.text"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.mimeType, DocumentEntry.languageCode, DocumentEntry.URI, DocumentEntry.size, DocumentEntry.hash, DocumentEntry.title, DocumentEntry.creationTime"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/languageCode, ClinicalDocument/title, ClinicalDocument/date"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content.attachment.id",
+                "path": "DocumentReference.content.attachment.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content.attachment.extension",
+                "path": "DocumentReference.content.attachment.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content.attachment.contentType",
+                "path": "DocumentReference.content.attachment.contentType",
+                "short": "Mime type of the content, with charset etc.",
+                "definition": "Identifies the type of the data in the attachment and allows a method to be chosen to interpret or render the data. Includes mime type parameters such as charset where appropriate.",
+                "requirements": "Processors of the data need to be able to know how to interpret the data.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Attachment.contentType",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueCode": "text/plain; charset=UTF-8, image/png"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "MimeType"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The mime type of an attachment. Any valid mime type is allowed.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/mimetypes|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "ED.2+ED.3/RP.2+RP.3. Note conversion may be needed if old style values are being used"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./mediaType, ./charset"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content.attachment.language",
+                "path": "DocumentReference.content.attachment.language",
+                "short": "Human language of the content (BCP-47)",
+                "definition": "The human language of the content. The value can be any valid value according to BCP 47.",
+                "requirements": "Users need to be able to choose between the languages in a set of attachments.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Attachment.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueCode": "en-AU"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "./language"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content.attachment.data",
+                "path": "DocumentReference.content.attachment.data",
+                "short": "Data inline, base64ed",
+                "definition": "The actual data of the attachment - a sequence of bytes, base64 encoded.",
+                "comment": "The base64-encoded data SHALL be expressed in the same character set as the base resource XML or JSON.",
+                "requirements": "The data needs to able to be transmitted inline.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Attachment.data",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "base64Binary"
+                    }
+                ],
+                "condition": [
+                    "us-core-6"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "ED.5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./data"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content.attachment.url",
+                "path": "DocumentReference.content.attachment.url",
+                "short": "Uri where the data can be found",
+                "definition": "A location where the data can be accessed.",
+                "comment": "If both data and url are provided, the url SHALL point to the same content as the data contains. Urls may be relative references or may reference transient locations such as a wrapping envelope using cid: though this has ramifications for using signatures. Relative URLs are interpreted relative to the service url, like a resource reference, rather than relative to the resource itself. If a URL is provided, it SHALL resolve to actual data.",
+                "requirements": "The data needs to be transmitted by reference.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Attachment.url",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "url"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueUrl": "http://www.acme.com/logo-small.png"
+                    }
+                ],
+                "condition": [
+                    "us-core-6"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RP.1+RP.2 - if they refer to a URL (see v2.6)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./reference/literal"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content.attachment.size",
+                "path": "DocumentReference.content.attachment.size",
+                "short": "Number of bytes of content (if url provided)",
+                "definition": "The number of bytes of data that make up this attachment (before base64 encoding, if that is done).",
+                "comment": "The number of bytes is redundant if the data is provided as a base64binary, but is useful if the data is provided as a url reference.",
+                "requirements": "Representing the size allows applications to determine whether they should fetch the content automatically in advance, or refuse to fetch it at all.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Attachment.size",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "unsignedInt"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A (needs data type R3 proposal)"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content.attachment.hash",
+                "path": "DocumentReference.content.attachment.hash",
+                "short": "Hash of the data (sha-1, base64ed)",
+                "definition": "The calculated hash of the data using SHA-1. Represented using base64.",
+                "comment": "The hash is calculated on the data prior to base64 encoding, if the data is based64 encoded. The hash is not intended to support digital signatures. Where protection against malicious threats a digital signature should be considered, see [Provenance.signature](http://hl7.org/fhir/R4/provenance-definitions.html#Provenance.signature) for mechanism to protect a resource with a digital signature.",
+                "requirements": "Included so that applications can verify that the contents of a location have not changed due to technical failures (e.g., storage rot, transport glitch, incorrect version).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Attachment.hash",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "base64Binary"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".integrityCheck[parent::ED/integrityCheckAlgorithm=\"SHA-1\"]"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content.attachment.title",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "DocumentReference.content.attachment.title",
+                "short": "Label to display in place of the data",
+                "definition": "A label or set of text to display in place of the data.",
+                "requirements": "Applications need a label to display to a human user in place of the actual data if the data cannot be rendered or perceived by the viewer.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Attachment.title",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "Official Corporate Logo"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "./title/data"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content.attachment.creation",
+                "path": "DocumentReference.content.attachment.creation",
+                "short": "Date attachment was first created",
+                "definition": "The date that the attachment was first created.",
+                "requirements": "This is often tracked as an integrity issue for use of the attachment.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Attachment.creation",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A (needs data type R3 proposal)"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content.format",
+                "path": "DocumentReference.content.format",
+                "short": "Format/content rules for the document",
+                "definition": "An identifier of the document encoding, structure, and template that the document conforms to beyond the base format indicated in the mimeType.",
+                "comment": "Note that while IHE mostly issues URNs for format types, not all documents can be identified by a URI.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.content.format",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/formatcodes"
+                },
+                "mapping": [
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.meta.profile"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "document.text"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.formatCode"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "derived from the IHE Profile or Implementation Guide templateID"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.context",
+                "path": "DocumentReference.context",
+                "short": "Clinical context of document",
+                "definition": "The clinical context in which the document was prepared.",
+                "comment": "These values are primarily added to help with searching for interesting/relevant documents.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.context",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=\"SUBJ\"].target[classCode<'ACT']"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.context.id",
+                "path": "DocumentReference.context.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.context.extension",
+                "path": "DocumentReference.context.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.context.modifierExtension",
+                "path": "DocumentReference.context.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.context.encounter",
+                "path": "DocumentReference.context.encounter",
+                "short": "Context of the document  content",
+                "definition": "Describes the clinical encounter or type of care that the document content is associated with.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.context.encounter",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.encounter"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "unique(highest(./outboundRelationship[typeCode=\"SUBJ\" and isNormalActRelationship()], priorityNumber)/target[moodCode=\"EVN\" and classCode=(\"ENC\", \"PCPR\") and isNormalAct])"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.context.event",
+                "path": "DocumentReference.context.event",
+                "short": "Main clinical acts documented",
+                "definition": "This list of codes represents the main clinical acts, such as a colonoscopy or an appendectomy, being documented. In some cases, the event is inherent in the type Code, such as a \"History and Physical Report\" in which the procedure being documented is necessarily a \"History and Physical\" act.",
+                "comment": "An event can further specialize the act inherent in the type, such as  where it is simply \"Procedure Report\" and the procedure was a \"colonoscopy\". If one or more event codes are included, they shall not conflict with the values inherent in the class or type elements as such a conflict would create an ambiguous situation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DocumentReference.context.event",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "DocumentEventType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "This list of codes represents the main clinical acts being documented.",
+                    "valueSet": "http://terminology.hl7.org/ValueSet/v3-ActCode"
+                },
+                "mapping": [
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.event.code"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".code"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.eventCodeList"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.context.period",
+                "path": "DocumentReference.context.period",
+                "short": "Time of service that is being documented",
+                "definition": "The time period over which the service that is described by the document was provided.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.context.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.event.period"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.serviceStartTime, DocumentEntry.serviceStopTime"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/documentationOf/\nserviceEvent/effectiveTime/low/\n@value --> ClinicalDocument/documentationOf/\nserviceEvent/effectiveTime/high/\n@value"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.context.facilityType",
+                "path": "DocumentReference.context.facilityType",
+                "short": "Kind of facility where patient was seen",
+                "definition": "The kind of facility where the patient was seen.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.context.facilityType",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "DocumentC80FacilityType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "XDS Facility Type.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/c80-facilitycodes"
+                },
+                "mapping": [
+                    {
+                        "identity": "fhircomposition",
+                        "map": "usually from a mapping to a local ValueSet"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=\"LOC\"].role[classCode=\"DSDLOC\"].code"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.healthcareFacilityTypeCode"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "usually a mapping to a local ValueSet. Must be consistent with /clinicalDocument/code"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.context.practiceSetting",
+                "path": "DocumentReference.context.practiceSetting",
+                "short": "Additional details about where the content was created (e.g. clinical specialty)",
+                "definition": "This property may convey specifics about the practice setting where the content was created, often reflecting the clinical specialty.",
+                "comment": "This element should be based on a coarse classification system for the class of specialty practice. Recommend the use of the classification system for Practice Setting, such as that described by the Subject Matter Domain in LOINC.",
+                "requirements": "This is an important piece of metadata that providers often rely upon to quickly sort and/or filter out to find specific content.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.context.practiceSetting",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "DocumentC80PracticeSetting"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Additional details about where the content was created (e.g. clinical specialty).",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/c80-practice-codes"
+                },
+                "mapping": [
+                    {
+                        "identity": "fhircomposition",
+                        "map": "usually from a mapping to a local ValueSet"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=\"LOC\"].role[classCode=\"DSDLOC\"].code"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.practiceSettingCode"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "usually from a mapping to a local ValueSet"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.context.sourcePatientInfo",
+                "path": "DocumentReference.context.sourcePatientInfo",
+                "short": "Patient demographics from source",
+                "definition": "The Patient Information as known when the document was published. May be a reference to a version specific, or contained.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.context.sourcePatientInfo",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Patient"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.subject"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=\"SBJ\"].role[typeCode=\"PAT\"]"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.sourcePatientInfo, DocumentEntry.sourcePatientId"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/recordTarget/"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.context.related",
+                "path": "DocumentReference.context.related",
+                "short": "Related identifiers or resources",
+                "definition": "Related identifiers or resources associated with the DocumentReference.",
+                "comment": "May be identifiers or resources that caused the DocumentReference or referenced Document to be created.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DocumentReference.context.related",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.event.detail"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./outboundRelationship[typeCode=\"PERT\" and isNormalActRelationship()] / target[isNormalAct]"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.referenceIdList"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/relatedDocument"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "DocumentReference",
+                "path": "DocumentReference",
+                "definition": "This is a basic constraint on DocumentRefernce for use in the US Core IG.",
+                "mustSupport": false
+            },
+            {
+                "id": "DocumentReference.identifier",
+                "path": "DocumentReference.identifier",
+                "min": 0,
+                "max": "*",
+                "mustSupport": true
+            },
+            {
+                "id": "DocumentReference.status",
+                "path": "DocumentReference.status",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/document-reference-status"
+                }
+            },
+            {
+                "id": "DocumentReference.type",
+                "path": "DocumentReference.type",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-minValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/us/core/ValueSet/us-core-clinical-note-type|3.1.1"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "All LOINC  values whose SCALE is DOC in the LOINC database and the HL7 v3 Code System NullFlavor concept 'unknown'",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-type|3.1.1"
+                }
+            },
+            {
+                "id": "DocumentReference.category",
+                "path": "DocumentReference.category",
+                "min": 1,
+                "max": "*",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The US Core DocumentReferences Type Value Set is a &#39;starter set&#39; of categories supported for fetching and storing clinical notes.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-category|3.1.1"
+                }
+            },
+            {
+                "id": "DocumentReference.subject",
+                "path": "DocumentReference.subject",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "DocumentReference.date",
+                "path": "DocumentReference.date",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "DocumentReference.author",
+                "path": "DocumentReference.author",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "DocumentReference.custodian",
+                "path": "DocumentReference.custodian",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "DocumentReference.content",
+                "path": "DocumentReference.content",
+                "min": 1,
+                "max": "*",
+                "mustSupport": true
+            },
+            {
+                "id": "DocumentReference.content.attachment",
+                "path": "DocumentReference.content.attachment",
+                "min": 1,
+                "max": "1",
+                "constraint": [
+                    {
+                        "key": "us-core-6",
+                        "severity": "error",
+                        "human": "DocumentReference.content.attachment.url or  DocumentReference.content.attachment.data or both SHALL be present.",
+                        "expression": "url.exists() or data.exists()",
+                        "xpath": "f:url or f:content"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "DocumentReference.content.attachment.contentType",
+                "path": "DocumentReference.content.attachment.contentType",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "DocumentReference.content.attachment.data",
+                "path": "DocumentReference.content.attachment.data",
+                "min": 0,
+                "max": "1",
+                "condition": [
+                    "us-core-6"
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "DocumentReference.content.attachment.url",
+                "path": "DocumentReference.content.attachment.url",
+                "min": 0,
+                "max": "1",
+                "condition": [
+                    "us-core-6"
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "DocumentReference.content.format",
+                "path": "DocumentReference.content.format",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/formatcodes"
+                }
+            },
+            {
+                "id": "DocumentReference.context",
+                "path": "DocumentReference.context",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "DocumentReference.context.encounter",
+                "path": "DocumentReference.context.encounter",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "DocumentReference.context.period",
+                "path": "DocumentReference.context.period",
+                "mustSupport": true
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-encounter.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-encounter.json
@@ -1,4122 +1,4122 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-encounter",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter\" title=\"This is basic constraint on Encounter for use in US Core resources.\">Encounter</a><a name=\"Encounter\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/encounter.html\">Encounter</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">An interaction during which services are provided to the patient</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.identifier\">identifier</a><a name=\"Encounter.identifier\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Identifier\">Identifier</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Identifier(s) by which this encounter is known</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.identifier.system\">system</a><a name=\"Encounter.identifier.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The namespace for the identifier value</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.identifier.value\">value</a><a name=\"Encounter.identifier.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The value that is unique</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.status\">status</a><a name=\"Encounter.status\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">planned | arrived | triaged | in-progress | onleave | finished | cancelled +</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.class\">class</a><a name=\"Encounter.class\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Classification of patient encounter</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.type\">type</a><a name=\"Encounter.type\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Specific type of encounter</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-encounter-type.html\">US Core Encounter Type</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)<br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.subject\">subject</a><a name=\"Encounter.subject\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The patient or group present at the encounter</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.participant\">participant</a><a name=\"Encounter.participant\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">List of participants involved in the encounter</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.participant.type\">type</a><a name=\"Encounter.participant.type\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Role of participant in encounter</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.participant.period\">period</a><a name=\"Encounter.participant.period\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Period\">Period</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Period of time during the encounter that the participant participated</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.participant.individual\">individual</a><a name=\"Encounter.participant.individual\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-practitioner.html\">US Core Practitioner Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Persons involved in the encounter other than the patient</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.period\">period</a><a name=\"Encounter.period\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Period\">Period</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The start and end time of the encounter</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.reasonCode\">reasonCode</a><a name=\"Encounter.reasonCode\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Coded reason the encounter takes place</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.hospitalization\">hospitalization</a><a name=\"Encounter.hospitalization\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Details about the admission to a healthcare service</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.hospitalization.dischargeDisposition\">dischargeDisposition</a><a name=\"Encounter.hospitalization.dischargeDisposition\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Category or kind of location after discharge</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.location\">location</a><a name=\"Encounter.location\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">List of locations where the patient has been</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.location.location\">location</a><a name=\"Encounter.location.location\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"http://hl7.org/fhir/R4/location.html\">Location</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Location the encounter takes place</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter",
-	"version": "3.1.1",
-	"name": "USCoreEncounterProfile",
-	"title": "US Core Encounter Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.healthit.gov"
-				}
-			]
-		}
-	],
-	"description": "The Encounter referenced in the US Core profiles.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Encounter",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Encounter",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Encounter",
-				"path": "Encounter",
-				"short": "An interaction during which services are provided to the patient",
-				"definition": "This is basic constraint on Encounter for use in US Core resources.",
-				"alias": [
-					"Visit"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "rim",
-						"map": "Encounter[@moodCode='EVN']"
-					}
-				]
-			},
-			{
-				"id": "Encounter.id",
-				"path": "Encounter.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Encounter.meta",
-				"path": "Encounter.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Encounter.implicitRules",
-				"path": "Encounter.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Encounter.language",
-				"path": "Encounter.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Encounter.text",
-				"path": "Encounter.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Encounter.contained",
-				"path": "Encounter.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Encounter.extension",
-				"path": "Encounter.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Encounter.modifierExtension",
-				"path": "Encounter.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Encounter.identifier",
-				"path": "Encounter.identifier",
-				"short": "Identifier(s) by which this encounter is known",
-				"definition": "Identifier(s) by which this encounter is known.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1-19"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					}
-				]
-			},
-			{
-				"id": "Encounter.identifier.id",
-				"path": "Encounter.identifier.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.identifier.extension",
-				"path": "Encounter.identifier.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.identifier.use",
-				"path": "Encounter.identifier.use",
-				"short": "usual | official | temp | secondary | old (If known)",
-				"definition": "The purpose of this identifier.",
-				"comment": "Applications can assume that an identifier is permanent unless it explicitly says that it is temporary.",
-				"requirements": "Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.use",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary id for a permanent one.",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "IdentifierUse"
-						}
-					],
-					"strength": "required",
-					"description": "Identifies the purpose for this identifier, if known .",
-					"valueSet": "http://hl7.org/fhir/ValueSet/identifier-use|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "Role.code or implied by context"
-					}
-				]
-			},
-			{
-				"id": "Encounter.identifier.type",
-				"path": "Encounter.identifier.type",
-				"short": "Description of identifier",
-				"definition": "A coded type for the identifier that can be used to determine which identifier to use for a specific purpose.",
-				"comment": "This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage.   Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type.",
-				"requirements": "Allows users to make use of identifiers when the identifier system is not known.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "IdentifierType"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "extensible",
-					"description": "A coded type for an identifier that can be used to determine which identifier to use for a specific purpose.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/identifier-type"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.5"
-					},
-					{
-						"identity": "rim",
-						"map": "Role.code or implied by context"
-					}
-				]
-			},
-			{
-				"id": "Encounter.identifier.system",
-				"path": "Encounter.identifier.system",
-				"short": "The namespace for the identifier value",
-				"definition": "Establishes the namespace for the value - that is, a URL that describes a set values that are unique.",
-				"comment": "Identifier.system is always case sensitive.",
-				"requirements": "There are many sets  of identifiers.  To perform matching of two identifiers, we need to know what set we're dealing with. The system identifies a particular set of unique identifiers.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Identifier.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueUri": "http://www.acme.com/identifiers/patient"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.4 / EI-2-4"
-					},
-					{
-						"identity": "rim",
-						"map": "II.root or Role.id.root"
-					},
-					{
-						"identity": "servd",
-						"map": "./IdentifierType"
-					}
-				]
-			},
-			{
-				"id": "Encounter.identifier.value",
-				"path": "Encounter.identifier.value",
-				"short": "The value that is unique",
-				"definition": "The portion of the identifier typically relevant to the user and which is unique within the context of the system.",
-				"comment": "If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986.  The value's primary purpose is computational mapping.  As a result, it may be normalized for comparison purposes (e.g. removing non-significant whitespace, dashes, etc.)  A value formatted for human display can be conveyed using the [Rendered Value extension](http://hl7.org/fhir/R4/extension-rendered-value.html). Identifier.value is to be treated as case sensitive unless knowledge of the Identifier.system allows the processer to be confident that non-case-sensitive processing is safe.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Identifier.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "123456"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.1 / EI.1"
-					},
-					{
-						"identity": "rim",
-						"map": "II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)"
-					},
-					{
-						"identity": "servd",
-						"map": "./Value"
-					}
-				]
-			},
-			{
-				"id": "Encounter.identifier.period",
-				"path": "Encounter.identifier.period",
-				"short": "Time period when id is/was valid for use",
-				"definition": "Time period during which identifier is/was valid for use.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.7 + CX.8"
-					},
-					{
-						"identity": "rim",
-						"map": "Role.effectiveTime or implied by context"
-					},
-					{
-						"identity": "servd",
-						"map": "./StartDate and ./EndDate"
-					}
-				]
-			},
-			{
-				"id": "Encounter.identifier.assigner",
-				"path": "Encounter.identifier.assigner",
-				"short": "Organization that issued id (may be just text)",
-				"definition": "Organization that issued/manages the identifier.",
-				"comment": "The Identifier.assigner may omit the .reference element and only contain a .display element reflecting the name or other textual information about the assigning organization.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.assigner",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.4 / (CX.4,CX.9,CX.10)"
-					},
-					{
-						"identity": "rim",
-						"map": "II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper"
-					},
-					{
-						"identity": "servd",
-						"map": "./IdentifierIssuingAuthority"
-					}
-				]
-			},
-			{
-				"id": "Encounter.status",
-				"path": "Encounter.status",
-				"short": "planned | arrived | triaged | in-progress | onleave | finished | cancelled +",
-				"definition": "planned | arrived | triaged | in-progress | onleave | finished | cancelled +.",
-				"comment": "Note that internal business rules will determine the appropriate transitions that may occur between statuses (and also classes).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Encounter.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "EncounterStatus"
-						}
-					],
-					"strength": "required",
-					"description": "Current state of the encounter.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/encounter-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "v2",
-						"map": "No clear equivalent in HL7 v2; active/finished could be inferred from PV1-44, PV1-45, PV2-24; inactive could be inferred from PV2-16"
-					},
-					{
-						"identity": "rim",
-						"map": ".statusCode"
-					}
-				]
-			},
-			{
-				"id": "Encounter.statusHistory",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name",
-						"valueString": "StatusHistory"
-					}
-				],
-				"path": "Encounter.statusHistory",
-				"short": "List of past encounter statuses",
-				"definition": "The status history permits the encounter resource to contain the status history without needing to read through the historical versions of the resource, or even have the server store them.",
-				"comment": "The current status is always found in the current version of the resource, not the status history.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter.statusHistory",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.statusHistory.id",
-				"path": "Encounter.statusHistory.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.statusHistory.extension",
-				"path": "Encounter.statusHistory.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.statusHistory.modifierExtension",
-				"path": "Encounter.statusHistory.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Encounter.statusHistory.status",
-				"path": "Encounter.statusHistory.status",
-				"short": "planned | arrived | triaged | in-progress | onleave | finished | cancelled +",
-				"definition": "planned | arrived | triaged | in-progress | onleave | finished | cancelled +.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Encounter.statusHistory.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "EncounterStatus"
-						}
-					],
-					"strength": "required",
-					"description": "Current state of the encounter.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/encounter-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.statusHistory.period",
-				"path": "Encounter.statusHistory.period",
-				"short": "The time that the episode was in the specified status",
-				"definition": "The time that the episode was in the specified status.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Encounter.statusHistory.period",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.class",
-				"path": "Encounter.class",
-				"short": "Classification of patient encounter",
-				"definition": "Concepts representing classification of patient encounter such as ambulatory (outpatient), inpatient, emergency, home health or others due to local variations.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Encounter.class",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "EncounterClass"
-						}
-					],
-					"strength": "extensible",
-					"description": "Classification of the encounter.",
-					"valueSet": "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1-2"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=SUBJ].source[classCode=LIST].code"
-					}
-				]
-			},
-			{
-				"id": "Encounter.classHistory",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name",
-						"valueString": "ClassHistory"
-					}
-				],
-				"path": "Encounter.classHistory",
-				"short": "List of past encounter classes",
-				"definition": "The class history permits the tracking of the encounters transitions without needing to go  through the resource history.  This would be used for a case where an admission starts of as an emergency encounter, then transitions into an inpatient scenario. Doing this and not restarting a new encounter ensures that any lab/diagnostic results can more easily follow the patient and not require re-processing and not get lost or cancelled during a kind of discharge from emergency to inpatient.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter.classHistory",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.classHistory.id",
-				"path": "Encounter.classHistory.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.classHistory.extension",
-				"path": "Encounter.classHistory.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.classHistory.modifierExtension",
-				"path": "Encounter.classHistory.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Encounter.classHistory.class",
-				"path": "Encounter.classHistory.class",
-				"short": "inpatient | outpatient | ambulatory | emergency +",
-				"definition": "inpatient | outpatient | ambulatory | emergency +.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Encounter.classHistory.class",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "EncounterClass"
-						}
-					],
-					"strength": "extensible",
-					"description": "Classification of the encounter.",
-					"valueSet": "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.classHistory.period",
-				"path": "Encounter.classHistory.period",
-				"short": "The time that the episode was in the specified class",
-				"definition": "The time that the episode was in the specified class.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Encounter.classHistory.period",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.type",
-				"path": "Encounter.type",
-				"short": "Specific type of encounter",
-				"definition": "Specific type of encounter (e.g. e-mail consultation, surgical day-care, skilled nursing, rehabilitation).",
-				"comment": "Since there are many ways to further classify encounters, this element is 0..*.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Encounter.type",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Valueset to describe the Encounter Type",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-encounter-type|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1-4 / PV1-18"
-					},
-					{
-						"identity": "rim",
-						"map": ".code"
-					}
-				]
-			},
-			{
-				"id": "Encounter.serviceType",
-				"path": "Encounter.serviceType",
-				"short": "Specific type of service",
-				"definition": "Broad categorization of the service that is to be provided (e.g. cardiology).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.serviceType",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "EncounterServiceType"
-						}
-					],
-					"strength": "example",
-					"description": "Broad categorization of the service that is to be provided.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/service-type"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1-10"
-					},
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.priority",
-				"path": "Encounter.priority",
-				"short": "Indicates the urgency of the encounter",
-				"definition": "Indicates the urgency of the encounter.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.priority",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Priority"
-						}
-					],
-					"strength": "example",
-					"description": "Indicates the urgency of the encounter.",
-					"valueSet": "http://terminology.hl7.org/ValueSet/v3-ActPriority"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.grade"
-					},
-					{
-						"identity": "v2",
-						"map": "PV2-25"
-					},
-					{
-						"identity": "rim",
-						"map": ".priorityCode"
-					}
-				]
-			},
-			{
-				"id": "Encounter.subject",
-				"path": "Encounter.subject",
-				"short": "The patient or group present at the encounter",
-				"definition": "The patient or group present at the encounter.",
-				"comment": "While the encounter is always about the patient, the patient might not actually be known in all contexts of use, and there may be a group of patients that could be anonymous (such as in a group therapy for Alcoholics Anonymous - where the recording of the encounter could be used for billing on the number of people/staff and not important to the context of the specific patients) or alternately in veterinary care a herd of sheep receiving treatment (where the animals are not individually tracked).",
-				"alias": [
-					"patient"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Encounter.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=SBJ]/role[classCode=PAT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Encounter.episodeOfCare",
-				"path": "Encounter.episodeOfCare",
-				"short": "Episode(s) of care that this encounter should be recorded against",
-				"definition": "Where a specific encounter should be classified as a part of a specific episode(s) of care this field should be used. This association can facilitate grouping of related encounters together for a specific purpose, such as government reporting, issue tracking, association via a common problem.  The association is recorded on the encounter as these are typically created after the episode of care and grouped on entry rather than editing the episode of care to append another encounter to it (the episode of care could span years).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter.episodeOfCare",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/EpisodeOfCare"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1-54, PV1-53"
-					},
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.basedOn",
-				"path": "Encounter.basedOn",
-				"short": "The ServiceRequest that initiated this encounter",
-				"definition": "The request this encounter satisfies (e.g. incoming referral or procedure request).",
-				"alias": [
-					"incomingReferral"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.basedOn"
-					},
-					{
-						"identity": "rim",
-						"map": ".reason.ClinicalDocument"
-					}
-				]
-			},
-			{
-				"id": "Encounter.participant",
-				"path": "Encounter.participant",
-				"short": "List of participants involved in the encounter",
-				"definition": "The list of people responsible for providing the service.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter.participant",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer"
-					},
-					{
-						"identity": "v2",
-						"map": "ROL"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=PFM]"
-					}
-				]
-			},
-			{
-				"id": "Encounter.participant.id",
-				"path": "Encounter.participant.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.participant.extension",
-				"path": "Encounter.participant.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.participant.modifierExtension",
-				"path": "Encounter.participant.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Encounter.participant.type",
-				"path": "Encounter.participant.type",
-				"short": "Role of participant in encounter",
-				"definition": "Role of participant in encounter.",
-				"comment": "The participant type indicates how an individual participates in an encounter. It includes non-practitioner participants, and for practitioners this is to describe the action type in the context of this encounter (e.g. Admitting Dr, Attending Dr, Translator, Consulting Dr). This is different to the practitioner roles which are functional roles, derived from terms of employment, education, licensing, etc.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter.participant.type",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ParticipantType"
-						}
-					],
-					"strength": "extensible",
-					"description": "Role of participant in encounter.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/encounter-participant-type"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.function"
-					},
-					{
-						"identity": "v2",
-						"map": "ROL-3 (or maybe PRT-4)"
-					},
-					{
-						"identity": "rim",
-						"map": ".functionCode"
-					}
-				]
-			},
-			{
-				"id": "Encounter.participant.period",
-				"path": "Encounter.participant.period",
-				"short": "Period of time during the encounter that the participant participated",
-				"definition": "The period of time that the specified participant participated in the encounter. These can overlap or be sub-sets of the overall encounter's period.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.participant.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "ROL-5, ROL-6 (or maybe PRT-5)"
-					},
-					{
-						"identity": "rim",
-						"map": ".time"
-					}
-				]
-			},
-			{
-				"id": "Encounter.participant.individual",
-				"path": "Encounter.participant.individual",
-				"short": "Persons involved in the encounter other than the patient",
-				"definition": "Persons involved in the encounter other than the patient.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.participant.individual",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.who"
-					},
-					{
-						"identity": "v2",
-						"map": "ROL-4"
-					},
-					{
-						"identity": "rim",
-						"map": ".role"
-					}
-				]
-			},
-			{
-				"id": "Encounter.appointment",
-				"path": "Encounter.appointment",
-				"short": "The appointment that scheduled this encounter",
-				"definition": "The appointment that scheduled this encounter.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter.appointment",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Appointment"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.basedOn"
-					},
-					{
-						"identity": "v2",
-						"map": "SCH-1 / SCH-2"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=FLFS].target[classCode=ENC, moodCode=APT]"
-					}
-				]
-			},
-			{
-				"id": "Encounter.period",
-				"path": "Encounter.period",
-				"short": "The start and end time of the encounter",
-				"definition": "The start and end time of the encounter.",
-				"comment": "If not (yet) known, the end of the Period may be omitted.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1-44, PV1-45"
-					},
-					{
-						"identity": "rim",
-						"map": ".effectiveTime (low & high)"
-					}
-				]
-			},
-			{
-				"id": "Encounter.length",
-				"path": "Encounter.length",
-				"short": "Quantity of time the encounter lasted (less time absent)",
-				"definition": "Quantity of time the encounter lasted. This excludes the time during leaves of absence.",
-				"comment": "May differ from the time the Encounter.period lasted because of leave of absence.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.length",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Duration"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "(PV1-45 less PV1-44) iff ( (PV1-44 not empty) and (PV1-45 not empty) ); units in minutes"
-					},
-					{
-						"identity": "rim",
-						"map": ".lengthOfStayQuantity"
-					}
-				]
-			},
-			{
-				"id": "Encounter.reasonCode",
-				"path": "Encounter.reasonCode",
-				"short": "Coded reason the encounter takes place",
-				"definition": "Reason the encounter takes place, expressed as a code. For admissions, this can be used for a coded admission diagnosis.",
-				"comment": "For systems that need to know which was the primary diagnosis, these will be marked with the standard extension primaryDiagnosis (which is a sequence value rather than a flag, 1 = primary diagnosis).",
-				"alias": [
-					"Indication",
-					"Admission diagnosis"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter.reasonCode",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "EncounterReason"
-						}
-					],
-					"strength": "preferred",
-					"description": "Reason why the encounter takes place.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/encounter-reason"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.reasonCode"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.why[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "EVN-4 / PV2-3 (note: PV2-3 is nominally constrained to inpatient admissions; HL7 v2 makes no vocabulary suggestions for PV2-3; would not expect PV2 segment or PV2-3 to be in use in all implementations )"
-					},
-					{
-						"identity": "rim",
-						"map": ".reasonCode"
-					}
-				]
-			},
-			{
-				"id": "Encounter.reasonReference",
-				"path": "Encounter.reasonReference",
-				"short": "Reason the encounter takes place (reference)",
-				"definition": "Reason the encounter takes place, expressed as a code. For admissions, this can be used for a coded admission diagnosis.",
-				"comment": "For systems that need to know which was the primary diagnosis, these will be marked with the standard extension primaryDiagnosis (which is a sequence value rather than a flag, 1 = primary diagnosis).",
-				"alias": [
-					"Indication",
-					"Admission diagnosis"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter.reasonReference",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Condition",
-							"http://hl7.org/fhir/StructureDefinition/Procedure",
-							"http://hl7.org/fhir/StructureDefinition/Observation",
-							"http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.reasonCode"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.why[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "EVN-4 / PV2-3 (note: PV2-3 is nominally constrained to inpatient admissions; HL7 v2 makes no vocabulary suggestions for PV2-3; would not expect PV2 segment or PV2-3 to be in use in all implementations )"
-					},
-					{
-						"identity": "rim",
-						"map": ".reasonCode"
-					}
-				]
-			},
-			{
-				"id": "Encounter.diagnosis",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name",
-						"valueString": "Diagnosis"
-					}
-				],
-				"path": "Encounter.diagnosis",
-				"short": "The list of diagnosis relevant to this encounter",
-				"definition": "The list of diagnosis relevant to this encounter.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter.diagnosis",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=RSON]"
-					}
-				]
-			},
-			{
-				"id": "Encounter.diagnosis.id",
-				"path": "Encounter.diagnosis.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.diagnosis.extension",
-				"path": "Encounter.diagnosis.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.diagnosis.modifierExtension",
-				"path": "Encounter.diagnosis.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Encounter.diagnosis.condition",
-				"path": "Encounter.diagnosis.condition",
-				"short": "The diagnosis or procedure relevant to the encounter",
-				"definition": "Reason the encounter takes place, as specified using information from another resource. For admissions, this is the admission diagnosis. The indication will typically be a Condition (with other resources referenced in the evidence.detail), or a Procedure.",
-				"comment": "For systems that need to know which was the primary diagnosis, these will be marked with the standard extension primaryDiagnosis (which is a sequence value rather than a flag, 1 = primary diagnosis).",
-				"alias": [
-					"Admission diagnosis",
-					"discharge diagnosis",
-					"indication"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Encounter.diagnosis.condition",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Condition",
-							"http://hl7.org/fhir/StructureDefinition/Procedure"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.reasonReference"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.why[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "Resources that would commonly referenced at Encounter.indication would be Condition and/or Procedure. These most closely align with DG1/PRB and PR1 respectively."
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=RSON].target"
-					}
-				]
-			},
-			{
-				"id": "Encounter.diagnosis.use",
-				"path": "Encounter.diagnosis.use",
-				"short": "Role that this diagnosis has within the encounter (e.g. admission, billing, discharge …)",
-				"definition": "Role that this diagnosis has within the encounter (e.g. admission, billing, discharge …).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.diagnosis.use",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "DiagnosisRole"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "The type of diagnosis this condition represents.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/diagnosis-role"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.diagnosis.rank",
-				"path": "Encounter.diagnosis.rank",
-				"short": "Ranking of the diagnosis (for each role type)",
-				"definition": "Ranking of the diagnosis (for each role type).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.diagnosis.rank",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "positiveInt"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=RSON].priority"
-					}
-				]
-			},
-			{
-				"id": "Encounter.account",
-				"path": "Encounter.account",
-				"short": "The set of accounts that may be used for billing for this Encounter",
-				"definition": "The set of accounts that may be used for billing for this Encounter.",
-				"comment": "The billing system may choose to allocate billable items associated with the Encounter to different referenced Accounts based on internal business rules.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter.account",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Account"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".pertains.A_Account"
-					}
-				]
-			},
-			{
-				"id": "Encounter.hospitalization",
-				"path": "Encounter.hospitalization",
-				"short": "Details about the admission to a healthcare service",
-				"definition": "Details about the admission to a healthcare service.",
-				"comment": "An Encounter may cover more than just the inpatient stay. Contexts such as outpatients, community clinics, and aged care facilities are also included.\r\rThe duration recorded in the period of this encounter covers the entire scope of this hospitalization record.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.hospitalization",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=COMP].target[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Encounter.hospitalization.id",
-				"path": "Encounter.hospitalization.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.hospitalization.extension",
-				"path": "Encounter.hospitalization.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.hospitalization.modifierExtension",
-				"path": "Encounter.hospitalization.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Encounter.hospitalization.preAdmissionIdentifier",
-				"path": "Encounter.hospitalization.preAdmissionIdentifier",
-				"short": "Pre-admission identifier",
-				"definition": "Pre-admission identifier.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.hospitalization.preAdmissionIdentifier",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PV1-5"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					}
-				]
-			},
-			{
-				"id": "Encounter.hospitalization.origin",
-				"path": "Encounter.hospitalization.origin",
-				"short": "The location/organization from which the patient came before admission",
-				"definition": "The location/organization from which the patient came before admission.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.hospitalization.origin",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Location",
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=ORG].role"
-					}
-				]
-			},
-			{
-				"id": "Encounter.hospitalization.admitSource",
-				"path": "Encounter.hospitalization.admitSource",
-				"short": "From where patient was admitted (physician referral, transfer)",
-				"definition": "From where patient was admitted (physician referral, transfer).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.hospitalization.admitSource",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AdmitSource"
-						}
-					],
-					"strength": "preferred",
-					"description": "From where the patient was admitted.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/encounter-admit-source"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PV1-14"
-					},
-					{
-						"identity": "rim",
-						"map": ".admissionReferralSourceCode"
-					}
-				]
-			},
-			{
-				"id": "Encounter.hospitalization.reAdmission",
-				"path": "Encounter.hospitalization.reAdmission",
-				"short": "The type of hospital re-admission that has occurred (if any). If the value is absent, then this is not identified as a readmission",
-				"definition": "Whether this hospitalization is a readmission and why if known.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.hospitalization.reAdmission",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ReAdmissionType"
-						}
-					],
-					"strength": "example",
-					"description": "The reason for re-admission of this hospitalization encounter.",
-					"valueSet": "http://terminology.hl7.org/ValueSet/v2-0092"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PV1-13"
-					},
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.hospitalization.dietPreference",
-				"path": "Encounter.hospitalization.dietPreference",
-				"short": "Diet preferences reported by the patient",
-				"definition": "Diet preferences reported by the patient.",
-				"comment": "For example, a patient may request both a dairy-free and nut-free diet preference (not mutually exclusive).",
-				"requirements": "Used to track patient's diet restrictions and/or preference. For a complete description of the nutrition needs of a patient during their stay, one should use the nutritionOrder resource which links to Encounter.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter.hospitalization.dietPreference",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "PatientDiet"
-						}
-					],
-					"strength": "example",
-					"description": "Medical, cultural or ethical food preferences to help with catering requirements.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/encounter-diet"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PV1-38"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=COMP].target[classCode=SBADM, moodCode=EVN, code=\"diet\"]"
-					}
-				]
-			},
-			{
-				"id": "Encounter.hospitalization.specialCourtesy",
-				"path": "Encounter.hospitalization.specialCourtesy",
-				"short": "Special courtesies (VIP, board member)",
-				"definition": "Special courtesies (VIP, board member).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter.hospitalization.specialCourtesy",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Courtesies"
-						}
-					],
-					"strength": "preferred",
-					"description": "Special courtesies.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/encounter-special-courtesy"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PV1-16"
-					},
-					{
-						"identity": "rim",
-						"map": ".specialCourtesiesCode"
-					}
-				]
-			},
-			{
-				"id": "Encounter.hospitalization.specialArrangement",
-				"path": "Encounter.hospitalization.specialArrangement",
-				"short": "Wheelchair, translator, stretcher, etc.",
-				"definition": "Any special requests that have been made for this hospitalization encounter, such as the provision of specific equipment or other things.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter.hospitalization.specialArrangement",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Arrangements"
-						}
-					],
-					"strength": "preferred",
-					"description": "Special arrangements.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/encounter-special-arrangements"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PV1-15 / OBR-30 / OBR-43"
-					},
-					{
-						"identity": "rim",
-						"map": ".specialArrangementCode"
-					}
-				]
-			},
-			{
-				"id": "Encounter.hospitalization.destination",
-				"path": "Encounter.hospitalization.destination",
-				"short": "Location/organization to which the patient is discharged",
-				"definition": "Location/organization to which the patient is discharged.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.hospitalization.destination",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Location",
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PV1-37"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=DST]"
-					}
-				]
-			},
-			{
-				"id": "Encounter.hospitalization.dischargeDisposition",
-				"path": "Encounter.hospitalization.dischargeDisposition",
-				"short": "Category or kind of location after discharge",
-				"definition": "Category or kind of location after discharge.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.hospitalization.dischargeDisposition",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "DischargeDisp"
-						}
-					],
-					"strength": "example",
-					"description": "Discharge Disposition.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/encounter-discharge-disposition"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PV1-36"
-					},
-					{
-						"identity": "rim",
-						"map": ".dischargeDispositionCode"
-					}
-				]
-			},
-			{
-				"id": "Encounter.location",
-				"path": "Encounter.location",
-				"short": "List of locations where the patient has been",
-				"definition": "List of locations where  the patient has been during this encounter.",
-				"comment": "Virtual encounters can be recorded in the Encounter by specifying a location reference to a location of type \"kind\" such as \"client's home\" and an encounter.class = \"virtual\".",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter.location",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=LOC]"
-					}
-				]
-			},
-			{
-				"id": "Encounter.location.id",
-				"path": "Encounter.location.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.location.extension",
-				"path": "Encounter.location.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.location.modifierExtension",
-				"path": "Encounter.location.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Encounter.location.location",
-				"path": "Encounter.location.location",
-				"short": "Location the encounter takes place",
-				"definition": "The location where the encounter takes place.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Encounter.location.location",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Location"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.location"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.where[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1-3 / PV1-6 / PV1-11 / PV1-42 / PV1-43"
-					},
-					{
-						"identity": "rim",
-						"map": ".role"
-					}
-				]
-			},
-			{
-				"id": "Encounter.location.status",
-				"path": "Encounter.location.status",
-				"short": "planned | active | reserved | completed",
-				"definition": "The status of the participants' presence at the specified location during the period specified. If the participant is no longer at the location, then the period will have an end date/time.",
-				"comment": "When the patient is no longer active at a location, then the period end date is entered, and the status may be changed to completed.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.location.status",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "EncounterLocationStatus"
-						}
-					],
-					"strength": "required",
-					"description": "The status of the location.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/encounter-location-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".role.statusCode"
-					}
-				]
-			},
-			{
-				"id": "Encounter.location.physicalType",
-				"path": "Encounter.location.physicalType",
-				"short": "The physical type of the location (usually the level in the location hierachy - bed room ward etc.)",
-				"definition": "This will be used to specify the required levels (bed/ward/room/etc.) desired to be recorded to simplify either messaging or query.",
-				"comment": "This information is de-normalized from the Location resource to support the easier understanding of the encounter resource and processing in messaging or query.\n\nThere may be many levels in the hierachy, and this may only pic specific levels that are required for a specific usage scenario.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.location.physicalType",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "PhysicalType"
-						}
-					],
-					"strength": "example",
-					"description": "Physical form of the location.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/location-physical-type"
-				}
-			},
-			{
-				"id": "Encounter.location.period",
-				"path": "Encounter.location.period",
-				"short": "Time period during which the patient was present at the location",
-				"definition": "Time period during which the patient was present at the location.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.location.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".time"
-					}
-				]
-			},
-			{
-				"id": "Encounter.serviceProvider",
-				"path": "Encounter.serviceProvider",
-				"short": "The organization (facility) responsible for this encounter",
-				"definition": "The organization that is primarily responsible for this Encounter's services. This MAY be the same as the organization on the Patient record, however it could be different, such as if the actor performing the services was from an external organization (which may be billed seperately) for an external consultation.  Refer to the example bundle showing an abbreviated set of Encounters for a colonoscopy.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.serviceProvider",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "PL.6  & PL.1"
-					},
-					{
-						"identity": "rim",
-						"map": ".particiaption[typeCode=PFM].role"
-					}
-				]
-			},
-			{
-				"id": "Encounter.partOf",
-				"path": "Encounter.partOf",
-				"short": "Another Encounter this encounter is part of",
-				"definition": "Another Encounter of which this encounter is a part of (administratively or in time).",
-				"comment": "This is also used for associating a child's encounter back to the mother's encounter.\r\rRefer to the Notes section in the Patient resource for further details.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.partOf",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-hierarchy",
-								"valueBoolean": true
-							}
-						],
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.partOf"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[classCode=COMP, moodCode=EVN]"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Encounter",
-				"path": "Encounter",
-				"definition": "This is basic constraint on Encounter for use in US Core resources.",
-				"alias": [
-					"Visit"
-				],
-				"mustSupport": false
-			},
-			{
-				"id": "Encounter.identifier",
-				"path": "Encounter.identifier",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.identifier.system",
-				"path": "Encounter.identifier.system",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.identifier.value",
-				"path": "Encounter.identifier.value",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.status",
-				"path": "Encounter.status",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.class",
-				"path": "Encounter.class",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.type",
-				"path": "Encounter.type",
-				"min": 1,
-				"max": "*",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Valueset to describe the Encounter Type",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-encounter-type|3.1.1"
-				}
-			},
-			{
-				"id": "Encounter.subject",
-				"path": "Encounter.subject",
-				"alias": [
-					"patient"
-				],
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.participant",
-				"path": "Encounter.participant",
-				"min": 0,
-				"max": "*",
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.participant.type",
-				"path": "Encounter.participant.type",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.participant.period",
-				"path": "Encounter.participant.period",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.participant.individual",
-				"path": "Encounter.participant.individual",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.period",
-				"path": "Encounter.period",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.reasonCode",
-				"path": "Encounter.reasonCode",
-				"alias": [
-					"Indication",
-					"Admission diagnosis"
-				],
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.hospitalization",
-				"path": "Encounter.hospitalization",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.hospitalization.dischargeDisposition",
-				"path": "Encounter.hospitalization.dischargeDisposition",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.location",
-				"path": "Encounter.location",
-				"min": 0,
-				"max": "*",
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.location.location",
-				"path": "Encounter.location.location",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Location"
-						]
-					}
-				],
-				"mustSupport": true
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-encounter",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter",
+    "version": "3.1.1",
+    "name": "USCoreEncounterProfile",
+    "title": "US Core Encounter Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.healthit.gov"
+                }
+            ]
+        }
+    ],
+    "description": "The Encounter referenced in the US Core profiles.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Encounter",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Encounter",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Encounter",
+                "path": "Encounter",
+                "short": "An interaction during which services are provided to the patient",
+                "definition": "This is basic constraint on Encounter for use in US Core resources.",
+                "alias": [
+                    "Visit"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Encounter[@moodCode='EVN']"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.id",
+                "path": "Encounter.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Encounter.meta",
+                "path": "Encounter.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Encounter.implicitRules",
+                "path": "Encounter.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Encounter.language",
+                "path": "Encounter.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Encounter.text",
+                "path": "Encounter.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.contained",
+                "path": "Encounter.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.extension",
+                "path": "Encounter.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.modifierExtension",
+                "path": "Encounter.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.identifier",
+                "path": "Encounter.identifier",
+                "short": "Identifier(s) by which this encounter is known",
+                "definition": "Identifier(s) by which this encounter is known.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1-19"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.identifier.id",
+                "path": "Encounter.identifier.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.identifier.extension",
+                "path": "Encounter.identifier.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.identifier.use",
+                "path": "Encounter.identifier.use",
+                "short": "usual | official | temp | secondary | old (If known)",
+                "definition": "The purpose of this identifier.",
+                "comment": "Applications can assume that an identifier is permanent unless it explicitly says that it is temporary.",
+                "requirements": "Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.use",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary id for a permanent one.",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "IdentifierUse"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Identifies the purpose for this identifier, if known .",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/identifier-use|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Role.code or implied by context"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.identifier.type",
+                "path": "Encounter.identifier.type",
+                "short": "Description of identifier",
+                "definition": "A coded type for the identifier that can be used to determine which identifier to use for a specific purpose.",
+                "comment": "This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage.   Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type.",
+                "requirements": "Allows users to make use of identifiers when the identifier system is not known.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "IdentifierType"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "A coded type for an identifier that can be used to determine which identifier to use for a specific purpose.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/identifier-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Role.code or implied by context"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.identifier.system",
+                "path": "Encounter.identifier.system",
+                "short": "The namespace for the identifier value",
+                "definition": "Establishes the namespace for the value - that is, a URL that describes a set values that are unique.",
+                "comment": "Identifier.system is always case sensitive.",
+                "requirements": "There are many sets  of identifiers.  To perform matching of two identifiers, we need to know what set we're dealing with. The system identifies a particular set of unique identifiers.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueUri": "http://www.acme.com/identifiers/patient"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.4 / EI-2-4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "II.root or Role.id.root"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./IdentifierType"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.identifier.value",
+                "path": "Encounter.identifier.value",
+                "short": "The value that is unique",
+                "definition": "The portion of the identifier typically relevant to the user and which is unique within the context of the system.",
+                "comment": "If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986.  The value's primary purpose is computational mapping.  As a result, it may be normalized for comparison purposes (e.g. removing non-significant whitespace, dashes, etc.)  A value formatted for human display can be conveyed using the [Rendered Value extension](http://hl7.org/fhir/R4/extension-rendered-value.html). Identifier.value is to be treated as case sensitive unless knowledge of the Identifier.system allows the processer to be confident that non-case-sensitive processing is safe.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "123456"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.1 / EI.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Value"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.identifier.period",
+                "path": "Encounter.identifier.period",
+                "short": "Time period when id is/was valid for use",
+                "definition": "Time period during which identifier is/was valid for use.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.7 + CX.8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Role.effectiveTime or implied by context"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./StartDate and ./EndDate"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.identifier.assigner",
+                "path": "Encounter.identifier.assigner",
+                "short": "Organization that issued id (may be just text)",
+                "definition": "Organization that issued/manages the identifier.",
+                "comment": "The Identifier.assigner may omit the .reference element and only contain a .display element reflecting the name or other textual information about the assigning organization.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.assigner",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.4 / (CX.4,CX.9,CX.10)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./IdentifierIssuingAuthority"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.status",
+                "path": "Encounter.status",
+                "short": "planned | arrived | triaged | in-progress | onleave | finished | cancelled +",
+                "definition": "planned | arrived | triaged | in-progress | onleave | finished | cancelled +.",
+                "comment": "Note that internal business rules will determine the appropriate transitions that may occur between statuses (and also classes).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "EncounterStatus"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Current state of the encounter.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/encounter-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "No clear equivalent in HL7 v2; active/finished could be inferred from PV1-44, PV1-45, PV2-24; inactive could be inferred from PV2-16"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".statusCode"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.statusHistory",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name",
+                        "valueString": "StatusHistory"
+                    }
+                ],
+                "path": "Encounter.statusHistory",
+                "short": "List of past encounter statuses",
+                "definition": "The status history permits the encounter resource to contain the status history without needing to read through the historical versions of the resource, or even have the server store them.",
+                "comment": "The current status is always found in the current version of the resource, not the status history.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.statusHistory",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.statusHistory.id",
+                "path": "Encounter.statusHistory.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.statusHistory.extension",
+                "path": "Encounter.statusHistory.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.statusHistory.modifierExtension",
+                "path": "Encounter.statusHistory.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.statusHistory.status",
+                "path": "Encounter.statusHistory.status",
+                "short": "planned | arrived | triaged | in-progress | onleave | finished | cancelled +",
+                "definition": "planned | arrived | triaged | in-progress | onleave | finished | cancelled +.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.statusHistory.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "EncounterStatus"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Current state of the encounter.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/encounter-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.statusHistory.period",
+                "path": "Encounter.statusHistory.period",
+                "short": "The time that the episode was in the specified status",
+                "definition": "The time that the episode was in the specified status.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.statusHistory.period",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.class",
+                "path": "Encounter.class",
+                "short": "Classification of patient encounter",
+                "definition": "Concepts representing classification of patient encounter such as ambulatory (outpatient), inpatient, emergency, home health or others due to local variations.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.class",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "EncounterClass"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Classification of the encounter.",
+                    "valueSet": "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1-2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=SUBJ].source[classCode=LIST].code"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.classHistory",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name",
+                        "valueString": "ClassHistory"
+                    }
+                ],
+                "path": "Encounter.classHistory",
+                "short": "List of past encounter classes",
+                "definition": "The class history permits the tracking of the encounters transitions without needing to go  through the resource history.  This would be used for a case where an admission starts of as an emergency encounter, then transitions into an inpatient scenario. Doing this and not restarting a new encounter ensures that any lab/diagnostic results can more easily follow the patient and not require re-processing and not get lost or cancelled during a kind of discharge from emergency to inpatient.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.classHistory",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.classHistory.id",
+                "path": "Encounter.classHistory.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.classHistory.extension",
+                "path": "Encounter.classHistory.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.classHistory.modifierExtension",
+                "path": "Encounter.classHistory.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.classHistory.class",
+                "path": "Encounter.classHistory.class",
+                "short": "inpatient | outpatient | ambulatory | emergency +",
+                "definition": "inpatient | outpatient | ambulatory | emergency +.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.classHistory.class",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "EncounterClass"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Classification of the encounter.",
+                    "valueSet": "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.classHistory.period",
+                "path": "Encounter.classHistory.period",
+                "short": "The time that the episode was in the specified class",
+                "definition": "The time that the episode was in the specified class.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.classHistory.period",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.type",
+                "path": "Encounter.type",
+                "short": "Specific type of encounter",
+                "definition": "Specific type of encounter (e.g. e-mail consultation, surgical day-care, skilled nursing, rehabilitation).",
+                "comment": "Since there are many ways to further classify encounters, this element is 0..*.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.type",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Valueset to describe the Encounter Type",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-encounter-type|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1-4 / PV1-18"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".code"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.serviceType",
+                "path": "Encounter.serviceType",
+                "short": "Specific type of service",
+                "definition": "Broad categorization of the service that is to be provided (e.g. cardiology).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.serviceType",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "EncounterServiceType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Broad categorization of the service that is to be provided.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/service-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.priority",
+                "path": "Encounter.priority",
+                "short": "Indicates the urgency of the encounter",
+                "definition": "Indicates the urgency of the encounter.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.priority",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Priority"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Indicates the urgency of the encounter.",
+                    "valueSet": "http://terminology.hl7.org/ValueSet/v3-ActPriority"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.grade"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV2-25"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".priorityCode"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.subject",
+                "path": "Encounter.subject",
+                "short": "The patient or group present at the encounter",
+                "definition": "The patient or group present at the encounter.",
+                "comment": "While the encounter is always about the patient, the patient might not actually be known in all contexts of use, and there may be a group of patients that could be anonymous (such as in a group therapy for Alcoholics Anonymous - where the recording of the encounter could be used for billing on the number of people/staff and not important to the context of the specific patients) or alternately in veterinary care a herd of sheep receiving treatment (where the animals are not individually tracked).",
+                "alias": [
+                    "patient"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=SBJ]/role[classCode=PAT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.episodeOfCare",
+                "path": "Encounter.episodeOfCare",
+                "short": "Episode(s) of care that this encounter should be recorded against",
+                "definition": "Where a specific encounter should be classified as a part of a specific episode(s) of care this field should be used. This association can facilitate grouping of related encounters together for a specific purpose, such as government reporting, issue tracking, association via a common problem.  The association is recorded on the encounter as these are typically created after the episode of care and grouped on entry rather than editing the episode of care to append another encounter to it (the episode of care could span years).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.episodeOfCare",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/EpisodeOfCare"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1-54, PV1-53"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.basedOn",
+                "path": "Encounter.basedOn",
+                "short": "The ServiceRequest that initiated this encounter",
+                "definition": "The request this encounter satisfies (e.g. incoming referral or procedure request).",
+                "alias": [
+                    "incomingReferral"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.basedOn"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".reason.ClinicalDocument"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.participant",
+                "path": "Encounter.participant",
+                "short": "List of participants involved in the encounter",
+                "definition": "The list of people responsible for providing the service.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.participant",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ROL"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=PFM]"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.participant.id",
+                "path": "Encounter.participant.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.participant.extension",
+                "path": "Encounter.participant.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.participant.modifierExtension",
+                "path": "Encounter.participant.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.participant.type",
+                "path": "Encounter.participant.type",
+                "short": "Role of participant in encounter",
+                "definition": "Role of participant in encounter.",
+                "comment": "The participant type indicates how an individual participates in an encounter. It includes non-practitioner participants, and for practitioners this is to describe the action type in the context of this encounter (e.g. Admitting Dr, Attending Dr, Translator, Consulting Dr). This is different to the practitioner roles which are functional roles, derived from terms of employment, education, licensing, etc.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.participant.type",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ParticipantType"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Role of participant in encounter.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/encounter-participant-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.function"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ROL-3 (or maybe PRT-4)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".functionCode"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.participant.period",
+                "path": "Encounter.participant.period",
+                "short": "Period of time during the encounter that the participant participated",
+                "definition": "The period of time that the specified participant participated in the encounter. These can overlap or be sub-sets of the overall encounter's period.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.participant.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "ROL-5, ROL-6 (or maybe PRT-5)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".time"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.participant.individual",
+                "path": "Encounter.participant.individual",
+                "short": "Persons involved in the encounter other than the patient",
+                "definition": "Persons involved in the encounter other than the patient.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.participant.individual",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.who"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ROL-4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".role"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.appointment",
+                "path": "Encounter.appointment",
+                "short": "The appointment that scheduled this encounter",
+                "definition": "The appointment that scheduled this encounter.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.appointment",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Appointment"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.basedOn"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "SCH-1 / SCH-2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=FLFS].target[classCode=ENC, moodCode=APT]"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.period",
+                "path": "Encounter.period",
+                "short": "The start and end time of the encounter",
+                "definition": "The start and end time of the encounter.",
+                "comment": "If not (yet) known, the end of the Period may be omitted.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1-44, PV1-45"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime (low & high)"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.length",
+                "path": "Encounter.length",
+                "short": "Quantity of time the encounter lasted (less time absent)",
+                "definition": "Quantity of time the encounter lasted. This excludes the time during leaves of absence.",
+                "comment": "May differ from the time the Encounter.period lasted because of leave of absence.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.length",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Duration"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "(PV1-45 less PV1-44) iff ( (PV1-44 not empty) and (PV1-45 not empty) ); units in minutes"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".lengthOfStayQuantity"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.reasonCode",
+                "path": "Encounter.reasonCode",
+                "short": "Coded reason the encounter takes place",
+                "definition": "Reason the encounter takes place, expressed as a code. For admissions, this can be used for a coded admission diagnosis.",
+                "comment": "For systems that need to know which was the primary diagnosis, these will be marked with the standard extension primaryDiagnosis (which is a sequence value rather than a flag, 1 = primary diagnosis).",
+                "alias": [
+                    "Indication",
+                    "Admission diagnosis"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.reasonCode",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "EncounterReason"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Reason why the encounter takes place.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/encounter-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.reasonCode"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.why[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "EVN-4 / PV2-3 (note: PV2-3 is nominally constrained to inpatient admissions; HL7 v2 makes no vocabulary suggestions for PV2-3; would not expect PV2 segment or PV2-3 to be in use in all implementations )"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".reasonCode"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.reasonReference",
+                "path": "Encounter.reasonReference",
+                "short": "Reason the encounter takes place (reference)",
+                "definition": "Reason the encounter takes place, expressed as a code. For admissions, this can be used for a coded admission diagnosis.",
+                "comment": "For systems that need to know which was the primary diagnosis, these will be marked with the standard extension primaryDiagnosis (which is a sequence value rather than a flag, 1 = primary diagnosis).",
+                "alias": [
+                    "Indication",
+                    "Admission diagnosis"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.reasonReference",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Condition",
+                            "http://hl7.org/fhir/StructureDefinition/Procedure",
+                            "http://hl7.org/fhir/StructureDefinition/Observation",
+                            "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.reasonCode"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.why[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "EVN-4 / PV2-3 (note: PV2-3 is nominally constrained to inpatient admissions; HL7 v2 makes no vocabulary suggestions for PV2-3; would not expect PV2 segment or PV2-3 to be in use in all implementations )"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".reasonCode"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.diagnosis",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name",
+                        "valueString": "Diagnosis"
+                    }
+                ],
+                "path": "Encounter.diagnosis",
+                "short": "The list of diagnosis relevant to this encounter",
+                "definition": "The list of diagnosis relevant to this encounter.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.diagnosis",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=RSON]"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.diagnosis.id",
+                "path": "Encounter.diagnosis.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.diagnosis.extension",
+                "path": "Encounter.diagnosis.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.diagnosis.modifierExtension",
+                "path": "Encounter.diagnosis.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.diagnosis.condition",
+                "path": "Encounter.diagnosis.condition",
+                "short": "The diagnosis or procedure relevant to the encounter",
+                "definition": "Reason the encounter takes place, as specified using information from another resource. For admissions, this is the admission diagnosis. The indication will typically be a Condition (with other resources referenced in the evidence.detail), or a Procedure.",
+                "comment": "For systems that need to know which was the primary diagnosis, these will be marked with the standard extension primaryDiagnosis (which is a sequence value rather than a flag, 1 = primary diagnosis).",
+                "alias": [
+                    "Admission diagnosis",
+                    "discharge diagnosis",
+                    "indication"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.diagnosis.condition",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Condition",
+                            "http://hl7.org/fhir/StructureDefinition/Procedure"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.reasonReference"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.why[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "Resources that would commonly referenced at Encounter.indication would be Condition and/or Procedure. These most closely align with DG1/PRB and PR1 respectively."
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=RSON].target"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.diagnosis.use",
+                "path": "Encounter.diagnosis.use",
+                "short": "Role that this diagnosis has within the encounter (e.g. admission, billing, discharge …)",
+                "definition": "Role that this diagnosis has within the encounter (e.g. admission, billing, discharge …).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.diagnosis.use",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "DiagnosisRole"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "The type of diagnosis this condition represents.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/diagnosis-role"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.diagnosis.rank",
+                "path": "Encounter.diagnosis.rank",
+                "short": "Ranking of the diagnosis (for each role type)",
+                "definition": "Ranking of the diagnosis (for each role type).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.diagnosis.rank",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "positiveInt"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=RSON].priority"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.account",
+                "path": "Encounter.account",
+                "short": "The set of accounts that may be used for billing for this Encounter",
+                "definition": "The set of accounts that may be used for billing for this Encounter.",
+                "comment": "The billing system may choose to allocate billable items associated with the Encounter to different referenced Accounts based on internal business rules.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.account",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Account"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".pertains.A_Account"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.hospitalization",
+                "path": "Encounter.hospitalization",
+                "short": "Details about the admission to a healthcare service",
+                "definition": "Details about the admission to a healthcare service.",
+                "comment": "An Encounter may cover more than just the inpatient stay. Contexts such as outpatients, community clinics, and aged care facilities are also included.\r\rThe duration recorded in the period of this encounter covers the entire scope of this hospitalization record.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.hospitalization",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=COMP].target[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.hospitalization.id",
+                "path": "Encounter.hospitalization.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.hospitalization.extension",
+                "path": "Encounter.hospitalization.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.hospitalization.modifierExtension",
+                "path": "Encounter.hospitalization.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.hospitalization.preAdmissionIdentifier",
+                "path": "Encounter.hospitalization.preAdmissionIdentifier",
+                "short": "Pre-admission identifier",
+                "definition": "Pre-admission identifier.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.hospitalization.preAdmissionIdentifier",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PV1-5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.hospitalization.origin",
+                "path": "Encounter.hospitalization.origin",
+                "short": "The location/organization from which the patient came before admission",
+                "definition": "The location/organization from which the patient came before admission.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.hospitalization.origin",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Location",
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=ORG].role"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.hospitalization.admitSource",
+                "path": "Encounter.hospitalization.admitSource",
+                "short": "From where patient was admitted (physician referral, transfer)",
+                "definition": "From where patient was admitted (physician referral, transfer).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.hospitalization.admitSource",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AdmitSource"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "From where the patient was admitted.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/encounter-admit-source"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PV1-14"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".admissionReferralSourceCode"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.hospitalization.reAdmission",
+                "path": "Encounter.hospitalization.reAdmission",
+                "short": "The type of hospital re-admission that has occurred (if any). If the value is absent, then this is not identified as a readmission",
+                "definition": "Whether this hospitalization is a readmission and why if known.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.hospitalization.reAdmission",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ReAdmissionType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "The reason for re-admission of this hospitalization encounter.",
+                    "valueSet": "http://terminology.hl7.org/ValueSet/v2-0092"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PV1-13"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.hospitalization.dietPreference",
+                "path": "Encounter.hospitalization.dietPreference",
+                "short": "Diet preferences reported by the patient",
+                "definition": "Diet preferences reported by the patient.",
+                "comment": "For example, a patient may request both a dairy-free and nut-free diet preference (not mutually exclusive).",
+                "requirements": "Used to track patient's diet restrictions and/or preference. For a complete description of the nutrition needs of a patient during their stay, one should use the nutritionOrder resource which links to Encounter.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.hospitalization.dietPreference",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "PatientDiet"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Medical, cultural or ethical food preferences to help with catering requirements.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/encounter-diet"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PV1-38"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=COMP].target[classCode=SBADM, moodCode=EVN, code=\"diet\"]"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.hospitalization.specialCourtesy",
+                "path": "Encounter.hospitalization.specialCourtesy",
+                "short": "Special courtesies (VIP, board member)",
+                "definition": "Special courtesies (VIP, board member).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.hospitalization.specialCourtesy",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Courtesies"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Special courtesies.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/encounter-special-courtesy"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PV1-16"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".specialCourtesiesCode"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.hospitalization.specialArrangement",
+                "path": "Encounter.hospitalization.specialArrangement",
+                "short": "Wheelchair, translator, stretcher, etc.",
+                "definition": "Any special requests that have been made for this hospitalization encounter, such as the provision of specific equipment or other things.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.hospitalization.specialArrangement",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Arrangements"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Special arrangements.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/encounter-special-arrangements"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PV1-15 / OBR-30 / OBR-43"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".specialArrangementCode"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.hospitalization.destination",
+                "path": "Encounter.hospitalization.destination",
+                "short": "Location/organization to which the patient is discharged",
+                "definition": "Location/organization to which the patient is discharged.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.hospitalization.destination",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Location",
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PV1-37"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=DST]"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.hospitalization.dischargeDisposition",
+                "path": "Encounter.hospitalization.dischargeDisposition",
+                "short": "Category or kind of location after discharge",
+                "definition": "Category or kind of location after discharge.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.hospitalization.dischargeDisposition",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "DischargeDisp"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Discharge Disposition.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/encounter-discharge-disposition"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PV1-36"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".dischargeDispositionCode"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.location",
+                "path": "Encounter.location",
+                "short": "List of locations where the patient has been",
+                "definition": "List of locations where  the patient has been during this encounter.",
+                "comment": "Virtual encounters can be recorded in the Encounter by specifying a location reference to a location of type \"kind\" such as \"client's home\" and an encounter.class = \"virtual\".",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.location",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=LOC]"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.location.id",
+                "path": "Encounter.location.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.location.extension",
+                "path": "Encounter.location.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.location.modifierExtension",
+                "path": "Encounter.location.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.location.location",
+                "path": "Encounter.location.location",
+                "short": "Location the encounter takes place",
+                "definition": "The location where the encounter takes place.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.location.location",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Location"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.location"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.where[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1-3 / PV1-6 / PV1-11 / PV1-42 / PV1-43"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".role"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.location.status",
+                "path": "Encounter.location.status",
+                "short": "planned | active | reserved | completed",
+                "definition": "The status of the participants' presence at the specified location during the period specified. If the participant is no longer at the location, then the period will have an end date/time.",
+                "comment": "When the patient is no longer active at a location, then the period end date is entered, and the status may be changed to completed.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.location.status",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "EncounterLocationStatus"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The status of the location.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/encounter-location-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".role.statusCode"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.location.physicalType",
+                "path": "Encounter.location.physicalType",
+                "short": "The physical type of the location (usually the level in the location hierachy - bed room ward etc.)",
+                "definition": "This will be used to specify the required levels (bed/ward/room/etc.) desired to be recorded to simplify either messaging or query.",
+                "comment": "This information is de-normalized from the Location resource to support the easier understanding of the encounter resource and processing in messaging or query.\n\nThere may be many levels in the hierachy, and this may only pic specific levels that are required for a specific usage scenario.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.location.physicalType",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "PhysicalType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Physical form of the location.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/location-physical-type"
+                }
+            },
+            {
+                "id": "Encounter.location.period",
+                "path": "Encounter.location.period",
+                "short": "Time period during which the patient was present at the location",
+                "definition": "Time period during which the patient was present at the location.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.location.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".time"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.serviceProvider",
+                "path": "Encounter.serviceProvider",
+                "short": "The organization (facility) responsible for this encounter",
+                "definition": "The organization that is primarily responsible for this Encounter's services. This MAY be the same as the organization on the Patient record, however it could be different, such as if the actor performing the services was from an external organization (which may be billed seperately) for an external consultation.  Refer to the example bundle showing an abbreviated set of Encounters for a colonoscopy.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.serviceProvider",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PL.6  & PL.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".particiaption[typeCode=PFM].role"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.partOf",
+                "path": "Encounter.partOf",
+                "short": "Another Encounter this encounter is part of",
+                "definition": "Another Encounter of which this encounter is a part of (administratively or in time).",
+                "comment": "This is also used for associating a child's encounter back to the mother's encounter.\r\rRefer to the Notes section in the Patient resource for further details.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.partOf",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-hierarchy",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.partOf"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[classCode=COMP, moodCode=EVN]"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Encounter",
+                "path": "Encounter",
+                "definition": "This is basic constraint on Encounter for use in US Core resources.",
+                "alias": [
+                    "Visit"
+                ],
+                "mustSupport": false
+            },
+            {
+                "id": "Encounter.identifier",
+                "path": "Encounter.identifier",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.identifier.system",
+                "path": "Encounter.identifier.system",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.identifier.value",
+                "path": "Encounter.identifier.value",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.status",
+                "path": "Encounter.status",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.class",
+                "path": "Encounter.class",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.type",
+                "path": "Encounter.type",
+                "min": 1,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Valueset to describe the Encounter Type",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-encounter-type|3.1.1"
+                }
+            },
+            {
+                "id": "Encounter.subject",
+                "path": "Encounter.subject",
+                "alias": [
+                    "patient"
+                ],
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.participant",
+                "path": "Encounter.participant",
+                "min": 0,
+                "max": "*",
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.participant.type",
+                "path": "Encounter.participant.type",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.participant.period",
+                "path": "Encounter.participant.period",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.participant.individual",
+                "path": "Encounter.participant.individual",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.period",
+                "path": "Encounter.period",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.reasonCode",
+                "path": "Encounter.reasonCode",
+                "alias": [
+                    "Indication",
+                    "Admission diagnosis"
+                ],
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.hospitalization",
+                "path": "Encounter.hospitalization",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.hospitalization.dischargeDisposition",
+                "path": "Encounter.hospitalization.dischargeDisposition",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.location",
+                "path": "Encounter.location",
+                "min": 0,
+                "max": "*",
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.location.location",
+                "path": "Encounter.location.location",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Location"
+                        ]
+                    }
+                ],
+                "mustSupport": true
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-ethnicity.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-ethnicity.json
@@ -1,2133 +1,2133 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-ethnicity",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-ethnicity-definitions.html#Extension\" title=\"Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.\">Extension</a><a name=\"Extension\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/extensibility.html#Extension\">Extension</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">US Core ethnicity Extension</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck15.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-ethnicity-definitions.html#Extension.extension:ombCategory\" title=\"Slice ombCategory: The 2 ethnicity category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).\">extension:ombCategory</a><a name=\"Extension.extension\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/extensibility.html#Extension\">Extension</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Hispanic or Latino|Not Hispanic or Latino</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck150.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-ethnicity-definitions.html#Extension.extension:ombCategory.url\">url</a><a name=\"Extension.extension.url\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"color: darkgreen\">&quot;ombCategory&quot;</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck140.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-ethnicity-definitions.html#Extension.extension:ombCategory.value[x]\">value[x]</a><a name=\"Extension.extension.value_x_\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Value of extension</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-omb-ethnicity-category.html\">OMB Ethnicity Categories</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck15.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-ethnicity-definitions.html#Extension.extension:detailed\" title=\"Slice detailed: The 41 CDC ethnicity codes that are grouped under one of the 2 OMB ethnicity category codes.\">extension:detailed</a><a name=\"Extension.extension\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/extensibility.html#Extension\">Extension</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Extended ethnicity codes<br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck150.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-ethnicity-definitions.html#Extension.extension:detailed.url\">url</a><a name=\"Extension.extension.url\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"color: darkgreen\">&quot;detailed&quot;</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck140.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-ethnicity-definitions.html#Extension.extension:detailed.value[x]\">value[x]</a><a name=\"Extension.extension.value_x_\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Value of extension</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-detailed-ethnicity.html\">Detailed ethnicity</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck15.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-ethnicity-definitions.html#Extension.extension:text\" title=\"Slice text: Plain text representation of the ethnicity concept(s).\">extension:text</a><a name=\"Extension.extension\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/extensibility.html#Extension\">Extension</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">ethnicity Text</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck150.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-ethnicity-definitions.html#Extension.extension:text.url\">url</a><a name=\"Extension.extension.url\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"color: darkgreen\">&quot;text&quot;</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck140.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-ethnicity-definitions.html#Extension.extension:text.value[x]\">value[x]</a><a name=\"Extension.extension.value_x_\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Value of extension</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-ethnicity-definitions.html#Extension.url\">url</a><a name=\"Extension.url\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"color: darkgreen\">&quot;http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity&quot;</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck00.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <span style=\"text-decoration:line-through\">value[x]</span><a name=\"Extension.value_x_\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"text-decoration:line-through\"/><span style=\"text-decoration:line-through\">0</span><span style=\"text-decoration:line-through\">..</span><span style=\"text-decoration:line-through\">0</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
-	"version": "3.1.1",
-	"name": "USCoreEthnicityExtension",
-	"title": "US Core Ethnicity Extension",
-	"status": "active",
-	"date": "2019-05-21T00:00:00-04:00",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.healthit.gov"
-				}
-			]
-		}
-	],
-	"description": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"purpose": "Complies with 2015 Edition Common Clinical Data Set for patient race.",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		}
-	],
-	"kind": "complex-type",
-	"abstract": false,
-	"context": [
-		{
-			"type": "element",
-			"expression": "Patient"
-		}
-	],
-	"type": "Extension",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Extension",
-				"path": "Extension",
-				"short": "US Core ethnicity Extension",
-				"definition": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Extension",
-					"min": 0,
-					"max": "*"
-				},
-				"condition": [
-					"ele-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false
-			},
-			{
-				"id": "Extension.id",
-				"path": "Extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension",
-				"path": "Extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory",
-				"path": "Extension.extension",
-				"sliceName": "ombCategory",
-				"short": "Hispanic or Latino|Not Hispanic or Latino",
-				"definition": "The 2 ethnicity category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "iso11179",
-						"map": "/ClinicalDocument/recordTarget/patientRole/patient/ethnicGroupCode"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.id",
-				"path": "Extension.extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.extension",
-				"path": "Extension.extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.extension.id",
-				"path": "Extension.extension.extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.extension.extension",
-				"path": "Extension.extension.extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.extension.url",
-				"path": "Extension.extension.extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "uri"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.extension.value[x]",
-				"path": "Extension.extension.extension.value[x]",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "base64Binary"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "canonical"
-					},
-					{
-						"code": "code"
-					},
-					{
-						"code": "date"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "decimal"
-					},
-					{
-						"code": "id"
-					},
-					{
-						"code": "instant"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "markdown"
-					},
-					{
-						"code": "oid"
-					},
-					{
-						"code": "positiveInt"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "unsignedInt"
-					},
-					{
-						"code": "uri"
-					},
-					{
-						"code": "url"
-					},
-					{
-						"code": "uuid"
-					},
-					{
-						"code": "Address"
-					},
-					{
-						"code": "Age"
-					},
-					{
-						"code": "Annotation"
-					},
-					{
-						"code": "Attachment"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "Coding"
-					},
-					{
-						"code": "ContactPoint"
-					},
-					{
-						"code": "Count"
-					},
-					{
-						"code": "Distance"
-					},
-					{
-						"code": "Duration"
-					},
-					{
-						"code": "HumanName"
-					},
-					{
-						"code": "Identifier"
-					},
-					{
-						"code": "Money"
-					},
-					{
-						"code": "Period"
-					},
-					{
-						"code": "Quantity"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "Reference"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "Signature"
-					},
-					{
-						"code": "Timing"
-					},
-					{
-						"code": "ContactDetail"
-					},
-					{
-						"code": "Contributor"
-					},
-					{
-						"code": "DataRequirement"
-					},
-					{
-						"code": "Expression"
-					},
-					{
-						"code": "ParameterDefinition"
-					},
-					{
-						"code": "RelatedArtifact"
-					},
-					{
-						"code": "TriggerDefinition"
-					},
-					{
-						"code": "UsageContext"
-					},
-					{
-						"code": "Dosage"
-					},
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.url",
-				"path": "Extension.extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "ombCategory",
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.value[x]",
-				"path": "Extension.extension.value[x]",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"strength": "required",
-					"description": "The 2 ethnicity category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/omb-ethnicity-category|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed",
-				"path": "Extension.extension",
-				"sliceName": "detailed",
-				"short": "Extended ethnicity codes",
-				"definition": "The 41 CDC ethnicity codes that are grouped under one of the 2 OMB ethnicity category codes.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "iso11179",
-						"map": "/ClinicalDocument/recordTarget/patientRole/patient/sdtc:ethnicGroupCode"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.id",
-				"path": "Extension.extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.extension",
-				"path": "Extension.extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.extension.id",
-				"path": "Extension.extension.extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.extension.extension",
-				"path": "Extension.extension.extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.extension.url",
-				"path": "Extension.extension.extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "uri"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.extension.value[x]",
-				"path": "Extension.extension.extension.value[x]",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "base64Binary"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "canonical"
-					},
-					{
-						"code": "code"
-					},
-					{
-						"code": "date"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "decimal"
-					},
-					{
-						"code": "id"
-					},
-					{
-						"code": "instant"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "markdown"
-					},
-					{
-						"code": "oid"
-					},
-					{
-						"code": "positiveInt"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "unsignedInt"
-					},
-					{
-						"code": "uri"
-					},
-					{
-						"code": "url"
-					},
-					{
-						"code": "uuid"
-					},
-					{
-						"code": "Address"
-					},
-					{
-						"code": "Age"
-					},
-					{
-						"code": "Annotation"
-					},
-					{
-						"code": "Attachment"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "Coding"
-					},
-					{
-						"code": "ContactPoint"
-					},
-					{
-						"code": "Count"
-					},
-					{
-						"code": "Distance"
-					},
-					{
-						"code": "Duration"
-					},
-					{
-						"code": "HumanName"
-					},
-					{
-						"code": "Identifier"
-					},
-					{
-						"code": "Money"
-					},
-					{
-						"code": "Period"
-					},
-					{
-						"code": "Quantity"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "Reference"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "Signature"
-					},
-					{
-						"code": "Timing"
-					},
-					{
-						"code": "ContactDetail"
-					},
-					{
-						"code": "Contributor"
-					},
-					{
-						"code": "DataRequirement"
-					},
-					{
-						"code": "Expression"
-					},
-					{
-						"code": "ParameterDefinition"
-					},
-					{
-						"code": "RelatedArtifact"
-					},
-					{
-						"code": "TriggerDefinition"
-					},
-					{
-						"code": "UsageContext"
-					},
-					{
-						"code": "Dosage"
-					},
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.url",
-				"path": "Extension.extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "detailed",
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.value[x]",
-				"path": "Extension.extension.value[x]",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"strength": "required",
-					"description": "The 41 [CDC ethnicity codes](http://www.cdc.gov/phin/resources/vocabulary/index.html) that are grouped under one of the 2 OMB ethnicity category codes.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/detailed-ethnicity|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text",
-				"path": "Extension.extension",
-				"sliceName": "text",
-				"short": "ethnicity Text",
-				"definition": "Plain text representation of the ethnicity concept(s).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Extension.extension:text.id",
-				"path": "Extension.extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text.extension",
-				"path": "Extension.extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text.extension.id",
-				"path": "Extension.extension.extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text.extension.extension",
-				"path": "Extension.extension.extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text.extension.url",
-				"path": "Extension.extension.extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "uri"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text.extension.value[x]",
-				"path": "Extension.extension.extension.value[x]",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "base64Binary"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "canonical"
-					},
-					{
-						"code": "code"
-					},
-					{
-						"code": "date"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "decimal"
-					},
-					{
-						"code": "id"
-					},
-					{
-						"code": "instant"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "markdown"
-					},
-					{
-						"code": "oid"
-					},
-					{
-						"code": "positiveInt"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "unsignedInt"
-					},
-					{
-						"code": "uri"
-					},
-					{
-						"code": "url"
-					},
-					{
-						"code": "uuid"
-					},
-					{
-						"code": "Address"
-					},
-					{
-						"code": "Age"
-					},
-					{
-						"code": "Annotation"
-					},
-					{
-						"code": "Attachment"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "Coding"
-					},
-					{
-						"code": "ContactPoint"
-					},
-					{
-						"code": "Count"
-					},
-					{
-						"code": "Distance"
-					},
-					{
-						"code": "Duration"
-					},
-					{
-						"code": "HumanName"
-					},
-					{
-						"code": "Identifier"
-					},
-					{
-						"code": "Money"
-					},
-					{
-						"code": "Period"
-					},
-					{
-						"code": "Quantity"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "Reference"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "Signature"
-					},
-					{
-						"code": "Timing"
-					},
-					{
-						"code": "ContactDetail"
-					},
-					{
-						"code": "Contributor"
-					},
-					{
-						"code": "DataRequirement"
-					},
-					{
-						"code": "Expression"
-					},
-					{
-						"code": "ParameterDefinition"
-					},
-					{
-						"code": "RelatedArtifact"
-					},
-					{
-						"code": "TriggerDefinition"
-					},
-					{
-						"code": "UsageContext"
-					},
-					{
-						"code": "Dosage"
-					},
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text.url",
-				"path": "Extension.extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "text",
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text.value[x]",
-				"path": "Extension.extension.value[x]",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.url",
-				"path": "Extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "uri"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.value[x]",
-				"path": "Extension.value[x]",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 0,
-				"max": "0",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "base64Binary"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "canonical"
-					},
-					{
-						"code": "code"
-					},
-					{
-						"code": "date"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "decimal"
-					},
-					{
-						"code": "id"
-					},
-					{
-						"code": "instant"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "markdown"
-					},
-					{
-						"code": "oid"
-					},
-					{
-						"code": "positiveInt"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "unsignedInt"
-					},
-					{
-						"code": "uri"
-					},
-					{
-						"code": "url"
-					},
-					{
-						"code": "uuid"
-					},
-					{
-						"code": "Address"
-					},
-					{
-						"code": "Age"
-					},
-					{
-						"code": "Annotation"
-					},
-					{
-						"code": "Attachment"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "Coding"
-					},
-					{
-						"code": "ContactPoint"
-					},
-					{
-						"code": "Count"
-					},
-					{
-						"code": "Distance"
-					},
-					{
-						"code": "Duration"
-					},
-					{
-						"code": "HumanName"
-					},
-					{
-						"code": "Identifier"
-					},
-					{
-						"code": "Money"
-					},
-					{
-						"code": "Period"
-					},
-					{
-						"code": "Quantity"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "Reference"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "Signature"
-					},
-					{
-						"code": "Timing"
-					},
-					{
-						"code": "ContactDetail"
-					},
-					{
-						"code": "Contributor"
-					},
-					{
-						"code": "DataRequirement"
-					},
-					{
-						"code": "Expression"
-					},
-					{
-						"code": "ParameterDefinition"
-					},
-					{
-						"code": "RelatedArtifact"
-					},
-					{
-						"code": "TriggerDefinition"
-					},
-					{
-						"code": "UsageContext"
-					},
-					{
-						"code": "Dosage"
-					},
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Extension",
-				"path": "Extension",
-				"short": "US Core ethnicity Extension",
-				"definition": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.",
-				"min": 0,
-				"max": "1"
-			},
-			{
-				"id": "Extension.extension:ombCategory",
-				"path": "Extension.extension",
-				"sliceName": "ombCategory",
-				"short": "Hispanic or Latino|Not Hispanic or Latino",
-				"definition": "The 2 ethnicity category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "iso11179",
-						"map": "/ClinicalDocument/recordTarget/patientRole/patient/ethnicGroupCode"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.url",
-				"path": "Extension.extension.url",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "ombCategory"
-			},
-			{
-				"id": "Extension.extension:ombCategory.value[x]",
-				"path": "Extension.extension.value[x]",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"binding": {
-					"strength": "required",
-					"description": "The 2 ethnicity category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/omb-ethnicity-category|3.1.1"
-				}
-			},
-			{
-				"id": "Extension.extension:detailed",
-				"path": "Extension.extension",
-				"sliceName": "detailed",
-				"short": "Extended ethnicity codes",
-				"definition": "The 41 CDC ethnicity codes that are grouped under one of the 2 OMB ethnicity category codes.",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"mapping": [
-					{
-						"identity": "iso11179",
-						"map": "/ClinicalDocument/recordTarget/patientRole/patient/sdtc:ethnicGroupCode"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.url",
-				"path": "Extension.extension.url",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "detailed"
-			},
-			{
-				"id": "Extension.extension:detailed.value[x]",
-				"path": "Extension.extension.value[x]",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"binding": {
-					"strength": "required",
-					"description": "The 41 [CDC ethnicity codes](http://www.cdc.gov/phin/resources/vocabulary/index.html) that are grouped under one of the 2 OMB ethnicity category codes.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/detailed-ethnicity|3.1.1"
-				}
-			},
-			{
-				"id": "Extension.extension:text",
-				"path": "Extension.extension",
-				"sliceName": "text",
-				"short": "ethnicity Text",
-				"definition": "Plain text representation of the ethnicity concept(s).",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Extension.extension:text.url",
-				"path": "Extension.extension.url",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "text"
-			},
-			{
-				"id": "Extension.extension:text.value[x]",
-				"path": "Extension.extension.value[x]",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				]
-			},
-			{
-				"id": "Extension.url",
-				"path": "Extension.url",
-				"min": 1,
-				"max": "1",
-				"fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
-			},
-			{
-				"id": "Extension.value[x]",
-				"path": "Extension.value[x]",
-				"min": 0,
-				"max": "0"
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-ethnicity",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+    "version": "3.1.1",
+    "name": "USCoreEthnicityExtension",
+    "title": "US Core Ethnicity Extension",
+    "status": "active",
+    "date": "2019-05-21T00:00:00-04:00",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.healthit.gov"
+                }
+            ]
+        }
+    ],
+    "description": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "purpose": "Complies with 2015 Edition Common Clinical Data Set for patient race.",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        }
+    ],
+    "kind": "complex-type",
+    "abstract": false,
+    "context": [
+        {
+            "type": "element",
+            "expression": "Patient"
+        }
+    ],
+    "type": "Extension",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Extension",
+                "path": "Extension",
+                "short": "US Core ethnicity Extension",
+                "definition": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "condition": [
+                    "ele-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false
+            },
+            {
+                "id": "Extension.id",
+                "path": "Extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension",
+                "path": "Extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory",
+                "path": "Extension.extension",
+                "sliceName": "ombCategory",
+                "short": "Hispanic or Latino|Not Hispanic or Latino",
+                "definition": "The 2 ethnicity category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "iso11179",
+                        "map": "/ClinicalDocument/recordTarget/patientRole/patient/ethnicGroupCode"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.id",
+                "path": "Extension.extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.extension",
+                "path": "Extension.extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.extension.id",
+                "path": "Extension.extension.extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.extension.extension",
+                "path": "Extension.extension.extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.extension.url",
+                "path": "Extension.extension.extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "uri"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.extension.value[x]",
+                "path": "Extension.extension.extension.value[x]",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "base64Binary"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "canonical"
+                    },
+                    {
+                        "code": "code"
+                    },
+                    {
+                        "code": "date"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "decimal"
+                    },
+                    {
+                        "code": "id"
+                    },
+                    {
+                        "code": "instant"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "markdown"
+                    },
+                    {
+                        "code": "oid"
+                    },
+                    {
+                        "code": "positiveInt"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "unsignedInt"
+                    },
+                    {
+                        "code": "uri"
+                    },
+                    {
+                        "code": "url"
+                    },
+                    {
+                        "code": "uuid"
+                    },
+                    {
+                        "code": "Address"
+                    },
+                    {
+                        "code": "Age"
+                    },
+                    {
+                        "code": "Annotation"
+                    },
+                    {
+                        "code": "Attachment"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "Coding"
+                    },
+                    {
+                        "code": "ContactPoint"
+                    },
+                    {
+                        "code": "Count"
+                    },
+                    {
+                        "code": "Distance"
+                    },
+                    {
+                        "code": "Duration"
+                    },
+                    {
+                        "code": "HumanName"
+                    },
+                    {
+                        "code": "Identifier"
+                    },
+                    {
+                        "code": "Money"
+                    },
+                    {
+                        "code": "Period"
+                    },
+                    {
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "Reference"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "Signature"
+                    },
+                    {
+                        "code": "Timing"
+                    },
+                    {
+                        "code": "ContactDetail"
+                    },
+                    {
+                        "code": "Contributor"
+                    },
+                    {
+                        "code": "DataRequirement"
+                    },
+                    {
+                        "code": "Expression"
+                    },
+                    {
+                        "code": "ParameterDefinition"
+                    },
+                    {
+                        "code": "RelatedArtifact"
+                    },
+                    {
+                        "code": "TriggerDefinition"
+                    },
+                    {
+                        "code": "UsageContext"
+                    },
+                    {
+                        "code": "Dosage"
+                    },
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.url",
+                "path": "Extension.extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "ombCategory",
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.value[x]",
+                "path": "Extension.extension.value[x]",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "strength": "required",
+                    "description": "The 2 ethnicity category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/omb-ethnicity-category|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed",
+                "path": "Extension.extension",
+                "sliceName": "detailed",
+                "short": "Extended ethnicity codes",
+                "definition": "The 41 CDC ethnicity codes that are grouped under one of the 2 OMB ethnicity category codes.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "iso11179",
+                        "map": "/ClinicalDocument/recordTarget/patientRole/patient/sdtc:ethnicGroupCode"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.id",
+                "path": "Extension.extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.extension",
+                "path": "Extension.extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.extension.id",
+                "path": "Extension.extension.extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.extension.extension",
+                "path": "Extension.extension.extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.extension.url",
+                "path": "Extension.extension.extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "uri"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.extension.value[x]",
+                "path": "Extension.extension.extension.value[x]",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "base64Binary"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "canonical"
+                    },
+                    {
+                        "code": "code"
+                    },
+                    {
+                        "code": "date"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "decimal"
+                    },
+                    {
+                        "code": "id"
+                    },
+                    {
+                        "code": "instant"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "markdown"
+                    },
+                    {
+                        "code": "oid"
+                    },
+                    {
+                        "code": "positiveInt"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "unsignedInt"
+                    },
+                    {
+                        "code": "uri"
+                    },
+                    {
+                        "code": "url"
+                    },
+                    {
+                        "code": "uuid"
+                    },
+                    {
+                        "code": "Address"
+                    },
+                    {
+                        "code": "Age"
+                    },
+                    {
+                        "code": "Annotation"
+                    },
+                    {
+                        "code": "Attachment"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "Coding"
+                    },
+                    {
+                        "code": "ContactPoint"
+                    },
+                    {
+                        "code": "Count"
+                    },
+                    {
+                        "code": "Distance"
+                    },
+                    {
+                        "code": "Duration"
+                    },
+                    {
+                        "code": "HumanName"
+                    },
+                    {
+                        "code": "Identifier"
+                    },
+                    {
+                        "code": "Money"
+                    },
+                    {
+                        "code": "Period"
+                    },
+                    {
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "Reference"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "Signature"
+                    },
+                    {
+                        "code": "Timing"
+                    },
+                    {
+                        "code": "ContactDetail"
+                    },
+                    {
+                        "code": "Contributor"
+                    },
+                    {
+                        "code": "DataRequirement"
+                    },
+                    {
+                        "code": "Expression"
+                    },
+                    {
+                        "code": "ParameterDefinition"
+                    },
+                    {
+                        "code": "RelatedArtifact"
+                    },
+                    {
+                        "code": "TriggerDefinition"
+                    },
+                    {
+                        "code": "UsageContext"
+                    },
+                    {
+                        "code": "Dosage"
+                    },
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.url",
+                "path": "Extension.extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "detailed",
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.value[x]",
+                "path": "Extension.extension.value[x]",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "strength": "required",
+                    "description": "The 41 [CDC ethnicity codes](http://www.cdc.gov/phin/resources/vocabulary/index.html) that are grouped under one of the 2 OMB ethnicity category codes.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/detailed-ethnicity|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text",
+                "path": "Extension.extension",
+                "sliceName": "text",
+                "short": "ethnicity Text",
+                "definition": "Plain text representation of the ethnicity concept(s).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Extension.extension:text.id",
+                "path": "Extension.extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text.extension",
+                "path": "Extension.extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text.extension.id",
+                "path": "Extension.extension.extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text.extension.extension",
+                "path": "Extension.extension.extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text.extension.url",
+                "path": "Extension.extension.extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "uri"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text.extension.value[x]",
+                "path": "Extension.extension.extension.value[x]",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "base64Binary"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "canonical"
+                    },
+                    {
+                        "code": "code"
+                    },
+                    {
+                        "code": "date"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "decimal"
+                    },
+                    {
+                        "code": "id"
+                    },
+                    {
+                        "code": "instant"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "markdown"
+                    },
+                    {
+                        "code": "oid"
+                    },
+                    {
+                        "code": "positiveInt"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "unsignedInt"
+                    },
+                    {
+                        "code": "uri"
+                    },
+                    {
+                        "code": "url"
+                    },
+                    {
+                        "code": "uuid"
+                    },
+                    {
+                        "code": "Address"
+                    },
+                    {
+                        "code": "Age"
+                    },
+                    {
+                        "code": "Annotation"
+                    },
+                    {
+                        "code": "Attachment"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "Coding"
+                    },
+                    {
+                        "code": "ContactPoint"
+                    },
+                    {
+                        "code": "Count"
+                    },
+                    {
+                        "code": "Distance"
+                    },
+                    {
+                        "code": "Duration"
+                    },
+                    {
+                        "code": "HumanName"
+                    },
+                    {
+                        "code": "Identifier"
+                    },
+                    {
+                        "code": "Money"
+                    },
+                    {
+                        "code": "Period"
+                    },
+                    {
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "Reference"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "Signature"
+                    },
+                    {
+                        "code": "Timing"
+                    },
+                    {
+                        "code": "ContactDetail"
+                    },
+                    {
+                        "code": "Contributor"
+                    },
+                    {
+                        "code": "DataRequirement"
+                    },
+                    {
+                        "code": "Expression"
+                    },
+                    {
+                        "code": "ParameterDefinition"
+                    },
+                    {
+                        "code": "RelatedArtifact"
+                    },
+                    {
+                        "code": "TriggerDefinition"
+                    },
+                    {
+                        "code": "UsageContext"
+                    },
+                    {
+                        "code": "Dosage"
+                    },
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text.url",
+                "path": "Extension.extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "text",
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text.value[x]",
+                "path": "Extension.extension.value[x]",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.url",
+                "path": "Extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "uri"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.value[x]",
+                "path": "Extension.value[x]",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 0,
+                "max": "0",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "base64Binary"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "canonical"
+                    },
+                    {
+                        "code": "code"
+                    },
+                    {
+                        "code": "date"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "decimal"
+                    },
+                    {
+                        "code": "id"
+                    },
+                    {
+                        "code": "instant"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "markdown"
+                    },
+                    {
+                        "code": "oid"
+                    },
+                    {
+                        "code": "positiveInt"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "unsignedInt"
+                    },
+                    {
+                        "code": "uri"
+                    },
+                    {
+                        "code": "url"
+                    },
+                    {
+                        "code": "uuid"
+                    },
+                    {
+                        "code": "Address"
+                    },
+                    {
+                        "code": "Age"
+                    },
+                    {
+                        "code": "Annotation"
+                    },
+                    {
+                        "code": "Attachment"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "Coding"
+                    },
+                    {
+                        "code": "ContactPoint"
+                    },
+                    {
+                        "code": "Count"
+                    },
+                    {
+                        "code": "Distance"
+                    },
+                    {
+                        "code": "Duration"
+                    },
+                    {
+                        "code": "HumanName"
+                    },
+                    {
+                        "code": "Identifier"
+                    },
+                    {
+                        "code": "Money"
+                    },
+                    {
+                        "code": "Period"
+                    },
+                    {
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "Reference"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "Signature"
+                    },
+                    {
+                        "code": "Timing"
+                    },
+                    {
+                        "code": "ContactDetail"
+                    },
+                    {
+                        "code": "Contributor"
+                    },
+                    {
+                        "code": "DataRequirement"
+                    },
+                    {
+                        "code": "Expression"
+                    },
+                    {
+                        "code": "ParameterDefinition"
+                    },
+                    {
+                        "code": "RelatedArtifact"
+                    },
+                    {
+                        "code": "TriggerDefinition"
+                    },
+                    {
+                        "code": "UsageContext"
+                    },
+                    {
+                        "code": "Dosage"
+                    },
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Extension",
+                "path": "Extension",
+                "short": "US Core ethnicity Extension",
+                "definition": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.",
+                "min": 0,
+                "max": "1"
+            },
+            {
+                "id": "Extension.extension:ombCategory",
+                "path": "Extension.extension",
+                "sliceName": "ombCategory",
+                "short": "Hispanic or Latino|Not Hispanic or Latino",
+                "definition": "The 2 ethnicity category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "iso11179",
+                        "map": "/ClinicalDocument/recordTarget/patientRole/patient/ethnicGroupCode"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.url",
+                "path": "Extension.extension.url",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "ombCategory"
+            },
+            {
+                "id": "Extension.extension:ombCategory.value[x]",
+                "path": "Extension.extension.value[x]",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "binding": {
+                    "strength": "required",
+                    "description": "The 2 ethnicity category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/omb-ethnicity-category|3.1.1"
+                }
+            },
+            {
+                "id": "Extension.extension:detailed",
+                "path": "Extension.extension",
+                "sliceName": "detailed",
+                "short": "Extended ethnicity codes",
+                "definition": "The 41 CDC ethnicity codes that are grouped under one of the 2 OMB ethnicity category codes.",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "mapping": [
+                    {
+                        "identity": "iso11179",
+                        "map": "/ClinicalDocument/recordTarget/patientRole/patient/sdtc:ethnicGroupCode"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.url",
+                "path": "Extension.extension.url",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "detailed"
+            },
+            {
+                "id": "Extension.extension:detailed.value[x]",
+                "path": "Extension.extension.value[x]",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "binding": {
+                    "strength": "required",
+                    "description": "The 41 [CDC ethnicity codes](http://www.cdc.gov/phin/resources/vocabulary/index.html) that are grouped under one of the 2 OMB ethnicity category codes.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/detailed-ethnicity|3.1.1"
+                }
+            },
+            {
+                "id": "Extension.extension:text",
+                "path": "Extension.extension",
+                "sliceName": "text",
+                "short": "ethnicity Text",
+                "definition": "Plain text representation of the ethnicity concept(s).",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Extension.extension:text.url",
+                "path": "Extension.extension.url",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "text"
+            },
+            {
+                "id": "Extension.extension:text.value[x]",
+                "path": "Extension.extension.value[x]",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.url",
+                "path": "Extension.url",
+                "min": 1,
+                "max": "1",
+                "fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
+            },
+            {
+                "id": "Extension.value[x]",
+                "path": "Extension.value[x]",
+                "min": 0,
+                "max": "0"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-goal.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-goal.json
@@ -1,1630 +1,1630 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-goal",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-goal-definitions.html#Goal\" title=\"The US Core Goal Profile is based upon the core FHIR Goal Resource and created to meet the 2015 Edition Common Clinical Data Set 'Goals' requirements.\">Goal</a><a name=\"Goal\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/goal.html\">Goal</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Describes the intended objective(s) for a patient, group or organization</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-goal-definitions.html#Goal.lifecycleStatus\">lifecycleStatus</a><a name=\"Goal.lifecycleStatus\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">proposed | planned | accepted | active | on-hold | completed | cancelled | entered-in-error | rejected</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-goal-status.html\">GoalLifecycleStatus</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-goal-definitions.html#Goal.description\">description</a><a name=\"Goal.description\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Code or text describing goal</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-goal-definitions.html#Goal.subject\">subject</a><a name=\"Goal.subject\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who this goal is intended for</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-goal-definitions.html#Goal.target\">target</a><a name=\"Goal.target\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Target outcome for the goal</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-goal-definitions.html#Goal.target.dueDate\">dueDate</a><a name=\"Goal.target.dueDate\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#date\">date</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Reach goal on or before</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal",
-	"version": "3.1.1",
-	"name": "USCoreGoalProfile",
-	"title": "US Core Goal Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.healthit.gov"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the Goal resource for the minimal set of data to query and retrieve a patient's goal(s).",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "argonaut-dq-dstu2",
-			"uri": "http://unknown.org/Argonaut-DQ-DSTU2",
-			"name": "Argonaut-DQ-DSTU2"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Goal",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Goal",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Goal",
-				"path": "Goal",
-				"short": "Describes the intended objective(s) for a patient, group or organization",
-				"definition": "The US Core Goal Profile is based upon the core FHIR Goal Resource and created to meet the 2015 Edition Common Clinical Data Set 'Goals' requirements.",
-				"comment": "Goal can be achieving a particular change or merely maintaining a current state or even slowing a decline.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Goal",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "v2",
-						"map": "GOL.1"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode<=OBJ]."
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Goal"
-					}
-				]
-			},
-			{
-				"id": "Goal.id",
-				"path": "Goal.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Goal.meta",
-				"path": "Goal.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Goal.implicitRules",
-				"path": "Goal.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Goal.language",
-				"path": "Goal.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Goal.text",
-				"path": "Goal.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Goal.contained",
-				"path": "Goal.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Goal.extension",
-				"path": "Goal.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Goal.modifierExtension",
-				"path": "Goal.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Goal.identifier",
-				"path": "Goal.identifier",
-				"short": "External Ids for this goal",
-				"definition": "Business identifiers assigned to this goal by the performer or other systems which remain constant as the resource is updated and propagates from server to server.",
-				"comment": "This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.",
-				"requirements": "Allows identification of the goal as it is known by various participating systems and in a way that remains consistent across servers.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Goal.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					}
-				]
-			},
-			{
-				"id": "Goal.lifecycleStatus",
-				"path": "Goal.lifecycleStatus",
-				"short": "proposed | planned | accepted | active | on-hold | completed | cancelled | entered-in-error | rejected",
-				"definition": "The state of the goal throughout its lifecycle.",
-				"comment": "This element is labeled as a modifier because the lifecycleStatus contains codes that mark the resource as not currently valid.",
-				"requirements": "Allows knowing whether goal needs to be further tracked.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Goal.lifecycleStatus",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labelled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/goal-status"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "v2",
-						"map": "GOL-18-goal life cycle status"
-					},
-					{
-						"identity": "rim",
-						"map": ".statusCode in-progress = active (classCode = OBJ) cancelled = aborted"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Goal.status"
-					}
-				]
-			},
-			{
-				"id": "Goal.achievementStatus",
-				"path": "Goal.achievementStatus",
-				"short": "in-progress | improving | worsening | no-change | achieved | sustaining | not-achieved | no-progress | not-attainable",
-				"definition": "Describes the progression, or lack thereof, towards the goal against the target.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Goal.achievementStatus",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "GoalAchievementStatus"
-						}
-					],
-					"strength": "preferred",
-					"description": "Indicates the progression, or lack thereof, towards the goal against the target.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/goal-achievement"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".statusCode achieved = complete sustaining = active"
-					}
-				]
-			},
-			{
-				"id": "Goal.category",
-				"path": "Goal.category",
-				"short": "E.g. Treatment, dietary, behavioral, etc.",
-				"definition": "Indicates a category the goal falls within.",
-				"requirements": "Allows goals to be filtered and sorted.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Goal.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "GoalCategory"
-						}
-					],
-					"strength": "example",
-					"description": "Codes for grouping and sorting goals.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/goal-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					}
-				]
-			},
-			{
-				"id": "Goal.priority",
-				"path": "Goal.priority",
-				"short": "high-priority | medium-priority | low-priority",
-				"definition": "Identifies the mutually agreed level of importance associated with reaching/sustaining the goal.",
-				"comment": "Extensions are available to track priorities as established by each participant (i.e. Priority from the patient's perspective, different practitioners' perspectives, family member's perspectives)\r\rThe ordinal extension on Coding can be used to convey a numerically comparable ranking to priority.  (Keep in mind that different coding systems may use a \"low value=important\".",
-				"requirements": "Used for sorting and presenting goals.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Goal.priority",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "GoalPriority"
-						}
-					],
-					"strength": "preferred",
-					"description": "The level of importance associated with a goal.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/goal-priority"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.grade"
-					},
-					{
-						"identity": "rim",
-						"map": ".priorityCode"
-					}
-				]
-			},
-			{
-				"id": "Goal.description",
-				"path": "Goal.description",
-				"short": "Code or text describing goal",
-				"definition": "Human-readable and/or coded description of a specific desired objective of care, such as \"control blood pressure\" or \"negotiate an obstacle course\" or \"dance with child at wedding\".",
-				"comment": "If no code is available, use CodeableConcept.text.",
-				"requirements": "Without a description of what's trying to be achieved, element has no purpose.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Goal.description",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "GoalDescription"
-						}
-					],
-					"strength": "example",
-					"description": "Codes providing the details of a particular goal.  This will generally be system or implementation guide-specific.  In many systems, only the text element will be used.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "GOL-3.2-goal ID.text"
-					},
-					{
-						"identity": "rim",
-						"map": ".text"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Goal.description"
-					}
-				]
-			},
-			{
-				"id": "Goal.subject",
-				"path": "Goal.subject",
-				"short": "Who this goal is intended for",
-				"definition": "Identifies the patient, group or organization for whom the goal is being established.",
-				"requirements": "Subject is optional to support annonymized reporting.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Goal.subject",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3-patient ID list"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=PAT].role[classCode=PAT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Goal.subject"
-					}
-				]
-			},
-			{
-				"id": "Goal.start[x]",
-				"path": "Goal.start[x]",
-				"short": "When goal pursuit begins",
-				"definition": "The date or event after which the goal should begin being pursued.",
-				"requirements": "Goals can be established prior to there being an intention to start pursuing them; e.g. Goals for post-surgical recovery established prior to surgery.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Goal.start[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "date"
-					},
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "GoalStartEvent"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing events that can trigger the initiation of a goal.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/goal-start-event"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.planned"
-					}
-				]
-			},
-			{
-				"id": "Goal.target",
-				"path": "Goal.target",
-				"short": "Target outcome for the goal",
-				"definition": "Indicates what should be done by when.",
-				"comment": "When multiple targets are present for a single goal instance, all targets must be met for the overall goal to be met.",
-				"requirements": "Allows the progress of the goal to be monitored against an observation or due date.  Target is 0..* to support Observations with multiple components, such as blood pressure goals with both a systolic and diastolic target.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Goal.target",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"condition": [
-					"gol-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "gol-1",
-						"severity": "error",
-						"human": "Goal.target.measure is required if Goal.target.detail is populated",
-						"expression": "(detail.exists() and measure.exists()) or detail.exists().not()",
-						"xpath": "(exists(f:*[starts-with(local-name(.), 'detail')]) and exists(f:measure)) or not(exists(f:*[starts-with(local-name(.), 'detail')]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Goal"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Goal.target.id",
-				"path": "Goal.target.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Goal.target.extension",
-				"path": "Goal.target.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Goal.target.modifierExtension",
-				"path": "Goal.target.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Goal.target.measure",
-				"path": "Goal.target.measure",
-				"short": "The parameter whose value is being tracked",
-				"definition": "The parameter whose value is being tracked, e.g. body weight, blood pressure, or hemoglobin A1c level.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Goal.target.measure",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"gol-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "GoalTargetMeasure"
-						}
-					],
-					"strength": "example",
-					"description": "Codes to identify the value being tracked, e.g. body weight, blood pressure, or hemoglobin A1c level.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-codes"
-				}
-			},
-			{
-				"id": "Goal.target.detail[x]",
-				"path": "Goal.target.detail[x]",
-				"short": "The target value to be achieved",
-				"definition": "The target value of the focus to be achieved to signify the fulfillment of the goal, e.g. 150 pounds, 7.0%. Either the high or low or both values of the range can be specified. When a low value is missing, it indicates that the goal is achieved at any focus value at or below the high value. Similarly, if the high value is missing, it indicates that the goal is achieved at any focus value at or above the low value.",
-				"comment": "A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Goal.target.measure defines a coded value.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Goal.target.detail[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "Ratio"
-					}
-				],
-				"condition": [
-					"gol-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "GoalTargetDetail"
-						}
-					],
-					"strength": "example",
-					"description": "Codes to identify the target value of the focus to be achieved to signify the fulfillment of the goal."
-				}
-			},
-			{
-				"id": "Goal.target.due[x]",
-				"path": "Goal.target.due[x]",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "type",
-							"path": "$this"
-						}
-					],
-					"ordered": false,
-					"rules": "closed"
-				},
-				"short": "Reach goal on or before",
-				"definition": "Indicates either the date or the duration after start by which the goal should be met.",
-				"requirements": "Identifies when the goal should be evaluated.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Goal.target.due[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "date"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					}
-				]
-			},
-			{
-				"id": "Goal.target.due[x]:dueDate",
-				"path": "Goal.target.due[x]",
-				"sliceName": "dueDate",
-				"short": "Reach goal on or before",
-				"definition": "Indicates either the date or the duration after start by which the goal should be met.",
-				"requirements": "Identifies when the goal should be evaluated.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Goal.target.due[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "date"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					}
-				]
-			},
-			{
-				"id": "Goal.statusDate",
-				"path": "Goal.statusDate",
-				"short": "When goal status took effect",
-				"definition": "Identifies when the current status.  I.e. When initially created, when achieved, when cancelled, etc.",
-				"comment": "To see the date for past statuses, query history.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Goal.statusDate",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "date"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					}
-				]
-			},
-			{
-				"id": "Goal.statusReason",
-				"path": "Goal.statusReason",
-				"short": "Reason for current status",
-				"definition": "Captures the reason for the current status.",
-				"comment": "This will typically be captured for statuses such as rejected, on-hold or cancelled, but could be present for others.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Goal.statusReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Goal.expressedBy",
-				"path": "Goal.expressedBy",
-				"short": "Who's responsible for creating Goal?",
-				"definition": "Indicates whose goal this is - patient goal, practitioner goal, etc.",
-				"comment": "This is the individual responsible for establishing the goal, not necessarily who recorded it.  (For that, use the Provenance resource.).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Goal.expressedBy",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.source"
-					}
-				]
-			},
-			{
-				"id": "Goal.addresses",
-				"path": "Goal.addresses",
-				"short": "Issues addressed by this goal",
-				"definition": "The identified conditions and other health record elements that are intended to be addressed by the goal.",
-				"requirements": "Allows specific goals to explicitly linked to the concerns they're dealing with - makes the goal more understandable.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Goal.addresses",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Condition",
-							"http://hl7.org/fhir/StructureDefinition/Observation",
-							"http://hl7.org/fhir/StructureDefinition/MedicationStatement",
-							"http://hl7.org/fhir/StructureDefinition/NutritionOrder",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest",
-							"http://hl7.org/fhir/StructureDefinition/RiskAssessment"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.why[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=SUBJ].target[classCode=CONC]"
-					}
-				]
-			},
-			{
-				"id": "Goal.note",
-				"path": "Goal.note",
-				"short": "Comments about the goal",
-				"definition": "Any comments related to the goal.",
-				"comment": "May be used for progress notes, concerns or other related information that doesn't actually describe the goal itself.",
-				"requirements": "There's a need to capture information about the goal that doesn't actually describe the goal.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Goal.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "GOL-16-goal evaluation + NTE?"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "Goal.outcomeCode",
-				"path": "Goal.outcomeCode",
-				"short": "What result was achieved regarding the goal?",
-				"definition": "Identifies the change (or lack of change) at the point when the status of the goal is assessed.",
-				"comment": "Note that this should not duplicate the goal status.",
-				"requirements": "Outcome tracking is a key aspect of care planning.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Goal.outcomeCode",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "GoalOutcome"
-						}
-					],
-					"strength": "example",
-					"description": "The result of the goal; e.g. \"25% increase in shoulder mobility\", \"Anxiety reduced to moderate levels\".  \"15 kg weight loss sustained over 6 months\".",
-					"valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
-				}
-			},
-			{
-				"id": "Goal.outcomeReference",
-				"path": "Goal.outcomeReference",
-				"short": "Observation that resulted from goal",
-				"definition": "Details of what's changed (or not changed).",
-				"comment": "The goal outcome is independent of the outcome of the related activities.  For example, if the Goal is to achieve a target body weight of 150 lb and a care plan activity is defined to diet, then the care plan’s activity outcome could be calories consumed whereas goal outcome is an observation for the actual body weight measured.",
-				"requirements": "Outcome tracking is a key aspect of care planning.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Goal.outcomeReference",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Observation"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Goal",
-				"path": "Goal",
-				"definition": "The US Core Goal Profile is based upon the core FHIR Goal Resource and created to meet the 2015 Edition Common Clinical Data Set 'Goals' requirements.",
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Goal"
-					}
-				]
-			},
-			{
-				"id": "Goal.lifecycleStatus",
-				"path": "Goal.lifecycleStatus",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/goal-status"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Goal.status"
-					}
-				]
-			},
-			{
-				"id": "Goal.description",
-				"path": "Goal.description",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Goal.description"
-					}
-				]
-			},
-			{
-				"id": "Goal.subject",
-				"path": "Goal.subject",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Goal.subject"
-					}
-				]
-			},
-			{
-				"id": "Goal.target",
-				"path": "Goal.target",
-				"min": 0,
-				"max": "*",
-				"mustSupport": true
-			},
-			{
-				"id": "Goal.target.dueDate",
-				"path": "Goal.target.dueDate",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-goal",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal",
+    "version": "3.1.1",
+    "name": "USCoreGoalProfile",
+    "title": "US Core Goal Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.healthit.gov"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the Goal resource for the minimal set of data to query and retrieve a patient's goal(s).",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "argonaut-dq-dstu2",
+            "uri": "http://unknown.org/Argonaut-DQ-DSTU2",
+            "name": "Argonaut-DQ-DSTU2"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Goal",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Goal",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Goal",
+                "path": "Goal",
+                "short": "Describes the intended objective(s) for a patient, group or organization",
+                "definition": "The US Core Goal Profile is based upon the core FHIR Goal Resource and created to meet the 2015 Edition Common Clinical Data Set 'Goals' requirements.",
+                "comment": "Goal can be achieving a particular change or merely maintaining a current state or even slowing a decline.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Goal",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "GOL.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode<=OBJ]."
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Goal"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.id",
+                "path": "Goal.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Goal.meta",
+                "path": "Goal.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Goal.implicitRules",
+                "path": "Goal.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Goal.language",
+                "path": "Goal.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Goal.text",
+                "path": "Goal.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.contained",
+                "path": "Goal.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.extension",
+                "path": "Goal.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.modifierExtension",
+                "path": "Goal.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.identifier",
+                "path": "Goal.identifier",
+                "short": "External Ids for this goal",
+                "definition": "Business identifiers assigned to this goal by the performer or other systems which remain constant as the resource is updated and propagates from server to server.",
+                "comment": "This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.",
+                "requirements": "Allows identification of the goal as it is known by various participating systems and in a way that remains consistent across servers.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Goal.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.lifecycleStatus",
+                "path": "Goal.lifecycleStatus",
+                "short": "proposed | planned | accepted | active | on-hold | completed | cancelled | entered-in-error | rejected",
+                "definition": "The state of the goal throughout its lifecycle.",
+                "comment": "This element is labeled as a modifier because the lifecycleStatus contains codes that mark the resource as not currently valid.",
+                "requirements": "Allows knowing whether goal needs to be further tracked.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Goal.lifecycleStatus",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labelled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/goal-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "GOL-18-goal life cycle status"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".statusCode in-progress = active (classCode = OBJ) cancelled = aborted"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Goal.status"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.achievementStatus",
+                "path": "Goal.achievementStatus",
+                "short": "in-progress | improving | worsening | no-change | achieved | sustaining | not-achieved | no-progress | not-attainable",
+                "definition": "Describes the progression, or lack thereof, towards the goal against the target.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Goal.achievementStatus",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "GoalAchievementStatus"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Indicates the progression, or lack thereof, towards the goal against the target.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/goal-achievement"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".statusCode achieved = complete sustaining = active"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.category",
+                "path": "Goal.category",
+                "short": "E.g. Treatment, dietary, behavioral, etc.",
+                "definition": "Indicates a category the goal falls within.",
+                "requirements": "Allows goals to be filtered and sorted.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Goal.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "GoalCategory"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes for grouping and sorting goals.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/goal-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.priority",
+                "path": "Goal.priority",
+                "short": "high-priority | medium-priority | low-priority",
+                "definition": "Identifies the mutually agreed level of importance associated with reaching/sustaining the goal.",
+                "comment": "Extensions are available to track priorities as established by each participant (i.e. Priority from the patient's perspective, different practitioners' perspectives, family member's perspectives)\r\rThe ordinal extension on Coding can be used to convey a numerically comparable ranking to priority.  (Keep in mind that different coding systems may use a \"low value=important\".",
+                "requirements": "Used for sorting and presenting goals.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Goal.priority",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "GoalPriority"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "The level of importance associated with a goal.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/goal-priority"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.grade"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".priorityCode"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.description",
+                "path": "Goal.description",
+                "short": "Code or text describing goal",
+                "definition": "Human-readable and/or coded description of a specific desired objective of care, such as \"control blood pressure\" or \"negotiate an obstacle course\" or \"dance with child at wedding\".",
+                "comment": "If no code is available, use CodeableConcept.text.",
+                "requirements": "Without a description of what's trying to be achieved, element has no purpose.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Goal.description",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "GoalDescription"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes providing the details of a particular goal.  This will generally be system or implementation guide-specific.  In many systems, only the text element will be used.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "GOL-3.2-goal ID.text"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".text"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Goal.description"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.subject",
+                "path": "Goal.subject",
+                "short": "Who this goal is intended for",
+                "definition": "Identifies the patient, group or organization for whom the goal is being established.",
+                "requirements": "Subject is optional to support annonymized reporting.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Goal.subject",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3-patient ID list"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=PAT].role[classCode=PAT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Goal.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.start[x]",
+                "path": "Goal.start[x]",
+                "short": "When goal pursuit begins",
+                "definition": "The date or event after which the goal should begin being pursued.",
+                "requirements": "Goals can be established prior to there being an intention to start pursuing them; e.g. Goals for post-surgical recovery established prior to surgery.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Goal.start[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "date"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "GoalStartEvent"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing events that can trigger the initiation of a goal.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/goal-start-event"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.planned"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.target",
+                "path": "Goal.target",
+                "short": "Target outcome for the goal",
+                "definition": "Indicates what should be done by when.",
+                "comment": "When multiple targets are present for a single goal instance, all targets must be met for the overall goal to be met.",
+                "requirements": "Allows the progress of the goal to be monitored against an observation or due date.  Target is 0..* to support Observations with multiple components, such as blood pressure goals with both a systolic and diastolic target.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Goal.target",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "condition": [
+                    "gol-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "gol-1",
+                        "severity": "error",
+                        "human": "Goal.target.measure is required if Goal.target.detail is populated",
+                        "expression": "(detail.exists() and measure.exists()) or detail.exists().not()",
+                        "xpath": "(exists(f:*[starts-with(local-name(.), 'detail')]) and exists(f:measure)) or not(exists(f:*[starts-with(local-name(.), 'detail')]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Goal"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Goal.target.id",
+                "path": "Goal.target.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.target.extension",
+                "path": "Goal.target.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.target.modifierExtension",
+                "path": "Goal.target.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.target.measure",
+                "path": "Goal.target.measure",
+                "short": "The parameter whose value is being tracked",
+                "definition": "The parameter whose value is being tracked, e.g. body weight, blood pressure, or hemoglobin A1c level.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Goal.target.measure",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "gol-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "GoalTargetMeasure"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes to identify the value being tracked, e.g. body weight, blood pressure, or hemoglobin A1c level.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-codes"
+                }
+            },
+            {
+                "id": "Goal.target.detail[x]",
+                "path": "Goal.target.detail[x]",
+                "short": "The target value to be achieved",
+                "definition": "The target value of the focus to be achieved to signify the fulfillment of the goal, e.g. 150 pounds, 7.0%. Either the high or low or both values of the range can be specified. When a low value is missing, it indicates that the goal is achieved at any focus value at or below the high value. Similarly, if the high value is missing, it indicates that the goal is achieved at any focus value at or above the low value.",
+                "comment": "A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Goal.target.measure defines a coded value.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Goal.target.detail[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "Ratio"
+                    }
+                ],
+                "condition": [
+                    "gol-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "GoalTargetDetail"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes to identify the target value of the focus to be achieved to signify the fulfillment of the goal."
+                }
+            },
+            {
+                "id": "Goal.target.due[x]",
+                "path": "Goal.target.due[x]",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "type",
+                            "path": "$this"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "closed"
+                },
+                "short": "Reach goal on or before",
+                "definition": "Indicates either the date or the duration after start by which the goal should be met.",
+                "requirements": "Identifies when the goal should be evaluated.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Goal.target.due[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "date"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.target.due[x]:dueDate",
+                "path": "Goal.target.due[x]",
+                "sliceName": "dueDate",
+                "short": "Reach goal on or before",
+                "definition": "Indicates either the date or the duration after start by which the goal should be met.",
+                "requirements": "Identifies when the goal should be evaluated.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Goal.target.due[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "date"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.statusDate",
+                "path": "Goal.statusDate",
+                "short": "When goal status took effect",
+                "definition": "Identifies when the current status.  I.e. When initially created, when achieved, when cancelled, etc.",
+                "comment": "To see the date for past statuses, query history.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Goal.statusDate",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "date"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.statusReason",
+                "path": "Goal.statusReason",
+                "short": "Reason for current status",
+                "definition": "Captures the reason for the current status.",
+                "comment": "This will typically be captured for statuses such as rejected, on-hold or cancelled, but could be present for others.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Goal.statusReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Goal.expressedBy",
+                "path": "Goal.expressedBy",
+                "short": "Who's responsible for creating Goal?",
+                "definition": "Indicates whose goal this is - patient goal, practitioner goal, etc.",
+                "comment": "This is the individual responsible for establishing the goal, not necessarily who recorded it.  (For that, use the Provenance resource.).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Goal.expressedBy",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.source"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.addresses",
+                "path": "Goal.addresses",
+                "short": "Issues addressed by this goal",
+                "definition": "The identified conditions and other health record elements that are intended to be addressed by the goal.",
+                "requirements": "Allows specific goals to explicitly linked to the concerns they're dealing with - makes the goal more understandable.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Goal.addresses",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Condition",
+                            "http://hl7.org/fhir/StructureDefinition/Observation",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationStatement",
+                            "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest",
+                            "http://hl7.org/fhir/StructureDefinition/RiskAssessment"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.why[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=SUBJ].target[classCode=CONC]"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.note",
+                "path": "Goal.note",
+                "short": "Comments about the goal",
+                "definition": "Any comments related to the goal.",
+                "comment": "May be used for progress notes, concerns or other related information that doesn't actually describe the goal itself.",
+                "requirements": "There's a need to capture information about the goal that doesn't actually describe the goal.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Goal.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "GOL-16-goal evaluation + NTE?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.outcomeCode",
+                "path": "Goal.outcomeCode",
+                "short": "What result was achieved regarding the goal?",
+                "definition": "Identifies the change (or lack of change) at the point when the status of the goal is assessed.",
+                "comment": "Note that this should not duplicate the goal status.",
+                "requirements": "Outcome tracking is a key aspect of care planning.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Goal.outcomeCode",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "GoalOutcome"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "The result of the goal; e.g. \"25% increase in shoulder mobility\", \"Anxiety reduced to moderate levels\".  \"15 kg weight loss sustained over 6 months\".",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
+                }
+            },
+            {
+                "id": "Goal.outcomeReference",
+                "path": "Goal.outcomeReference",
+                "short": "Observation that resulted from goal",
+                "definition": "Details of what's changed (or not changed).",
+                "comment": "The goal outcome is independent of the outcome of the related activities.  For example, if the Goal is to achieve a target body weight of 150 lb and a care plan activity is defined to diet, then the care plan’s activity outcome could be calories consumed whereas goal outcome is an observation for the actual body weight measured.",
+                "requirements": "Outcome tracking is a key aspect of care planning.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Goal.outcomeReference",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Observation"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Goal",
+                "path": "Goal",
+                "definition": "The US Core Goal Profile is based upon the core FHIR Goal Resource and created to meet the 2015 Edition Common Clinical Data Set 'Goals' requirements.",
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Goal"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.lifecycleStatus",
+                "path": "Goal.lifecycleStatus",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/goal-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Goal.status"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.description",
+                "path": "Goal.description",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Goal.description"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.subject",
+                "path": "Goal.subject",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Goal.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.target",
+                "path": "Goal.target",
+                "min": 0,
+                "max": "*",
+                "mustSupport": true
+            },
+            {
+                "id": "Goal.target.dueDate",
+                "path": "Goal.target.dueDate",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-immunization.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-immunization.json
@@ -1,3216 +1,3216 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-immunization",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-immunization-definitions.html#Immunization\" title=\"The US Core Immunization Profile is based upon the core FHIR Immunization Resource and created to meet the 2015 Edition Common Clinical Data Set 'Immunizations' requirements.\">Immunization</a><a name=\"Immunization\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/immunization.html\">Immunization</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Immunization event information</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-immunization-definitions.html#Immunization.status\">status</a><a name=\"Immunization.status\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">completed | entered-in-error | not-done</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-immunization-status.html\">ImmunizationStatusCodes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-immunization-definitions.html#Immunization.statusReason\">statusReason</a><a name=\"Immunization.statusReason\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Reason not done</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-immunization-status-reason.html\">ImmunizationStatusReasonCodes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#example\" title=\"Instances are not expected or even encouraged to draw from the specified value set.  The value set merely provides examples of the types of concepts intended to be included.\">example</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-immunization-definitions.html#Immunization.vaccineCode\">vaccineCode</a><a name=\"Immunization.vaccineCode\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-1, us-core-1)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Vaccine Product Type (bind to CVX)<br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-vaccines-cvx.html\">US Core Vaccine Administered Value Set (CVX)</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)<br/><span style=\"font-weight:bold\">us-core-1: </span>SHOULD have a translation to the NDC value set</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-immunization-definitions.html#Immunization.patient\">patient</a><a name=\"Immunization.patient\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who was immunized</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_choice.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Choice of Types\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-immunization-definitions.html#Immunization.occurrence[x]\">occurrence[x]</a><a name=\"Immunization.occurrence_x_\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Vaccine administration date</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for dateTime Type: A date, date-time or partial date (e.g. just year or year + month).  If hours and minutes are specified, a time zone SHALL be populated. The format is a union of the schema types gYear, gYearMonth, date and dateTime. Seconds must be provided due to schema type constraints but may be zero-filled and may be ignored.                 Dates SHALL be valid dates.\">occurrenceDateTime</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#dateTime\">dateTime</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for string Type: A sequence of Unicode characters\">occurrenceString</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck00.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-immunization-definitions.html#Immunization.primarySource\">primarySource</a><a name=\"Immunization.primarySource\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#boolean\">boolean</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Indicates context the data was recorded in</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization",
-	"version": "3.1.1",
-	"name": "USCoreImmunizationProfile",
-	"title": "US Core Immunization Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2019-08-26",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.healthit.gov"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the Immunization resource for the minimal set of data to query and retrieve  patient's immunization information.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "quick",
-			"uri": "http://unknown.org/QUICK",
-			"name": "QUICK"
-		},
-		{
-			"identity": "argonaut-dq-dstu2",
-			"uri": "http://unknown.org/Argonaut-DQ-DSTU2",
-			"name": "Argonaut-DQ-DSTU2"
-		},
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "cda",
-			"uri": "http://hl7.org/v3/cda",
-			"name": "CDA (R2)"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Immunization",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Immunization",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Immunization",
-				"path": "Immunization",
-				"short": "Immunization event information",
-				"definition": "The US Core Immunization Profile is based upon the core FHIR Immunization Resource and created to meet the 2015 Edition Common Clinical Data Set 'Immunizations' requirements.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Immunization",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "v2",
-						"map": "VXU_V04"
-					},
-					{
-						"identity": "rim",
-						"map": "SubstanceAdministration"
-					},
-					{
-						"identity": "quick",
-						"map": "ImmunizationPerformanceOccurrence"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Immunization"
-					}
-				]
-			},
-			{
-				"id": "Immunization.id",
-				"path": "Immunization.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Immunization.meta",
-				"path": "Immunization.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Immunization.implicitRules",
-				"path": "Immunization.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Immunization.language",
-				"path": "Immunization.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Immunization.text",
-				"path": "Immunization.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Immunization.contained",
-				"path": "Immunization.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.extension",
-				"path": "Immunization.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.modifierExtension",
-				"path": "Immunization.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.identifier",
-				"path": "Immunization.identifier",
-				"short": "Business identifier",
-				"definition": "A unique identifier assigned to this immunization record.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Immunization.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/component/StructuredBody/component/section/entry/substanceAdministration/id"
-					}
-				]
-			},
-			{
-				"id": "Immunization.status",
-				"path": "Immunization.status",
-				"short": "completed | entered-in-error | not-done",
-				"definition": "Indicates the current status of the immunization event.",
-				"comment": "Will generally be set to show that the immunization has been completed or not done.  This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Immunization.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains statuses entered-in-error and not-done which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"description": "Constrained list of immunizaiotn status",
-					"valueSet": "http://hl7.org/fhir/ValueSet/immunization-status"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "rim",
-						"map": "statusCode"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Immunization.status"
-					}
-				]
-			},
-			{
-				"id": "Immunization.statusReason",
-				"path": "Immunization.statusReason",
-				"short": "Reason not done",
-				"definition": "Indicates the reason the immunization event was not performed.",
-				"comment": "This is generally only used for the status of \"not-done\". The reason for performing the immunization event is captured in reasonCode, not here.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.statusReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"strength": "example",
-					"valueSet": "http://hl7.org/fhir/ValueSet/immunization-status-reason"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.statusReason"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=SUBJ].source[classCode=CACT, moodCode=EVN].reasonCOde"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Immunization.wasNotGiven"
-					}
-				]
-			},
-			{
-				"id": "Immunization.vaccineCode",
-				"path": "Immunization.vaccineCode",
-				"short": "Vaccine Product Type (bind to CVX)",
-				"definition": "Vaccine that was administered or was to be administered.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Immunization.vaccineCode",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"us-core-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							}
-						],
-						"key": "us-core-1",
-						"severity": "warning",
-						"human": "SHOULD have a translation to the NDC value set",
-						"expression": "coding.where(system='http://hl7.org/fhir/sid/ndc').empty()",
-						"xpath": "not(exists(f:coding/f:system[@value='http://hl7.org/fhir/sid/ndc']))"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The CVX (vaccine administered) code system",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vaccines-cvx|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "RXA-5"
-					},
-					{
-						"identity": "rim",
-						"map": ".code"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/component/StructuredBody/component/section/entry/substanceAdministration/consumable/manfacturedProduct/manufacturedMaterial/realmCode/code"
-					},
-					{
-						"identity": "quick",
-						"map": "vaccine"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Immunization.vaccineCode"
-					}
-				]
-			},
-			{
-				"id": "Immunization.patient",
-				"path": "Immunization.patient",
-				"short": "Who was immunized",
-				"definition": "The patient who either received or did not receive the immunization.",
-				"alias": [
-					"Patient"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Immunization.patient",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": ".partipication[ttypeCode=].role"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					},
-					{
-						"identity": "quick",
-						"map": "subject"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Immunization.patient"
-					}
-				]
-			},
-			{
-				"id": "Immunization.encounter",
-				"path": "Immunization.encounter",
-				"short": "Encounter immunization was part of",
-				"definition": "The visit or admission or other contact between patient and health care provider the immunization was performed as part of.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1-19"
-					},
-					{
-						"identity": "rim",
-						"map": "component->EncounterEvent"
-					}
-				]
-			},
-			{
-				"id": "Immunization.occurrence[x]",
-				"path": "Immunization.occurrence[x]",
-				"short": "Vaccine administration date",
-				"definition": "Date vaccine administered or was to be administered.",
-				"comment": "When immunizations are given a specific date and time should always be known.   When immunizations are patient reported, a specific date might not be known.  Although partial dates are allowed, an adult patient might not be able to recall the year a childhood immunization was given. An exact date is always preferable, but the use of the String data type is acceptable when an exact date is not known. A small number of vaccines (e.g. live oral typhoid vaccine) are given as a series of patient self-administered dose over a span of time. In cases like this, often, only the first dose (typically a provider supervised dose) is recorded with the occurrence indicating the date/time of the first dose.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Immunization.occurrence[x]",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "RXA-3"
-					},
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/component/StructuredBody/component/section/entry/substanceAdministration/effectiveTime/value"
-					},
-					{
-						"identity": "quick",
-						"map": "performanceTime"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Immunization.date"
-					}
-				]
-			},
-			{
-				"id": "Immunization.recorded",
-				"path": "Immunization.recorded",
-				"short": "When the immunization was first captured in the subject's record",
-				"definition": "The date the occurrence of the immunization was first captured in the record - potentially significantly after the occurrence of the event.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.recorded",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=AUT].time"
-					}
-				]
-			},
-			{
-				"id": "Immunization.primarySource",
-				"path": "Immunization.primarySource",
-				"short": "Indicates context the data was recorded in",
-				"definition": "An indication that the content of the record is based on information from the person who administered the vaccine. This reflects the context under which the data was originally recorded.",
-				"comment": "Reflects the “reliability” of the content.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Immunization.primarySource",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.source"
-					},
-					{
-						"identity": "v2",
-						"map": "RXA-9"
-					},
-					{
-						"identity": "rim",
-						"map": "immunization.uncertaintycode (if primary source=false, uncertainty=U)"
-					},
-					{
-						"identity": "quick",
-						"map": "reported"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Immunization.reported"
-					}
-				]
-			},
-			{
-				"id": "Immunization.reportOrigin",
-				"path": "Immunization.reportOrigin",
-				"short": "Indicates the source of a secondarily reported record",
-				"definition": "The source of the data when the report of the immunization event is not based on information from the person who administered the vaccine.",
-				"comment": "Should not be populated if primarySource = True, not required even if primarySource = False.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.reportOrigin",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ImmunizationReportOrigin"
-						}
-					],
-					"strength": "example",
-					"description": "The source of the data for a record which is not from a primary source.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/immunization-origin"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.source"
-					},
-					{
-						"identity": "v2",
-						"map": "RXA-9"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=INF].role[classCode=PAT] (this syntax for self-reported) .participation[typeCode=INF].role[classCode=LIC] (this syntax for health care professional) .participation[typeCode=INF].role[classCode=PRS] (this syntax for family member)"
-					}
-				]
-			},
-			{
-				"id": "Immunization.location",
-				"path": "Immunization.location",
-				"short": "Where immunization occurred",
-				"definition": "The service delivery location where the vaccine administration occurred.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.location",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Location"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.location"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.where[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "RXA-27  (or RXA-11, deprecated as of v2.7)"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=LOC].COCT_MT240000UV"
-					}
-				]
-			},
-			{
-				"id": "Immunization.manufacturer",
-				"path": "Immunization.manufacturer",
-				"short": "Vaccine manufacturer",
-				"definition": "Name of vaccine manufacturer.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.manufacturer",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXA-17"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=CSM].role[classCode=INST].scopedRole.scoper[classCode=ORG]"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/component/StructuredBody/component/section/entry/substanceAdministration/consumable/manfacturedProduct/manufacuturerOrganization/name"
-					}
-				]
-			},
-			{
-				"id": "Immunization.lotNumber",
-				"path": "Immunization.lotNumber",
-				"short": "Vaccine lot number",
-				"definition": "Lot number of the  vaccine product.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.lotNumber",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXA-15"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=CSM].role[classCode=INST].scopedRole.scoper[classCode=MMAT].id"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/component/StructuredBody/component/section/entry/substanceAdministration/consumable/manfacturedProduct/manufacturedMaterial/lotNumberText"
-					}
-				]
-			},
-			{
-				"id": "Immunization.expirationDate",
-				"path": "Immunization.expirationDate",
-				"short": "Vaccine expiration date",
-				"definition": "Date vaccine batch expires.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.expirationDate",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "date"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXA-16"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=CSM].role[classCode=INST].scopedRole.scoper[classCode=MMAT].expirationTime"
-					}
-				]
-			},
-			{
-				"id": "Immunization.site",
-				"path": "Immunization.site",
-				"short": "Body site vaccine  was administered",
-				"definition": "Body site where vaccine was administered.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.site",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ImmunizationSite"
-						}
-					],
-					"strength": "example",
-					"description": "The site at which the vaccine was administered.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/immunization-site"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXR-2"
-					},
-					{
-						"identity": "rim",
-						"map": "observation.targetSiteCode"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/component/StructuredBody/component/section/entry/substanceAdministration/approachSiteCode/code"
-					}
-				]
-			},
-			{
-				"id": "Immunization.route",
-				"path": "Immunization.route",
-				"short": "How vaccine entered body",
-				"definition": "The path by which the vaccine product is taken into the body.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.route",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ImmunizationRoute"
-						}
-					],
-					"strength": "example",
-					"description": "The route by which the vaccine was administered.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/immunization-route"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXR-1"
-					},
-					{
-						"identity": "rim",
-						"map": ".routeCode"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/component/StructuredBody/component/section/entry/substanceAdministration/routeCode/code"
-					}
-				]
-			},
-			{
-				"id": "Immunization.doseQuantity",
-				"path": "Immunization.doseQuantity",
-				"short": "Amount of vaccine administered",
-				"definition": "The quantity of vaccine product that was administered.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.doseQuantity",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXA-6 / RXA-7"
-					},
-					{
-						"identity": "rim",
-						"map": ".doseQuantity"
-					}
-				]
-			},
-			{
-				"id": "Immunization.performer",
-				"path": "Immunization.performer",
-				"short": "Who performed event",
-				"definition": "Indicates who performed the immunization event.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Immunization.performer",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC-12 / RXA-10"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=PRF].role[scoper.determinerCode=INSTANCE]"
-					}
-				]
-			},
-			{
-				"id": "Immunization.performer.id",
-				"path": "Immunization.performer.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Immunization.performer.extension",
-				"path": "Immunization.performer.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Immunization.performer.modifierExtension",
-				"path": "Immunization.performer.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.performer.function",
-				"path": "Immunization.performer.function",
-				"short": "What type of performance was done",
-				"definition": "Describes the type of performance (e.g. ordering provider, administering provider, etc.).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.performer.function",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ImmunizationFunction"
-						}
-					],
-					"strength": "extensible",
-					"description": "The role a practitioner or organization plays in the immunization event.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/immunization-function"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.function"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation.functionCode"
-					}
-				]
-			},
-			{
-				"id": "Immunization.performer.actor",
-				"path": "Immunization.performer.actor",
-				"short": "Individual or organization who was performing",
-				"definition": "The practitioner or organization who performed the action.",
-				"comment": "When the individual practitioner who performed the action is known, it is best to send.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Immunization.performer.actor",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "rim",
-						"map": ".player"
-					}
-				]
-			},
-			{
-				"id": "Immunization.note",
-				"path": "Immunization.note",
-				"short": "Additional immunization notes",
-				"definition": "Extra information about the immunization that is not conveyed by the other attributes.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Immunization.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.note"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-5 : OBX-3 = 48767-8"
-					},
-					{
-						"identity": "rim",
-						"map": "note"
-					}
-				]
-			},
-			{
-				"id": "Immunization.reasonCode",
-				"path": "Immunization.reasonCode",
-				"short": "Why immunization occurred",
-				"definition": "Reasons why the vaccine was administered.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Immunization.reasonCode",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ImmunizationReason"
-						}
-					],
-					"strength": "example",
-					"description": "The reason why a vaccine was administered.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/immunization-reason"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.reasonCode"
-					},
-					{
-						"identity": "rim",
-						"map": "[actionNegationInd=false].reasonCode"
-					}
-				]
-			},
-			{
-				"id": "Immunization.reasonReference",
-				"path": "Immunization.reasonReference",
-				"short": "Why immunization occurred",
-				"definition": "Condition, Observation or DiagnosticReport that supports why the immunization was administered.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Immunization.reasonReference",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Condition",
-							"http://hl7.org/fhir/StructureDefinition/Observation",
-							"http://hl7.org/fhir/StructureDefinition/DiagnosticReport"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.reasonReference"
-					},
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.isSubpotent",
-				"path": "Immunization.isSubpotent",
-				"short": "Dose potency",
-				"definition": "Indication if a dose is considered to be subpotent. By default, a dose should be considered to be potent.",
-				"comment": "Typically, the recognition of the dose being sub-potent is retrospective, after the administration (ex. notification of a manufacturer recall after administration). However, in the case of a partial administration (the patient moves unexpectedly and only some of the dose is actually administered), subpotency may be recognized immediately, but it is still important to record the event.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.isSubpotent",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"meaningWhenMissing": "By default, a dose should be considered to be potent.",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because an immunization event with a subpotent vaccine doesn't protect the patient the same way as a potent dose.",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXA-20 = PA (partial administration)"
-					},
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.subpotentReason",
-				"path": "Immunization.subpotentReason",
-				"short": "Reason for being subpotent",
-				"definition": "Reason why a dose is considered to be subpotent.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Immunization.subpotentReason",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "SubpotentReason"
-						}
-					],
-					"strength": "example",
-					"description": "The reason why a dose is considered to be subpotent.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/immunization-subpotent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.education",
-				"path": "Immunization.education",
-				"short": "Educational material presented to patient",
-				"definition": "Educational material presented to the patient (or guardian) at the time of vaccine administration.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Immunization.education",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "imm-1",
-						"severity": "error",
-						"human": "One of documentType or reference SHALL be present",
-						"expression": "documentType.exists() or reference.exists()",
-						"xpath": "exists(f:documentType) or exists(f:reference)"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.education.id",
-				"path": "Immunization.education.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Immunization.education.extension",
-				"path": "Immunization.education.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Immunization.education.modifierExtension",
-				"path": "Immunization.education.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.education.documentType",
-				"path": "Immunization.education.documentType",
-				"short": "Educational material document identifier",
-				"definition": "Identifier of the material presented to the patient.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.education.documentType",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-5 : OBX-3 = 69764-9"
-					},
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.education.reference",
-				"path": "Immunization.education.reference",
-				"short": "Educational material reference pointer",
-				"definition": "Reference pointer to the educational material given to the patient if the information was on line.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.education.reference",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.education.publicationDate",
-				"path": "Immunization.education.publicationDate",
-				"short": "Educational material publication date",
-				"definition": "Date the educational material was published.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.education.publicationDate",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-5 : OBX-3 = 29768-9"
-					},
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.education.presentationDate",
-				"path": "Immunization.education.presentationDate",
-				"short": "Educational material presentation date",
-				"definition": "Date the educational material was given to the patient.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.education.presentationDate",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-5 : OBX-3 = 29769-7"
-					},
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.programEligibility",
-				"path": "Immunization.programEligibility",
-				"short": "Patient eligibility for a vaccination program",
-				"definition": "Indicates a patient's eligibility for a funding program.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Immunization.programEligibility",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProgramEligibility"
-						}
-					],
-					"strength": "example",
-					"description": "The patient's eligibility for a vaccation program.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/immunization-program-eligibility"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-5 : OBX-3 = 64994-7"
-					},
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.fundingSource",
-				"path": "Immunization.fundingSource",
-				"short": "Funding source for the vaccine",
-				"definition": "Indicates the source of the vaccine actually administered. This may be different than the patient eligibility (e.g. the patient may be eligible for a publically purchased vaccine but due to inventory issues, vaccine purchased with private funds was actually administered).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.fundingSource",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "FundingSource"
-						}
-					],
-					"strength": "example",
-					"description": "The source of funding used to purchase the vaccine administered.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/immunization-funding-source"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.reaction",
-				"path": "Immunization.reaction",
-				"short": "Details of a reaction that follows immunization",
-				"definition": "Categorical data indicating that an adverse event is associated in time to an immunization.",
-				"comment": "A reaction may be an indication of an allergy or intolerance and, if this is determined to be the case, it should be recorded as a new AllergyIntolerance resource instance as most systems will not query against past Immunization.reaction elements.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Immunization.reaction",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation[classCode=obs].code"
-					}
-				]
-			},
-			{
-				"id": "Immunization.reaction.id",
-				"path": "Immunization.reaction.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Immunization.reaction.extension",
-				"path": "Immunization.reaction.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Immunization.reaction.modifierExtension",
-				"path": "Immunization.reaction.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.reaction.date",
-				"path": "Immunization.reaction.date",
-				"short": "When reaction started",
-				"definition": "Date of reaction to the immunization.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.reaction.date",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-14 (ideally this would be reported in an IAM segment, but IAM is not part of the HL7 v2 VXU message - most likely would appear in OBX segments if at all)"
-					},
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "Immunization.reaction.detail",
-				"path": "Immunization.reaction.detail",
-				"short": "Additional information on reaction",
-				"definition": "Details of the reaction.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.reaction.detail",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Observation"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-5"
-					},
-					{
-						"identity": "rim",
-						"map": ".value"
-					}
-				]
-			},
-			{
-				"id": "Immunization.reaction.reported",
-				"path": "Immunization.reaction.reported",
-				"short": "Indicates self-reported reaction",
-				"definition": "Self-reported indicator.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.reaction.reported",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(HL7 v2 doesn't seem to provide for this)"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=INF].role[classCode=PAT] (this syntax for self-reported=true)"
-					}
-				]
-			},
-			{
-				"id": "Immunization.protocolApplied",
-				"path": "Immunization.protocolApplied",
-				"short": "Protocol followed by the provider",
-				"definition": "The protocol (set of recommendations) being followed by the provider who administered the dose.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Immunization.protocolApplied",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.protocolApplied.id",
-				"path": "Immunization.protocolApplied.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Immunization.protocolApplied.extension",
-				"path": "Immunization.protocolApplied.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Immunization.protocolApplied.modifierExtension",
-				"path": "Immunization.protocolApplied.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.protocolApplied.series",
-				"path": "Immunization.protocolApplied.series",
-				"short": "Name of vaccine series",
-				"definition": "One possible path to achieve presumed immunity against a disease - within the context of an authority.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.protocolApplied.series",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.protocolApplied.authority",
-				"path": "Immunization.protocolApplied.authority",
-				"short": "Who is responsible for publishing the recommendations",
-				"definition": "Indicates the authority who published the protocol (e.g. ACIP) that is being followed.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.protocolApplied.authority",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.protocolApplied.targetDisease",
-				"path": "Immunization.protocolApplied.targetDisease",
-				"short": "Vaccine preventatable disease being targetted",
-				"definition": "The vaccine preventable disease the dose is being administered against.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Immunization.protocolApplied.targetDisease",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "TargetDisease"
-						}
-					],
-					"strength": "example",
-					"description": "The vaccine preventable disease the dose is being administered for.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/immunization-target-disease"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.protocolApplied.doseNumber[x]",
-				"path": "Immunization.protocolApplied.doseNumber[x]",
-				"short": "Dose number within series",
-				"definition": "Nominal position in a series.",
-				"comment": "The use of an integer is preferred if known. A string should only be used in cases where an integer is not available (such as when documenting a recurring booster dose).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Immunization.protocolApplied.doseNumber[x]",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "positiveInt"
-					},
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.protocolApplied.seriesDoses[x]",
-				"path": "Immunization.protocolApplied.seriesDoses[x]",
-				"short": "Recommended number of doses for immunity",
-				"definition": "The recommended number of doses to achieve immunity.",
-				"comment": "The use of an integer is preferred if known. A string should only be used in cases where an integer is not available (such as when documenting a recurring booster dose).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.protocolApplied.seriesDoses[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "positiveInt"
-					},
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Immunization",
-				"path": "Immunization",
-				"definition": "The US Core Immunization Profile is based upon the core FHIR Immunization Resource and created to meet the 2015 Edition Common Clinical Data Set 'Immunizations' requirements.",
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "quick",
-						"map": "ImmunizationPerformanceOccurrence"
-					},
-					{
-						"identity": "quick",
-						"map": "ImmunizationPerformanceOccurrence"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Immunization"
-					}
-				]
-			},
-			{
-				"id": "Immunization.status",
-				"path": "Immunization.status",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"description": "Constrained list of immunizaiotn status",
-					"valueSet": "http://hl7.org/fhir/ValueSet/immunization-status"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Immunization.status"
-					}
-				]
-			},
-			{
-				"id": "Immunization.statusReason",
-				"path": "Immunization.statusReason",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true,
-				"binding": {
-					"strength": "example",
-					"valueSet": "http://hl7.org/fhir/ValueSet/immunization-status-reason"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Immunization.wasNotGiven"
-					}
-				]
-			},
-			{
-				"id": "Immunization.vaccineCode",
-				"path": "Immunization.vaccineCode",
-				"short": "Vaccine Product Type (bind to CVX)",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"us-core-1"
-				],
-				"constraint": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							}
-						],
-						"key": "us-core-1",
-						"severity": "warning",
-						"human": "SHOULD have a translation to the NDC value set",
-						"expression": "coding.where(system='http://hl7.org/fhir/sid/ndc').empty()",
-						"xpath": "not(exists(f:coding/f:system[@value='http://hl7.org/fhir/sid/ndc']))"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The CVX (vaccine administered) code system",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vaccines-cvx|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "quick",
-						"map": "vaccine"
-					},
-					{
-						"identity": "quick",
-						"map": "vaccine"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Immunization.vaccineCode"
-					}
-				]
-			},
-			{
-				"id": "Immunization.patient",
-				"path": "Immunization.patient",
-				"alias": [
-					"Patient"
-				],
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "quick",
-						"map": "subject"
-					},
-					{
-						"identity": "quick",
-						"map": "subject"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Immunization.patient"
-					}
-				]
-			},
-			{
-				"id": "Immunization.occurrence[x]",
-				"path": "Immunization.occurrence[x]",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "quick",
-						"map": "performanceTime"
-					},
-					{
-						"identity": "quick",
-						"map": "performanceTime"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Immunization.date"
-					}
-				]
-			},
-			{
-				"id": "Immunization.primarySource",
-				"path": "Immunization.primarySource",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "quick",
-						"map": "reported"
-					},
-					{
-						"identity": "quick",
-						"map": "reported"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Immunization.reported"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-immunization",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization",
+    "version": "3.1.1",
+    "name": "USCoreImmunizationProfile",
+    "title": "US Core Immunization Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2019-08-26",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.healthit.gov"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the Immunization resource for the minimal set of data to query and retrieve  patient's immunization information.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "quick",
+            "uri": "http://unknown.org/QUICK",
+            "name": "QUICK"
+        },
+        {
+            "identity": "argonaut-dq-dstu2",
+            "uri": "http://unknown.org/Argonaut-DQ-DSTU2",
+            "name": "Argonaut-DQ-DSTU2"
+        },
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "cda",
+            "uri": "http://hl7.org/v3/cda",
+            "name": "CDA (R2)"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Immunization",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Immunization",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Immunization",
+                "path": "Immunization",
+                "short": "Immunization event information",
+                "definition": "The US Core Immunization Profile is based upon the core FHIR Immunization Resource and created to meet the 2015 Edition Common Clinical Data Set 'Immunizations' requirements.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Immunization",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "VXU_V04"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "SubstanceAdministration"
+                    },
+                    {
+                        "identity": "quick",
+                        "map": "ImmunizationPerformanceOccurrence"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Immunization"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.id",
+                "path": "Immunization.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Immunization.meta",
+                "path": "Immunization.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Immunization.implicitRules",
+                "path": "Immunization.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Immunization.language",
+                "path": "Immunization.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Immunization.text",
+                "path": "Immunization.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.contained",
+                "path": "Immunization.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.extension",
+                "path": "Immunization.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.modifierExtension",
+                "path": "Immunization.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.identifier",
+                "path": "Immunization.identifier",
+                "short": "Business identifier",
+                "definition": "A unique identifier assigned to this immunization record.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Immunization.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/component/StructuredBody/component/section/entry/substanceAdministration/id"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.status",
+                "path": "Immunization.status",
+                "short": "completed | entered-in-error | not-done",
+                "definition": "Indicates the current status of the immunization event.",
+                "comment": "Will generally be set to show that the immunization has been completed or not done.  This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains statuses entered-in-error and not-done which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "description": "Constrained list of immunizaiotn status",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/immunization-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "statusCode"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Immunization.status"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.statusReason",
+                "path": "Immunization.statusReason",
+                "short": "Reason not done",
+                "definition": "Indicates the reason the immunization event was not performed.",
+                "comment": "This is generally only used for the status of \"not-done\". The reason for performing the immunization event is captured in reasonCode, not here.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.statusReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "strength": "example",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/immunization-status-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.statusReason"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=SUBJ].source[classCode=CACT, moodCode=EVN].reasonCOde"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Immunization.wasNotGiven"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.vaccineCode",
+                "path": "Immunization.vaccineCode",
+                "short": "Vaccine Product Type (bind to CVX)",
+                "definition": "Vaccine that was administered or was to be administered.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.vaccineCode",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "us-core-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "key": "us-core-1",
+                        "severity": "warning",
+                        "human": "SHOULD have a translation to the NDC value set",
+                        "expression": "coding.where(system='http://hl7.org/fhir/sid/ndc').empty()",
+                        "xpath": "not(exists(f:coding/f:system[@value='http://hl7.org/fhir/sid/ndc']))"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The CVX (vaccine administered) code system",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vaccines-cvx|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXA-5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".code"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/component/StructuredBody/component/section/entry/substanceAdministration/consumable/manfacturedProduct/manufacturedMaterial/realmCode/code"
+                    },
+                    {
+                        "identity": "quick",
+                        "map": "vaccine"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Immunization.vaccineCode"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.patient",
+                "path": "Immunization.patient",
+                "short": "Who was immunized",
+                "definition": "The patient who either received or did not receive the immunization.",
+                "alias": [
+                    "Patient"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.patient",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".partipication[ttypeCode=].role"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    },
+                    {
+                        "identity": "quick",
+                        "map": "subject"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Immunization.patient"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.encounter",
+                "path": "Immunization.encounter",
+                "short": "Encounter immunization was part of",
+                "definition": "The visit or admission or other contact between patient and health care provider the immunization was performed as part of.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1-19"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "component->EncounterEvent"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.occurrence[x]",
+                "path": "Immunization.occurrence[x]",
+                "short": "Vaccine administration date",
+                "definition": "Date vaccine administered or was to be administered.",
+                "comment": "When immunizations are given a specific date and time should always be known.   When immunizations are patient reported, a specific date might not be known.  Although partial dates are allowed, an adult patient might not be able to recall the year a childhood immunization was given. An exact date is always preferable, but the use of the String data type is acceptable when an exact date is not known. A small number of vaccines (e.g. live oral typhoid vaccine) are given as a series of patient self-administered dose over a span of time. In cases like this, often, only the first dose (typically a provider supervised dose) is recorded with the occurrence indicating the date/time of the first dose.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.occurrence[x]",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXA-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/component/StructuredBody/component/section/entry/substanceAdministration/effectiveTime/value"
+                    },
+                    {
+                        "identity": "quick",
+                        "map": "performanceTime"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Immunization.date"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.recorded",
+                "path": "Immunization.recorded",
+                "short": "When the immunization was first captured in the subject's record",
+                "definition": "The date the occurrence of the immunization was first captured in the record - potentially significantly after the occurrence of the event.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.recorded",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.primarySource",
+                "path": "Immunization.primarySource",
+                "short": "Indicates context the data was recorded in",
+                "definition": "An indication that the content of the record is based on information from the person who administered the vaccine. This reflects the context under which the data was originally recorded.",
+                "comment": "Reflects the “reliability” of the content.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.primarySource",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.source"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXA-9"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "immunization.uncertaintycode (if primary source=false, uncertainty=U)"
+                    },
+                    {
+                        "identity": "quick",
+                        "map": "reported"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Immunization.reported"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.reportOrigin",
+                "path": "Immunization.reportOrigin",
+                "short": "Indicates the source of a secondarily reported record",
+                "definition": "The source of the data when the report of the immunization event is not based on information from the person who administered the vaccine.",
+                "comment": "Should not be populated if primarySource = True, not required even if primarySource = False.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.reportOrigin",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ImmunizationReportOrigin"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "The source of the data for a record which is not from a primary source.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/immunization-origin"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.source"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXA-9"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=INF].role[classCode=PAT] (this syntax for self-reported) .participation[typeCode=INF].role[classCode=LIC] (this syntax for health care professional) .participation[typeCode=INF].role[classCode=PRS] (this syntax for family member)"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.location",
+                "path": "Immunization.location",
+                "short": "Where immunization occurred",
+                "definition": "The service delivery location where the vaccine administration occurred.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.location",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Location"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.location"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.where[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXA-27  (or RXA-11, deprecated as of v2.7)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=LOC].COCT_MT240000UV"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.manufacturer",
+                "path": "Immunization.manufacturer",
+                "short": "Vaccine manufacturer",
+                "definition": "Name of vaccine manufacturer.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.manufacturer",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXA-17"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=CSM].role[classCode=INST].scopedRole.scoper[classCode=ORG]"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/component/StructuredBody/component/section/entry/substanceAdministration/consumable/manfacturedProduct/manufacuturerOrganization/name"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.lotNumber",
+                "path": "Immunization.lotNumber",
+                "short": "Vaccine lot number",
+                "definition": "Lot number of the  vaccine product.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.lotNumber",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXA-15"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=CSM].role[classCode=INST].scopedRole.scoper[classCode=MMAT].id"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/component/StructuredBody/component/section/entry/substanceAdministration/consumable/manfacturedProduct/manufacturedMaterial/lotNumberText"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.expirationDate",
+                "path": "Immunization.expirationDate",
+                "short": "Vaccine expiration date",
+                "definition": "Date vaccine batch expires.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.expirationDate",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "date"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXA-16"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=CSM].role[classCode=INST].scopedRole.scoper[classCode=MMAT].expirationTime"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.site",
+                "path": "Immunization.site",
+                "short": "Body site vaccine  was administered",
+                "definition": "Body site where vaccine was administered.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.site",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ImmunizationSite"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "The site at which the vaccine was administered.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/immunization-site"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXR-2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "observation.targetSiteCode"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/component/StructuredBody/component/section/entry/substanceAdministration/approachSiteCode/code"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.route",
+                "path": "Immunization.route",
+                "short": "How vaccine entered body",
+                "definition": "The path by which the vaccine product is taken into the body.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.route",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ImmunizationRoute"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "The route by which the vaccine was administered.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/immunization-route"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXR-1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".routeCode"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/component/StructuredBody/component/section/entry/substanceAdministration/routeCode/code"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.doseQuantity",
+                "path": "Immunization.doseQuantity",
+                "short": "Amount of vaccine administered",
+                "definition": "The quantity of vaccine product that was administered.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.doseQuantity",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXA-6 / RXA-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".doseQuantity"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.performer",
+                "path": "Immunization.performer",
+                "short": "Who performed event",
+                "definition": "Indicates who performed the immunization event.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Immunization.performer",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC-12 / RXA-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=PRF].role[scoper.determinerCode=INSTANCE]"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.performer.id",
+                "path": "Immunization.performer.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.performer.extension",
+                "path": "Immunization.performer.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.performer.modifierExtension",
+                "path": "Immunization.performer.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.performer.function",
+                "path": "Immunization.performer.function",
+                "short": "What type of performance was done",
+                "definition": "Describes the type of performance (e.g. ordering provider, administering provider, etc.).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.performer.function",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ImmunizationFunction"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "The role a practitioner or organization plays in the immunization event.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/immunization-function"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.function"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation.functionCode"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.performer.actor",
+                "path": "Immunization.performer.actor",
+                "short": "Individual or organization who was performing",
+                "definition": "The practitioner or organization who performed the action.",
+                "comment": "When the individual practitioner who performed the action is known, it is best to send.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.performer.actor",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".player"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.note",
+                "path": "Immunization.note",
+                "short": "Additional immunization notes",
+                "definition": "Extra information about the immunization that is not conveyed by the other attributes.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Immunization.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.note"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-5 : OBX-3 = 48767-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "note"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.reasonCode",
+                "path": "Immunization.reasonCode",
+                "short": "Why immunization occurred",
+                "definition": "Reasons why the vaccine was administered.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Immunization.reasonCode",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ImmunizationReason"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "The reason why a vaccine was administered.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/immunization-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.reasonCode"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "[actionNegationInd=false].reasonCode"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.reasonReference",
+                "path": "Immunization.reasonReference",
+                "short": "Why immunization occurred",
+                "definition": "Condition, Observation or DiagnosticReport that supports why the immunization was administered.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Immunization.reasonReference",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Condition",
+                            "http://hl7.org/fhir/StructureDefinition/Observation",
+                            "http://hl7.org/fhir/StructureDefinition/DiagnosticReport"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.reasonReference"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.isSubpotent",
+                "path": "Immunization.isSubpotent",
+                "short": "Dose potency",
+                "definition": "Indication if a dose is considered to be subpotent. By default, a dose should be considered to be potent.",
+                "comment": "Typically, the recognition of the dose being sub-potent is retrospective, after the administration (ex. notification of a manufacturer recall after administration). However, in the case of a partial administration (the patient moves unexpectedly and only some of the dose is actually administered), subpotency may be recognized immediately, but it is still important to record the event.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.isSubpotent",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "meaningWhenMissing": "By default, a dose should be considered to be potent.",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because an immunization event with a subpotent vaccine doesn't protect the patient the same way as a potent dose.",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXA-20 = PA (partial administration)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.subpotentReason",
+                "path": "Immunization.subpotentReason",
+                "short": "Reason for being subpotent",
+                "definition": "Reason why a dose is considered to be subpotent.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Immunization.subpotentReason",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "SubpotentReason"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "The reason why a dose is considered to be subpotent.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/immunization-subpotent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.education",
+                "path": "Immunization.education",
+                "short": "Educational material presented to patient",
+                "definition": "Educational material presented to the patient (or guardian) at the time of vaccine administration.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Immunization.education",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "imm-1",
+                        "severity": "error",
+                        "human": "One of documentType or reference SHALL be present",
+                        "expression": "documentType.exists() or reference.exists()",
+                        "xpath": "exists(f:documentType) or exists(f:reference)"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.education.id",
+                "path": "Immunization.education.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.education.extension",
+                "path": "Immunization.education.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.education.modifierExtension",
+                "path": "Immunization.education.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.education.documentType",
+                "path": "Immunization.education.documentType",
+                "short": "Educational material document identifier",
+                "definition": "Identifier of the material presented to the patient.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.education.documentType",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-5 : OBX-3 = 69764-9"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.education.reference",
+                "path": "Immunization.education.reference",
+                "short": "Educational material reference pointer",
+                "definition": "Reference pointer to the educational material given to the patient if the information was on line.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.education.reference",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.education.publicationDate",
+                "path": "Immunization.education.publicationDate",
+                "short": "Educational material publication date",
+                "definition": "Date the educational material was published.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.education.publicationDate",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-5 : OBX-3 = 29768-9"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.education.presentationDate",
+                "path": "Immunization.education.presentationDate",
+                "short": "Educational material presentation date",
+                "definition": "Date the educational material was given to the patient.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.education.presentationDate",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-5 : OBX-3 = 29769-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.programEligibility",
+                "path": "Immunization.programEligibility",
+                "short": "Patient eligibility for a vaccination program",
+                "definition": "Indicates a patient's eligibility for a funding program.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Immunization.programEligibility",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProgramEligibility"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "The patient's eligibility for a vaccation program.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/immunization-program-eligibility"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-5 : OBX-3 = 64994-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.fundingSource",
+                "path": "Immunization.fundingSource",
+                "short": "Funding source for the vaccine",
+                "definition": "Indicates the source of the vaccine actually administered. This may be different than the patient eligibility (e.g. the patient may be eligible for a publically purchased vaccine but due to inventory issues, vaccine purchased with private funds was actually administered).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.fundingSource",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "FundingSource"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "The source of funding used to purchase the vaccine administered.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/immunization-funding-source"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.reaction",
+                "path": "Immunization.reaction",
+                "short": "Details of a reaction that follows immunization",
+                "definition": "Categorical data indicating that an adverse event is associated in time to an immunization.",
+                "comment": "A reaction may be an indication of an allergy or intolerance and, if this is determined to be the case, it should be recorded as a new AllergyIntolerance resource instance as most systems will not query against past Immunization.reaction elements.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Immunization.reaction",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation[classCode=obs].code"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.reaction.id",
+                "path": "Immunization.reaction.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.reaction.extension",
+                "path": "Immunization.reaction.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.reaction.modifierExtension",
+                "path": "Immunization.reaction.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.reaction.date",
+                "path": "Immunization.reaction.date",
+                "short": "When reaction started",
+                "definition": "Date of reaction to the immunization.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.reaction.date",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-14 (ideally this would be reported in an IAM segment, but IAM is not part of the HL7 v2 VXU message - most likely would appear in OBX segments if at all)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.reaction.detail",
+                "path": "Immunization.reaction.detail",
+                "short": "Additional information on reaction",
+                "definition": "Details of the reaction.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.reaction.detail",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Observation"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".value"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.reaction.reported",
+                "path": "Immunization.reaction.reported",
+                "short": "Indicates self-reported reaction",
+                "definition": "Self-reported indicator.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.reaction.reported",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(HL7 v2 doesn't seem to provide for this)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=INF].role[classCode=PAT] (this syntax for self-reported=true)"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.protocolApplied",
+                "path": "Immunization.protocolApplied",
+                "short": "Protocol followed by the provider",
+                "definition": "The protocol (set of recommendations) being followed by the provider who administered the dose.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Immunization.protocolApplied",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.protocolApplied.id",
+                "path": "Immunization.protocolApplied.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.protocolApplied.extension",
+                "path": "Immunization.protocolApplied.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.protocolApplied.modifierExtension",
+                "path": "Immunization.protocolApplied.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.protocolApplied.series",
+                "path": "Immunization.protocolApplied.series",
+                "short": "Name of vaccine series",
+                "definition": "One possible path to achieve presumed immunity against a disease - within the context of an authority.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.protocolApplied.series",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.protocolApplied.authority",
+                "path": "Immunization.protocolApplied.authority",
+                "short": "Who is responsible for publishing the recommendations",
+                "definition": "Indicates the authority who published the protocol (e.g. ACIP) that is being followed.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.protocolApplied.authority",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.protocolApplied.targetDisease",
+                "path": "Immunization.protocolApplied.targetDisease",
+                "short": "Vaccine preventatable disease being targetted",
+                "definition": "The vaccine preventable disease the dose is being administered against.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Immunization.protocolApplied.targetDisease",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "TargetDisease"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "The vaccine preventable disease the dose is being administered for.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/immunization-target-disease"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.protocolApplied.doseNumber[x]",
+                "path": "Immunization.protocolApplied.doseNumber[x]",
+                "short": "Dose number within series",
+                "definition": "Nominal position in a series.",
+                "comment": "The use of an integer is preferred if known. A string should only be used in cases where an integer is not available (such as when documenting a recurring booster dose).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.protocolApplied.doseNumber[x]",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "positiveInt"
+                    },
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.protocolApplied.seriesDoses[x]",
+                "path": "Immunization.protocolApplied.seriesDoses[x]",
+                "short": "Recommended number of doses for immunity",
+                "definition": "The recommended number of doses to achieve immunity.",
+                "comment": "The use of an integer is preferred if known. A string should only be used in cases where an integer is not available (such as when documenting a recurring booster dose).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.protocolApplied.seriesDoses[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "positiveInt"
+                    },
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Immunization",
+                "path": "Immunization",
+                "definition": "The US Core Immunization Profile is based upon the core FHIR Immunization Resource and created to meet the 2015 Edition Common Clinical Data Set 'Immunizations' requirements.",
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "quick",
+                        "map": "ImmunizationPerformanceOccurrence"
+                    },
+                    {
+                        "identity": "quick",
+                        "map": "ImmunizationPerformanceOccurrence"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Immunization"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.status",
+                "path": "Immunization.status",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "description": "Constrained list of immunizaiotn status",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/immunization-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Immunization.status"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.statusReason",
+                "path": "Immunization.statusReason",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "example",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/immunization-status-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Immunization.wasNotGiven"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.vaccineCode",
+                "path": "Immunization.vaccineCode",
+                "short": "Vaccine Product Type (bind to CVX)",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "us-core-1"
+                ],
+                "constraint": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "key": "us-core-1",
+                        "severity": "warning",
+                        "human": "SHOULD have a translation to the NDC value set",
+                        "expression": "coding.where(system='http://hl7.org/fhir/sid/ndc').empty()",
+                        "xpath": "not(exists(f:coding/f:system[@value='http://hl7.org/fhir/sid/ndc']))"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The CVX (vaccine administered) code system",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vaccines-cvx|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "quick",
+                        "map": "vaccine"
+                    },
+                    {
+                        "identity": "quick",
+                        "map": "vaccine"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Immunization.vaccineCode"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.patient",
+                "path": "Immunization.patient",
+                "alias": [
+                    "Patient"
+                ],
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "quick",
+                        "map": "subject"
+                    },
+                    {
+                        "identity": "quick",
+                        "map": "subject"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Immunization.patient"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.occurrence[x]",
+                "path": "Immunization.occurrence[x]",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "quick",
+                        "map": "performanceTime"
+                    },
+                    {
+                        "identity": "quick",
+                        "map": "performanceTime"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Immunization.date"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.primarySource",
+                "path": "Immunization.primarySource",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "quick",
+                        "map": "reported"
+                    },
+                    {
+                        "identity": "quick",
+                        "map": "reported"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Immunization.reported"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-implantable-device.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-implantable-device.json
@@ -1,3115 +1,3115 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-implantable-device",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-implantable-device-definitions.html#Device\" title=\"The US Core Implantable Device Profile is based upon the core FHIR Device Resource and created to meet the 2015 Edition Common Clinical Data Set 'Unique device identifier(s) for a patient’s implantable device(s)' requirements.\">Device</a><a name=\"Device\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-12, us-core-9)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/device.html\">Device</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Item used in healthcare</span><br/><span style=\"font-weight:bold\">us-core-12: </span>Implantable medical devices that have UDI information SHALL represent this information in either carrierAIDC or carrierHRF.<br/><span style=\"font-weight:bold\">us-core-9: </span>For implantable medical devices that have UDI information,  at least one of the Production Identifiers (UDI-PI) SHALL be present.</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-implantable-device-definitions.html#Device.udiCarrier\">udiCarrier</a><a name=\"Device.udiCarrier\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Unique Device Identifier (UDI) Barcode string</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-implantable-device-definitions.html#Device.udiCarrier.deviceIdentifier\">deviceIdentifier</a><a name=\"Device.udiCarrier.deviceIdentifier\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Mandatory fixed portion of UDI</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-implantable-device-definitions.html#Device.udiCarrier.carrierAIDC\">carrierAIDC</a><a name=\"Device.udiCarrier.carrierAIDC\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-12)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#base64Binary\">base64Binary</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">UDI Machine Readable Barcode String</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-implantable-device-definitions.html#Device.udiCarrier.carrierHRF\">carrierHRF</a><a name=\"Device.udiCarrier.carrierHRF\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-12)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">UDI Human Readable Barcode String</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-implantable-device-definitions.html#Device.distinctIdentifier\">distinctIdentifier</a><a name=\"Device.distinctIdentifier\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-9)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The distinct identification string</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-implantable-device-definitions.html#Device.manufactureDate\">manufactureDate</a><a name=\"Device.manufactureDate\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-9)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#dateTime\">dateTime</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Date when the device was made</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-implantable-device-definitions.html#Device.expirationDate\">expirationDate</a><a name=\"Device.expirationDate\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-9)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#dateTime\">dateTime</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Date and time of expiry of this device (if applicable)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-implantable-device-definitions.html#Device.lotNumber\">lotNumber</a><a name=\"Device.lotNumber\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-9)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Lot number of manufacture</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-implantable-device-definitions.html#Device.serialNumber\">serialNumber</a><a name=\"Device.serialNumber\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-9)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Serial number assigned by the manufacturer</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-implantable-device-definitions.html#Device.type\">type</a><a name=\"Device.type\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The kind or type of device</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-device-kind.html\">FHIRDeviceTypes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck00.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-implantable-device-definitions.html#Device.patient\">patient</a><a name=\"Device.patient\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Patient to whom Device is affixed</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device",
-	"version": "3.1.1",
-	"name": "USCoreImplantableDeviceProfile",
-	"title": "US Core Implantable Device Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2019-09-17",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.healthit.gov"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the Device resource for the minimal set of data to query and retrieve a patient's implantable device(s).",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "argonaut-dq-dstu2",
-			"uri": "http://unknown.org/Argonaut-DQ-DSTU2",
-			"name": "Argonaut-DQ-DSTU2"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "udi",
-			"uri": "http://fda.gov/UDI",
-			"name": "UDI Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Device",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Device",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Device",
-				"path": "Device",
-				"short": "Item used in healthcare",
-				"definition": "The US Core Implantable Device Profile is based upon the core FHIR Device Resource and created to meet the 2015 Edition Common Clinical Data Set 'Unique device identifier(s) for a patient’s implantable device(s)' requirements.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Device",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "us-core-12",
-						"severity": "error",
-						"human": "Implantable medical devices that have UDI information SHALL represent this information in either carrierAIDC or carrierHRF.",
-						"expression": "udiCarrier.empty() or (udiCarrier.carrierAIDC.exists() or udiCarrier.carrierHRF.exists())",
-						"xpath": "not(f:udiCarrier) or (f:carrierHRF or f:carrierAIDC)"
-					},
-					{
-						"key": "us-core-9",
-						"severity": "error",
-						"human": "For implantable medical devices that have UDI information,  at least one of the Production Identifiers (UDI-PI) SHALL be present.",
-						"expression": "udiCarrier.empty() or (manufactureDate.exists() or expirationDate.exists() or lotNumber.exists() or serialNumber.exists() or distinctIdentifier.exists())",
-						"xpath": "not(f:udiCarrier) or (f:manufactureDate or f:expirationDate or f:lotNumber or f:serialNumber or f:distinctIdentifier)"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "rim",
-						"map": "Device"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Device"
-					}
-				]
-			},
-			{
-				"id": "Device.id",
-				"path": "Device.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Device.meta",
-				"path": "Device.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Device.implicitRules",
-				"path": "Device.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Device.language",
-				"path": "Device.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Device.text",
-				"path": "Device.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Device.contained",
-				"path": "Device.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Device.extension",
-				"path": "Device.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Device.modifierExtension",
-				"path": "Device.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Device.identifier",
-				"path": "Device.identifier",
-				"short": "Instance identifier",
-				"definition": "Unique instance identifiers assigned to a device by manufacturers other organizations or owners.",
-				"comment": "The barcode string from a barcode present on a device label or package may identify the instance, include names given to the device in local usage, or may identify the type of device. If the identifier identifies the type of device, Device.type element should be used.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Device.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					},
-					{
-						"identity": "udi",
-						"map": "The serial number which is a component of the production identifier (PI), a conditional, variable portion of a UDI.   The identifier.type code should be set to “SNO”(Serial Number) and the system left empty."
-					}
-				]
-			},
-			{
-				"id": "Device.definition",
-				"path": "Device.definition",
-				"short": "The reference to the definition for the device",
-				"definition": "The reference to the definition for the device.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.definition",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/DeviceDefinition"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Device.udiCarrier",
-				"path": "Device.udiCarrier",
-				"short": "Unique Device Identifier (UDI) Barcode string",
-				"definition": "Unique device identifier (UDI) assigned to device label or package.  Note that the Device may include multiple udiCarriers as it either may include just the udiCarrier for the jurisdiction it is sold, or for multiple jurisdictions it could have been sold.",
-				"comment": "Some devices may not have UDI information (for example. historical data or patient reported data).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.udiCarrier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "rim",
-						"map": ".id and .code"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Device.udi"
-					}
-				]
-			},
-			{
-				"id": "Device.udiCarrier.id",
-				"path": "Device.udiCarrier.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Device.udiCarrier.extension",
-				"path": "Device.udiCarrier.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Device.udiCarrier.modifierExtension",
-				"path": "Device.udiCarrier.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Device.udiCarrier.deviceIdentifier",
-				"path": "Device.udiCarrier.deviceIdentifier",
-				"short": "Mandatory fixed portion of UDI",
-				"definition": "The device identifier (DI) is a mandatory, fixed portion of a UDI that identifies the labeler and the specific version or model of a device.",
-				"alias": [
-					"DI"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Device.udiCarrier.deviceIdentifier",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "rim",
-						"map": "Role.id.extension"
-					},
-					{
-						"identity": "udi",
-						"map": "The device identifier (DI), a mandatory, fixed portion of a UDI that identifies the labeler and the specific version or model of a device."
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA (not Supported)"
-					}
-				]
-			},
-			{
-				"id": "Device.udiCarrier.issuer",
-				"path": "Device.udiCarrier.issuer",
-				"short": "UDI Issuing Organization",
-				"definition": "Organization that is charged with issuing UDIs for devices.  For example, the US FDA issuers include :\n1) GS1: \nhttp://hl7.org/fhir/NamingSystem/gs1-di, \n2) HIBCC:\nhttp://hl7.org/fhir/NamingSystem/hibcc-dI, \n3) ICCBBA for blood containers:\nhttp://hl7.org/fhir/NamingSystem/iccbba-blood-di, \n4) ICCBA for other devices:\nhttp://hl7.org/fhir/NamingSystem/iccbba-other-di.",
-				"alias": [
-					"Barcode System"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.udiCarrier.issuer",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Role.id.root"
-					},
-					{
-						"identity": "udi",
-						"map": "All UDIs are to be issued under a system operated by an Jurisdiction-accredited issuing agency.\nGS1 DIs: \n http://hl7.org/fhir/NamingSystem/gs1\nHIBCC DIs:\n http://hl7.org/fhir/NamingSystem/hibcc\nICCBBA DIs for blood containers:\n http://hl7.org/fhir/NamingSystem/iccbba-blood\nICCBA DIs for other devices:\n http://hl7.org/fhir/NamingSystem/iccbba-other"
-					}
-				]
-			},
-			{
-				"id": "Device.udiCarrier.jurisdiction",
-				"path": "Device.udiCarrier.jurisdiction",
-				"short": "Regional UDI authority",
-				"definition": "The identity of the authoritative source for UDI generation within a  jurisdiction.  All UDIs are globally unique within a single namespace with the appropriate repository uri as the system.  For example,  UDIs of devices managed in the U.S. by the FDA, the value is  http://hl7.org/fhir/NamingSystem/fda-udi.",
-				"requirements": "Allows a recipient of a UDI to know which database will contain the UDI-associated metadata.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.udiCarrier.jurisdiction",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Role.scoper"
-					}
-				]
-			},
-			{
-				"id": "Device.udiCarrier.carrierAIDC",
-				"path": "Device.udiCarrier.carrierAIDC",
-				"short": "UDI Machine Readable Barcode String",
-				"definition": "The full UDI carrier of the Automatic Identification and Data Capture (AIDC) technology representation of the barcode string as printed on the packaging of the device - e.g., a barcode or RFID.   Because of limitations on character sets in XML and the need to round-trip JSON data through XML, AIDC Formats *SHALL* be base64 encoded.",
-				"comment": "The AIDC form of UDIs should be scanned or otherwise used for the identification of the device whenever possible to minimize errors in records resulting from manual transcriptions. If separate barcodes for DI and PI are present, concatenate the string with DI first and in order of human readable expression on label.",
-				"alias": [
-					"Automatic Identification and Data Capture",
-					"UDI",
-					"Barcode String"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.udiCarrier.carrierAIDC",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "base64Binary"
-					}
-				],
-				"condition": [
-					"us-core-12"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Role.id.extension"
-					},
-					{
-						"identity": "udi",
-						"map": "A unique device identifier (UDI) on a device label a form that uses automatic identification and data capture (AIDC) technology."
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA (not Supported)"
-					}
-				]
-			},
-			{
-				"id": "Device.udiCarrier.carrierHRF",
-				"path": "Device.udiCarrier.carrierHRF",
-				"short": "UDI Human Readable Barcode String",
-				"definition": "The full UDI carrier as the human readable form (HRF) representation of the barcode string as printed on the packaging of the device.",
-				"comment": "If separate barcodes for DI and PI are present, concatenate the string with DI first and in order of human readable expression on label.",
-				"alias": [
-					"Human Readable Form",
-					"UDI",
-					"Barcode String"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.udiCarrier.carrierHRF",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"condition": [
-					"us-core-12"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Role.id.extension"
-					},
-					{
-						"identity": "udi",
-						"map": "A unique device identifier (UDI) on a device label in plain text"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Device.udi"
-					}
-				]
-			},
-			{
-				"id": "Device.udiCarrier.entryType",
-				"path": "Device.udiCarrier.entryType",
-				"short": "barcode | rfid | manual +",
-				"definition": "A coded entry to indicate how the data was entered.",
-				"requirements": "Supports a way to distinguish hand entered from machine read data.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.udiCarrier.entryType",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "UDIEntryType"
-						}
-					],
-					"strength": "required",
-					"description": "Codes to identify how UDI data was entered.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/udi-entry-type|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Device.status",
-				"path": "Device.status",
-				"short": "active | inactive | entered-in-error | unknown",
-				"definition": "Status of the Device availability.",
-				"comment": "This element is labeled as a modifier because the status contains the codes inactive and entered-in-error that mark the device (record)as not currently valid.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.status",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labelled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "FHIRDeviceStatus"
-						}
-					],
-					"strength": "required",
-					"description": "The availability status of the device.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/device-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "rim",
-						"map": ".statusCode"
-					}
-				]
-			},
-			{
-				"id": "Device.statusReason",
-				"path": "Device.statusReason",
-				"short": "online | paused | standby | offline | not-ready | transduc-discon | hw-discon | off",
-				"definition": "Reason for the dtatus of the Device availability.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Device.statusReason",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "FHIRDeviceStatusReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "The availability status reason of the device.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/device-status-reason"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					}
-				]
-			},
-			{
-				"id": "Device.distinctIdentifier",
-				"path": "Device.distinctIdentifier",
-				"short": "The distinct identification string",
-				"definition": "The distinct identification string as required by regulation for a human cell, tissue, or cellular and tissue-based product.",
-				"comment": "For example, this applies to devices in the United States regulated under *Code of Federal Regulation 21CFR§1271.290(c)*.",
-				"alias": [
-					"Distinct Identification Code (DIC)"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.distinctIdentifier",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"condition": [
-					"us-core-9"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".lotNumberText"
-					},
-					{
-						"identity": "udi",
-						"map": "The lot or batch number within which a device was manufactured - which is a component of the production identifier (PI), a conditional, variable portion of a UDI."
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA (not Supported)"
-					}
-				]
-			},
-			{
-				"id": "Device.manufacturer",
-				"path": "Device.manufacturer",
-				"short": "Name of device manufacturer",
-				"definition": "A name of the manufacturer.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.manufacturer",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".playedRole[typeCode=MANU].scoper.name"
-					},
-					{
-						"identity": "udi",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Device.manufactureDate",
-				"path": "Device.manufactureDate",
-				"short": "Date when the device was made",
-				"definition": "The date and time when the device was manufactured.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.manufactureDate",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					}
-				],
-				"condition": [
-					"us-core-9"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".existenceTime.low"
-					},
-					{
-						"identity": "udi",
-						"map": "The date a specific device was manufactured - which is a component of the production identifier (PI), a conditional, variable portion of a UDI.  For FHIR, The datetime syntax must converted to YYYY-MM-DD[THH:MM:SS].  If hour is present, the minutes and seconds should both be set to “00”."
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA (not Supported)"
-					}
-				]
-			},
-			{
-				"id": "Device.expirationDate",
-				"path": "Device.expirationDate",
-				"short": "Date and time of expiry of this device (if applicable)",
-				"definition": "The date and time beyond which this device is no longer valid or should not be used (if applicable).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.expirationDate",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					}
-				],
-				"condition": [
-					"us-core-9"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".expirationTime"
-					},
-					{
-						"identity": "udi",
-						"map": "the expiration date of a specific device -  which is a component of the production identifier (PI), a conditional, variable portion of a UDI.  For FHIR, The datetime syntax must converted to YYYY-MM-DD[THH:MM:SS].  If hour is present, the minutes and seconds should both be set to “00”."
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA (not Supported)"
-					}
-				]
-			},
-			{
-				"id": "Device.lotNumber",
-				"path": "Device.lotNumber",
-				"short": "Lot number of manufacture",
-				"definition": "Lot number assigned by the manufacturer.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.lotNumber",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"condition": [
-					"us-core-9"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".lotNumberText"
-					},
-					{
-						"identity": "udi",
-						"map": "The lot or batch number within which a device was manufactured - which is a component of the production identifier (PI), a conditional, variable portion of a UDI."
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA (not Supported)"
-					}
-				]
-			},
-			{
-				"id": "Device.serialNumber",
-				"path": "Device.serialNumber",
-				"short": "Serial number assigned by the manufacturer",
-				"definition": "The serial number assigned by the organization when the device was manufactured.",
-				"comment": "Alphanumeric Maximum 20.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.serialNumber",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"condition": [
-					"us-core-9"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".playedRole[typeCode=MANU].id"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA (not Supported)"
-					}
-				]
-			},
-			{
-				"id": "Device.deviceName",
-				"path": "Device.deviceName",
-				"short": "The name of the device as given by the manufacturer",
-				"definition": "This represents the manufacturer's name of the device as provided by the device, from a UDI label, or by a person describing the Device.  This typically would be used when a person provides the name(s) or when the device represents one of the names available from DeviceDefinition.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Device.deviceName",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Device.deviceName.id",
-				"path": "Device.deviceName.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Device.deviceName.extension",
-				"path": "Device.deviceName.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Device.deviceName.modifierExtension",
-				"path": "Device.deviceName.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Device.deviceName.name",
-				"path": "Device.deviceName.name",
-				"short": "The name of the device",
-				"definition": "The name of the device.",
-				"alias": [
-					"Σ"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Device.deviceName.name",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Device.deviceName.type",
-				"path": "Device.deviceName.type",
-				"short": "udi-label-name | user-friendly-name | patient-reported-name | manufacturer-name | model-name | other",
-				"definition": "The type of deviceName.\nUDILabelName | UserFriendlyName | PatientReportedName | ManufactureDeviceName | ModelName.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Device.deviceName.type",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "DeviceNameType"
-						}
-					],
-					"strength": "required",
-					"description": "The type of name the device is referred by.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/device-nametype|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".playedRole[typeCode=MANU].code"
-					}
-				]
-			},
-			{
-				"id": "Device.modelNumber",
-				"path": "Device.modelNumber",
-				"short": "The model number for the device",
-				"definition": "The model number for the device.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.modelNumber",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".softwareName (included as part)"
-					}
-				]
-			},
-			{
-				"id": "Device.partNumber",
-				"path": "Device.partNumber",
-				"short": "The part number of the device",
-				"definition": "The part number of the device.",
-				"comment": "Alphanumeric Maximum 20.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.partNumber",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".playedRole[typeCode=MANU].id"
-					}
-				]
-			},
-			{
-				"id": "Device.type",
-				"path": "Device.type",
-				"short": "The kind or type of device",
-				"definition": "The kind or type of device.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Device.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"strength": "extensible",
-					"description": "Codes to identify medical devices",
-					"valueSet": "http://hl7.org/fhir/ValueSet/device-kind"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Device.type"
-					}
-				]
-			},
-			{
-				"id": "Device.specialization",
-				"path": "Device.specialization",
-				"short": "The capabilities supported on a  device, the standards to which the device conforms for a particular purpose, and used for the communication",
-				"definition": "The capabilities supported on a  device, the standards to which the device conforms for a particular purpose, and used for the communication.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Device.specialization",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Device.specialization.id",
-				"path": "Device.specialization.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Device.specialization.extension",
-				"path": "Device.specialization.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Device.specialization.modifierExtension",
-				"path": "Device.specialization.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Device.specialization.systemType",
-				"path": "Device.specialization.systemType",
-				"short": "The standard that is used to operate and communicate",
-				"definition": "The standard that is used to operate and communicate.",
-				"alias": [
-					"Σ"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Device.specialization.systemType",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Device.specialization.version",
-				"path": "Device.specialization.version",
-				"short": "The version of the standard that is used to operate and communicate",
-				"definition": "The version of the standard that is used to operate and communicate.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.specialization.version",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					}
-				]
-			},
-			{
-				"id": "Device.version",
-				"path": "Device.version",
-				"short": "The actual design of the device or software version running on the device",
-				"definition": "The actual design of the device or software version running on the device.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Device.version",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Device.version.id",
-				"path": "Device.version.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Device.version.extension",
-				"path": "Device.version.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Device.version.modifierExtension",
-				"path": "Device.version.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Device.version.type",
-				"path": "Device.version.type",
-				"short": "The type of the device version",
-				"definition": "The type of the device version.",
-				"alias": [
-					"Σ"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.version.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Device.version.component",
-				"path": "Device.version.component",
-				"short": "A single component of the device version",
-				"definition": "A single component of the device version.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.version.component",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					}
-				]
-			},
-			{
-				"id": "Device.version.value",
-				"path": "Device.version.value",
-				"short": "The version text",
-				"definition": "The version text.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Device.version.value",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Device.property",
-				"path": "Device.property",
-				"short": "The actual configuration settings of a device as it actually operates, e.g., regulation status, time properties",
-				"definition": "The actual configuration settings of a device as it actually operates, e.g., regulation status, time properties.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Device.property",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Device.property.id",
-				"path": "Device.property.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Device.property.extension",
-				"path": "Device.property.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Device.property.modifierExtension",
-				"path": "Device.property.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Device.property.type",
-				"path": "Device.property.type",
-				"short": "Code that specifies the property DeviceDefinitionPropetyCode (Extensible)",
-				"definition": "Code that specifies the property DeviceDefinitionPropetyCode (Extensible).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Device.property.type",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Device.property.valueQuantity",
-				"path": "Device.property.valueQuantity",
-				"short": "Property value as a quantity",
-				"definition": "Property value as a quantity.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Device.property.valueQuantity",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Device.property.valueCode",
-				"path": "Device.property.valueCode",
-				"short": "Property value as a code, e.g., NTP4 (synced to NTP)",
-				"definition": "Property value as a code, e.g., NTP4 (synced to NTP).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Device.property.valueCode",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Device.patient",
-				"path": "Device.patient",
-				"short": "Patient to whom Device is affixed",
-				"definition": "Patient information, If the device is affixed to a person.",
-				"requirements": "If the device is implanted in a patient, then need to associate the device to the patient.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Device.patient",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".playedRole[typeCode=USED].scoper.playedRole[typeCode=PAT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Device.patient"
-					}
-				]
-			},
-			{
-				"id": "Device.owner",
-				"path": "Device.owner",
-				"short": "Organization responsible for device",
-				"definition": "An organization that is responsible for the provision and ongoing maintenance of the device.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.owner",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.source"
-					},
-					{
-						"identity": "rim",
-						"map": ".playedRole[typeCode=OWN].scoper"
-					}
-				]
-			},
-			{
-				"id": "Device.contact",
-				"path": "Device.contact",
-				"short": "Details for human/organization for support",
-				"definition": "Contact details for an organization or a particular human that is responsible for the device.",
-				"comment": "used for troubleshooting etc.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Device.contact",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "ContactPoint"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.source"
-					},
-					{
-						"identity": "rim",
-						"map": ".scopedRole[typeCode=CON].player"
-					}
-				]
-			},
-			{
-				"id": "Device.location",
-				"path": "Device.location",
-				"short": "Where the device is found",
-				"definition": "The place where the device can be found.",
-				"requirements": "Device.location can be used to track device location.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.location",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Location"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.where[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".playedRole[typeCode=LOCE].scoper"
-					}
-				]
-			},
-			{
-				"id": "Device.url",
-				"path": "Device.url",
-				"short": "Network address to contact device",
-				"definition": "A network address on which the device may be contacted directly.",
-				"comment": "If the device is running a FHIR server, the network address should  be the Base URL from which a conformance statement may be retrieved.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.url",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.where[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".telecom"
-					}
-				]
-			},
-			{
-				"id": "Device.note",
-				"path": "Device.note",
-				"short": "Device notes and comments",
-				"definition": "Descriptive information, usage information or implantation information that is not captured in an existing element.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Device.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".text"
-					}
-				]
-			},
-			{
-				"id": "Device.safety",
-				"path": "Device.safety",
-				"short": "Safety Characteristics of Device",
-				"definition": "Provides additional safety characteristics about a medical device.  For example devices containing latex.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Device.safety",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Device.parent",
-				"path": "Device.parent",
-				"short": "The parent device",
-				"definition": "The parent device.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.parent",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Device"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Device",
-				"path": "Device",
-				"definition": "The US Core Implantable Device Profile is based upon the core FHIR Device Resource and created to meet the 2015 Edition Common Clinical Data Set 'Unique device identifier(s) for a patient’s implantable device(s)' requirements.",
-				"constraint": [
-					{
-						"key": "us-core-12",
-						"severity": "error",
-						"human": "Implantable medical devices that have UDI information SHALL represent this information in either carrierAIDC or carrierHRF.",
-						"expression": "udiCarrier.empty() or (udiCarrier.carrierAIDC.exists() or udiCarrier.carrierHRF.exists())",
-						"xpath": "not(f:udiCarrier) or (f:carrierHRF or f:carrierAIDC)"
-					},
-					{
-						"key": "us-core-9",
-						"severity": "error",
-						"human": "For implantable medical devices that have UDI information,  at least one of the Production Identifiers (UDI-PI) SHALL be present.",
-						"expression": "udiCarrier.empty() or (manufactureDate.exists() or expirationDate.exists() or lotNumber.exists() or serialNumber.exists() or distinctIdentifier.exists())",
-						"xpath": "not(f:udiCarrier) or (f:manufactureDate or f:expirationDate or f:lotNumber or f:serialNumber or f:distinctIdentifier)"
-					}
-				],
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Device"
-					}
-				]
-			},
-			{
-				"id": "Device.udiCarrier",
-				"path": "Device.udiCarrier",
-				"comment": "Some devices may not have UDI information (for example. historical data or patient reported data).",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Device.udi"
-					}
-				]
-			},
-			{
-				"id": "Device.udiCarrier.deviceIdentifier",
-				"path": "Device.udiCarrier.deviceIdentifier",
-				"alias": [
-					"DI"
-				],
-				"min": 1,
-				"max": "1",
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA (not Supported)"
-					}
-				]
-			},
-			{
-				"id": "Device.udiCarrier.carrierAIDC",
-				"path": "Device.udiCarrier.carrierAIDC",
-				"alias": [
-					"UDI",
-					"Barcode String"
-				],
-				"min": 0,
-				"max": "1",
-				"condition": [
-					"us-core-12"
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA (not Supported)"
-					}
-				]
-			},
-			{
-				"id": "Device.udiCarrier.carrierHRF",
-				"path": "Device.udiCarrier.carrierHRF",
-				"alias": [
-					"UDI",
-					"Barcode String"
-				],
-				"min": 0,
-				"max": "1",
-				"condition": [
-					"us-core-12"
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Device.udi"
-					}
-				]
-			},
-			{
-				"id": "Device.distinctIdentifier",
-				"path": "Device.distinctIdentifier",
-				"min": 0,
-				"max": "1",
-				"condition": [
-					"us-core-9"
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA (not Supported)"
-					}
-				]
-			},
-			{
-				"id": "Device.manufactureDate",
-				"path": "Device.manufactureDate",
-				"min": 0,
-				"max": "1",
-				"condition": [
-					"us-core-9"
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA (not Supported)"
-					}
-				]
-			},
-			{
-				"id": "Device.expirationDate",
-				"path": "Device.expirationDate",
-				"min": 0,
-				"max": "1",
-				"condition": [
-					"us-core-9"
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA (not Supported)"
-					}
-				]
-			},
-			{
-				"id": "Device.lotNumber",
-				"path": "Device.lotNumber",
-				"min": 0,
-				"max": "1",
-				"condition": [
-					"us-core-9"
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA (not Supported)"
-					}
-				]
-			},
-			{
-				"id": "Device.serialNumber",
-				"path": "Device.serialNumber",
-				"min": 0,
-				"max": "1",
-				"condition": [
-					"us-core-9"
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA (not Supported)"
-					}
-				]
-			},
-			{
-				"id": "Device.type",
-				"path": "Device.type",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Codes to identify medical devices",
-					"valueSet": "http://hl7.org/fhir/ValueSet/device-kind"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Device.type"
-					}
-				]
-			},
-			{
-				"id": "Device.patient",
-				"path": "Device.patient",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Device.patient"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-implantable-device",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device",
+    "version": "3.1.1",
+    "name": "USCoreImplantableDeviceProfile",
+    "title": "US Core Implantable Device Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2019-09-17",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.healthit.gov"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the Device resource for the minimal set of data to query and retrieve a patient's implantable device(s).",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "argonaut-dq-dstu2",
+            "uri": "http://unknown.org/Argonaut-DQ-DSTU2",
+            "name": "Argonaut-DQ-DSTU2"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "udi",
+            "uri": "http://fda.gov/UDI",
+            "name": "UDI Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Device",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Device",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Device",
+                "path": "Device",
+                "short": "Item used in healthcare",
+                "definition": "The US Core Implantable Device Profile is based upon the core FHIR Device Resource and created to meet the 2015 Edition Common Clinical Data Set 'Unique device identifier(s) for a patient’s implantable device(s)' requirements.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Device",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "us-core-12",
+                        "severity": "error",
+                        "human": "Implantable medical devices that have UDI information SHALL represent this information in either carrierAIDC or carrierHRF.",
+                        "expression": "udiCarrier.empty() or (udiCarrier.carrierAIDC.exists() or udiCarrier.carrierHRF.exists())",
+                        "xpath": "not(f:udiCarrier) or (f:carrierHRF or f:carrierAIDC)"
+                    },
+                    {
+                        "key": "us-core-9",
+                        "severity": "error",
+                        "human": "For implantable medical devices that have UDI information,  at least one of the Production Identifiers (UDI-PI) SHALL be present.",
+                        "expression": "udiCarrier.empty() or (manufactureDate.exists() or expirationDate.exists() or lotNumber.exists() or serialNumber.exists() or distinctIdentifier.exists())",
+                        "xpath": "not(f:udiCarrier) or (f:manufactureDate or f:expirationDate or f:lotNumber or f:serialNumber or f:distinctIdentifier)"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Device"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Device"
+                    }
+                ]
+            },
+            {
+                "id": "Device.id",
+                "path": "Device.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Device.meta",
+                "path": "Device.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Device.implicitRules",
+                "path": "Device.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Device.language",
+                "path": "Device.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Device.text",
+                "path": "Device.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Device.contained",
+                "path": "Device.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Device.extension",
+                "path": "Device.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Device.modifierExtension",
+                "path": "Device.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Device.identifier",
+                "path": "Device.identifier",
+                "short": "Instance identifier",
+                "definition": "Unique instance identifiers assigned to a device by manufacturers other organizations or owners.",
+                "comment": "The barcode string from a barcode present on a device label or package may identify the instance, include names given to the device in local usage, or may identify the type of device. If the identifier identifies the type of device, Device.type element should be used.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Device.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    },
+                    {
+                        "identity": "udi",
+                        "map": "The serial number which is a component of the production identifier (PI), a conditional, variable portion of a UDI.   The identifier.type code should be set to “SNO”(Serial Number) and the system left empty."
+                    }
+                ]
+            },
+            {
+                "id": "Device.definition",
+                "path": "Device.definition",
+                "short": "The reference to the definition for the device",
+                "definition": "The reference to the definition for the device.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.definition",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/DeviceDefinition"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Device.udiCarrier",
+                "path": "Device.udiCarrier",
+                "short": "Unique Device Identifier (UDI) Barcode string",
+                "definition": "Unique device identifier (UDI) assigned to device label or package.  Note that the Device may include multiple udiCarriers as it either may include just the udiCarrier for the jurisdiction it is sold, or for multiple jurisdictions it could have been sold.",
+                "comment": "Some devices may not have UDI information (for example. historical data or patient reported data).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.udiCarrier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id and .code"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Device.udi"
+                    }
+                ]
+            },
+            {
+                "id": "Device.udiCarrier.id",
+                "path": "Device.udiCarrier.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Device.udiCarrier.extension",
+                "path": "Device.udiCarrier.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Device.udiCarrier.modifierExtension",
+                "path": "Device.udiCarrier.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Device.udiCarrier.deviceIdentifier",
+                "path": "Device.udiCarrier.deviceIdentifier",
+                "short": "Mandatory fixed portion of UDI",
+                "definition": "The device identifier (DI) is a mandatory, fixed portion of a UDI that identifies the labeler and the specific version or model of a device.",
+                "alias": [
+                    "DI"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Device.udiCarrier.deviceIdentifier",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Role.id.extension"
+                    },
+                    {
+                        "identity": "udi",
+                        "map": "The device identifier (DI), a mandatory, fixed portion of a UDI that identifies the labeler and the specific version or model of a device."
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA (not Supported)"
+                    }
+                ]
+            },
+            {
+                "id": "Device.udiCarrier.issuer",
+                "path": "Device.udiCarrier.issuer",
+                "short": "UDI Issuing Organization",
+                "definition": "Organization that is charged with issuing UDIs for devices.  For example, the US FDA issuers include :\n1) GS1: \nhttp://hl7.org/fhir/NamingSystem/gs1-di, \n2) HIBCC:\nhttp://hl7.org/fhir/NamingSystem/hibcc-dI, \n3) ICCBBA for blood containers:\nhttp://hl7.org/fhir/NamingSystem/iccbba-blood-di, \n4) ICCBA for other devices:\nhttp://hl7.org/fhir/NamingSystem/iccbba-other-di.",
+                "alias": [
+                    "Barcode System"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.udiCarrier.issuer",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Role.id.root"
+                    },
+                    {
+                        "identity": "udi",
+                        "map": "All UDIs are to be issued under a system operated by an Jurisdiction-accredited issuing agency.\nGS1 DIs: \n http://hl7.org/fhir/NamingSystem/gs1\nHIBCC DIs:\n http://hl7.org/fhir/NamingSystem/hibcc\nICCBBA DIs for blood containers:\n http://hl7.org/fhir/NamingSystem/iccbba-blood\nICCBA DIs for other devices:\n http://hl7.org/fhir/NamingSystem/iccbba-other"
+                    }
+                ]
+            },
+            {
+                "id": "Device.udiCarrier.jurisdiction",
+                "path": "Device.udiCarrier.jurisdiction",
+                "short": "Regional UDI authority",
+                "definition": "The identity of the authoritative source for UDI generation within a  jurisdiction.  All UDIs are globally unique within a single namespace with the appropriate repository uri as the system.  For example,  UDIs of devices managed in the U.S. by the FDA, the value is  http://hl7.org/fhir/NamingSystem/fda-udi.",
+                "requirements": "Allows a recipient of a UDI to know which database will contain the UDI-associated metadata.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.udiCarrier.jurisdiction",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Role.scoper"
+                    }
+                ]
+            },
+            {
+                "id": "Device.udiCarrier.carrierAIDC",
+                "path": "Device.udiCarrier.carrierAIDC",
+                "short": "UDI Machine Readable Barcode String",
+                "definition": "The full UDI carrier of the Automatic Identification and Data Capture (AIDC) technology representation of the barcode string as printed on the packaging of the device - e.g., a barcode or RFID.   Because of limitations on character sets in XML and the need to round-trip JSON data through XML, AIDC Formats *SHALL* be base64 encoded.",
+                "comment": "The AIDC form of UDIs should be scanned or otherwise used for the identification of the device whenever possible to minimize errors in records resulting from manual transcriptions. If separate barcodes for DI and PI are present, concatenate the string with DI first and in order of human readable expression on label.",
+                "alias": [
+                    "Automatic Identification and Data Capture",
+                    "UDI",
+                    "Barcode String"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.udiCarrier.carrierAIDC",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "base64Binary"
+                    }
+                ],
+                "condition": [
+                    "us-core-12"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Role.id.extension"
+                    },
+                    {
+                        "identity": "udi",
+                        "map": "A unique device identifier (UDI) on a device label a form that uses automatic identification and data capture (AIDC) technology."
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA (not Supported)"
+                    }
+                ]
+            },
+            {
+                "id": "Device.udiCarrier.carrierHRF",
+                "path": "Device.udiCarrier.carrierHRF",
+                "short": "UDI Human Readable Barcode String",
+                "definition": "The full UDI carrier as the human readable form (HRF) representation of the barcode string as printed on the packaging of the device.",
+                "comment": "If separate barcodes for DI and PI are present, concatenate the string with DI first and in order of human readable expression on label.",
+                "alias": [
+                    "Human Readable Form",
+                    "UDI",
+                    "Barcode String"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.udiCarrier.carrierHRF",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "condition": [
+                    "us-core-12"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Role.id.extension"
+                    },
+                    {
+                        "identity": "udi",
+                        "map": "A unique device identifier (UDI) on a device label in plain text"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Device.udi"
+                    }
+                ]
+            },
+            {
+                "id": "Device.udiCarrier.entryType",
+                "path": "Device.udiCarrier.entryType",
+                "short": "barcode | rfid | manual +",
+                "definition": "A coded entry to indicate how the data was entered.",
+                "requirements": "Supports a way to distinguish hand entered from machine read data.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.udiCarrier.entryType",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "UDIEntryType"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Codes to identify how UDI data was entered.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/udi-entry-type|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Device.status",
+                "path": "Device.status",
+                "short": "active | inactive | entered-in-error | unknown",
+                "definition": "Status of the Device availability.",
+                "comment": "This element is labeled as a modifier because the status contains the codes inactive and entered-in-error that mark the device (record)as not currently valid.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.status",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labelled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "FHIRDeviceStatus"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The availability status of the device.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/device-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".statusCode"
+                    }
+                ]
+            },
+            {
+                "id": "Device.statusReason",
+                "path": "Device.statusReason",
+                "short": "online | paused | standby | offline | not-ready | transduc-discon | hw-discon | off",
+                "definition": "Reason for the dtatus of the Device availability.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Device.statusReason",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "FHIRDeviceStatusReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "The availability status reason of the device.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/device-status-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    }
+                ]
+            },
+            {
+                "id": "Device.distinctIdentifier",
+                "path": "Device.distinctIdentifier",
+                "short": "The distinct identification string",
+                "definition": "The distinct identification string as required by regulation for a human cell, tissue, or cellular and tissue-based product.",
+                "comment": "For example, this applies to devices in the United States regulated under *Code of Federal Regulation 21CFR§1271.290(c)*.",
+                "alias": [
+                    "Distinct Identification Code (DIC)"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.distinctIdentifier",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "condition": [
+                    "us-core-9"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".lotNumberText"
+                    },
+                    {
+                        "identity": "udi",
+                        "map": "The lot or batch number within which a device was manufactured - which is a component of the production identifier (PI), a conditional, variable portion of a UDI."
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA (not Supported)"
+                    }
+                ]
+            },
+            {
+                "id": "Device.manufacturer",
+                "path": "Device.manufacturer",
+                "short": "Name of device manufacturer",
+                "definition": "A name of the manufacturer.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.manufacturer",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".playedRole[typeCode=MANU].scoper.name"
+                    },
+                    {
+                        "identity": "udi",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Device.manufactureDate",
+                "path": "Device.manufactureDate",
+                "short": "Date when the device was made",
+                "definition": "The date and time when the device was manufactured.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.manufactureDate",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "condition": [
+                    "us-core-9"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".existenceTime.low"
+                    },
+                    {
+                        "identity": "udi",
+                        "map": "The date a specific device was manufactured - which is a component of the production identifier (PI), a conditional, variable portion of a UDI.  For FHIR, The datetime syntax must converted to YYYY-MM-DD[THH:MM:SS].  If hour is present, the minutes and seconds should both be set to “00”."
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA (not Supported)"
+                    }
+                ]
+            },
+            {
+                "id": "Device.expirationDate",
+                "path": "Device.expirationDate",
+                "short": "Date and time of expiry of this device (if applicable)",
+                "definition": "The date and time beyond which this device is no longer valid or should not be used (if applicable).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.expirationDate",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "condition": [
+                    "us-core-9"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".expirationTime"
+                    },
+                    {
+                        "identity": "udi",
+                        "map": "the expiration date of a specific device -  which is a component of the production identifier (PI), a conditional, variable portion of a UDI.  For FHIR, The datetime syntax must converted to YYYY-MM-DD[THH:MM:SS].  If hour is present, the minutes and seconds should both be set to “00”."
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA (not Supported)"
+                    }
+                ]
+            },
+            {
+                "id": "Device.lotNumber",
+                "path": "Device.lotNumber",
+                "short": "Lot number of manufacture",
+                "definition": "Lot number assigned by the manufacturer.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.lotNumber",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "condition": [
+                    "us-core-9"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".lotNumberText"
+                    },
+                    {
+                        "identity": "udi",
+                        "map": "The lot or batch number within which a device was manufactured - which is a component of the production identifier (PI), a conditional, variable portion of a UDI."
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA (not Supported)"
+                    }
+                ]
+            },
+            {
+                "id": "Device.serialNumber",
+                "path": "Device.serialNumber",
+                "short": "Serial number assigned by the manufacturer",
+                "definition": "The serial number assigned by the organization when the device was manufactured.",
+                "comment": "Alphanumeric Maximum 20.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.serialNumber",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "condition": [
+                    "us-core-9"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".playedRole[typeCode=MANU].id"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA (not Supported)"
+                    }
+                ]
+            },
+            {
+                "id": "Device.deviceName",
+                "path": "Device.deviceName",
+                "short": "The name of the device as given by the manufacturer",
+                "definition": "This represents the manufacturer's name of the device as provided by the device, from a UDI label, or by a person describing the Device.  This typically would be used when a person provides the name(s) or when the device represents one of the names available from DeviceDefinition.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Device.deviceName",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Device.deviceName.id",
+                "path": "Device.deviceName.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Device.deviceName.extension",
+                "path": "Device.deviceName.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Device.deviceName.modifierExtension",
+                "path": "Device.deviceName.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Device.deviceName.name",
+                "path": "Device.deviceName.name",
+                "short": "The name of the device",
+                "definition": "The name of the device.",
+                "alias": [
+                    "Σ"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Device.deviceName.name",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Device.deviceName.type",
+                "path": "Device.deviceName.type",
+                "short": "udi-label-name | user-friendly-name | patient-reported-name | manufacturer-name | model-name | other",
+                "definition": "The type of deviceName.\nUDILabelName | UserFriendlyName | PatientReportedName | ManufactureDeviceName | ModelName.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Device.deviceName.type",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "DeviceNameType"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The type of name the device is referred by.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/device-nametype|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".playedRole[typeCode=MANU].code"
+                    }
+                ]
+            },
+            {
+                "id": "Device.modelNumber",
+                "path": "Device.modelNumber",
+                "short": "The model number for the device",
+                "definition": "The model number for the device.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.modelNumber",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".softwareName (included as part)"
+                    }
+                ]
+            },
+            {
+                "id": "Device.partNumber",
+                "path": "Device.partNumber",
+                "short": "The part number of the device",
+                "definition": "The part number of the device.",
+                "comment": "Alphanumeric Maximum 20.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.partNumber",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".playedRole[typeCode=MANU].id"
+                    }
+                ]
+            },
+            {
+                "id": "Device.type",
+                "path": "Device.type",
+                "short": "The kind or type of device",
+                "definition": "The kind or type of device.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Device.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Codes to identify medical devices",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/device-kind"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Device.type"
+                    }
+                ]
+            },
+            {
+                "id": "Device.specialization",
+                "path": "Device.specialization",
+                "short": "The capabilities supported on a  device, the standards to which the device conforms for a particular purpose, and used for the communication",
+                "definition": "The capabilities supported on a  device, the standards to which the device conforms for a particular purpose, and used for the communication.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Device.specialization",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Device.specialization.id",
+                "path": "Device.specialization.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Device.specialization.extension",
+                "path": "Device.specialization.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Device.specialization.modifierExtension",
+                "path": "Device.specialization.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Device.specialization.systemType",
+                "path": "Device.specialization.systemType",
+                "short": "The standard that is used to operate and communicate",
+                "definition": "The standard that is used to operate and communicate.",
+                "alias": [
+                    "Σ"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Device.specialization.systemType",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Device.specialization.version",
+                "path": "Device.specialization.version",
+                "short": "The version of the standard that is used to operate and communicate",
+                "definition": "The version of the standard that is used to operate and communicate.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.specialization.version",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    }
+                ]
+            },
+            {
+                "id": "Device.version",
+                "path": "Device.version",
+                "short": "The actual design of the device or software version running on the device",
+                "definition": "The actual design of the device or software version running on the device.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Device.version",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Device.version.id",
+                "path": "Device.version.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Device.version.extension",
+                "path": "Device.version.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Device.version.modifierExtension",
+                "path": "Device.version.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Device.version.type",
+                "path": "Device.version.type",
+                "short": "The type of the device version",
+                "definition": "The type of the device version.",
+                "alias": [
+                    "Σ"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.version.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Device.version.component",
+                "path": "Device.version.component",
+                "short": "A single component of the device version",
+                "definition": "A single component of the device version.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.version.component",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    }
+                ]
+            },
+            {
+                "id": "Device.version.value",
+                "path": "Device.version.value",
+                "short": "The version text",
+                "definition": "The version text.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Device.version.value",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Device.property",
+                "path": "Device.property",
+                "short": "The actual configuration settings of a device as it actually operates, e.g., regulation status, time properties",
+                "definition": "The actual configuration settings of a device as it actually operates, e.g., regulation status, time properties.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Device.property",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Device.property.id",
+                "path": "Device.property.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Device.property.extension",
+                "path": "Device.property.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Device.property.modifierExtension",
+                "path": "Device.property.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Device.property.type",
+                "path": "Device.property.type",
+                "short": "Code that specifies the property DeviceDefinitionPropetyCode (Extensible)",
+                "definition": "Code that specifies the property DeviceDefinitionPropetyCode (Extensible).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Device.property.type",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Device.property.valueQuantity",
+                "path": "Device.property.valueQuantity",
+                "short": "Property value as a quantity",
+                "definition": "Property value as a quantity.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Device.property.valueQuantity",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Device.property.valueCode",
+                "path": "Device.property.valueCode",
+                "short": "Property value as a code, e.g., NTP4 (synced to NTP)",
+                "definition": "Property value as a code, e.g., NTP4 (synced to NTP).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Device.property.valueCode",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Device.patient",
+                "path": "Device.patient",
+                "short": "Patient to whom Device is affixed",
+                "definition": "Patient information, If the device is affixed to a person.",
+                "requirements": "If the device is implanted in a patient, then need to associate the device to the patient.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Device.patient",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".playedRole[typeCode=USED].scoper.playedRole[typeCode=PAT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Device.patient"
+                    }
+                ]
+            },
+            {
+                "id": "Device.owner",
+                "path": "Device.owner",
+                "short": "Organization responsible for device",
+                "definition": "An organization that is responsible for the provision and ongoing maintenance of the device.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.owner",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.source"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".playedRole[typeCode=OWN].scoper"
+                    }
+                ]
+            },
+            {
+                "id": "Device.contact",
+                "path": "Device.contact",
+                "short": "Details for human/organization for support",
+                "definition": "Contact details for an organization or a particular human that is responsible for the device.",
+                "comment": "used for troubleshooting etc.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Device.contact",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "ContactPoint"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.source"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".scopedRole[typeCode=CON].player"
+                    }
+                ]
+            },
+            {
+                "id": "Device.location",
+                "path": "Device.location",
+                "short": "Where the device is found",
+                "definition": "The place where the device can be found.",
+                "requirements": "Device.location can be used to track device location.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.location",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Location"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.where[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".playedRole[typeCode=LOCE].scoper"
+                    }
+                ]
+            },
+            {
+                "id": "Device.url",
+                "path": "Device.url",
+                "short": "Network address to contact device",
+                "definition": "A network address on which the device may be contacted directly.",
+                "comment": "If the device is running a FHIR server, the network address should  be the Base URL from which a conformance statement may be retrieved.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.url",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.where[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".telecom"
+                    }
+                ]
+            },
+            {
+                "id": "Device.note",
+                "path": "Device.note",
+                "short": "Device notes and comments",
+                "definition": "Descriptive information, usage information or implantation information that is not captured in an existing element.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Device.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".text"
+                    }
+                ]
+            },
+            {
+                "id": "Device.safety",
+                "path": "Device.safety",
+                "short": "Safety Characteristics of Device",
+                "definition": "Provides additional safety characteristics about a medical device.  For example devices containing latex.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Device.safety",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Device.parent",
+                "path": "Device.parent",
+                "short": "The parent device",
+                "definition": "The parent device.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.parent",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Device"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Device",
+                "path": "Device",
+                "definition": "The US Core Implantable Device Profile is based upon the core FHIR Device Resource and created to meet the 2015 Edition Common Clinical Data Set 'Unique device identifier(s) for a patient’s implantable device(s)' requirements.",
+                "constraint": [
+                    {
+                        "key": "us-core-12",
+                        "severity": "error",
+                        "human": "Implantable medical devices that have UDI information SHALL represent this information in either carrierAIDC or carrierHRF.",
+                        "expression": "udiCarrier.empty() or (udiCarrier.carrierAIDC.exists() or udiCarrier.carrierHRF.exists())",
+                        "xpath": "not(f:udiCarrier) or (f:carrierHRF or f:carrierAIDC)"
+                    },
+                    {
+                        "key": "us-core-9",
+                        "severity": "error",
+                        "human": "For implantable medical devices that have UDI information,  at least one of the Production Identifiers (UDI-PI) SHALL be present.",
+                        "expression": "udiCarrier.empty() or (manufactureDate.exists() or expirationDate.exists() or lotNumber.exists() or serialNumber.exists() or distinctIdentifier.exists())",
+                        "xpath": "not(f:udiCarrier) or (f:manufactureDate or f:expirationDate or f:lotNumber or f:serialNumber or f:distinctIdentifier)"
+                    }
+                ],
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Device"
+                    }
+                ]
+            },
+            {
+                "id": "Device.udiCarrier",
+                "path": "Device.udiCarrier",
+                "comment": "Some devices may not have UDI information (for example. historical data or patient reported data).",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Device.udi"
+                    }
+                ]
+            },
+            {
+                "id": "Device.udiCarrier.deviceIdentifier",
+                "path": "Device.udiCarrier.deviceIdentifier",
+                "alias": [
+                    "DI"
+                ],
+                "min": 1,
+                "max": "1",
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA (not Supported)"
+                    }
+                ]
+            },
+            {
+                "id": "Device.udiCarrier.carrierAIDC",
+                "path": "Device.udiCarrier.carrierAIDC",
+                "alias": [
+                    "UDI",
+                    "Barcode String"
+                ],
+                "min": 0,
+                "max": "1",
+                "condition": [
+                    "us-core-12"
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA (not Supported)"
+                    }
+                ]
+            },
+            {
+                "id": "Device.udiCarrier.carrierHRF",
+                "path": "Device.udiCarrier.carrierHRF",
+                "alias": [
+                    "UDI",
+                    "Barcode String"
+                ],
+                "min": 0,
+                "max": "1",
+                "condition": [
+                    "us-core-12"
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Device.udi"
+                    }
+                ]
+            },
+            {
+                "id": "Device.distinctIdentifier",
+                "path": "Device.distinctIdentifier",
+                "min": 0,
+                "max": "1",
+                "condition": [
+                    "us-core-9"
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA (not Supported)"
+                    }
+                ]
+            },
+            {
+                "id": "Device.manufactureDate",
+                "path": "Device.manufactureDate",
+                "min": 0,
+                "max": "1",
+                "condition": [
+                    "us-core-9"
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA (not Supported)"
+                    }
+                ]
+            },
+            {
+                "id": "Device.expirationDate",
+                "path": "Device.expirationDate",
+                "min": 0,
+                "max": "1",
+                "condition": [
+                    "us-core-9"
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA (not Supported)"
+                    }
+                ]
+            },
+            {
+                "id": "Device.lotNumber",
+                "path": "Device.lotNumber",
+                "min": 0,
+                "max": "1",
+                "condition": [
+                    "us-core-9"
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA (not Supported)"
+                    }
+                ]
+            },
+            {
+                "id": "Device.serialNumber",
+                "path": "Device.serialNumber",
+                "min": 0,
+                "max": "1",
+                "condition": [
+                    "us-core-9"
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA (not Supported)"
+                    }
+                ]
+            },
+            {
+                "id": "Device.type",
+                "path": "Device.type",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Codes to identify medical devices",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/device-kind"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Device.type"
+                    }
+                ]
+            },
+            {
+                "id": "Device.patient",
+                "path": "Device.patient",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Device.patient"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-location.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-location.json
@@ -1,2541 +1,2541 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-location",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-location-definitions.html#Location\">Location</a><a name=\"Location\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/location.html\">Location</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Details and position information for a physical place</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-location-definitions.html#Location.status\">status</a><a name=\"Location.status\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">active | suspended | inactive</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-location-definitions.html#Location.name\">name</a><a name=\"Location.name\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Name of the location as used by humans</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-location-definitions.html#Location.telecom\">telecom</a><a name=\"Location.telecom\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#ContactPoint\">ContactPoint</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Contact details of the location</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-location-definitions.html#Location.address\">address</a><a name=\"Location.address\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Address\">Address</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Physical location</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-location-definitions.html#Location.address.line\">line</a><a name=\"Location.address.line\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Street name, number, direction &amp; P.O. Box etc.</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-location-definitions.html#Location.address.city\">city</a><a name=\"Location.address.city\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Name of city, town etc.</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-location-definitions.html#Location.address.state\">state</a><a name=\"Location.address.state\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Sub-unit of country (abbreviations ok)</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-usps-state.html\">USPS Two Letter Alphabetic Codes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-location-definitions.html#Location.address.postalCode\">postalCode</a><a name=\"Location.address.postalCode\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">US Zip Codes</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck00.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-location-definitions.html#Location.managingOrganization\">managingOrganization</a><a name=\"Location.managingOrganization\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-organization.html\">US Core Organization Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Organization responsible for provisioning and upkeep</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-location",
-	"version": "3.1.1",
-	"name": "USCoreLocation",
-	"title": "US Core Location Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.healthit.gov"
-				}
-			]
-		}
-	],
-	"description": "Defines basic constraints and extensions on the Location resource for use with other US Core resources",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "servd",
-			"uri": "http://www.omg.org/spec/ServD/1.0/",
-			"name": "ServD"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Location",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Location",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Location",
-				"path": "Location",
-				"short": "Details and position information for a physical place",
-				"definition": "Details and position information for a physical place where services are provided and resources and participants may be stored, found, contained, or accommodated.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Location",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "rim",
-						"map": ".Role[classCode=SDLC]"
-					},
-					{
-						"identity": "servd",
-						"map": "Organization"
-					}
-				]
-			},
-			{
-				"id": "Location.id",
-				"path": "Location.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Location.meta",
-				"path": "Location.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Location.implicitRules",
-				"path": "Location.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Location.language",
-				"path": "Location.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Location.text",
-				"path": "Location.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Location.contained",
-				"path": "Location.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Location.extension",
-				"path": "Location.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Location.modifierExtension",
-				"path": "Location.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Location.identifier",
-				"path": "Location.identifier",
-				"short": "Unique code or number identifying the location to its users",
-				"definition": "Unique code or number identifying the location to its users.",
-				"requirements": "Organization label locations in registries, need to keep track of those.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Location.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					}
-				]
-			},
-			{
-				"id": "Location.status",
-				"path": "Location.status",
-				"short": "active | suspended | inactive",
-				"definition": "The status property covers the general availability of the resource, not the current value which may be covered by the operationStatus, or by a schedule/slots if they are configured for the location.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Location.status",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "LocationStatus"
-						}
-					],
-					"strength": "required",
-					"description": "Indicates whether the location is still in use.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/location-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "rim",
-						"map": ".statusCode"
-					}
-				]
-			},
-			{
-				"id": "Location.operationalStatus",
-				"path": "Location.operationalStatus",
-				"short": "The operational status of the location (typically only for a bed/room)",
-				"definition": "The operational status covers operation values most relevant to beds (but can also apply to rooms/units/chairs/etc. such as an isolation unit/dialysis chair). This typically covers concepts such as contamination, housekeeping, and other activities like maintenance.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Location.operationalStatus",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "OperationalStatus"
-						}
-					],
-					"strength": "preferred",
-					"description": "The operational status if the location (where typically a bed/room).",
-					"valueSet": "http://terminology.hl7.org/ValueSet/v2-0116"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Location.name",
-				"path": "Location.name",
-				"short": "Name of the location as used by humans",
-				"definition": "Name of the location as used by humans. Does not need to be unique.",
-				"comment": "If the name of a location changes, consider putting the old name in the alias column so that it can still be located through searches.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Location.name",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".name"
-					},
-					{
-						"identity": "servd",
-						"map": "./PrimaryAddress and ./OtherAddresses"
-					}
-				]
-			},
-			{
-				"id": "Location.alias",
-				"path": "Location.alias",
-				"short": "A list of alternate names that the location is known as, or was known as, in the past",
-				"definition": "A list of alternate names that the location is known as, or was known as, in the past.",
-				"comment": "There are no dates associated with the alias/historic names, as this is not intended to track when names were used, but to assist in searching so that older names can still result in identifying the location.",
-				"requirements": "Over time locations and organizations go through many changes and can be known by different names.\n\nFor searching knowing previous names that the location was known by can be very useful.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Location.alias",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".name"
-					}
-				]
-			},
-			{
-				"id": "Location.description",
-				"path": "Location.description",
-				"short": "Additional details about the location that could be displayed as further information to identify the location beyond its name",
-				"definition": "Description of the Location, which helps in finding or referencing the place.",
-				"requirements": "Humans need additional information to verify a correct location has been identified.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Location.description",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".playingEntity[classCode=PLC determinerCode=INSTANCE].desc"
-					}
-				]
-			},
-			{
-				"id": "Location.mode",
-				"path": "Location.mode",
-				"short": "instance | kind",
-				"definition": "Indicates whether a resource instance represents a specific location or a class of locations.",
-				"comment": "This is labeled as a modifier because whether or not the location is a class of locations changes how it can be used and understood.",
-				"requirements": "When using a Location resource for scheduling or orders, we need to be able to refer to a class of Locations instead of a specific Location.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Location.mode",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "LocationMode"
-						}
-					],
-					"strength": "required",
-					"description": "Indicates whether a resource instance represents a specific location or a class of locations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/location-mode|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".playingEntity[classCode=PLC].determinerCode"
-					}
-				]
-			},
-			{
-				"id": "Location.type",
-				"path": "Location.type",
-				"short": "Type of function performed",
-				"definition": "Indicates the type of function performed at the location.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Location.type",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "LocationType"
-						}
-					],
-					"strength": "extensible",
-					"description": "Indicates the type of function performed at the location.",
-					"valueSet": "http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".code"
-					}
-				]
-			},
-			{
-				"id": "Location.telecom",
-				"path": "Location.telecom",
-				"short": "Contact details of the location",
-				"definition": "The contact details of communication devices available at the location. This can include phone numbers, fax numbers, mobile numbers, email addresses and web sites.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Location.telecom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "ContactPoint"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".telecom"
-					}
-				]
-			},
-			{
-				"id": "Location.address",
-				"path": "Location.address",
-				"short": "Physical location",
-				"definition": "Physical location.",
-				"comment": "Additional addresses should be recorded using another instance of the Location resource, or via the Organization.",
-				"requirements": "If locations can be visited, we need to keep track of their address.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Location.address",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Address"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".addr"
-					},
-					{
-						"identity": "servd",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Location.address.id",
-				"path": "Location.address.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Location.address.extension",
-				"path": "Location.address.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Location.address.use",
-				"path": "Location.address.use",
-				"short": "home | work | temp | old | billing - purpose of this address",
-				"definition": "The purpose of this address.",
-				"comment": "Applications can assume that an address is current unless it explicitly says that it is temporary or old.",
-				"requirements": "Allows an appropriate address to be chosen from a list of many.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.use",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueCode": "home"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old address etc.for a current/permanent one",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AddressUse"
-						}
-					],
-					"strength": "required",
-					"description": "The use of an address.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/address-use|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.7"
-					},
-					{
-						"identity": "rim",
-						"map": "unique(./use)"
-					},
-					{
-						"identity": "servd",
-						"map": "./AddressPurpose"
-					}
-				]
-			},
-			{
-				"id": "Location.address.type",
-				"path": "Location.address.type",
-				"short": "postal | physical | both",
-				"definition": "Distinguishes between physical addresses (those you can visit) and mailing addresses (e.g. PO Boxes and care-of addresses). Most addresses are both.",
-				"comment": "The definition of Address states that \"address is intended to describe postal addresses, not physical locations\". However, many applications track whether an address has a dual purpose of being a location that can be visited as well as being a valid delivery destination, and Postal addresses are often used as proxies for physical locations (also see the [Location](http://hl7.org/fhir/R4/location.html#) resource).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueCode": "both"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AddressType"
-						}
-					],
-					"strength": "required",
-					"description": "The type of an address (physical / postal).",
-					"valueSet": "http://hl7.org/fhir/ValueSet/address-type|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.18"
-					},
-					{
-						"identity": "rim",
-						"map": "unique(./use)"
-					},
-					{
-						"identity": "vcard",
-						"map": "address type parameter"
-					}
-				]
-			},
-			{
-				"id": "Location.address.text",
-				"path": "Location.address.text",
-				"short": "Text representation of the address",
-				"definition": "Specifies the entire address as it should be displayed e.g. on a postal label. This may be provided instead of or as well as the specific parts.",
-				"comment": "Can provide both a text representation and parts. Applications updating an address SHALL ensure that  when both text and parts are present,  no content is included in the text that isn't found in a part.",
-				"requirements": "A renderable, unencoded form.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "137 Nowhere Street, Erewhon 9132"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.1 + XAD.2 + XAD.3 + XAD.4 + XAD.5 + XAD.6"
-					},
-					{
-						"identity": "rim",
-						"map": "./formatted"
-					},
-					{
-						"identity": "vcard",
-						"map": "address label parameter"
-					}
-				]
-			},
-			{
-				"id": "Location.address.line",
-				"path": "Location.address.line",
-				"short": "Street name, number, direction & P.O. Box etc.",
-				"definition": "This component contains the house number, apartment number, street name, street direction,  P.O. Box number, delivery hints, and similar address information.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Address.line",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"orderMeaning": "The order in which lines should appear in an address label",
-				"example": [
-					{
-						"label": "General",
-						"valueString": "137 Nowhere Street"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.1 + XAD.2 (note: XAD.1 and XAD.2 have different meanings for a company address than for a person address)"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = AL]"
-					},
-					{
-						"identity": "vcard",
-						"map": "street"
-					},
-					{
-						"identity": "servd",
-						"map": "./StreetAddress (newline delimitted)"
-					}
-				]
-			},
-			{
-				"id": "Location.address.city",
-				"path": "Location.address.city",
-				"short": "Name of city, town etc.",
-				"definition": "The name of the city, town, suburb, village or other community or delivery center.",
-				"alias": [
-					"Municpality"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.city",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "Erewhon"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.3"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = CTY]"
-					},
-					{
-						"identity": "vcard",
-						"map": "locality"
-					},
-					{
-						"identity": "servd",
-						"map": "./Jurisdiction"
-					}
-				]
-			},
-			{
-				"id": "Location.address.district",
-				"path": "Location.address.district",
-				"short": "District name (aka county)",
-				"definition": "The name of the administrative area (county).",
-				"comment": "District is sometimes known as county, but in some regions 'county' is used in place of city (municipality), so county name should be conveyed in city instead.",
-				"alias": [
-					"County"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.district",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "Madison"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.9"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = CNT | CPA]"
-					}
-				]
-			},
-			{
-				"id": "Location.address.state",
-				"path": "Location.address.state",
-				"short": "Sub-unit of country (abbreviations ok)",
-				"definition": "Sub-unit of a country with limited sovereignty in a federally organized country. A code may be used if codes are in common use (e.g. US 2 letter state codes).",
-				"alias": [
-					"Province",
-					"Territory"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.state",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Two letter USPS alphabetic codes.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.4"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = STA]"
-					},
-					{
-						"identity": "vcard",
-						"map": "region"
-					},
-					{
-						"identity": "servd",
-						"map": "./Region"
-					},
-					{
-						"identity": "servd",
-						"map": "./Sites"
-					}
-				]
-			},
-			{
-				"id": "Location.address.postalCode",
-				"path": "Location.address.postalCode",
-				"short": "US Zip Codes",
-				"definition": "A postal code designating a region defined by the postal service.",
-				"alias": [
-					"Zip"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.postalCode",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "9132"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.5"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = ZIP]"
-					},
-					{
-						"identity": "vcard",
-						"map": "code"
-					},
-					{
-						"identity": "servd",
-						"map": "./PostalIdentificationCode"
-					}
-				]
-			},
-			{
-				"id": "Location.address.country",
-				"path": "Location.address.country",
-				"short": "Country (e.g. can be ISO 3166 2 or 3 letter code)",
-				"definition": "Country - a nation as commonly understood or generally accepted.",
-				"comment": "ISO 3166 3 letter codes can be used in place of a human readable country name.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.country",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.6"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = CNT]"
-					},
-					{
-						"identity": "vcard",
-						"map": "country"
-					},
-					{
-						"identity": "servd",
-						"map": "./Country"
-					}
-				]
-			},
-			{
-				"id": "Location.address.period",
-				"path": "Location.address.period",
-				"short": "Time period when address was/is in use",
-				"definition": "Time period when address was/is in use.",
-				"requirements": "Allows addresses to be placed in historical context.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valuePeriod": {
-							"start": "2010-03-23",
-							"end": "2010-07-01"
-						}
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.12 / XAD.13 + XAD.14"
-					},
-					{
-						"identity": "rim",
-						"map": "./usablePeriod[type=\"IVL<TS>\"]"
-					},
-					{
-						"identity": "servd",
-						"map": "./StartDate and ./EndDate"
-					}
-				]
-			},
-			{
-				"id": "Location.physicalType",
-				"path": "Location.physicalType",
-				"short": "Physical form of the location",
-				"definition": "Physical form of the location, e.g. building, room, vehicle, road.",
-				"requirements": "For purposes of showing relevant locations in queries, we need to categorize locations.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Location.physicalType",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "PhysicalType"
-						}
-					],
-					"strength": "example",
-					"description": "Physical form of the location.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/location-physical-type"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".playingEntity [classCode=PLC].code"
-					}
-				]
-			},
-			{
-				"id": "Location.position",
-				"path": "Location.position",
-				"short": "The absolute geographic location",
-				"definition": "The absolute geographic location of the Location, expressed using the WGS84 datum (This is the same co-ordinate system used in KML).",
-				"requirements": "For mobile applications and automated route-finding knowing the exact location of the Location is required.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Location.position",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".playingEntity [classCode=PLC determinerCode=INSTANCE].positionText"
-					}
-				]
-			},
-			{
-				"id": "Location.position.id",
-				"path": "Location.position.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Location.position.extension",
-				"path": "Location.position.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Location.position.modifierExtension",
-				"path": "Location.position.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Location.position.longitude",
-				"path": "Location.position.longitude",
-				"short": "Longitude with WGS84 datum",
-				"definition": "Longitude. The value domain and the interpretation are the same as for the text of the longitude element in KML (see notes below).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Location.position.longitude",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "(RIM Opted not to map the sub-elements of GPS location, is now an OBS)"
-					}
-				]
-			},
-			{
-				"id": "Location.position.latitude",
-				"path": "Location.position.latitude",
-				"short": "Latitude with WGS84 datum",
-				"definition": "Latitude. The value domain and the interpretation are the same as for the text of the latitude element in KML (see notes below).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Location.position.latitude",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "(RIM Opted not to map the sub-elements of GPS location, is now an OBS)"
-					}
-				]
-			},
-			{
-				"id": "Location.position.altitude",
-				"path": "Location.position.altitude",
-				"short": "Altitude with WGS84 datum",
-				"definition": "Altitude. The value domain and the interpretation are the same as for the text of the altitude element in KML (see notes below).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Location.position.altitude",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "(RIM Opted not to map the sub-elements of GPS location, is now an OBS)"
-					}
-				]
-			},
-			{
-				"id": "Location.managingOrganization",
-				"path": "Location.managingOrganization",
-				"short": "Organization responsible for provisioning and upkeep",
-				"definition": "The organization responsible for the provisioning and upkeep of the location.",
-				"comment": "This can also be used as the part of the organization hierarchy where this location provides services. These services can be defined through the HealthcareService resource.",
-				"requirements": "Need to know who manages the location.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Location.managingOrganization",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".scopingEntity[classCode=ORG determinerKind=INSTANCE]"
-					}
-				]
-			},
-			{
-				"id": "Location.partOf",
-				"path": "Location.partOf",
-				"short": "Another Location this one is physically a part of",
-				"definition": "Another Location of which this Location is physically a part of.",
-				"requirements": "For purposes of location, display and identification, knowing which locations are located within other locations is important.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Location.partOf",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-hierarchy",
-								"valueBoolean": true
-							}
-						],
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Location"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".inboundLink[typeCode=PART].source[classCode=SDLC]"
-					}
-				]
-			},
-			{
-				"id": "Location.hoursOfOperation",
-				"path": "Location.hoursOfOperation",
-				"short": "What days/times during a week is this location usually open",
-				"definition": "What days/times during a week is this location usually open.",
-				"comment": "This type of information is commonly found published in directories and on websites informing customers when the facility is available.\n\nSpecific services within the location may have their own hours which could be shorter (or longer) than the locations hours.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Location.hoursOfOperation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "Location.hoursOfOperation.id",
-				"path": "Location.hoursOfOperation.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Location.hoursOfOperation.extension",
-				"path": "Location.hoursOfOperation.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Location.hoursOfOperation.modifierExtension",
-				"path": "Location.hoursOfOperation.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Location.hoursOfOperation.daysOfWeek",
-				"path": "Location.hoursOfOperation.daysOfWeek",
-				"short": "mon | tue | wed | thu | fri | sat | sun",
-				"definition": "Indicates which days of the week are available between the start and end Times.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Location.hoursOfOperation.daysOfWeek",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "DaysOfWeek"
-						}
-					],
-					"strength": "required",
-					"description": "The days of the week.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/days-of-week|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "Location.hoursOfOperation.allDay",
-				"path": "Location.hoursOfOperation.allDay",
-				"short": "The Location is open all day",
-				"definition": "The Location is open all day.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Location.hoursOfOperation.allDay",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "Location.hoursOfOperation.openingTime",
-				"path": "Location.hoursOfOperation.openingTime",
-				"short": "Time that the Location opens",
-				"definition": "Time that the Location opens.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Location.hoursOfOperation.openingTime",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "time"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "Location.hoursOfOperation.closingTime",
-				"path": "Location.hoursOfOperation.closingTime",
-				"short": "Time that the Location closes",
-				"definition": "Time that the Location closes.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Location.hoursOfOperation.closingTime",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "time"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "Location.availabilityExceptions",
-				"path": "Location.availabilityExceptions",
-				"short": "Description of availability exceptions",
-				"definition": "A description of when the locations opening ours are different to normal, e.g. public holiday availability. Succinctly describing all possible exceptions to normal site availability as detailed in the opening hours Times.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Location.availabilityExceptions",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Location.endpoint",
-				"path": "Location.endpoint",
-				"short": "Technical endpoints providing access to services operated for the location",
-				"definition": "Technical endpoints providing access to services operated for the location.",
-				"requirements": "Organizations may have different systems at different locations that provide various services and need to be able to define the technical connection details for how to connect to them, and for what purpose.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Location.endpoint",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Endpoint"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Location",
-				"path": "Location",
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "servd",
-						"map": "Organization"
-					}
-				]
-			},
-			{
-				"id": "Location.status",
-				"path": "Location.status",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Location.name",
-				"path": "Location.name",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "servd",
-						"map": "./PrimaryAddress and ./OtherAddresses"
-					}
-				]
-			},
-			{
-				"id": "Location.telecom",
-				"path": "Location.telecom",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "ContactPoint"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Location.address",
-				"path": "Location.address",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Address"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "servd",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Location.address.line",
-				"path": "Location.address.line",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Location.address.city",
-				"path": "Location.address.city",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Location.address.state",
-				"path": "Location.address.state",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Two letter USPS alphabetic codes.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "servd",
-						"map": "./Sites"
-					}
-				]
-			},
-			{
-				"id": "Location.address.postalCode",
-				"path": "Location.address.postalCode",
-				"short": "US Zip Codes",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Location.managingOrganization",
-				"path": "Location.managingOrganization",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-location",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-location",
+    "version": "3.1.1",
+    "name": "USCoreLocation",
+    "title": "US Core Location Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.healthit.gov"
+                }
+            ]
+        }
+    ],
+    "description": "Defines basic constraints and extensions on the Location resource for use with other US Core resources",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "servd",
+            "uri": "http://www.omg.org/spec/ServD/1.0/",
+            "name": "ServD"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Location",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Location",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Location",
+                "path": "Location",
+                "short": "Details and position information for a physical place",
+                "definition": "Details and position information for a physical place where services are provided and resources and participants may be stored, found, contained, or accommodated.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Location",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".Role[classCode=SDLC]"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "Organization"
+                    }
+                ]
+            },
+            {
+                "id": "Location.id",
+                "path": "Location.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Location.meta",
+                "path": "Location.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Location.implicitRules",
+                "path": "Location.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Location.language",
+                "path": "Location.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Location.text",
+                "path": "Location.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Location.contained",
+                "path": "Location.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Location.extension",
+                "path": "Location.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Location.modifierExtension",
+                "path": "Location.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Location.identifier",
+                "path": "Location.identifier",
+                "short": "Unique code or number identifying the location to its users",
+                "definition": "Unique code or number identifying the location to its users.",
+                "requirements": "Organization label locations in registries, need to keep track of those.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Location.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    }
+                ]
+            },
+            {
+                "id": "Location.status",
+                "path": "Location.status",
+                "short": "active | suspended | inactive",
+                "definition": "The status property covers the general availability of the resource, not the current value which may be covered by the operationStatus, or by a schedule/slots if they are configured for the location.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Location.status",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "LocationStatus"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Indicates whether the location is still in use.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/location-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".statusCode"
+                    }
+                ]
+            },
+            {
+                "id": "Location.operationalStatus",
+                "path": "Location.operationalStatus",
+                "short": "The operational status of the location (typically only for a bed/room)",
+                "definition": "The operational status covers operation values most relevant to beds (but can also apply to rooms/units/chairs/etc. such as an isolation unit/dialysis chair). This typically covers concepts such as contamination, housekeeping, and other activities like maintenance.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Location.operationalStatus",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "OperationalStatus"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "The operational status if the location (where typically a bed/room).",
+                    "valueSet": "http://terminology.hl7.org/ValueSet/v2-0116"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Location.name",
+                "path": "Location.name",
+                "short": "Name of the location as used by humans",
+                "definition": "Name of the location as used by humans. Does not need to be unique.",
+                "comment": "If the name of a location changes, consider putting the old name in the alias column so that it can still be located through searches.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Location.name",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".name"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./PrimaryAddress and ./OtherAddresses"
+                    }
+                ]
+            },
+            {
+                "id": "Location.alias",
+                "path": "Location.alias",
+                "short": "A list of alternate names that the location is known as, or was known as, in the past",
+                "definition": "A list of alternate names that the location is known as, or was known as, in the past.",
+                "comment": "There are no dates associated with the alias/historic names, as this is not intended to track when names were used, but to assist in searching so that older names can still result in identifying the location.",
+                "requirements": "Over time locations and organizations go through many changes and can be known by different names.\n\nFor searching knowing previous names that the location was known by can be very useful.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Location.alias",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".name"
+                    }
+                ]
+            },
+            {
+                "id": "Location.description",
+                "path": "Location.description",
+                "short": "Additional details about the location that could be displayed as further information to identify the location beyond its name",
+                "definition": "Description of the Location, which helps in finding or referencing the place.",
+                "requirements": "Humans need additional information to verify a correct location has been identified.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Location.description",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".playingEntity[classCode=PLC determinerCode=INSTANCE].desc"
+                    }
+                ]
+            },
+            {
+                "id": "Location.mode",
+                "path": "Location.mode",
+                "short": "instance | kind",
+                "definition": "Indicates whether a resource instance represents a specific location or a class of locations.",
+                "comment": "This is labeled as a modifier because whether or not the location is a class of locations changes how it can be used and understood.",
+                "requirements": "When using a Location resource for scheduling or orders, we need to be able to refer to a class of Locations instead of a specific Location.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Location.mode",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "LocationMode"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Indicates whether a resource instance represents a specific location or a class of locations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/location-mode|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".playingEntity[classCode=PLC].determinerCode"
+                    }
+                ]
+            },
+            {
+                "id": "Location.type",
+                "path": "Location.type",
+                "short": "Type of function performed",
+                "definition": "Indicates the type of function performed at the location.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Location.type",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "LocationType"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Indicates the type of function performed at the location.",
+                    "valueSet": "http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".code"
+                    }
+                ]
+            },
+            {
+                "id": "Location.telecom",
+                "path": "Location.telecom",
+                "short": "Contact details of the location",
+                "definition": "The contact details of communication devices available at the location. This can include phone numbers, fax numbers, mobile numbers, email addresses and web sites.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Location.telecom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "ContactPoint"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".telecom"
+                    }
+                ]
+            },
+            {
+                "id": "Location.address",
+                "path": "Location.address",
+                "short": "Physical location",
+                "definition": "Physical location.",
+                "comment": "Additional addresses should be recorded using another instance of the Location resource, or via the Organization.",
+                "requirements": "If locations can be visited, we need to keep track of their address.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Location.address",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Address"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".addr"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Location.address.id",
+                "path": "Location.address.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Location.address.extension",
+                "path": "Location.address.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Location.address.use",
+                "path": "Location.address.use",
+                "short": "home | work | temp | old | billing - purpose of this address",
+                "definition": "The purpose of this address.",
+                "comment": "Applications can assume that an address is current unless it explicitly says that it is temporary or old.",
+                "requirements": "Allows an appropriate address to be chosen from a list of many.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.use",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueCode": "home"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old address etc.for a current/permanent one",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AddressUse"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The use of an address.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/address-use|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "unique(./use)"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./AddressPurpose"
+                    }
+                ]
+            },
+            {
+                "id": "Location.address.type",
+                "path": "Location.address.type",
+                "short": "postal | physical | both",
+                "definition": "Distinguishes between physical addresses (those you can visit) and mailing addresses (e.g. PO Boxes and care-of addresses). Most addresses are both.",
+                "comment": "The definition of Address states that \"address is intended to describe postal addresses, not physical locations\". However, many applications track whether an address has a dual purpose of being a location that can be visited as well as being a valid delivery destination, and Postal addresses are often used as proxies for physical locations (also see the [Location](http://hl7.org/fhir/R4/location.html#) resource).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueCode": "both"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AddressType"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The type of an address (physical / postal).",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/address-type|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.18"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "unique(./use)"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "address type parameter"
+                    }
+                ]
+            },
+            {
+                "id": "Location.address.text",
+                "path": "Location.address.text",
+                "short": "Text representation of the address",
+                "definition": "Specifies the entire address as it should be displayed e.g. on a postal label. This may be provided instead of or as well as the specific parts.",
+                "comment": "Can provide both a text representation and parts. Applications updating an address SHALL ensure that  when both text and parts are present,  no content is included in the text that isn't found in a part.",
+                "requirements": "A renderable, unencoded form.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "137 Nowhere Street, Erewhon 9132"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.1 + XAD.2 + XAD.3 + XAD.4 + XAD.5 + XAD.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./formatted"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "address label parameter"
+                    }
+                ]
+            },
+            {
+                "id": "Location.address.line",
+                "path": "Location.address.line",
+                "short": "Street name, number, direction & P.O. Box etc.",
+                "definition": "This component contains the house number, apartment number, street name, street direction,  P.O. Box number, delivery hints, and similar address information.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Address.line",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "orderMeaning": "The order in which lines should appear in an address label",
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "137 Nowhere Street"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.1 + XAD.2 (note: XAD.1 and XAD.2 have different meanings for a company address than for a person address)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = AL]"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "street"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./StreetAddress (newline delimitted)"
+                    }
+                ]
+            },
+            {
+                "id": "Location.address.city",
+                "path": "Location.address.city",
+                "short": "Name of city, town etc.",
+                "definition": "The name of the city, town, suburb, village or other community or delivery center.",
+                "alias": [
+                    "Municpality"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.city",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "Erewhon"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = CTY]"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "locality"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Jurisdiction"
+                    }
+                ]
+            },
+            {
+                "id": "Location.address.district",
+                "path": "Location.address.district",
+                "short": "District name (aka county)",
+                "definition": "The name of the administrative area (county).",
+                "comment": "District is sometimes known as county, but in some regions 'county' is used in place of city (municipality), so county name should be conveyed in city instead.",
+                "alias": [
+                    "County"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.district",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "Madison"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.9"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = CNT | CPA]"
+                    }
+                ]
+            },
+            {
+                "id": "Location.address.state",
+                "path": "Location.address.state",
+                "short": "Sub-unit of country (abbreviations ok)",
+                "definition": "Sub-unit of a country with limited sovereignty in a federally organized country. A code may be used if codes are in common use (e.g. US 2 letter state codes).",
+                "alias": [
+                    "Province",
+                    "Territory"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.state",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Two letter USPS alphabetic codes.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = STA]"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "region"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Region"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Sites"
+                    }
+                ]
+            },
+            {
+                "id": "Location.address.postalCode",
+                "path": "Location.address.postalCode",
+                "short": "US Zip Codes",
+                "definition": "A postal code designating a region defined by the postal service.",
+                "alias": [
+                    "Zip"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.postalCode",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "9132"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = ZIP]"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "code"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./PostalIdentificationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Location.address.country",
+                "path": "Location.address.country",
+                "short": "Country (e.g. can be ISO 3166 2 or 3 letter code)",
+                "definition": "Country - a nation as commonly understood or generally accepted.",
+                "comment": "ISO 3166 3 letter codes can be used in place of a human readable country name.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.country",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = CNT]"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "country"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Country"
+                    }
+                ]
+            },
+            {
+                "id": "Location.address.period",
+                "path": "Location.address.period",
+                "short": "Time period when address was/is in use",
+                "definition": "Time period when address was/is in use.",
+                "requirements": "Allows addresses to be placed in historical context.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valuePeriod": {
+                            "start": "2010-03-23",
+                            "end": "2010-07-01"
+                        }
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.12 / XAD.13 + XAD.14"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./usablePeriod[type=\"IVL<TS>\"]"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./StartDate and ./EndDate"
+                    }
+                ]
+            },
+            {
+                "id": "Location.physicalType",
+                "path": "Location.physicalType",
+                "short": "Physical form of the location",
+                "definition": "Physical form of the location, e.g. building, room, vehicle, road.",
+                "requirements": "For purposes of showing relevant locations in queries, we need to categorize locations.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Location.physicalType",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "PhysicalType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Physical form of the location.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/location-physical-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".playingEntity [classCode=PLC].code"
+                    }
+                ]
+            },
+            {
+                "id": "Location.position",
+                "path": "Location.position",
+                "short": "The absolute geographic location",
+                "definition": "The absolute geographic location of the Location, expressed using the WGS84 datum (This is the same co-ordinate system used in KML).",
+                "requirements": "For mobile applications and automated route-finding knowing the exact location of the Location is required.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Location.position",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".playingEntity [classCode=PLC determinerCode=INSTANCE].positionText"
+                    }
+                ]
+            },
+            {
+                "id": "Location.position.id",
+                "path": "Location.position.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Location.position.extension",
+                "path": "Location.position.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Location.position.modifierExtension",
+                "path": "Location.position.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Location.position.longitude",
+                "path": "Location.position.longitude",
+                "short": "Longitude with WGS84 datum",
+                "definition": "Longitude. The value domain and the interpretation are the same as for the text of the longitude element in KML (see notes below).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Location.position.longitude",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "(RIM Opted not to map the sub-elements of GPS location, is now an OBS)"
+                    }
+                ]
+            },
+            {
+                "id": "Location.position.latitude",
+                "path": "Location.position.latitude",
+                "short": "Latitude with WGS84 datum",
+                "definition": "Latitude. The value domain and the interpretation are the same as for the text of the latitude element in KML (see notes below).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Location.position.latitude",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "(RIM Opted not to map the sub-elements of GPS location, is now an OBS)"
+                    }
+                ]
+            },
+            {
+                "id": "Location.position.altitude",
+                "path": "Location.position.altitude",
+                "short": "Altitude with WGS84 datum",
+                "definition": "Altitude. The value domain and the interpretation are the same as for the text of the altitude element in KML (see notes below).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Location.position.altitude",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "(RIM Opted not to map the sub-elements of GPS location, is now an OBS)"
+                    }
+                ]
+            },
+            {
+                "id": "Location.managingOrganization",
+                "path": "Location.managingOrganization",
+                "short": "Organization responsible for provisioning and upkeep",
+                "definition": "The organization responsible for the provisioning and upkeep of the location.",
+                "comment": "This can also be used as the part of the organization hierarchy where this location provides services. These services can be defined through the HealthcareService resource.",
+                "requirements": "Need to know who manages the location.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Location.managingOrganization",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".scopingEntity[classCode=ORG determinerKind=INSTANCE]"
+                    }
+                ]
+            },
+            {
+                "id": "Location.partOf",
+                "path": "Location.partOf",
+                "short": "Another Location this one is physically a part of",
+                "definition": "Another Location of which this Location is physically a part of.",
+                "requirements": "For purposes of location, display and identification, knowing which locations are located within other locations is important.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Location.partOf",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-hierarchy",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Location"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".inboundLink[typeCode=PART].source[classCode=SDLC]"
+                    }
+                ]
+            },
+            {
+                "id": "Location.hoursOfOperation",
+                "path": "Location.hoursOfOperation",
+                "short": "What days/times during a week is this location usually open",
+                "definition": "What days/times during a week is this location usually open.",
+                "comment": "This type of information is commonly found published in directories and on websites informing customers when the facility is available.\n\nSpecific services within the location may have their own hours which could be shorter (or longer) than the locations hours.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Location.hoursOfOperation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "Location.hoursOfOperation.id",
+                "path": "Location.hoursOfOperation.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Location.hoursOfOperation.extension",
+                "path": "Location.hoursOfOperation.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Location.hoursOfOperation.modifierExtension",
+                "path": "Location.hoursOfOperation.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Location.hoursOfOperation.daysOfWeek",
+                "path": "Location.hoursOfOperation.daysOfWeek",
+                "short": "mon | tue | wed | thu | fri | sat | sun",
+                "definition": "Indicates which days of the week are available between the start and end Times.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Location.hoursOfOperation.daysOfWeek",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "DaysOfWeek"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The days of the week.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/days-of-week|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "Location.hoursOfOperation.allDay",
+                "path": "Location.hoursOfOperation.allDay",
+                "short": "The Location is open all day",
+                "definition": "The Location is open all day.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Location.hoursOfOperation.allDay",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "Location.hoursOfOperation.openingTime",
+                "path": "Location.hoursOfOperation.openingTime",
+                "short": "Time that the Location opens",
+                "definition": "Time that the Location opens.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Location.hoursOfOperation.openingTime",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "time"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "Location.hoursOfOperation.closingTime",
+                "path": "Location.hoursOfOperation.closingTime",
+                "short": "Time that the Location closes",
+                "definition": "Time that the Location closes.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Location.hoursOfOperation.closingTime",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "time"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "Location.availabilityExceptions",
+                "path": "Location.availabilityExceptions",
+                "short": "Description of availability exceptions",
+                "definition": "A description of when the locations opening ours are different to normal, e.g. public holiday availability. Succinctly describing all possible exceptions to normal site availability as detailed in the opening hours Times.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Location.availabilityExceptions",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Location.endpoint",
+                "path": "Location.endpoint",
+                "short": "Technical endpoints providing access to services operated for the location",
+                "definition": "Technical endpoints providing access to services operated for the location.",
+                "requirements": "Organizations may have different systems at different locations that provide various services and need to be able to define the technical connection details for how to connect to them, and for what purpose.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Location.endpoint",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Endpoint"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Location",
+                "path": "Location",
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "servd",
+                        "map": "Organization"
+                    }
+                ]
+            },
+            {
+                "id": "Location.status",
+                "path": "Location.status",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Location.name",
+                "path": "Location.name",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "servd",
+                        "map": "./PrimaryAddress and ./OtherAddresses"
+                    }
+                ]
+            },
+            {
+                "id": "Location.telecom",
+                "path": "Location.telecom",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "ContactPoint"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Location.address",
+                "path": "Location.address",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Address"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "servd",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Location.address.line",
+                "path": "Location.address.line",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Location.address.city",
+                "path": "Location.address.city",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Location.address.state",
+                "path": "Location.address.state",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Two letter USPS alphabetic codes.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "servd",
+                        "map": "./Sites"
+                    }
+                ]
+            },
+            {
+                "id": "Location.address.postalCode",
+                "path": "Location.address.postalCode",
+                "short": "US Zip Codes",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Location.managingOrganization",
+                "path": "Location.managingOrganization",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-medication.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-medication.json
@@ -1,1371 +1,1371 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-medication",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-medication-definitions.html#Medication\" title=\"The US Core Medication Profile is based upon the core FHIR Medication Resource and created to meet the 2015 Edition Common Clinical Data Set 'Medications' requirements.\">Medication</a><a name=\"Medication\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/medication.html\">Medication</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Definition of a Medication</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck00.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-medication-definitions.html#Medication.code\">code</a><a name=\"Medication.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Codes that identify this medication</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-medication-codes.html\">US Core Medication Codes (RxNorm)</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)</td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication",
-	"version": "3.1.1",
-	"name": "USCoreMedicationProfile",
-	"title": "US Core Medication Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.healthit.gov"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the Medication resource for the minimal set of data to query and retrieve patient retrieving patient's medication information.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "argonaut-dq-dstu2",
-			"uri": "http://unknown.org/Argonaut-DQ-DSTU2",
-			"name": "Argonaut-DQ-DSTU2"
-		},
-		{
-			"identity": "script10.6",
-			"uri": "http://ncpdp.org/SCRIPT10_6",
-			"name": "Mapping to NCPDP SCRIPT 10.6"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Medication",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Medication",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Medication",
-				"path": "Medication",
-				"short": "Definition of a Medication",
-				"definition": "The US Core Medication Profile is based upon the core FHIR Medication Resource and created to meet the 2015 Edition Common Clinical Data Set 'Medications' requirements.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Medication",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "script10.6",
-						"map": "NewRx/MedicationPrescribed\r-or-\rRxFill/MedicationDispensed\r-or-\rRxHistoryResponse/MedicationDispensed\r-or-\rRxHistoryResponse/MedicationPrescribed"
-					},
-					{
-						"identity": "rim",
-						"map": "ManufacturedProduct[classCode=ADMM]"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Medication"
-					}
-				]
-			},
-			{
-				"id": "Medication.id",
-				"path": "Medication.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Medication.meta",
-				"path": "Medication.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Medication.implicitRules",
-				"path": "Medication.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Medication.language",
-				"path": "Medication.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Medication.text",
-				"path": "Medication.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Medication.contained",
-				"path": "Medication.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Medication.extension",
-				"path": "Medication.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Medication.modifierExtension",
-				"path": "Medication.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Medication.identifier",
-				"path": "Medication.identifier",
-				"short": "Business identifier for this medication",
-				"definition": "Business identifier for this medication.",
-				"comment": "The serial number could be included as an identifier.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Medication.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					}
-				]
-			},
-			{
-				"id": "Medication.code",
-				"path": "Medication.code",
-				"short": "Codes that identify this medication",
-				"definition": "A code (or set of codes) that specify this medication, or a textual description if no code is available. Usage note: This could be a standard medication code such as a code from RxNorm, SNOMED CT, IDMP etc. It could also be a national or local formulary code, optionally with translations to other code systems.",
-				"comment": "Depending on the context of use, the code that was actually selected by the user (prescriber, dispenser, etc.) will have the coding.userSelected set to true.  As described in the coding datatype: \"A coding may be marked as a \"userSelected\" if a user selected the particular coded value in a user interface (e.g. the user selects an item in a pick-list). If a user selected coding exists, it is the preferred choice for performing translations etc. Other codes can only be literal translations to alternative code systems, or codes at a lower level of granularity (e.g. a generic code for a vendor-specific primary one).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Medication.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Prescribable medications",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-medication-codes|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "coding.code = //element(*,MedicationType)/DrugCoded/ProductCode\r\rcoding.system = //element(*,MedicationType)/DrugCoded/ProductCodeQualifier\r\rcoding.display = //element(*,MedicationType)/DrugDescription"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "v2",
-						"map": "RXO-1.1-Requested Give Code.code / RXE-2.1-Give Code.code / RXD-2.1-Dispense/Give Code.code / RXG-4.1-Give Code.code /RXA-5.1-Administered Code.code / RXC-2.1 Component Code"
-					},
-					{
-						"identity": "rim",
-						"map": ".code"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Medication.code"
-					}
-				]
-			},
-			{
-				"id": "Medication.status",
-				"path": "Medication.status",
-				"short": "active | inactive | entered-in-error",
-				"definition": "A code to indicate if the medication is in active use.",
-				"comment": "This status is intended to identify if the medication in a local system is in active use within a drug database or inventory.  For example, a pharmacy system may create a new drug file record for a compounded product \"ABC Hospital Special Cream\" with an active status.  At some point in the future, it may be determined that the drug record was created with an error and the status is changed to \"entered in error\".   This status is not intended to specify if a medication is part of a particular formulary.  It is possible that the drug record may be referenced by multiple formularies or catalogues and each of those entries would have a separate status.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Medication.status",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element changes the interpretation of all descriptive attributes.",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "MedicationStatus"
-						}
-					],
-					"strength": "required",
-					"description": "A coded concept defining if the medication is in active use.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/medication-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".statusCode"
-					}
-				]
-			},
-			{
-				"id": "Medication.manufacturer",
-				"path": "Medication.manufacturer",
-				"short": "Manufacturer of the item",
-				"definition": "Describes the details of the manufacturer of the medication product.  This is not intended to represent the distributor of a medication product.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Medication.manufacturer",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "no mapping"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "RXD-20-Substance Manufacturer Name / RXG-21-Substance Manufacturer Name / RXA-17-Substance Manufacturer Name"
-					},
-					{
-						"identity": "rim",
-						"map": ".player.scopingRole[typeCode=MANU].scoper"
-					}
-				]
-			},
-			{
-				"id": "Medication.form",
-				"path": "Medication.form",
-				"short": "powder | tablets | capsule +",
-				"definition": "Describes the form of the item.  Powder; tablets; capsule.",
-				"comment": "When Medication is referenced from MedicationRequest, this is the ordered form.  When Medication is referenced within MedicationDispense, this is the dispensed form.  When Medication is referenced within MedicationAdministration, this is administered form.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Medication.form",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "MedicationForm"
-						}
-					],
-					"strength": "example",
-					"description": "A coded concept defining the form of a medication.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/medication-form-codes"
-				},
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "coding.code =  //element(*,DrugCodedType)/FormCode\r\rcoding.system = //element(*,DrugCodedType)/FormSourceCode"
-					},
-					{
-						"identity": "v2",
-						"map": "RXO-5-Requested Dosage Form / RXE-6-Give Dosage Form / RXD-6-Actual Dosage Form / RXG-8-Give Dosage Form / RXA-8-Administered Dosage Form"
-					},
-					{
-						"identity": "rim",
-						"map": ".formCode"
-					}
-				]
-			},
-			{
-				"id": "Medication.amount",
-				"path": "Medication.amount",
-				"short": "Amount of drug in package",
-				"definition": "Specific amount of the drug in the packaged product.  For example, when specifying a product that has the same strength (For example, Insulin glargine 100 unit per mL solution for injection), this attribute provides additional clarification of the package amount (For example, 3 mL, 10mL, etc.).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Medication.amount",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Ratio"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".quantity"
-					}
-				]
-			},
-			{
-				"id": "Medication.ingredient",
-				"path": "Medication.ingredient",
-				"short": "Active or inactive ingredient",
-				"definition": "Identifies a particular constituent of interest in the product.",
-				"comment": "The ingredients need not be a complete list.  If an ingredient is not specified, this does not indicate whether an ingredient is present or absent.  If an ingredient is specified it does not mean that all ingredients are specified.  It is possible to specify both inactive and active ingredients.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Medication.ingredient",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".scopesRole[typeCode=INGR]"
-					}
-				]
-			},
-			{
-				"id": "Medication.ingredient.id",
-				"path": "Medication.ingredient.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Medication.ingredient.extension",
-				"path": "Medication.ingredient.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Medication.ingredient.modifierExtension",
-				"path": "Medication.ingredient.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Medication.ingredient.item[x]",
-				"path": "Medication.ingredient.item[x]",
-				"short": "The actual ingredient or content",
-				"definition": "The actual ingredient - either a substance (simple ingredient) or another medication of a medication.",
-				"requirements": "The ingredient may reference a substance (for example, amoxicillin) or another medication (for example in the case of a compounded product, Glaxal Base).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Medication.ingredient.item[x]",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Substance",
-							"http://hl7.org/fhir/StructureDefinition/Medication"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "coding.code = //element(*,MedicationType)/DrugCoded/ProductCode\r\rcoding.system = //element(*,MedicationType)/DrugCoded/ProductCodeQualifier\r\rcoding.display = //element(*,MedicationType)/DrugDescription"
-					},
-					{
-						"identity": "v2",
-						"map": "RXC-2-Component Code  if medication: RXO-1-Requested Give Code / RXE-2-Give Code / RXD-2-Dispense/Give Code / RXG-4-Give Code / RXA-5-Administered Code"
-					},
-					{
-						"identity": "rim",
-						"map": ".player"
-					}
-				]
-			},
-			{
-				"id": "Medication.ingredient.isActive",
-				"path": "Medication.ingredient.isActive",
-				"short": "Active ingredient indicator",
-				"definition": "Indication of whether this ingredient affects the therapeutic action of the drug.",
-				"requirements": "True indicates that the ingredient affects the therapeutic action of the drug (i.e. active). \rFalse indicates that the ingredient does not affect the therapeutic action of the drug (i.e. inactive).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Medication.ingredient.isActive",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Medication.ingredient.strength",
-				"path": "Medication.ingredient.strength",
-				"short": "Quantity of ingredient present",
-				"definition": "Specifies how many (or how much) of the items there are in this Medication.  For example, 250 mg per tablet.  This is expressed as a ratio where the numerator is 250mg and the denominator is 1 tablet.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Medication.ingredient.strength",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Ratio"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "//element(*,DrugCodedType)/Strength"
-					},
-					{
-						"identity": "v2",
-						"map": "RXC-3-Component Amount & RXC-4-Component Units  if medication: RXO-2-Requested Give Amount - Minimum & RXO-4-Requested Give Units / RXO-3-Requested Give Amount - Maximum & RXO-4-Requested Give Units / RXO-11-Requested Dispense Amount & RXO-12-Requested Dispense Units / RXE-3-Give Amount - Minimum & RXE-5-Give Units / RXE-4-Give Amount - Maximum & RXE-5-Give Units / RXE-10-Dispense Amount & RXE-10-Dispense Units"
-					},
-					{
-						"identity": "rim",
-						"map": ".quantity"
-					}
-				]
-			},
-			{
-				"id": "Medication.batch",
-				"path": "Medication.batch",
-				"short": "Details about packaged medications",
-				"definition": "Information that only applies to packages (not products).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Medication.batch",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "no mapping"
-					},
-					{
-						"identity": "rim",
-						"map": ".player[classCode=CONT]"
-					}
-				]
-			},
-			{
-				"id": "Medication.batch.id",
-				"path": "Medication.batch.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Medication.batch.extension",
-				"path": "Medication.batch.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Medication.batch.modifierExtension",
-				"path": "Medication.batch.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Medication.batch.lotNumber",
-				"path": "Medication.batch.lotNumber",
-				"short": "Identifier assigned to batch",
-				"definition": "The assigned lot number of a batch of the specified product.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Medication.batch.lotNumber",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "no mapping"
-					},
-					{
-						"identity": "v2",
-						"map": "RXA-15 Substance Lot Number / RXG-19 Substance Lot Number"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					}
-				]
-			},
-			{
-				"id": "Medication.batch.expirationDate",
-				"path": "Medication.batch.expirationDate",
-				"short": "When batch will expire",
-				"definition": "When this specific batch of product will expire.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Medication.batch.expirationDate",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "no mapping"
-					},
-					{
-						"identity": "v2",
-						"map": "RXA-16 Substance Expiration Date / RXG-20 Substance Expiration Date"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=CSM].role[classCode=INST].scopedRole.scoper[classCode=MMAT].expirationTime"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Medication",
-				"path": "Medication",
-				"definition": "The US Core Medication Profile is based upon the core FHIR Medication Resource and created to meet the 2015 Edition Common Clinical Data Set 'Medications' requirements.",
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Medication"
-					}
-				]
-			},
-			{
-				"id": "Medication.code",
-				"path": "Medication.code",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Prescribable medications",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-medication-codes|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Medication.code"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-medication",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication",
+    "version": "3.1.1",
+    "name": "USCoreMedicationProfile",
+    "title": "US Core Medication Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.healthit.gov"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the Medication resource for the minimal set of data to query and retrieve patient retrieving patient's medication information.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "argonaut-dq-dstu2",
+            "uri": "http://unknown.org/Argonaut-DQ-DSTU2",
+            "name": "Argonaut-DQ-DSTU2"
+        },
+        {
+            "identity": "script10.6",
+            "uri": "http://ncpdp.org/SCRIPT10_6",
+            "name": "Mapping to NCPDP SCRIPT 10.6"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Medication",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Medication",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Medication",
+                "path": "Medication",
+                "short": "Definition of a Medication",
+                "definition": "The US Core Medication Profile is based upon the core FHIR Medication Resource and created to meet the 2015 Edition Common Clinical Data Set 'Medications' requirements.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Medication",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "script10.6",
+                        "map": "NewRx/MedicationPrescribed\r-or-\rRxFill/MedicationDispensed\r-or-\rRxHistoryResponse/MedicationDispensed\r-or-\rRxHistoryResponse/MedicationPrescribed"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "ManufacturedProduct[classCode=ADMM]"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Medication"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.id",
+                "path": "Medication.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Medication.meta",
+                "path": "Medication.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Medication.implicitRules",
+                "path": "Medication.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Medication.language",
+                "path": "Medication.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Medication.text",
+                "path": "Medication.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.contained",
+                "path": "Medication.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.extension",
+                "path": "Medication.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.modifierExtension",
+                "path": "Medication.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.identifier",
+                "path": "Medication.identifier",
+                "short": "Business identifier for this medication",
+                "definition": "Business identifier for this medication.",
+                "comment": "The serial number could be included as an identifier.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Medication.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.code",
+                "path": "Medication.code",
+                "short": "Codes that identify this medication",
+                "definition": "A code (or set of codes) that specify this medication, or a textual description if no code is available. Usage note: This could be a standard medication code such as a code from RxNorm, SNOMED CT, IDMP etc. It could also be a national or local formulary code, optionally with translations to other code systems.",
+                "comment": "Depending on the context of use, the code that was actually selected by the user (prescriber, dispenser, etc.) will have the coding.userSelected set to true.  As described in the coding datatype: \"A coding may be marked as a \"userSelected\" if a user selected the particular coded value in a user interface (e.g. the user selects an item in a pick-list). If a user selected coding exists, it is the preferred choice for performing translations etc. Other codes can only be literal translations to alternative code systems, or codes at a lower level of granularity (e.g. a generic code for a vendor-specific primary one).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Medication.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Prescribable medications",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-medication-codes|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "coding.code = //element(*,MedicationType)/DrugCoded/ProductCode\r\rcoding.system = //element(*,MedicationType)/DrugCoded/ProductCodeQualifier\r\rcoding.display = //element(*,MedicationType)/DrugDescription"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXO-1.1-Requested Give Code.code / RXE-2.1-Give Code.code / RXD-2.1-Dispense/Give Code.code / RXG-4.1-Give Code.code /RXA-5.1-Administered Code.code / RXC-2.1 Component Code"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".code"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Medication.code"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.status",
+                "path": "Medication.status",
+                "short": "active | inactive | entered-in-error",
+                "definition": "A code to indicate if the medication is in active use.",
+                "comment": "This status is intended to identify if the medication in a local system is in active use within a drug database or inventory.  For example, a pharmacy system may create a new drug file record for a compounded product \"ABC Hospital Special Cream\" with an active status.  At some point in the future, it may be determined that the drug record was created with an error and the status is changed to \"entered in error\".   This status is not intended to specify if a medication is part of a particular formulary.  It is possible that the drug record may be referenced by multiple formularies or catalogues and each of those entries would have a separate status.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Medication.status",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element changes the interpretation of all descriptive attributes.",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "MedicationStatus"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "A coded concept defining if the medication is in active use.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/medication-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".statusCode"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.manufacturer",
+                "path": "Medication.manufacturer",
+                "short": "Manufacturer of the item",
+                "definition": "Describes the details of the manufacturer of the medication product.  This is not intended to represent the distributor of a medication product.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Medication.manufacturer",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "no mapping"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXD-20-Substance Manufacturer Name / RXG-21-Substance Manufacturer Name / RXA-17-Substance Manufacturer Name"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".player.scopingRole[typeCode=MANU].scoper"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.form",
+                "path": "Medication.form",
+                "short": "powder | tablets | capsule +",
+                "definition": "Describes the form of the item.  Powder; tablets; capsule.",
+                "comment": "When Medication is referenced from MedicationRequest, this is the ordered form.  When Medication is referenced within MedicationDispense, this is the dispensed form.  When Medication is referenced within MedicationAdministration, this is administered form.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Medication.form",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "MedicationForm"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "A coded concept defining the form of a medication.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/medication-form-codes"
+                },
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "coding.code =  //element(*,DrugCodedType)/FormCode\r\rcoding.system = //element(*,DrugCodedType)/FormSourceCode"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXO-5-Requested Dosage Form / RXE-6-Give Dosage Form / RXD-6-Actual Dosage Form / RXG-8-Give Dosage Form / RXA-8-Administered Dosage Form"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".formCode"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.amount",
+                "path": "Medication.amount",
+                "short": "Amount of drug in package",
+                "definition": "Specific amount of the drug in the packaged product.  For example, when specifying a product that has the same strength (For example, Insulin glargine 100 unit per mL solution for injection), this attribute provides additional clarification of the package amount (For example, 3 mL, 10mL, etc.).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Medication.amount",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Ratio"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".quantity"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.ingredient",
+                "path": "Medication.ingredient",
+                "short": "Active or inactive ingredient",
+                "definition": "Identifies a particular constituent of interest in the product.",
+                "comment": "The ingredients need not be a complete list.  If an ingredient is not specified, this does not indicate whether an ingredient is present or absent.  If an ingredient is specified it does not mean that all ingredients are specified.  It is possible to specify both inactive and active ingredients.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Medication.ingredient",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".scopesRole[typeCode=INGR]"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.ingredient.id",
+                "path": "Medication.ingredient.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.ingredient.extension",
+                "path": "Medication.ingredient.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.ingredient.modifierExtension",
+                "path": "Medication.ingredient.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.ingredient.item[x]",
+                "path": "Medication.ingredient.item[x]",
+                "short": "The actual ingredient or content",
+                "definition": "The actual ingredient - either a substance (simple ingredient) or another medication of a medication.",
+                "requirements": "The ingredient may reference a substance (for example, amoxicillin) or another medication (for example in the case of a compounded product, Glaxal Base).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Medication.ingredient.item[x]",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Substance",
+                            "http://hl7.org/fhir/StructureDefinition/Medication"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "coding.code = //element(*,MedicationType)/DrugCoded/ProductCode\r\rcoding.system = //element(*,MedicationType)/DrugCoded/ProductCodeQualifier\r\rcoding.display = //element(*,MedicationType)/DrugDescription"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXC-2-Component Code  if medication: RXO-1-Requested Give Code / RXE-2-Give Code / RXD-2-Dispense/Give Code / RXG-4-Give Code / RXA-5-Administered Code"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".player"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.ingredient.isActive",
+                "path": "Medication.ingredient.isActive",
+                "short": "Active ingredient indicator",
+                "definition": "Indication of whether this ingredient affects the therapeutic action of the drug.",
+                "requirements": "True indicates that the ingredient affects the therapeutic action of the drug (i.e. active). \rFalse indicates that the ingredient does not affect the therapeutic action of the drug (i.e. inactive).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Medication.ingredient.isActive",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.ingredient.strength",
+                "path": "Medication.ingredient.strength",
+                "short": "Quantity of ingredient present",
+                "definition": "Specifies how many (or how much) of the items there are in this Medication.  For example, 250 mg per tablet.  This is expressed as a ratio where the numerator is 250mg and the denominator is 1 tablet.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Medication.ingredient.strength",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Ratio"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "//element(*,DrugCodedType)/Strength"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXC-3-Component Amount & RXC-4-Component Units  if medication: RXO-2-Requested Give Amount - Minimum & RXO-4-Requested Give Units / RXO-3-Requested Give Amount - Maximum & RXO-4-Requested Give Units / RXO-11-Requested Dispense Amount & RXO-12-Requested Dispense Units / RXE-3-Give Amount - Minimum & RXE-5-Give Units / RXE-4-Give Amount - Maximum & RXE-5-Give Units / RXE-10-Dispense Amount & RXE-10-Dispense Units"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".quantity"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.batch",
+                "path": "Medication.batch",
+                "short": "Details about packaged medications",
+                "definition": "Information that only applies to packages (not products).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Medication.batch",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "no mapping"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".player[classCode=CONT]"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.batch.id",
+                "path": "Medication.batch.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.batch.extension",
+                "path": "Medication.batch.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.batch.modifierExtension",
+                "path": "Medication.batch.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.batch.lotNumber",
+                "path": "Medication.batch.lotNumber",
+                "short": "Identifier assigned to batch",
+                "definition": "The assigned lot number of a batch of the specified product.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Medication.batch.lotNumber",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "no mapping"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXA-15 Substance Lot Number / RXG-19 Substance Lot Number"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.batch.expirationDate",
+                "path": "Medication.batch.expirationDate",
+                "short": "When batch will expire",
+                "definition": "When this specific batch of product will expire.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Medication.batch.expirationDate",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "no mapping"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXA-16 Substance Expiration Date / RXG-20 Substance Expiration Date"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=CSM].role[classCode=INST].scopedRole.scoper[classCode=MMAT].expirationTime"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Medication",
+                "path": "Medication",
+                "definition": "The US Core Medication Profile is based upon the core FHIR Medication Resource and created to meet the 2015 Edition Common Clinical Data Set 'Medications' requirements.",
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Medication"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.code",
+                "path": "Medication.code",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Prescribable medications",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-medication-codes|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Medication.code"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-medicationrequest.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-medicationrequest.json
@@ -1,4136 +1,4136 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-medicationrequest",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-medicationrequest-definitions.html#MedicationRequest\" title=\"The US Core Medication Request (Order) Profile is based upon the core FHIR MedicationRequest Resource and created to meet the 2015 Edition Common Clinical Data Set 'Medications' requirements.\">MedicationRequest</a><a name=\"MedicationRequest\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/medicationrequest.html\">MedicationRequest</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Ordering of medication for patient or group</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-medicationrequest-definitions.html#MedicationRequest.status\">status</a><a name=\"MedicationRequest.status\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">active | on-hold | cancelled | completed | entered-in-error | stopped | draft | unknown</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-medicationrequest-status.html\">medicationrequest Status</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-medicationrequest-definitions.html#MedicationRequest.intent\">intent</a><a name=\"MedicationRequest.intent\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">proposal | plan | order | original-order | reflex-order | filler-order | instance-order | option</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-medicationrequest-intent.html\">medicationRequest Intent</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_choice.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Choice of Types\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-medicationrequest-definitions.html#MedicationRequest.reported[x]\">reported[x]</a><a name=\"MedicationRequest.reported_x_\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Reported rather than primary record</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for boolean Type: Value of &quot;true&quot; or &quot;false&quot;\">reportedBoolean</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#boolean\">boolean</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> reportedReference</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html#Reference\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a> | <a href=\"StructureDefinition-us-core-practitioner.html\">US Core Practitioner Profile</a> | <a href=\"StructureDefinition-us-core-organization.html\">US Core Organization Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_choice.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Choice of Types\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-medicationrequest-definitions.html#MedicationRequest.medication[x]\">medication[x]</a><a name=\"MedicationRequest.medication_x_\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Medication to be taken</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-medication-codes.html\">US Core Medication Codes (RxNorm)</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for CodeableConcept Type: A concept that may be defined by a formal reference to a terminology or ontology or may be provided by text.\">medicationCodeableConcept</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> medicationReference</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html#Reference\">Reference</a>(<a href=\"StructureDefinition-us-core-medication.html\">US Core Medication Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-medicationrequest-definitions.html#MedicationRequest.subject\">subject</a><a name=\"MedicationRequest.subject\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who or group medication request is for</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-medicationrequest-definitions.html#MedicationRequest.encounter\">encounter</a><a name=\"MedicationRequest.encounter\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/encounter.html\">Encounter</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Encounter created as part of encounter/admission/stay</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-medicationrequest-definitions.html#MedicationRequest.authoredOn\">authoredOn</a><a name=\"MedicationRequest.authoredOn\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#dateTime\">dateTime</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">When request was initially authored</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-medicationrequest-definitions.html#MedicationRequest.requester\">requester</a><a name=\"MedicationRequest.requester\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-practitioner.html\">US Core Practitioner Profile</a> | <a href=\"StructureDefinition-us-core-organization.html\">US Core Organization Profile</a> | <a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who/What requested the Request</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-medicationrequest-definitions.html#MedicationRequest.dosageInstruction\">dosageInstruction</a><a name=\"MedicationRequest.dosageInstruction\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Dosage\">Dosage</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">How the medication should be taken</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-medicationrequest-definitions.html#MedicationRequest.dosageInstruction.text\">text</a><a name=\"MedicationRequest.dosageInstruction.text\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Free text dosage instructions e.g. SIG</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest",
-	"version": "3.1.1",
-	"name": "USCoreMedicationRequestProfile",
-	"title": "US Core MedicationRequest Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-06-26",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.healthit.gov"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the MedicationRequest resource for the minimal set of data to query and retrieve prescription information.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "argonaut-dq-dstu2",
-			"uri": "http://unknown.org/Argonaut-DQ-DSTU2",
-			"name": "Argonaut-DQ-DSTU2"
-		},
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "script10.6",
-			"uri": "http://ncpdp.org/SCRIPT10_6",
-			"name": "Mapping to NCPDP SCRIPT 10.6"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "MedicationRequest",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "MedicationRequest",
-				"path": "MedicationRequest",
-				"short": "Ordering of medication for patient or group",
-				"definition": "The US Core Medication Request (Order) Profile is based upon the core FHIR MedicationRequest Resource and created to meet the 2015 Edition Common Clinical Data Set 'Medications' requirements.",
-				"alias": [
-					"Prescription",
-					"Order"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "MedicationRequest",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Request"
-					},
-					{
-						"identity": "script10.6",
-						"map": "Message/Body/NewRx"
-					},
-					{
-						"identity": "rim",
-						"map": "CombinedMedicationRequest"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.id",
-				"path": "MedicationRequest.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "MedicationRequest.meta",
-				"path": "MedicationRequest.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "MedicationRequest.implicitRules",
-				"path": "MedicationRequest.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "MedicationRequest.language",
-				"path": "MedicationRequest.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "MedicationRequest.text",
-				"path": "MedicationRequest.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.contained",
-				"path": "MedicationRequest.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.extension",
-				"path": "MedicationRequest.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.modifierExtension",
-				"path": "MedicationRequest.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.identifier",
-				"path": "MedicationRequest.identifier",
-				"short": "External ids for this request",
-				"definition": "Identifiers associated with this medication request that are defined by business processes and/or used to refer to it when a direct URL reference to the resource itself is not appropriate. They are business identifiers assigned to this resource by the performer or other systems and remain constant as the resource is updated and propagates from server to server.",
-				"comment": "This is a business identifier, not a resource identifier.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "MedicationRequest.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.identifier"
-					},
-					{
-						"identity": "script10.6",
-						"map": "Message/Header/PrescriberOrderNumber"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC-2-Placer Order Number / ORC-3-Filler Order Number"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.status",
-				"path": "MedicationRequest.status",
-				"short": "active | on-hold | cancelled | completed | entered-in-error | stopped | draft | unknown",
-				"definition": "A code specifying the current state of the order.  Generally, this will be active or completed state.",
-				"comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"description": "A code specifying the state of the prescribing event. Describes the lifecycle of the prescription.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/medicationrequest-status"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.status"
-					},
-					{
-						"identity": "script10.6",
-						"map": "no mapping"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "rim",
-						"map": ".statusCode"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder.status"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.statusReason",
-				"path": "MedicationRequest.statusReason",
-				"short": "Reason for current status",
-				"definition": "Captures the reason for the current state of the MedicationRequest.",
-				"comment": "This is generally only used for \"exception\" statuses such as \"suspended\" or \"cancelled\". The reason why the MedicationRequest was created at all is captured in reasonCode, not here.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.statusReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "MedicationRequestStatusReason"
-						}
-					],
-					"strength": "example",
-					"description": "Identifies the reasons for a given status.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/medicationrequest-status-reason"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.statusReason"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=SUBJ].source[classCode=CACT, moodCode=EVN].reasonCOde"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.intent",
-				"path": "MedicationRequest.intent",
-				"short": "proposal | plan | order | original-order | reflex-order | filler-order | instance-order | option",
-				"definition": "Whether the request is a proposal, plan, or an original order.",
-				"comment": "It is expected that the type of requester will be restricted for different stages of a MedicationRequest.  For example, Proposals can be created by a patient, relatedPerson, Practitioner or Device.  Plans can be created by Practitioners, Patients, RelatedPersons and Devices.  Original orders can be created by a Practitioner only.\r\rAn instance-order is an instantiation of a request or order and may be used to populate Medication Administration Record.\r\rThis element is labeled as a modifier because the intent alters when and how the resource is actually applicable.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.intent",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element changes the interpretation of all descriptive attributes. For example \"the time the request is recommended to occur\" vs. \"the time the request is authorized to occur\" or \"who is recommended to perform the request\" vs. \"who is authorized to perform the request",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"description": "The kind of medication order.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/medicationrequest-intent"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.intent"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".moodCode (nuances beyond PRP/PLAN/RQO would need to be elsewhere)"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder.status"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.category",
-				"path": "MedicationRequest.category",
-				"short": "Type of medication usage",
-				"definition": "Indicates the type of medication request (for example, where the medication is expected to be consumed or administered (i.e. inpatient or outpatient)).",
-				"comment": "The category can be used to include where the medication is expected to be consumed or other types of requests.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "MedicationRequest.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "MedicationRequestCategory"
-						}
-					],
-					"strength": "example",
-					"description": "A coded concept identifying the category of medication request.  For example, where the medication is to be consumed or administered, or the type of medication treatment.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/medicationrequest-category"
-				},
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "Message/Body/NewRx/MedicationPrescribed/Directions\r\ror \r\rMessage/Body/NewRx/MedicationPrescribed/StructuredSIG"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[classCode=OBS, moodCode=EVN, code=\"type of medication usage\"].value"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.priority",
-				"path": "MedicationRequest.priority",
-				"short": "routine | urgent | asap | stat",
-				"definition": "Indicates how quickly the Medication Request should be addressed with respect to other requests.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.priority",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "MedicationRequestPriority"
-						}
-					],
-					"strength": "required",
-					"description": "Identifies the level of importance to be assigned to actioning the request.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/request-priority|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.priority"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.grade"
-					},
-					{
-						"identity": "rim",
-						"map": ".priorityCode"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.doNotPerform",
-				"path": "MedicationRequest.doNotPerform",
-				"short": "True if request is prohibiting action",
-				"definition": "If true indicates that the provider is asking for the medication request not to occur.",
-				"comment": "If do not perform is not specified, the request is a positive request e.g. \"do perform\".",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.doNotPerform",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because this element negates the request to occur (ie, this is a request for the medication not to be ordered or prescribed, etc)",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "SubstanceAdministration.actionNegationInd"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.reported[x]",
-				"path": "MedicationRequest.reported[x]",
-				"short": "Reported rather than primary record",
-				"definition": "Indicates if this record was captured as a secondary 'reported' record rather than as an original primary source-of-truth record.  It may also indicate the source of the report.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.reported[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=INF].role"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder.status"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.medication[x]",
-				"path": "MedicationRequest.medication[x]",
-				"short": "Medication to be taken",
-				"definition": "Identifies the medication being requested. This is a link to a resource that represents the medication which may be the details of the medication or simply an attribute carrying a code that identifies the medication from a known list of medications.",
-				"comment": "If only a code is specified, then it needs to be a code for a specific product. If more information is required, then the use of the Medication resource is recommended.  For example, if you require form or lot number or if the medication is compounded or extemporaneously prepared, then you must reference the Medication resource.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.medication[x]",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Prescribable medications",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-medication-codes|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.code"
-					},
-					{
-						"identity": "script10.6",
-						"map": "Message/Body/NewRx/MedicationPrescribed\r\rMedication.code.coding.code = Message/Body/NewRx/MedicationPrescribed/DrugCoded/ProductCode\r\rMedication.code.coding.system = Message/Body/NewRx/MedicationPrescribed/DrugCoded/ProductCodeQualifier\r\rMedication.code.coding.display = Message/Body/NewRx/MedicationPrescribed/DrugDescription"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "RXE-2-Give Code / RXO-1-Requested Give Code / RXC-2-Component Code"
-					},
-					{
-						"identity": "rim",
-						"map": "consumable.administrableMedication"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder.medication[x]"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.subject",
-				"path": "MedicationRequest.subject",
-				"short": "Who or group medication request is for",
-				"definition": "A link to a resource representing the person or set of individuals to whom the medication will be given.",
-				"comment": "The subject on a medication request is mandatory.  For the secondary use case where the actual subject is not provided, there still must be an anonymized subject specified.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.subject",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.subject"
-					},
-					{
-						"identity": "script10.6",
-						"map": "Message/Body/NewRx/Patient\r\r(need detail to link to specific patient … Patient.Identification in SCRIPT)"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3-Patient ID List"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=AUT].role"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder.patient"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.encounter",
-				"path": "MedicationRequest.encounter",
-				"short": "Encounter created as part of encounter/admission/stay",
-				"definition": "The Encounter during which this [x] was created or to which the creation of this record is tightly associated.",
-				"comment": "This will typically be the encounter the event occurred within, but some activities may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter.\"    If there is a need to link to episodes of care they will be handled with an extension.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.context"
-					},
-					{
-						"identity": "script10.6",
-						"map": "no mapping"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1-19-Visit Number"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN, code=\"type of encounter or episode\"]"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder.patient"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.supportingInformation",
-				"path": "MedicationRequest.supportingInformation",
-				"short": "Information to support ordering of the medication",
-				"definition": "Include additional information (for example, patient height and weight) that supports the ordering of the medication.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "MedicationRequest.supportingInformation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.supportingInfo"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=PERT].target[A_SupportingClinicalStatement CMET minimal with many different choices of classCodes(ORG, ENC, PROC, SPLY, SBADM, OBS) and each of the act class codes draws from one or more of the following moodCodes (EVN, DEF, INT PRMS, RQO, PRP, APT, ARQ, GOL)]"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.authoredOn",
-				"path": "MedicationRequest.authoredOn",
-				"short": "When request was initially authored",
-				"definition": "The date (and perhaps time) when the prescription was initially written or authored on.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.authoredOn",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.authoredOn"
-					},
-					{
-						"identity": "script10.6",
-						"map": "Message/Body/NewRx/MedicationPrescribed/WrittenDate"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "v2",
-						"map": "RXE-32-Original Order Date/Time / ORC-9-Date/Time of Transaction"
-					},
-					{
-						"identity": "rim",
-						"map": "author.time"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder.dateWritten"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.requester",
-				"path": "MedicationRequest.requester",
-				"short": "Who/What requested the Request",
-				"definition": "The individual, organization, or device that initiated the request and has responsibility for its activation.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.requester",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.requester"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.author"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=AUT].role"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder.prescriber"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.performer",
-				"path": "MedicationRequest.performer",
-				"short": "Intended performer of administration",
-				"definition": "The specified desired performer of the medication treatment (e.g. the performer of the medication administration).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.performer",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.performer"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=PRF].role[scoper.determinerCode=INSTANCE]"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.performerType",
-				"path": "MedicationRequest.performerType",
-				"short": "Desired kind of performer of the medication administration",
-				"definition": "Indicates the type of performer of the administration of the medication.",
-				"comment": "If specified without indicating a performer, this indicates that the performer must be of the specified type. If specified with a performer then it indicates the requirements of the performer if the designated performer is not available.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.performerType",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "MedicationRequestPerformerType"
-						}
-					],
-					"strength": "example",
-					"description": "Identifies the type of individual that is desired to administer the medication.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/performer-role"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.performerType"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=PRF].role[scoper.determinerCode=KIND].code"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.recorder",
-				"path": "MedicationRequest.recorder",
-				"short": "Person who entered the request",
-				"definition": "The person who entered the order on behalf of another individual for example in the case of a verbal or a telephone order.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.recorder",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.who"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=TRANS].role[classCode=ASSIGNED].code (HealthcareProviderType)"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.reasonCode",
-				"path": "MedicationRequest.reasonCode",
-				"short": "Reason or indication for ordering or not ordering the medication",
-				"definition": "The reason or the indication for ordering or not ordering the medication.",
-				"comment": "This could be a diagnosis code. If a full condition record exists or additional detail is needed, use reasonReference.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "MedicationRequest.reasonCode",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "MedicationRequestReason"
-						}
-					],
-					"strength": "example",
-					"description": "A coded concept indicating why the medication was ordered.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/condition-code"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.reasonCode"
-					},
-					{
-						"identity": "script10.6",
-						"map": "Message/Body/NewRx/MedicationPrescribed/Diagnosis/Primary/Value"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.why[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC-16-Order Control Code Reason /RXE-27-Give Indication/RXO-20-Indication / RXD-21-Indication / RXG-22-Indication / RXA-19-Indication"
-					},
-					{
-						"identity": "rim",
-						"map": "reason.observation.reasonCode"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.reasonReference",
-				"path": "MedicationRequest.reasonReference",
-				"short": "Condition or observation that supports why the prescription is being written",
-				"definition": "Condition or observation that supports why the medication was ordered.",
-				"comment": "This is a reference to a condition or observation that is the reason for the medication order.  If only a code exists, use reasonCode.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "MedicationRequest.reasonReference",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Condition",
-							"http://hl7.org/fhir/StructureDefinition/Observation"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.reasonReference"
-					},
-					{
-						"identity": "script10.6",
-						"map": "no mapping"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.why[x]"
-					},
-					{
-						"identity": "rim",
-						"map": "reason.observation[code=ASSERTION].value"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.instantiatesCanonical",
-				"path": "MedicationRequest.instantiatesCanonical",
-				"short": "Instantiates FHIR protocol or definition",
-				"definition": "The URL pointing to a protocol, guideline, orderset, or other definition that is adhered to in whole or in part by this MedicationRequest.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "MedicationRequest.instantiatesCanonical",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "canonical"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.instantiates"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=DEFN].target"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.instantiatesUri",
-				"path": "MedicationRequest.instantiatesUri",
-				"short": "Instantiates external protocol or definition",
-				"definition": "The URL pointing to an externally maintained protocol, guideline, orderset or other definition that is adhered to in whole or in part by this MedicationRequest.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "MedicationRequest.instantiatesUri",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=DEFN].target"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.basedOn",
-				"path": "MedicationRequest.basedOn",
-				"short": "What request fulfills",
-				"definition": "A plan or request that is fulfilled in whole or in part by this medication request.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "MedicationRequest.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan",
-							"http://hl7.org/fhir/StructureDefinition/MedicationRequest",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest",
-							"http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.basedOn"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=FLFS].target[classCode=SBADM or PROC or PCPR or OBS, moodCode=RQO orPLAN or PRP]"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.groupIdentifier",
-				"path": "MedicationRequest.groupIdentifier",
-				"short": "Composite request this is part of",
-				"definition": "A shared identifier common to all requests that were authorized more or less simultaneously by a single author, representing the identifier of the requisition or prescription.",
-				"requirements": "Requests are linked either by a \"basedOn\" relationship (i.e. one request is fulfilling another) or by having a common requisition. Requests that are part of the same requisition are generally treated independently from the perspective of changing their state or maintaining them after initial creation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.groupIdentifier",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.groupIdentifier"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship(typeCode=COMP].target[classCode=SBADM, moodCode=INT].id"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.courseOfTherapyType",
-				"path": "MedicationRequest.courseOfTherapyType",
-				"short": "Overall pattern of medication administration",
-				"definition": "The description of the overall patte3rn of the administration of the medication to the patient.",
-				"comment": "This attribute should not be confused with the protocol of the medication.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.courseOfTherapyType",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "MedicationRequestCourseOfTherapy"
-						}
-					],
-					"strength": "example",
-					"description": "Identifies the overall pattern of medication administratio.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/medicationrequest-course-of-therapy"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.code where classCode = LIST and moodCode = EVN"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.insurance",
-				"path": "MedicationRequest.insurance",
-				"short": "Associated insurance coverage",
-				"definition": "Insurance plans, coverage extensions, pre-authorizations and/or pre-determinations that may be required for delivering the requested service.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "MedicationRequest.insurance",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Coverage",
-							"http://hl7.org/fhir/StructureDefinition/ClaimResponse"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.insurance"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=COVBY].target"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.note",
-				"path": "MedicationRequest.note",
-				"short": "Information about the prescription",
-				"definition": "Extra information about the prescription that could not be conveyed by the other attributes.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "MedicationRequest.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.note"
-					},
-					{
-						"identity": "script10.6",
-						"map": "Message/Body/NewRx/MedicationPrescribed/Note"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=SUBJ]/source[classCode=OBS,moodCode=EVN,code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction",
-				"path": "MedicationRequest.dosageInstruction",
-				"short": "How the medication should be taken",
-				"definition": "Indicates how the medication is to be used by the patient.",
-				"comment": "There are examples where a medication request may include the option of an oral dose or an Intravenous or Intramuscular dose.  For example, \"Ondansetron 8mg orally or IV twice a day as needed for nausea\" or \"Compazine® (prochlorperazine) 5-10mg PO or 25mg PR bid prn nausea or vomiting\".  In these cases, two medication requests would be created that could be grouped together.  The decision on which dose and route of administration to use is based on the patient's condition at the time the dose is needed.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "MedicationRequest.dosageInstruction",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Dosage"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.occurrence[x]"
-					},
-					{
-						"identity": "rim",
-						"map": "see dosageInstruction mapping"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.id",
-				"path": "MedicationRequest.dosageInstruction.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.extension",
-				"path": "MedicationRequest.dosageInstruction.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.modifierExtension",
-				"path": "MedicationRequest.dosageInstruction.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.sequence",
-				"path": "MedicationRequest.dosageInstruction.sequence",
-				"short": "The order of the dosage instructions",
-				"definition": "Indicates the order in which the dosage instructions should be applied or interpreted.",
-				"requirements": "If the sequence number of multiple Dosages is the same, then it is implied that the instructions are to be treated as concurrent.  If the sequence number is different, then the Dosages are intended to be sequential.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Dosage.sequence",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "integer"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "TQ1-1"
-					},
-					{
-						"identity": "rim",
-						"map": ".text"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.text",
-				"path": "MedicationRequest.dosageInstruction.text",
-				"short": "Free text dosage instructions e.g. SIG",
-				"definition": "Free text dosage instructions e.g. SIG.",
-				"requirements": "Free text dosage instructions can be used for cases where the instructions are too complex to code.  The content of this attribute does not include the name or description of the medication. When coded instructions are present, the free text instructions may still be present for display to humans taking or administering the medication. It is expected that the text instructions will always be populated.  If the dosage.timing attribute is also populated, then the dosage.text should reflect the same information as the timing.  Additional information about administration or preparation of the medication should be included as text.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Dosage.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXO-6; RXE-21"
-					},
-					{
-						"identity": "rim",
-						"map": ".text"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.additionalInstruction",
-				"path": "MedicationRequest.dosageInstruction.additionalInstruction",
-				"short": "Supplemental instruction or warnings to the patient - e.g. \"with meals\", \"may cause drowsiness\"",
-				"definition": "Supplemental instructions to the patient on how to take the medication  (e.g. \"with meals\" or\"take half to one hour before food\") or warnings for the patient about the medication (e.g. \"may cause drowsiness\" or \"avoid exposure of skin to direct sunlight or sunlamps\").",
-				"comment": "Information about administration or preparation of the medication (e.g. \"infuse as rapidly as possibly via intraperitoneal port\" or \"immediately following drug x\") should be populated in dosage.text.",
-				"requirements": "Additional instruction is intended to be coded, but where no code exists, the element could include text.  For example, \"Swallow with plenty of water\" which might or might not be coded.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Dosage.additionalInstruction",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AdditionalInstruction"
-						}
-					],
-					"strength": "example",
-					"description": "A coded concept identifying additional instructions such as \"take with water\" or \"avoid operating heavy machinery\".",
-					"valueSet": "http://hl7.org/fhir/ValueSet/additional-instruction-codes"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXO-7"
-					},
-					{
-						"identity": "rim",
-						"map": ".text"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.patientInstruction",
-				"path": "MedicationRequest.dosageInstruction.patientInstruction",
-				"short": "Patient or consumer oriented instructions",
-				"definition": "Instructions in terms that are understood by the patient or consumer.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Dosage.patientInstruction",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXO-7"
-					},
-					{
-						"identity": "rim",
-						"map": ".text"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.timing",
-				"path": "MedicationRequest.dosageInstruction.timing",
-				"short": "When medication should be administered",
-				"definition": "When medication should be administered.",
-				"comment": "This attribute might not always be populated while the Dosage.text is expected to be populated.  If both are populated, then the Dosage.text should reflect the content of the Dosage.timing.",
-				"requirements": "The timing schedule for giving the medication to the patient. This  data type allows many different expressions. For example: \"Every 8 hours\"; \"Three times a day\"; \"1/2 an hour before breakfast for 10 days from 23-Dec 2011:\"; \"15 Oct 2013, 17 Oct 2013 and 1 Nov 2013\".  Sometimes, a rate can imply duration when expressed as total volume / duration (e.g.  500mL/2 hours implies a duration of 2 hours).  However, when rate doesn't imply duration (e.g. 250mL/hour), then the timing.repeat.duration is needed to convey the infuse over time period.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Dosage.timing",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Timing"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.asNeeded[x]",
-				"path": "MedicationRequest.dosageInstruction.asNeeded[x]",
-				"short": "Take \"as needed\" (for x)",
-				"definition": "Indicates whether the Medication is only taken when needed within a specific dosing schedule (Boolean option), or it indicates the precondition for taking the Medication (CodeableConcept).",
-				"comment": "Can express \"as needed\" without a reason by setting the Boolean = True.  In this case the CodeableConcept is not populated.  Or you can express \"as needed\" with a reason by including the CodeableConcept.  In this case the Boolean is assumed to be True.  If you set the Boolean to False, then the dose is given according to the schedule and is not \"prn\" or \"as needed\".",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Dosage.asNeeded[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "MedicationAsNeededReason"
-						}
-					],
-					"strength": "example",
-					"description": "A coded concept identifying the precondition that should be met or evaluated prior to consuming or administering a medication dose.  For example \"pain\", \"30 minutes prior to sexual intercourse\", \"on flare-up\" etc.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/medication-as-needed-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "TQ1-9"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=PRCN].target[classCode=OBS, moodCode=EVN, code=\"as needed\"].value=boolean or codable concept"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.site",
-				"path": "MedicationRequest.dosageInstruction.site",
-				"short": "Body site to administer to",
-				"definition": "Body site to administer to.",
-				"comment": "If the use case requires attributes from the BodySite resource (e.g. to identify and track separately) then use the standard extension [bodySite](http://hl7.org/fhir/R4/extension-bodysite.html).  May be a summary code, or a reference to a very precise definition of the location, or both.",
-				"requirements": "A coded specification of the anatomic site where the medication first enters the body.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Dosage.site",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "MedicationAdministrationSite"
-						}
-					],
-					"strength": "example",
-					"description": "A coded concept describing the site location the medicine enters into or onto the body.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/approach-site-codes"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXR-2"
-					},
-					{
-						"identity": "rim",
-						"map": ".approachSiteCode"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.route",
-				"path": "MedicationRequest.dosageInstruction.route",
-				"short": "How drug should enter body",
-				"definition": "How drug should enter body.",
-				"requirements": "A code specifying the route or physiological path of administration of a therapeutic agent into or onto a patient's body.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Dosage.route",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "RouteOfAdministration"
-						}
-					],
-					"strength": "example",
-					"description": "A coded concept describing the route or physiological path of administration of a therapeutic agent into or onto the body of a subject.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/route-codes"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXR-1"
-					},
-					{
-						"identity": "rim",
-						"map": ".routeCode"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.method",
-				"path": "MedicationRequest.dosageInstruction.method",
-				"short": "Technique for administering medication",
-				"definition": "Technique for administering medication.",
-				"comment": "Terminologies used often pre-coordinate this term with the route and or form of administration.",
-				"requirements": "A coded value indicating the method by which the medication is introduced into or onto the body. Most commonly used for injections.  For examples, Slow Push; Deep IV.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Dosage.method",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "MedicationAdministrationMethod"
-						}
-					],
-					"strength": "example",
-					"description": "A coded concept describing the technique by which the medicine is administered.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/administration-method-codes"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXR-4"
-					},
-					{
-						"identity": "rim",
-						"map": ".doseQuantity"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.doseAndRate",
-				"path": "MedicationRequest.dosageInstruction.doseAndRate",
-				"short": "Amount of medication administered",
-				"definition": "The amount of medication administered.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Dosage.doseAndRate",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Element"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "TQ1-2"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.doseAndRate.id",
-				"path": "MedicationRequest.dosageInstruction.doseAndRate.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.doseAndRate.extension",
-				"path": "MedicationRequest.dosageInstruction.doseAndRate.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.doseAndRate.type",
-				"path": "MedicationRequest.dosageInstruction.doseAndRate.type",
-				"short": "The kind of dose or rate specified",
-				"definition": "The kind of dose or rate specified, for example, ordered or calculated.",
-				"requirements": "If the type is not populated, assume to be \"ordered\".",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Dosage.doseAndRate.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "DoseAndRateType"
-						}
-					],
-					"strength": "example",
-					"description": "The kind of dose or rate specified.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/dose-rate-type"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXO-21; RXE-23"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.doseAndRate.dose[x]",
-				"path": "MedicationRequest.dosageInstruction.doseAndRate.dose[x]",
-				"short": "Amount of medication per dose",
-				"definition": "Amount of medication per dose.",
-				"comment": "Note that this specifies the quantity of the specified medication, not the quantity for each active ingredient(s). Each ingredient amount can be communicated in the Medication resource. For example, if one wants to communicate that a tablet was 375 mg, where the dose was one tablet, you can use the Medication resource to document that the tablet was comprised of 375 mg of drug XYZ. Alternatively if the dose was 375 mg, then you may only need to use the Medication resource to indicate this was a tablet. If the example were an IV such as dopamine and you wanted to communicate that 400mg of dopamine was mixed in 500 ml of some IV solution, then this would all be communicated in the Medication resource. If the administration is not intended to be instantaneous (rate is present or timing has a duration), this can be specified to convey the total amount to be administered over the period of time as indicated by the schedule e.g. 500 ml in dose, with timing used to convey that this should be done over 4 hours.",
-				"requirements": "The amount of therapeutic or other substance given at one administration event.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Dosage.doseAndRate.dose[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXO-2, RXE-3"
-					},
-					{
-						"identity": "rim",
-						"map": ".doseQuantity"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.doseAndRate.rate[x]",
-				"path": "MedicationRequest.dosageInstruction.doseAndRate.rate[x]",
-				"short": "Amount of medication per unit of time",
-				"definition": "Amount of medication per unit of time.",
-				"comment": "It is possible to supply both a rate and a doseQuantity to provide full details about how the medication is to be administered and supplied. If the rate is intended to change over time, depending on local rules/regulations, each change should be captured as a new version of the MedicationRequest with an updated rate, or captured with a new MedicationRequest with the new rate.\r\rIt is possible to specify a rate over time (for example, 100 ml/hour) using either the rateRatio and rateQuantity.  The rateQuantity approach requires systems to have the capability to parse UCUM grammer where ml/hour is included rather than a specific ratio where the time is specified as the denominator.  Where a rate such as 500ml over 2 hours is specified, the use of rateRatio may be more semantically correct than specifying using a rateQuantity of 250 mg/hour.",
-				"requirements": "Identifies the speed with which the medication was or will be introduced into the patient. Typically the rate for an infusion e.g. 100 ml per 1 hour or 100 ml/hr.  May also be expressed as a rate per unit of time e.g. 500 ml per 2 hours.   Other examples: 200 mcg/min or 200 mcg/1 minute; 1 liter/8 hours.  Sometimes, a rate can imply duration when expressed as total volume / duration (e.g.  500mL/2 hours implies a duration of 2 hours).  However, when rate doesn't imply duration (e.g. 250mL/hour), then the timing.repeat.duration is needed to convey the infuse over time period.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Dosage.doseAndRate.rate[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXE22, RXE23, RXE-24"
-					},
-					{
-						"identity": "rim",
-						"map": ".rateQuantity"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.maxDosePerPeriod",
-				"path": "MedicationRequest.dosageInstruction.maxDosePerPeriod",
-				"short": "Upper limit on medication per unit of time",
-				"definition": "Upper limit on medication per unit of time.",
-				"comment": "This is intended for use as an adjunct to the dosage when there is an upper cap.  For example \"2 tablets every 4 hours to a maximum of 8/day\".",
-				"requirements": "The maximum total quantity of a therapeutic substance that may be administered to a subject over the period of time.  For example, 1000mg in 24 hours.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Dosage.maxDosePerPeriod",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Ratio"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXO-23, RXE-19"
-					},
-					{
-						"identity": "rim",
-						"map": ".maxDoseQuantity"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.maxDosePerAdministration",
-				"path": "MedicationRequest.dosageInstruction.maxDosePerAdministration",
-				"short": "Upper limit on medication per administration",
-				"definition": "Upper limit on medication per administration.",
-				"comment": "This is intended for use as an adjunct to the dosage when there is an upper cap.  For example, a body surface area related dose with a maximum amount, such as 1.5 mg/m2 (maximum 2 mg) IV over 5 – 10 minutes would have doseQuantity of 1.5 mg/m2 and maxDosePerAdministration of 2 mg.",
-				"requirements": "The maximum total quantity of a therapeutic substance that may be administered to a subject per administration.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Dosage.maxDosePerAdministration",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "not supported"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.maxDosePerLifetime",
-				"path": "MedicationRequest.dosageInstruction.maxDosePerLifetime",
-				"short": "Upper limit on medication per lifetime of the patient",
-				"definition": "Upper limit on medication per lifetime of the patient.",
-				"requirements": "The maximum total quantity of a therapeutic substance that may be administered per lifetime of the subject.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Dosage.maxDosePerLifetime",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "not supported"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest",
-				"path": "MedicationRequest.dispenseRequest",
-				"short": "Medication supply authorization",
-				"definition": "Indicates the specific details for the dispense or medication supply part of a medication request (also known as a Medication Prescription or Medication Order).  Note that this information is not always sent with the order.  There may be in some settings (e.g. hospitals) institutional or system support for completing the dispense details in the pharmacy department.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.dispenseRequest",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "Message/Body/NewRx/MedicationPrescribed/ExpirationDate"
-					},
-					{
-						"identity": "rim",
-						"map": "component.supplyEvent"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest.id",
-				"path": "MedicationRequest.dispenseRequest.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest.extension",
-				"path": "MedicationRequest.dispenseRequest.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest.modifierExtension",
-				"path": "MedicationRequest.dispenseRequest.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest.initialFill",
-				"path": "MedicationRequest.dispenseRequest.initialFill",
-				"short": "First fill details",
-				"definition": "Indicates the quantity or duration for the first dispense of the medication.",
-				"comment": "If populating this element, either the quantity or the duration must be included.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.dispenseRequest.initialFill",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "SubstanceAdministration -> ActRelationship[sequenceNumber = '1'] -> Supply"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest.initialFill.id",
-				"path": "MedicationRequest.dispenseRequest.initialFill.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest.initialFill.extension",
-				"path": "MedicationRequest.dispenseRequest.initialFill.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest.initialFill.modifierExtension",
-				"path": "MedicationRequest.dispenseRequest.initialFill.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest.initialFill.quantity",
-				"path": "MedicationRequest.dispenseRequest.initialFill.quantity",
-				"short": "First fill quantity",
-				"definition": "The amount or quantity to provide as part of the first dispense.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.dispenseRequest.initialFill.quantity",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Supply.quantity[moodCode=RQO]"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest.initialFill.duration",
-				"path": "MedicationRequest.dispenseRequest.initialFill.duration",
-				"short": "First fill duration",
-				"definition": "The length of time that the first dispense is expected to last.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.dispenseRequest.initialFill.duration",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Duration"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Supply.effectivetime[moodCode=RQO]"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest.dispenseInterval",
-				"path": "MedicationRequest.dispenseRequest.dispenseInterval",
-				"short": "Minimum period of time between dispenses",
-				"definition": "The minimum period of time that must occur between dispenses of the medication.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.dispenseRequest.dispenseInterval",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Duration"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Supply.effectivetime[moodCode=RQO]"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest.validityPeriod",
-				"path": "MedicationRequest.dispenseRequest.validityPeriod",
-				"short": "Time period supply is authorized for",
-				"definition": "This indicates the validity period of a prescription (stale dating the Prescription).",
-				"comment": "It reflects the prescribers' perspective for the validity of the prescription. Dispenses must not be made against the prescription outside of this period. The lower-bound of the Dispensing Window signifies the earliest date that the prescription can be filled for the first time. If an upper-bound is not specified then the Prescription is open-ended or will default to a stale-date based on regulations.",
-				"requirements": "Indicates when the Prescription becomes valid, and when it ceases to be a dispensable Prescription.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.dispenseRequest.validityPeriod",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "Message/Body/NewRx/MedicationPrescribed/Refills"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest.numberOfRepeatsAllowed",
-				"path": "MedicationRequest.dispenseRequest.numberOfRepeatsAllowed",
-				"short": "Number of refills authorized",
-				"definition": "An integer indicating the number of times, in addition to the original dispense, (aka refills or repeats) that the patient can receive the prescribed medication. Usage Notes: This integer does not include the original order dispense. This means that if an order indicates dispense 30 tablets plus \"3 repeats\", then the order can be dispensed a total of 4 times and the patient can receive a total of 120 tablets.  A prescriber may explicitly say that zero refills are permitted after the initial dispense.",
-				"comment": "If displaying \"number of authorized fills\", add 1 to this number.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.dispenseRequest.numberOfRepeatsAllowed",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "unsignedInt"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "Message/Body/NewRx/MedicationPrescribed/Quantity"
-					},
-					{
-						"identity": "v2",
-						"map": "RXE-12-Number of Refills"
-					},
-					{
-						"identity": "rim",
-						"map": "repeatNumber"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest.quantity",
-				"path": "MedicationRequest.dispenseRequest.quantity",
-				"short": "Amount of medication to supply per dispense",
-				"definition": "The amount that is to be dispensed for one fill.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.dispenseRequest.quantity",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "Message/Body/NewRx/MedicationPrescribed/DaysSupply"
-					},
-					{
-						"identity": "v2",
-						"map": "RXD-4-Actual Dispense Amount / RXD-5.1-Actual Dispense Units.code / RXD-5.3-Actual Dispense Units.name of coding system"
-					},
-					{
-						"identity": "rim",
-						"map": "quantity"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest.expectedSupplyDuration",
-				"path": "MedicationRequest.dispenseRequest.expectedSupplyDuration",
-				"short": "Number of days supply per dispense",
-				"definition": "Identifies the period time over which the supplied product is expected to be used, or the length of time the dispense is expected to last.",
-				"comment": "In some situations, this attribute may be used instead of quantity to identify the amount supplied by how long it is expected to last, rather than the physical quantity issued, e.g. 90 days supply of medication (based on an ordered dosage). When possible, it is always better to specify quantity, as this tends to be more precise. expectedSupplyDuration will always be an estimate that can be influenced by external factors.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.dispenseRequest.expectedSupplyDuration",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Duration"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "Message/Body/NewRx/MedicationPrescribed/Substitutions"
-					},
-					{
-						"identity": "rim",
-						"map": "expectedUseTime"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest.performer",
-				"path": "MedicationRequest.dispenseRequest.performer",
-				"short": "Intended dispenser",
-				"definition": "Indicates the intended dispensing Organization specified by the prescriber.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.dispenseRequest.performer",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.who"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=COMP].target[classCode=SPLY, moodCode=RQO] .participation[typeCode=PRF].role[scoper.determinerCode=INSTANCE]"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.substitution",
-				"path": "MedicationRequest.substitution",
-				"short": "Any restrictions on medication substitution",
-				"definition": "Indicates whether or not substitution can or should be part of the dispense. In some cases, substitution must happen, in other cases substitution must not happen. This block explains the prescriber's intent. If nothing is specified substitution may be done.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.substitution",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "specific values within Message/Body/NewRx/MedicationPrescribed/Substitutions"
-					},
-					{
-						"identity": "rim",
-						"map": "subjectOf.substitutionPersmission"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.substitution.id",
-				"path": "MedicationRequest.substitution.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.substitution.extension",
-				"path": "MedicationRequest.substitution.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.substitution.modifierExtension",
-				"path": "MedicationRequest.substitution.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.substitution.allowed[x]",
-				"path": "MedicationRequest.substitution.allowed[x]",
-				"short": "Whether substitution is allowed or not",
-				"definition": "True if the prescriber allows a different drug to be dispensed from what was prescribed.",
-				"comment": "This element is labeled as a modifier because whether substitution is allow or not, it cannot be ignored.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.substitution.allowed[x]",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "MedicationRequestSubstitution"
-						}
-					],
-					"strength": "example",
-					"description": "Identifies the type of substitution allowed.",
-					"valueSet": "http://terminology.hl7.org/ValueSet/v3-ActSubstanceAdminSubstitutionCode"
-				},
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "specific values within Message/Body/NewRx/MedicationPrescribed/Substitutions"
-					},
-					{
-						"identity": "v2",
-						"map": "RXO-9-Allow Substitutions / RXE-9-Substitution Status"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.substitution.reason",
-				"path": "MedicationRequest.substitution.reason",
-				"short": "Why should (not) substitution be made",
-				"definition": "Indicates the reason for the substitution, or why substitution must or must not be performed.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.substitution.reason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "MedicationIntendedSubstitutionReason"
-						}
-					],
-					"strength": "example",
-					"description": "A coded concept describing the reason that a different medication should (or should not) be substituted from what was prescribed.",
-					"valueSet": "http://terminology.hl7.org/ValueSet/v3-SubstanceAdminSubstitutionReason"
-				},
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "not mapped"
-					},
-					{
-						"identity": "v2",
-						"map": "RXE-9 Substition status"
-					},
-					{
-						"identity": "rim",
-						"map": "reasonCode"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.priorPrescription",
-				"path": "MedicationRequest.priorPrescription",
-				"short": "An order/prescription that is being replaced",
-				"definition": "A link to a resource representing an earlier order related order or prescription.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.priorPrescription",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/MedicationRequest"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.replaces"
-					},
-					{
-						"identity": "script10.6",
-						"map": "not mapped"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=?RPLC or ?SUCC]/target[classCode=SBADM,moodCode=RQO]"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.detectedIssue",
-				"path": "MedicationRequest.detectedIssue",
-				"short": "Clinical Issue with action",
-				"definition": "Indicates an actual or potential clinical issue with or between one or more active or proposed clinical actions for a patient; e.g. Drug-drug interaction, duplicate therapy, dosage alert etc.",
-				"comment": "This element can include a detected issue that has been identified either by a decision support system or by a clinician and may include information on the steps that were taken to address the issue.",
-				"alias": [
-					"Contraindication",
-					"Drug Utilization Review (DUR)",
-					"Alert"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "MedicationRequest.detectedIssue",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/DetectedIssue"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=SUBJ]/source[classCode=ALRT,moodCode=EVN].value"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.eventHistory",
-				"path": "MedicationRequest.eventHistory",
-				"short": "A list of events of interest in the lifecycle",
-				"definition": "Links to Provenance records for past versions of this resource or fulfilling request or event resources that identify key state transitions or updates that are likely to be relevant to a user looking at the current version of the resource.",
-				"comment": "This might not include provenances for all versions of the request – only those deemed “relevant” or important. This SHALL NOT include the provenance associated with this current version of the resource. (If that provenance is deemed to be a “relevant” change, it will need to be added as part of a later update. Until then, it can be queried directly as the provenance that points to this version using _revinclude All Provenances should have some historical version of this Request as their subject.).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "MedicationRequest.eventHistory",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Provenance"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.relevantHistory"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship(typeCode=SUBJ].source[classCode=CACT, moodCode=EVN]"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "MedicationRequest",
-				"path": "MedicationRequest",
-				"definition": "The US Core Medication Request (Order) Profile is based upon the core FHIR MedicationRequest Resource and created to meet the 2015 Edition Common Clinical Data Set 'Medications' requirements.",
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.status",
-				"path": "MedicationRequest.status",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"description": "A code specifying the state of the prescribing event. Describes the lifecycle of the prescription.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/medicationrequest-status"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder.status"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.intent",
-				"path": "MedicationRequest.intent",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"description": "The kind of medication order.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/medicationrequest-intent"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder.status"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.reported[x]",
-				"path": "MedicationRequest.reported[x]",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder.status"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.medication[x]",
-				"path": "MedicationRequest.medication[x]",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Prescribable medications",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-medication-codes|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder.medication[x]"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.subject",
-				"path": "MedicationRequest.subject",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder.patient"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.encounter",
-				"path": "MedicationRequest.encounter",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder.patient"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.authoredOn",
-				"path": "MedicationRequest.authoredOn",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder.dateWritten"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.requester",
-				"path": "MedicationRequest.requester",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder.prescriber"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction",
-				"path": "MedicationRequest.dosageInstruction",
-				"mustSupport": true
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.text",
-				"path": "MedicationRequest.dosageInstruction.text",
-				"mustSupport": true
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-medicationrequest",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest",
+    "version": "3.1.1",
+    "name": "USCoreMedicationRequestProfile",
+    "title": "US Core MedicationRequest Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-06-26",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.healthit.gov"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the MedicationRequest resource for the minimal set of data to query and retrieve prescription information.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "argonaut-dq-dstu2",
+            "uri": "http://unknown.org/Argonaut-DQ-DSTU2",
+            "name": "Argonaut-DQ-DSTU2"
+        },
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "script10.6",
+            "uri": "http://ncpdp.org/SCRIPT10_6",
+            "name": "Mapping to NCPDP SCRIPT 10.6"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "MedicationRequest",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "MedicationRequest",
+                "path": "MedicationRequest",
+                "short": "Ordering of medication for patient or group",
+                "definition": "The US Core Medication Request (Order) Profile is based upon the core FHIR MedicationRequest Resource and created to meet the 2015 Edition Common Clinical Data Set 'Medications' requirements.",
+                "alias": [
+                    "Prescription",
+                    "Order"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "MedicationRequest",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Request"
+                    },
+                    {
+                        "identity": "script10.6",
+                        "map": "Message/Body/NewRx"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CombinedMedicationRequest"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.id",
+                "path": "MedicationRequest.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "MedicationRequest.meta",
+                "path": "MedicationRequest.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "MedicationRequest.implicitRules",
+                "path": "MedicationRequest.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "MedicationRequest.language",
+                "path": "MedicationRequest.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "MedicationRequest.text",
+                "path": "MedicationRequest.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.contained",
+                "path": "MedicationRequest.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.extension",
+                "path": "MedicationRequest.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.modifierExtension",
+                "path": "MedicationRequest.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.identifier",
+                "path": "MedicationRequest.identifier",
+                "short": "External ids for this request",
+                "definition": "Identifiers associated with this medication request that are defined by business processes and/or used to refer to it when a direct URL reference to the resource itself is not appropriate. They are business identifiers assigned to this resource by the performer or other systems and remain constant as the resource is updated and propagates from server to server.",
+                "comment": "This is a business identifier, not a resource identifier.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "MedicationRequest.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.identifier"
+                    },
+                    {
+                        "identity": "script10.6",
+                        "map": "Message/Header/PrescriberOrderNumber"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC-2-Placer Order Number / ORC-3-Filler Order Number"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.status",
+                "path": "MedicationRequest.status",
+                "short": "active | on-hold | cancelled | completed | entered-in-error | stopped | draft | unknown",
+                "definition": "A code specifying the current state of the order.  Generally, this will be active or completed state.",
+                "comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "description": "A code specifying the state of the prescribing event. Describes the lifecycle of the prescription.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/medicationrequest-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.status"
+                    },
+                    {
+                        "identity": "script10.6",
+                        "map": "no mapping"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".statusCode"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder.status"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.statusReason",
+                "path": "MedicationRequest.statusReason",
+                "short": "Reason for current status",
+                "definition": "Captures the reason for the current state of the MedicationRequest.",
+                "comment": "This is generally only used for \"exception\" statuses such as \"suspended\" or \"cancelled\". The reason why the MedicationRequest was created at all is captured in reasonCode, not here.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.statusReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "MedicationRequestStatusReason"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Identifies the reasons for a given status.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/medicationrequest-status-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.statusReason"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=SUBJ].source[classCode=CACT, moodCode=EVN].reasonCOde"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.intent",
+                "path": "MedicationRequest.intent",
+                "short": "proposal | plan | order | original-order | reflex-order | filler-order | instance-order | option",
+                "definition": "Whether the request is a proposal, plan, or an original order.",
+                "comment": "It is expected that the type of requester will be restricted for different stages of a MedicationRequest.  For example, Proposals can be created by a patient, relatedPerson, Practitioner or Device.  Plans can be created by Practitioners, Patients, RelatedPersons and Devices.  Original orders can be created by a Practitioner only.\r\rAn instance-order is an instantiation of a request or order and may be used to populate Medication Administration Record.\r\rThis element is labeled as a modifier because the intent alters when and how the resource is actually applicable.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.intent",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element changes the interpretation of all descriptive attributes. For example \"the time the request is recommended to occur\" vs. \"the time the request is authorized to occur\" or \"who is recommended to perform the request\" vs. \"who is authorized to perform the request",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "description": "The kind of medication order.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/medicationrequest-intent"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.intent"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".moodCode (nuances beyond PRP/PLAN/RQO would need to be elsewhere)"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder.status"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.category",
+                "path": "MedicationRequest.category",
+                "short": "Type of medication usage",
+                "definition": "Indicates the type of medication request (for example, where the medication is expected to be consumed or administered (i.e. inpatient or outpatient)).",
+                "comment": "The category can be used to include where the medication is expected to be consumed or other types of requests.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "MedicationRequest.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "MedicationRequestCategory"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "A coded concept identifying the category of medication request.  For example, where the medication is to be consumed or administered, or the type of medication treatment.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/medicationrequest-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "Message/Body/NewRx/MedicationPrescribed/Directions\r\ror \r\rMessage/Body/NewRx/MedicationPrescribed/StructuredSIG"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[classCode=OBS, moodCode=EVN, code=\"type of medication usage\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.priority",
+                "path": "MedicationRequest.priority",
+                "short": "routine | urgent | asap | stat",
+                "definition": "Indicates how quickly the Medication Request should be addressed with respect to other requests.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.priority",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "MedicationRequestPriority"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Identifies the level of importance to be assigned to actioning the request.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/request-priority|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.priority"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.grade"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".priorityCode"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.doNotPerform",
+                "path": "MedicationRequest.doNotPerform",
+                "short": "True if request is prohibiting action",
+                "definition": "If true indicates that the provider is asking for the medication request not to occur.",
+                "comment": "If do not perform is not specified, the request is a positive request e.g. \"do perform\".",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.doNotPerform",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because this element negates the request to occur (ie, this is a request for the medication not to be ordered or prescribed, etc)",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "SubstanceAdministration.actionNegationInd"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.reported[x]",
+                "path": "MedicationRequest.reported[x]",
+                "short": "Reported rather than primary record",
+                "definition": "Indicates if this record was captured as a secondary 'reported' record rather than as an original primary source-of-truth record.  It may also indicate the source of the report.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.reported[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=INF].role"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder.status"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.medication[x]",
+                "path": "MedicationRequest.medication[x]",
+                "short": "Medication to be taken",
+                "definition": "Identifies the medication being requested. This is a link to a resource that represents the medication which may be the details of the medication or simply an attribute carrying a code that identifies the medication from a known list of medications.",
+                "comment": "If only a code is specified, then it needs to be a code for a specific product. If more information is required, then the use of the Medication resource is recommended.  For example, if you require form or lot number or if the medication is compounded or extemporaneously prepared, then you must reference the Medication resource.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.medication[x]",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Prescribable medications",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-medication-codes|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.code"
+                    },
+                    {
+                        "identity": "script10.6",
+                        "map": "Message/Body/NewRx/MedicationPrescribed\r\rMedication.code.coding.code = Message/Body/NewRx/MedicationPrescribed/DrugCoded/ProductCode\r\rMedication.code.coding.system = Message/Body/NewRx/MedicationPrescribed/DrugCoded/ProductCodeQualifier\r\rMedication.code.coding.display = Message/Body/NewRx/MedicationPrescribed/DrugDescription"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXE-2-Give Code / RXO-1-Requested Give Code / RXC-2-Component Code"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "consumable.administrableMedication"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder.medication[x]"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.subject",
+                "path": "MedicationRequest.subject",
+                "short": "Who or group medication request is for",
+                "definition": "A link to a resource representing the person or set of individuals to whom the medication will be given.",
+                "comment": "The subject on a medication request is mandatory.  For the secondary use case where the actual subject is not provided, there still must be an anonymized subject specified.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.subject",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.subject"
+                    },
+                    {
+                        "identity": "script10.6",
+                        "map": "Message/Body/NewRx/Patient\r\r(need detail to link to specific patient … Patient.Identification in SCRIPT)"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3-Patient ID List"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=AUT].role"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder.patient"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.encounter",
+                "path": "MedicationRequest.encounter",
+                "short": "Encounter created as part of encounter/admission/stay",
+                "definition": "The Encounter during which this [x] was created or to which the creation of this record is tightly associated.",
+                "comment": "This will typically be the encounter the event occurred within, but some activities may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter.\"    If there is a need to link to episodes of care they will be handled with an extension.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.context"
+                    },
+                    {
+                        "identity": "script10.6",
+                        "map": "no mapping"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1-19-Visit Number"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN, code=\"type of encounter or episode\"]"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder.patient"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.supportingInformation",
+                "path": "MedicationRequest.supportingInformation",
+                "short": "Information to support ordering of the medication",
+                "definition": "Include additional information (for example, patient height and weight) that supports the ordering of the medication.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "MedicationRequest.supportingInformation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.supportingInfo"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=PERT].target[A_SupportingClinicalStatement CMET minimal with many different choices of classCodes(ORG, ENC, PROC, SPLY, SBADM, OBS) and each of the act class codes draws from one or more of the following moodCodes (EVN, DEF, INT PRMS, RQO, PRP, APT, ARQ, GOL)]"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.authoredOn",
+                "path": "MedicationRequest.authoredOn",
+                "short": "When request was initially authored",
+                "definition": "The date (and perhaps time) when the prescription was initially written or authored on.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.authoredOn",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.authoredOn"
+                    },
+                    {
+                        "identity": "script10.6",
+                        "map": "Message/Body/NewRx/MedicationPrescribed/WrittenDate"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXE-32-Original Order Date/Time / ORC-9-Date/Time of Transaction"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "author.time"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder.dateWritten"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.requester",
+                "path": "MedicationRequest.requester",
+                "short": "Who/What requested the Request",
+                "definition": "The individual, organization, or device that initiated the request and has responsibility for its activation.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.requester",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.requester"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.author"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=AUT].role"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder.prescriber"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.performer",
+                "path": "MedicationRequest.performer",
+                "short": "Intended performer of administration",
+                "definition": "The specified desired performer of the medication treatment (e.g. the performer of the medication administration).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.performer",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.performer"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=PRF].role[scoper.determinerCode=INSTANCE]"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.performerType",
+                "path": "MedicationRequest.performerType",
+                "short": "Desired kind of performer of the medication administration",
+                "definition": "Indicates the type of performer of the administration of the medication.",
+                "comment": "If specified without indicating a performer, this indicates that the performer must be of the specified type. If specified with a performer then it indicates the requirements of the performer if the designated performer is not available.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.performerType",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "MedicationRequestPerformerType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Identifies the type of individual that is desired to administer the medication.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/performer-role"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.performerType"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=PRF].role[scoper.determinerCode=KIND].code"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.recorder",
+                "path": "MedicationRequest.recorder",
+                "short": "Person who entered the request",
+                "definition": "The person who entered the order on behalf of another individual for example in the case of a verbal or a telephone order.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.recorder",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.who"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=TRANS].role[classCode=ASSIGNED].code (HealthcareProviderType)"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.reasonCode",
+                "path": "MedicationRequest.reasonCode",
+                "short": "Reason or indication for ordering or not ordering the medication",
+                "definition": "The reason or the indication for ordering or not ordering the medication.",
+                "comment": "This could be a diagnosis code. If a full condition record exists or additional detail is needed, use reasonReference.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "MedicationRequest.reasonCode",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "MedicationRequestReason"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "A coded concept indicating why the medication was ordered.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/condition-code"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.reasonCode"
+                    },
+                    {
+                        "identity": "script10.6",
+                        "map": "Message/Body/NewRx/MedicationPrescribed/Diagnosis/Primary/Value"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.why[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC-16-Order Control Code Reason /RXE-27-Give Indication/RXO-20-Indication / RXD-21-Indication / RXG-22-Indication / RXA-19-Indication"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "reason.observation.reasonCode"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.reasonReference",
+                "path": "MedicationRequest.reasonReference",
+                "short": "Condition or observation that supports why the prescription is being written",
+                "definition": "Condition or observation that supports why the medication was ordered.",
+                "comment": "This is a reference to a condition or observation that is the reason for the medication order.  If only a code exists, use reasonCode.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "MedicationRequest.reasonReference",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Condition",
+                            "http://hl7.org/fhir/StructureDefinition/Observation"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.reasonReference"
+                    },
+                    {
+                        "identity": "script10.6",
+                        "map": "no mapping"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.why[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "reason.observation[code=ASSERTION].value"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.instantiatesCanonical",
+                "path": "MedicationRequest.instantiatesCanonical",
+                "short": "Instantiates FHIR protocol or definition",
+                "definition": "The URL pointing to a protocol, guideline, orderset, or other definition that is adhered to in whole or in part by this MedicationRequest.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "MedicationRequest.instantiatesCanonical",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "canonical"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.instantiates"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=DEFN].target"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.instantiatesUri",
+                "path": "MedicationRequest.instantiatesUri",
+                "short": "Instantiates external protocol or definition",
+                "definition": "The URL pointing to an externally maintained protocol, guideline, orderset or other definition that is adhered to in whole or in part by this MedicationRequest.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "MedicationRequest.instantiatesUri",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=DEFN].target"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.basedOn",
+                "path": "MedicationRequest.basedOn",
+                "short": "What request fulfills",
+                "definition": "A plan or request that is fulfilled in whole or in part by this medication request.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "MedicationRequest.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest",
+                            "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.basedOn"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=FLFS].target[classCode=SBADM or PROC or PCPR or OBS, moodCode=RQO orPLAN or PRP]"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.groupIdentifier",
+                "path": "MedicationRequest.groupIdentifier",
+                "short": "Composite request this is part of",
+                "definition": "A shared identifier common to all requests that were authorized more or less simultaneously by a single author, representing the identifier of the requisition or prescription.",
+                "requirements": "Requests are linked either by a \"basedOn\" relationship (i.e. one request is fulfilling another) or by having a common requisition. Requests that are part of the same requisition are generally treated independently from the perspective of changing their state or maintaining them after initial creation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.groupIdentifier",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.groupIdentifier"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship(typeCode=COMP].target[classCode=SBADM, moodCode=INT].id"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.courseOfTherapyType",
+                "path": "MedicationRequest.courseOfTherapyType",
+                "short": "Overall pattern of medication administration",
+                "definition": "The description of the overall patte3rn of the administration of the medication to the patient.",
+                "comment": "This attribute should not be confused with the protocol of the medication.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.courseOfTherapyType",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "MedicationRequestCourseOfTherapy"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Identifies the overall pattern of medication administratio.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/medicationrequest-course-of-therapy"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.code where classCode = LIST and moodCode = EVN"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.insurance",
+                "path": "MedicationRequest.insurance",
+                "short": "Associated insurance coverage",
+                "definition": "Insurance plans, coverage extensions, pre-authorizations and/or pre-determinations that may be required for delivering the requested service.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "MedicationRequest.insurance",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Coverage",
+                            "http://hl7.org/fhir/StructureDefinition/ClaimResponse"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.insurance"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=COVBY].target"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.note",
+                "path": "MedicationRequest.note",
+                "short": "Information about the prescription",
+                "definition": "Extra information about the prescription that could not be conveyed by the other attributes.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "MedicationRequest.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.note"
+                    },
+                    {
+                        "identity": "script10.6",
+                        "map": "Message/Body/NewRx/MedicationPrescribed/Note"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=SUBJ]/source[classCode=OBS,moodCode=EVN,code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction",
+                "path": "MedicationRequest.dosageInstruction",
+                "short": "How the medication should be taken",
+                "definition": "Indicates how the medication is to be used by the patient.",
+                "comment": "There are examples where a medication request may include the option of an oral dose or an Intravenous or Intramuscular dose.  For example, \"Ondansetron 8mg orally or IV twice a day as needed for nausea\" or \"Compazine® (prochlorperazine) 5-10mg PO or 25mg PR bid prn nausea or vomiting\".  In these cases, two medication requests would be created that could be grouped together.  The decision on which dose and route of administration to use is based on the patient's condition at the time the dose is needed.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "MedicationRequest.dosageInstruction",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Dosage"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.occurrence[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "see dosageInstruction mapping"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.id",
+                "path": "MedicationRequest.dosageInstruction.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.extension",
+                "path": "MedicationRequest.dosageInstruction.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.modifierExtension",
+                "path": "MedicationRequest.dosageInstruction.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.sequence",
+                "path": "MedicationRequest.dosageInstruction.sequence",
+                "short": "The order of the dosage instructions",
+                "definition": "Indicates the order in which the dosage instructions should be applied or interpreted.",
+                "requirements": "If the sequence number of multiple Dosages is the same, then it is implied that the instructions are to be treated as concurrent.  If the sequence number is different, then the Dosages are intended to be sequential.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Dosage.sequence",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "integer"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "TQ1-1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".text"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.text",
+                "path": "MedicationRequest.dosageInstruction.text",
+                "short": "Free text dosage instructions e.g. SIG",
+                "definition": "Free text dosage instructions e.g. SIG.",
+                "requirements": "Free text dosage instructions can be used for cases where the instructions are too complex to code.  The content of this attribute does not include the name or description of the medication. When coded instructions are present, the free text instructions may still be present for display to humans taking or administering the medication. It is expected that the text instructions will always be populated.  If the dosage.timing attribute is also populated, then the dosage.text should reflect the same information as the timing.  Additional information about administration or preparation of the medication should be included as text.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Dosage.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXO-6; RXE-21"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".text"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.additionalInstruction",
+                "path": "MedicationRequest.dosageInstruction.additionalInstruction",
+                "short": "Supplemental instruction or warnings to the patient - e.g. \"with meals\", \"may cause drowsiness\"",
+                "definition": "Supplemental instructions to the patient on how to take the medication  (e.g. \"with meals\" or\"take half to one hour before food\") or warnings for the patient about the medication (e.g. \"may cause drowsiness\" or \"avoid exposure of skin to direct sunlight or sunlamps\").",
+                "comment": "Information about administration or preparation of the medication (e.g. \"infuse as rapidly as possibly via intraperitoneal port\" or \"immediately following drug x\") should be populated in dosage.text.",
+                "requirements": "Additional instruction is intended to be coded, but where no code exists, the element could include text.  For example, \"Swallow with plenty of water\" which might or might not be coded.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Dosage.additionalInstruction",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AdditionalInstruction"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "A coded concept identifying additional instructions such as \"take with water\" or \"avoid operating heavy machinery\".",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/additional-instruction-codes"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXO-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".text"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.patientInstruction",
+                "path": "MedicationRequest.dosageInstruction.patientInstruction",
+                "short": "Patient or consumer oriented instructions",
+                "definition": "Instructions in terms that are understood by the patient or consumer.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Dosage.patientInstruction",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXO-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".text"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.timing",
+                "path": "MedicationRequest.dosageInstruction.timing",
+                "short": "When medication should be administered",
+                "definition": "When medication should be administered.",
+                "comment": "This attribute might not always be populated while the Dosage.text is expected to be populated.  If both are populated, then the Dosage.text should reflect the content of the Dosage.timing.",
+                "requirements": "The timing schedule for giving the medication to the patient. This  data type allows many different expressions. For example: \"Every 8 hours\"; \"Three times a day\"; \"1/2 an hour before breakfast for 10 days from 23-Dec 2011:\"; \"15 Oct 2013, 17 Oct 2013 and 1 Nov 2013\".  Sometimes, a rate can imply duration when expressed as total volume / duration (e.g.  500mL/2 hours implies a duration of 2 hours).  However, when rate doesn't imply duration (e.g. 250mL/hour), then the timing.repeat.duration is needed to convey the infuse over time period.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Dosage.timing",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Timing"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.asNeeded[x]",
+                "path": "MedicationRequest.dosageInstruction.asNeeded[x]",
+                "short": "Take \"as needed\" (for x)",
+                "definition": "Indicates whether the Medication is only taken when needed within a specific dosing schedule (Boolean option), or it indicates the precondition for taking the Medication (CodeableConcept).",
+                "comment": "Can express \"as needed\" without a reason by setting the Boolean = True.  In this case the CodeableConcept is not populated.  Or you can express \"as needed\" with a reason by including the CodeableConcept.  In this case the Boolean is assumed to be True.  If you set the Boolean to False, then the dose is given according to the schedule and is not \"prn\" or \"as needed\".",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Dosage.asNeeded[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "MedicationAsNeededReason"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "A coded concept identifying the precondition that should be met or evaluated prior to consuming or administering a medication dose.  For example \"pain\", \"30 minutes prior to sexual intercourse\", \"on flare-up\" etc.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/medication-as-needed-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "TQ1-9"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=PRCN].target[classCode=OBS, moodCode=EVN, code=\"as needed\"].value=boolean or codable concept"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.site",
+                "path": "MedicationRequest.dosageInstruction.site",
+                "short": "Body site to administer to",
+                "definition": "Body site to administer to.",
+                "comment": "If the use case requires attributes from the BodySite resource (e.g. to identify and track separately) then use the standard extension [bodySite](http://hl7.org/fhir/R4/extension-bodysite.html).  May be a summary code, or a reference to a very precise definition of the location, or both.",
+                "requirements": "A coded specification of the anatomic site where the medication first enters the body.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Dosage.site",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "MedicationAdministrationSite"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "A coded concept describing the site location the medicine enters into or onto the body.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/approach-site-codes"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXR-2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".approachSiteCode"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.route",
+                "path": "MedicationRequest.dosageInstruction.route",
+                "short": "How drug should enter body",
+                "definition": "How drug should enter body.",
+                "requirements": "A code specifying the route or physiological path of administration of a therapeutic agent into or onto a patient's body.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Dosage.route",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "RouteOfAdministration"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "A coded concept describing the route or physiological path of administration of a therapeutic agent into or onto the body of a subject.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/route-codes"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXR-1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".routeCode"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.method",
+                "path": "MedicationRequest.dosageInstruction.method",
+                "short": "Technique for administering medication",
+                "definition": "Technique for administering medication.",
+                "comment": "Terminologies used often pre-coordinate this term with the route and or form of administration.",
+                "requirements": "A coded value indicating the method by which the medication is introduced into or onto the body. Most commonly used for injections.  For examples, Slow Push; Deep IV.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Dosage.method",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "MedicationAdministrationMethod"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "A coded concept describing the technique by which the medicine is administered.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/administration-method-codes"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXR-4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".doseQuantity"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.doseAndRate",
+                "path": "MedicationRequest.dosageInstruction.doseAndRate",
+                "short": "Amount of medication administered",
+                "definition": "The amount of medication administered.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Dosage.doseAndRate",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Element"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "TQ1-2"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.doseAndRate.id",
+                "path": "MedicationRequest.dosageInstruction.doseAndRate.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.doseAndRate.extension",
+                "path": "MedicationRequest.dosageInstruction.doseAndRate.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.doseAndRate.type",
+                "path": "MedicationRequest.dosageInstruction.doseAndRate.type",
+                "short": "The kind of dose or rate specified",
+                "definition": "The kind of dose or rate specified, for example, ordered or calculated.",
+                "requirements": "If the type is not populated, assume to be \"ordered\".",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Dosage.doseAndRate.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "DoseAndRateType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "The kind of dose or rate specified.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/dose-rate-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXO-21; RXE-23"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.doseAndRate.dose[x]",
+                "path": "MedicationRequest.dosageInstruction.doseAndRate.dose[x]",
+                "short": "Amount of medication per dose",
+                "definition": "Amount of medication per dose.",
+                "comment": "Note that this specifies the quantity of the specified medication, not the quantity for each active ingredient(s). Each ingredient amount can be communicated in the Medication resource. For example, if one wants to communicate that a tablet was 375 mg, where the dose was one tablet, you can use the Medication resource to document that the tablet was comprised of 375 mg of drug XYZ. Alternatively if the dose was 375 mg, then you may only need to use the Medication resource to indicate this was a tablet. If the example were an IV such as dopamine and you wanted to communicate that 400mg of dopamine was mixed in 500 ml of some IV solution, then this would all be communicated in the Medication resource. If the administration is not intended to be instantaneous (rate is present or timing has a duration), this can be specified to convey the total amount to be administered over the period of time as indicated by the schedule e.g. 500 ml in dose, with timing used to convey that this should be done over 4 hours.",
+                "requirements": "The amount of therapeutic or other substance given at one administration event.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Dosage.doseAndRate.dose[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXO-2, RXE-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".doseQuantity"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.doseAndRate.rate[x]",
+                "path": "MedicationRequest.dosageInstruction.doseAndRate.rate[x]",
+                "short": "Amount of medication per unit of time",
+                "definition": "Amount of medication per unit of time.",
+                "comment": "It is possible to supply both a rate and a doseQuantity to provide full details about how the medication is to be administered and supplied. If the rate is intended to change over time, depending on local rules/regulations, each change should be captured as a new version of the MedicationRequest with an updated rate, or captured with a new MedicationRequest with the new rate.\r\rIt is possible to specify a rate over time (for example, 100 ml/hour) using either the rateRatio and rateQuantity.  The rateQuantity approach requires systems to have the capability to parse UCUM grammer where ml/hour is included rather than a specific ratio where the time is specified as the denominator.  Where a rate such as 500ml over 2 hours is specified, the use of rateRatio may be more semantically correct than specifying using a rateQuantity of 250 mg/hour.",
+                "requirements": "Identifies the speed with which the medication was or will be introduced into the patient. Typically the rate for an infusion e.g. 100 ml per 1 hour or 100 ml/hr.  May also be expressed as a rate per unit of time e.g. 500 ml per 2 hours.   Other examples: 200 mcg/min or 200 mcg/1 minute; 1 liter/8 hours.  Sometimes, a rate can imply duration when expressed as total volume / duration (e.g.  500mL/2 hours implies a duration of 2 hours).  However, when rate doesn't imply duration (e.g. 250mL/hour), then the timing.repeat.duration is needed to convey the infuse over time period.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Dosage.doseAndRate.rate[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXE22, RXE23, RXE-24"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".rateQuantity"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.maxDosePerPeriod",
+                "path": "MedicationRequest.dosageInstruction.maxDosePerPeriod",
+                "short": "Upper limit on medication per unit of time",
+                "definition": "Upper limit on medication per unit of time.",
+                "comment": "This is intended for use as an adjunct to the dosage when there is an upper cap.  For example \"2 tablets every 4 hours to a maximum of 8/day\".",
+                "requirements": "The maximum total quantity of a therapeutic substance that may be administered to a subject over the period of time.  For example, 1000mg in 24 hours.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Dosage.maxDosePerPeriod",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Ratio"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXO-23, RXE-19"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".maxDoseQuantity"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.maxDosePerAdministration",
+                "path": "MedicationRequest.dosageInstruction.maxDosePerAdministration",
+                "short": "Upper limit on medication per administration",
+                "definition": "Upper limit on medication per administration.",
+                "comment": "This is intended for use as an adjunct to the dosage when there is an upper cap.  For example, a body surface area related dose with a maximum amount, such as 1.5 mg/m2 (maximum 2 mg) IV over 5 – 10 minutes would have doseQuantity of 1.5 mg/m2 and maxDosePerAdministration of 2 mg.",
+                "requirements": "The maximum total quantity of a therapeutic substance that may be administered to a subject per administration.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Dosage.maxDosePerAdministration",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "not supported"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.maxDosePerLifetime",
+                "path": "MedicationRequest.dosageInstruction.maxDosePerLifetime",
+                "short": "Upper limit on medication per lifetime of the patient",
+                "definition": "Upper limit on medication per lifetime of the patient.",
+                "requirements": "The maximum total quantity of a therapeutic substance that may be administered per lifetime of the subject.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Dosage.maxDosePerLifetime",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "not supported"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest",
+                "path": "MedicationRequest.dispenseRequest",
+                "short": "Medication supply authorization",
+                "definition": "Indicates the specific details for the dispense or medication supply part of a medication request (also known as a Medication Prescription or Medication Order).  Note that this information is not always sent with the order.  There may be in some settings (e.g. hospitals) institutional or system support for completing the dispense details in the pharmacy department.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.dispenseRequest",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "Message/Body/NewRx/MedicationPrescribed/ExpirationDate"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "component.supplyEvent"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest.id",
+                "path": "MedicationRequest.dispenseRequest.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest.extension",
+                "path": "MedicationRequest.dispenseRequest.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest.modifierExtension",
+                "path": "MedicationRequest.dispenseRequest.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest.initialFill",
+                "path": "MedicationRequest.dispenseRequest.initialFill",
+                "short": "First fill details",
+                "definition": "Indicates the quantity or duration for the first dispense of the medication.",
+                "comment": "If populating this element, either the quantity or the duration must be included.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.dispenseRequest.initialFill",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "SubstanceAdministration -> ActRelationship[sequenceNumber = '1'] -> Supply"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest.initialFill.id",
+                "path": "MedicationRequest.dispenseRequest.initialFill.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest.initialFill.extension",
+                "path": "MedicationRequest.dispenseRequest.initialFill.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest.initialFill.modifierExtension",
+                "path": "MedicationRequest.dispenseRequest.initialFill.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest.initialFill.quantity",
+                "path": "MedicationRequest.dispenseRequest.initialFill.quantity",
+                "short": "First fill quantity",
+                "definition": "The amount or quantity to provide as part of the first dispense.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.dispenseRequest.initialFill.quantity",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Supply.quantity[moodCode=RQO]"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest.initialFill.duration",
+                "path": "MedicationRequest.dispenseRequest.initialFill.duration",
+                "short": "First fill duration",
+                "definition": "The length of time that the first dispense is expected to last.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.dispenseRequest.initialFill.duration",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Duration"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Supply.effectivetime[moodCode=RQO]"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest.dispenseInterval",
+                "path": "MedicationRequest.dispenseRequest.dispenseInterval",
+                "short": "Minimum period of time between dispenses",
+                "definition": "The minimum period of time that must occur between dispenses of the medication.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.dispenseRequest.dispenseInterval",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Duration"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Supply.effectivetime[moodCode=RQO]"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest.validityPeriod",
+                "path": "MedicationRequest.dispenseRequest.validityPeriod",
+                "short": "Time period supply is authorized for",
+                "definition": "This indicates the validity period of a prescription (stale dating the Prescription).",
+                "comment": "It reflects the prescribers' perspective for the validity of the prescription. Dispenses must not be made against the prescription outside of this period. The lower-bound of the Dispensing Window signifies the earliest date that the prescription can be filled for the first time. If an upper-bound is not specified then the Prescription is open-ended or will default to a stale-date based on regulations.",
+                "requirements": "Indicates when the Prescription becomes valid, and when it ceases to be a dispensable Prescription.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.dispenseRequest.validityPeriod",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "Message/Body/NewRx/MedicationPrescribed/Refills"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest.numberOfRepeatsAllowed",
+                "path": "MedicationRequest.dispenseRequest.numberOfRepeatsAllowed",
+                "short": "Number of refills authorized",
+                "definition": "An integer indicating the number of times, in addition to the original dispense, (aka refills or repeats) that the patient can receive the prescribed medication. Usage Notes: This integer does not include the original order dispense. This means that if an order indicates dispense 30 tablets plus \"3 repeats\", then the order can be dispensed a total of 4 times and the patient can receive a total of 120 tablets.  A prescriber may explicitly say that zero refills are permitted after the initial dispense.",
+                "comment": "If displaying \"number of authorized fills\", add 1 to this number.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.dispenseRequest.numberOfRepeatsAllowed",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "unsignedInt"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "Message/Body/NewRx/MedicationPrescribed/Quantity"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXE-12-Number of Refills"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "repeatNumber"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest.quantity",
+                "path": "MedicationRequest.dispenseRequest.quantity",
+                "short": "Amount of medication to supply per dispense",
+                "definition": "The amount that is to be dispensed for one fill.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.dispenseRequest.quantity",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "Message/Body/NewRx/MedicationPrescribed/DaysSupply"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXD-4-Actual Dispense Amount / RXD-5.1-Actual Dispense Units.code / RXD-5.3-Actual Dispense Units.name of coding system"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "quantity"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest.expectedSupplyDuration",
+                "path": "MedicationRequest.dispenseRequest.expectedSupplyDuration",
+                "short": "Number of days supply per dispense",
+                "definition": "Identifies the period time over which the supplied product is expected to be used, or the length of time the dispense is expected to last.",
+                "comment": "In some situations, this attribute may be used instead of quantity to identify the amount supplied by how long it is expected to last, rather than the physical quantity issued, e.g. 90 days supply of medication (based on an ordered dosage). When possible, it is always better to specify quantity, as this tends to be more precise. expectedSupplyDuration will always be an estimate that can be influenced by external factors.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.dispenseRequest.expectedSupplyDuration",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Duration"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "Message/Body/NewRx/MedicationPrescribed/Substitutions"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "expectedUseTime"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest.performer",
+                "path": "MedicationRequest.dispenseRequest.performer",
+                "short": "Intended dispenser",
+                "definition": "Indicates the intended dispensing Organization specified by the prescriber.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.dispenseRequest.performer",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.who"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=COMP].target[classCode=SPLY, moodCode=RQO] .participation[typeCode=PRF].role[scoper.determinerCode=INSTANCE]"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.substitution",
+                "path": "MedicationRequest.substitution",
+                "short": "Any restrictions on medication substitution",
+                "definition": "Indicates whether or not substitution can or should be part of the dispense. In some cases, substitution must happen, in other cases substitution must not happen. This block explains the prescriber's intent. If nothing is specified substitution may be done.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.substitution",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "specific values within Message/Body/NewRx/MedicationPrescribed/Substitutions"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "subjectOf.substitutionPersmission"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.substitution.id",
+                "path": "MedicationRequest.substitution.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.substitution.extension",
+                "path": "MedicationRequest.substitution.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.substitution.modifierExtension",
+                "path": "MedicationRequest.substitution.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.substitution.allowed[x]",
+                "path": "MedicationRequest.substitution.allowed[x]",
+                "short": "Whether substitution is allowed or not",
+                "definition": "True if the prescriber allows a different drug to be dispensed from what was prescribed.",
+                "comment": "This element is labeled as a modifier because whether substitution is allow or not, it cannot be ignored.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.substitution.allowed[x]",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "MedicationRequestSubstitution"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Identifies the type of substitution allowed.",
+                    "valueSet": "http://terminology.hl7.org/ValueSet/v3-ActSubstanceAdminSubstitutionCode"
+                },
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "specific values within Message/Body/NewRx/MedicationPrescribed/Substitutions"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXO-9-Allow Substitutions / RXE-9-Substitution Status"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.substitution.reason",
+                "path": "MedicationRequest.substitution.reason",
+                "short": "Why should (not) substitution be made",
+                "definition": "Indicates the reason for the substitution, or why substitution must or must not be performed.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.substitution.reason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "MedicationIntendedSubstitutionReason"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "A coded concept describing the reason that a different medication should (or should not) be substituted from what was prescribed.",
+                    "valueSet": "http://terminology.hl7.org/ValueSet/v3-SubstanceAdminSubstitutionReason"
+                },
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "not mapped"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXE-9 Substition status"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "reasonCode"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.priorPrescription",
+                "path": "MedicationRequest.priorPrescription",
+                "short": "An order/prescription that is being replaced",
+                "definition": "A link to a resource representing an earlier order related order or prescription.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.priorPrescription",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/MedicationRequest"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.replaces"
+                    },
+                    {
+                        "identity": "script10.6",
+                        "map": "not mapped"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=?RPLC or ?SUCC]/target[classCode=SBADM,moodCode=RQO]"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.detectedIssue",
+                "path": "MedicationRequest.detectedIssue",
+                "short": "Clinical Issue with action",
+                "definition": "Indicates an actual or potential clinical issue with or between one or more active or proposed clinical actions for a patient; e.g. Drug-drug interaction, duplicate therapy, dosage alert etc.",
+                "comment": "This element can include a detected issue that has been identified either by a decision support system or by a clinician and may include information on the steps that were taken to address the issue.",
+                "alias": [
+                    "Contraindication",
+                    "Drug Utilization Review (DUR)",
+                    "Alert"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "MedicationRequest.detectedIssue",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/DetectedIssue"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=SUBJ]/source[classCode=ALRT,moodCode=EVN].value"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.eventHistory",
+                "path": "MedicationRequest.eventHistory",
+                "short": "A list of events of interest in the lifecycle",
+                "definition": "Links to Provenance records for past versions of this resource or fulfilling request or event resources that identify key state transitions or updates that are likely to be relevant to a user looking at the current version of the resource.",
+                "comment": "This might not include provenances for all versions of the request – only those deemed “relevant” or important. This SHALL NOT include the provenance associated with this current version of the resource. (If that provenance is deemed to be a “relevant” change, it will need to be added as part of a later update. Until then, it can be queried directly as the provenance that points to this version using _revinclude All Provenances should have some historical version of this Request as their subject.).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "MedicationRequest.eventHistory",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Provenance"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.relevantHistory"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship(typeCode=SUBJ].source[classCode=CACT, moodCode=EVN]"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "MedicationRequest",
+                "path": "MedicationRequest",
+                "definition": "The US Core Medication Request (Order) Profile is based upon the core FHIR MedicationRequest Resource and created to meet the 2015 Edition Common Clinical Data Set 'Medications' requirements.",
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.status",
+                "path": "MedicationRequest.status",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "description": "A code specifying the state of the prescribing event. Describes the lifecycle of the prescription.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/medicationrequest-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder.status"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.intent",
+                "path": "MedicationRequest.intent",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "description": "The kind of medication order.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/medicationrequest-intent"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder.status"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.reported[x]",
+                "path": "MedicationRequest.reported[x]",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder.status"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.medication[x]",
+                "path": "MedicationRequest.medication[x]",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Prescribable medications",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-medication-codes|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder.medication[x]"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.subject",
+                "path": "MedicationRequest.subject",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder.patient"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.encounter",
+                "path": "MedicationRequest.encounter",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder.patient"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.authoredOn",
+                "path": "MedicationRequest.authoredOn",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder.dateWritten"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.requester",
+                "path": "MedicationRequest.requester",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder.prescriber"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction",
+                "path": "MedicationRequest.dosageInstruction",
+                "mustSupport": true
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.text",
+                "path": "MedicationRequest.dosageInstruction.text",
+                "mustSupport": true
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-observation-lab.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-observation-lab.json
@@ -1,3093 +1,3093 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-observation-lab",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-observation-lab-definitions.html#Observation\" title=\"This profile is  created to meet the 2015 Edition Common Clinical Data Set 'Laboratory test(s) and Laboratory value(s)/result(s)' requirements.\">Observation</a><a name=\"Observation\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-2)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/observation.html\">Observation</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Measurements and simple assertions</span><br/><span style=\"font-weight:bold\">us-core-2: </span>If there is no component or hasMember element then either a value[x] or a data absent reason must be present</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-observation-lab-definitions.html#Observation.status\">status</a><a name=\"Observation.status\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">registered | preliminary | final | amended +</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-observation-status.html\">ObservationStatus</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck13.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Slice Definition\" class=\"hierarchy\"/> <a style=\"font-style: italic\" href=\"StructureDefinition-us-core-observation-lab-definitions.html#Observation.category\">category</a><a name=\"Observation.category\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red; font-style: italic\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"font-style: italic\"/><span style=\"font-style: italic\">1</span><span style=\"font-style: italic\">..</span><span style=\"font-style: italic\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"font-style: italic\" href=\"http://hl7.org/fhir/R4/profiling.html#slicing\">(Slice Definition)</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5; font-style: italic\">Classification of  type of observation</span><br style=\"font-style: italic\"/><span style=\"font-weight:bold; font-style: italic\">Slice: </span><span style=\"font-style: italic\">Unordered, Open by pattern:$this</span><br style=\"font-style: italic\"/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck125.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-observation-lab-definitions.html#Observation.category:Laboratory\" title=\"Slice Laboratory\">category:Laboratory</a><a name=\"Observation.category\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Classification of  type of observation</span><br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1241.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#CodeableConcept.coding\">coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Code defined by a terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">(complex)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck12410.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"https://terminology.hl7.org/1.0.0//CodeSystem-observation-category.html\">http://terminology.hl7.org/CodeSystem/observation-category</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck12400.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">laboratory</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-observation-lab-definitions.html#Observation.code\" title=\"The test that was performed.  A LOINC **SHALL** be used if the concept is present in LOINC.\">code</a><a name=\"Observation.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Laboratory Test Name<br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-observation-codes.html\">LOINCCodes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-observation-lab-definitions.html#Observation.subject\">subject</a><a name=\"Observation.subject\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who and/or what the observation is about</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_choice.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Choice of Types\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-observation-lab-definitions.html#Observation.effective[x]\" title=\"For lab tests this is the specimen collection date.  For Ask at Order Entry Questions (AOE)'s this is the date the question was asked.\">effective[x]</a><a name=\"Observation.effective_x_\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-1, us-core-1)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Clinically relevant time/time-period for observation</span><br/><span style=\"font-weight:bold\">us-core-1: </span>Datetime must be at least to day.</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for dateTime Type: A date, date-time or partial date (e.g. just year or year + month).  If hours and minutes are specified, a time zone SHALL be populated. The format is a union of the schema types gYear, gYearMonth, date and dateTime. Seconds must be provided due to schema type constraints but may be zero-filled and may be ignored.                 Dates SHALL be valid dates.\">effectiveDateTime</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#dateTime\">dateTime</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for Period Type: A time period defined by a start and end date and optionally time.\">effectivePeriod</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Period\">Period</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-observation-lab-definitions.html#Observation.value[x]\" title=\"The Laboratory result value.  If a coded value,  the valueCodeableConcept.code **SHOULD**  be selected from [SNOMED CT](http://hl7.org/fhir/ValueSet/uslab-obs-codedresults).  If a numeric value, valueQuantity.code **SHALL** be selected from [UCUM](http://unitsofmeasure.org).  A FHIR [UCUM Codes value set](http://hl7.org/fhir/STU3/valueset-ucum-units.html) that defines all UCUM codes is in the FHIR specification.\">value[x]</a><a name=\"Observation.value_x_\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-4, us-core-3, us-core-2, us-core-3, us-core-4)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Quantity\">Quantity</a><span style=\"opacity: 0.5\">, </span><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a><span style=\"opacity: 0.5\">, </span><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a><span style=\"opacity: 0.5\">, </span><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#boolean\">boolean</a><span style=\"opacity: 0.5\">, </span><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#integer\">integer</a><span style=\"opacity: 0.5\">, </span><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Range\">Range</a><span style=\"opacity: 0.5\">, </span><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Ratio\">Ratio</a><span style=\"opacity: 0.5\">, </span><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#SampledData\">SampledData</a><span style=\"opacity: 0.5\">, </span><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#time\">time</a><span style=\"opacity: 0.5\">, </span><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#dateTime\">dateTime</a><span style=\"opacity: 0.5\">, </span><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Period\">Period</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Result Value<br/><span style=\"font-weight:bold\">us-core-4: </span>SHOULD use Snomed CT for coded Results<br/><span style=\"font-weight:bold\">us-core-3: </span>SHALL use UCUM for coded quantity units.</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck00.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-observation-lab-definitions.html#Observation.dataAbsentReason\">dataAbsentReason</a><a name=\"Observation.dataAbsentReason\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-2)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Why the result is missing</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-data-absent-reason.html\">DataAbsentReason</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)</td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab",
-	"version": "3.1.1",
-	"name": "USCoreLaboratoryResultObservationProfile",
-	"title": "US Core Laboratory Result Observation Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-06-27",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.healthit.gov"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the Observation resource for the minimal set of data to query and retrieve laboratory test results",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "argonaut-dq-dstu2",
-			"uri": "http://unknown.org/Argonaut-DQ-DSTU2",
-			"name": "Argonaut-DQ-DSTU2"
-		},
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "sct-concept",
-			"uri": "http://snomed.info/conceptdomain",
-			"name": "SNOMED CT Concept Domain Binding"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "sct-attr",
-			"uri": "http://snomed.org/attributebinding",
-			"name": "SNOMED CT Attribute Binding"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Observation",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Observation",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "Measurements and simple assertions",
-				"definition": "This profile is  created to meet the 2015 Edition Common Clinical Data Set 'Laboratory test(s) and Laboratory value(s)/result(s)' requirements.",
-				"comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
-				"alias": [
-					"Vital Signs",
-					"Measurement",
-					"Results",
-					"Tests"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "obs-6",
-						"severity": "error",
-						"human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
-						"expression": "dataAbsentReason.empty() or value.empty()",
-						"xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "obs-7",
-						"severity": "error",
-						"human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
-						"expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
-						"xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "us-core-2",
-						"severity": "error",
-						"human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present",
-						"expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
-						"xpath": "exists(f:component) or exists(f:hasMember) or exists(f:*[starts-with(local-name(.), 'value')]) or exists(f:dataAbsentReason)"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation[classCode=OBS, moodCode=EVN]"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation"
-					}
-				]
-			},
-			{
-				"id": "Observation.id",
-				"path": "Observation.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.meta",
-				"path": "Observation.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.implicitRules",
-				"path": "Observation.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Observation.language",
-				"path": "Observation.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Observation.text",
-				"path": "Observation.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Observation.contained",
-				"path": "Observation.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.extension",
-				"path": "Observation.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.modifierExtension",
-				"path": "Observation.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.identifier",
-				"path": "Observation.identifier",
-				"short": "Business Identifier for observation",
-				"definition": "A unique identifier assigned to this observation.",
-				"requirements": "Allows observations to be distinguished and referenced.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
-					},
-					{
-						"identity": "rim",
-						"map": "id"
-					}
-				]
-			},
-			{
-				"id": "Observation.basedOn",
-				"path": "Observation.basedOn",
-				"short": "Fulfills plan, proposal or order",
-				"definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
-				"requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
-				"alias": [
-					"Fulfills"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan",
-							"http://hl7.org/fhir/StructureDefinition/DeviceRequest",
-							"http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
-							"http://hl7.org/fhir/StructureDefinition/MedicationRequest",
-							"http://hl7.org/fhir/StructureDefinition/NutritionOrder",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.basedOn"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.partOf",
-				"path": "Observation.partOf",
-				"short": "Part of referenced event",
-				"definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
-				"comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/R4/observation.html#obsgrouping) below for guidance on referencing another Observation.",
-				"alias": [
-					"Container"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.partOf",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
-							"http://hl7.org/fhir/StructureDefinition/MedicationDispense",
-							"http://hl7.org/fhir/StructureDefinition/MedicationStatement",
-							"http://hl7.org/fhir/StructureDefinition/Procedure",
-							"http://hl7.org/fhir/StructureDefinition/Immunization",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.partOf"
-					},
-					{
-						"identity": "v2",
-						"map": "Varies by domain"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=FLFS].target"
-					}
-				]
-			},
-			{
-				"id": "Observation.status",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
-						"valueString": "default: final"
-					}
-				],
-				"path": "Observation.status",
-				"short": "registered | preliminary | final | amended +",
-				"definition": "The status of the result value.",
-				"comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
-				"requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-status"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 445584004 |Report by finality status|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-11"
-					},
-					{
-						"identity": "rim",
-						"map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.status"
-					}
-				]
-			},
-			{
-				"id": "Observation.category",
-				"path": "Observation.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "$this"
-						}
-					],
-					"rules": "open"
-				},
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.category"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:Laboratory",
-				"path": "Observation.category",
-				"sliceName": "Laboratory",
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://terminology.hl7.org/CodeSystem/observation-category",
-							"code": "laboratory"
-						}
-					]
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.category"
-					}
-				]
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Laboratory Test Name",
-				"definition": "The test that was performed.  A LOINC **SHALL** be used if the concept is present in LOINC.",
-				"comment": "The typical patterns for codes are:  1)  a LOINC code either as a  translation from a \"local\" code or as a primary code, or 2)  a local code only if no suitable LOINC exists,  or 3)  both the local and the LOINC translation.   Systems SHALL be capable of sending the local code if one exists.  When using LOINC , Use either the SHORTNAME or LONG_COMMON_NAME field for the display.",
-				"requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
-				"alias": [
-					"Name",
-					"Test Name",
-					"Observation Identifer"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "LOINC codes",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-codes"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "116680003 |Is a|"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.subject",
-				"path": "Observation.subject",
-				"short": "Who and/or what the observation is about",
-				"definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
-				"comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
-				"requirements": "Observations have no value if you don't know who or what they're about.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=RTGT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.focus",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
-						"valueCode": "trial-use"
-					}
-				],
-				"path": "Observation.focus",
-				"short": "What the observation is about, when it is not about the subject of record",
-				"definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
-				"comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/R4/extension-observation-focuscode.html).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.focus",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SBJ]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.encounter",
-				"path": "Observation.encounter",
-				"short": "Healthcare event during which this observation is made",
-				"definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
-				"comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
-				"requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
-				"alias": [
-					"Context"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.effective[x]",
-				"path": "Observation.effective[x]",
-				"short": "Clinically relevant time/time-period for observation",
-				"definition": "For lab tests this is the specimen collection date.  For Ask at Order Entry Questions (AOE)'s this is the date the question was asked.",
-				"comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/R4/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
-				"requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
-				"alias": [
-					"Occurrence"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.effective[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"us-core-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "us-core-1",
-						"severity": "error",
-						"human": "Datetime must be at least to day.",
-						"expression": "($this as dateTime).toString().length() >= 8",
-						"xpath": "f:matches(effectiveDateTime,/\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z)/)"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.effective[x]"
-					}
-				]
-			},
-			{
-				"id": "Observation.issued",
-				"path": "Observation.issued",
-				"short": "Date/Time this version was made available",
-				"definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
-				"comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/R4/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.issued",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=AUT].time"
-					}
-				]
-			},
-			{
-				"id": "Observation.performer",
-				"path": "Observation.performer",
-				"short": "Who is responsible for the observation",
-				"definition": "Who was responsible for asserting the observed value as \"true\".",
-				"requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.performer",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=PRF]"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]",
-				"path": "Observation.value[x]",
-				"short": "Result Value",
-				"definition": "The Laboratory result value.  If a coded value,  the valueCodeableConcept.code **SHOULD**  be selected from [SNOMED CT](http://hl7.org/fhir/ValueSet/uslab-obs-codedresults).  If a numeric value, valueQuantity.code **SHALL** be selected from [UCUM](http://unitsofmeasure.org).  A FHIR [UCUM Codes value set](http://hl7.org/fhir/STU3/valueset-ucum-units.html) that defines all UCUM codes is in the FHIR specification.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/R4/observation.html#notes) below.",
-				"requirements": "An observation exists to have a value, though it might not if it is in error, or if it represents a group of observations.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"us-core-2",
-					"us-core-3",
-					"us-core-4"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							}
-						],
-						"key": "us-core-4",
-						"severity": "warning",
-						"human": "SHOULD use Snomed CT for coded Results",
-						"expression": "valueCodeableConcept.coding.system.empty() or valueCodeableConcept.coding.system = 'http://snomed.info/sct'",
-						"xpath": "not(exists(f:valueCodeableConcept/f:coding/f:system) ) or  f:valueCodeableConcept/f:coding/f:system[@value='http://snomed.info/sct']"
-					},
-					{
-						"key": "us-core-3",
-						"severity": "error",
-						"human": "SHALL use UCUM for coded quantity units.",
-						"expression": "valueQuantity.system.empty() or valueQuantity.system = 'http://unitsofmeasure.org'",
-						"xpath": "not(exists(f:valueQuantity/f:system) ) or  f:valueQuantity/f:system[@value='http://unitsofmeasure.org']"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.value[x]"
-					}
-				]
-			},
-			{
-				"id": "Observation.dataAbsentReason",
-				"path": "Observation.dataAbsentReason",
-				"short": "Why the result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
-				"comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"us-core-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.dataAbsentReason"
-					}
-				]
-			},
-			{
-				"id": "Observation.interpretation",
-				"path": "Observation.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.note",
-				"path": "Observation.note",
-				"short": "Comments about the observation",
-				"definition": "Comments about the observation or the results.",
-				"comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
-				"requirements": "Need to be able to provide free text additional information.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
-					},
-					{
-						"identity": "rim",
-						"map": "subjectOf.observationEvent[code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.bodySite",
-				"path": "Observation.bodySite",
-				"short": "Observed body part",
-				"definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
-				"comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/R4/extension-bodysite.html).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.bodySite",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "BodySite"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing anatomical locations. May include laterality.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/body-site"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123037004 |Body structure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-20"
-					},
-					{
-						"identity": "rim",
-						"map": "targetSiteCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "718497002 |Inherent location|"
-					}
-				]
-			},
-			{
-				"id": "Observation.method",
-				"path": "Observation.method",
-				"short": "How it was done",
-				"definition": "Indicates the mechanism used to perform the observation.",
-				"comment": "Only used if not implicit in code for Observation.code.",
-				"requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.method",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationMethod"
-						}
-					],
-					"strength": "example",
-					"description": "Methods for simple observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-17"
-					},
-					{
-						"identity": "rim",
-						"map": "methodCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.specimen",
-				"path": "Observation.specimen",
-				"short": "Specimen used for this observation",
-				"definition": "The specimen that was used when this observation was made.",
-				"comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.specimen",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Specimen"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123038009 |Specimen|"
-					},
-					{
-						"identity": "v2",
-						"map": "SPM segment"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SPC].specimen"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "704319004 |Inherent in|"
-					}
-				]
-			},
-			{
-				"id": "Observation.device",
-				"path": "Observation.device",
-				"short": "(Measurement) Device",
-				"definition": "The device used to generate the observation data.",
-				"comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.device",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/DeviceMetric"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 49062001 |Device|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-17 / PRT -10"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=DEV]"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "424226004 |Using device|"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange",
-				"path": "Observation.referenceRange",
-				"short": "Provides guide for interpretation",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "obs-3",
-						"severity": "error",
-						"human": "Must have at least a low or a high or text",
-						"expression": "low.exists() or high.exists() or text.exists()",
-						"xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.id",
-				"path": "Observation.referenceRange.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.extension",
-				"path": "Observation.referenceRange.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.modifierExtension",
-				"path": "Observation.referenceRange.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.low",
-				"path": "Observation.referenceRange.low",
-				"short": "Low Range, if relevant",
-				"definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.low",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.low"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.high",
-				"path": "Observation.referenceRange.high",
-				"short": "High Range, if relevant",
-				"definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.high",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.high"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.type",
-				"path": "Observation.referenceRange.type",
-				"short": "Reference range qualifier",
-				"definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
-				"requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeMeaning"
-						}
-					],
-					"strength": "preferred",
-					"description": "Code for the meaning of a reference range.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.appliesTo",
-				"path": "Observation.referenceRange.appliesTo",
-				"short": "Reference range population",
-				"definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
-				"requirements": "Need to be able to identify the target population for proper interpretation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange.appliesTo",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeType"
-						}
-					],
-					"strength": "example",
-					"description": "Codes identifying the population the reference range applies to.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.age",
-				"path": "Observation.referenceRange.age",
-				"short": "Applicable age range, if relevant",
-				"definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
-				"requirements": "Some analytes vary greatly over age.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.age",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Range"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.text",
-				"path": "Observation.referenceRange.text",
-				"short": "Text based reference range in an observation",
-				"definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:ST"
-					}
-				]
-			},
-			{
-				"id": "Observation.hasMember",
-				"path": "Observation.hasMember",
-				"short": "Related resource that belongs to the Observation group",
-				"definition": "This observation is a group observation (e.g. a battery, a panel of tests, a set of vital sign measurements) that includes the target as a member of the group.",
-				"comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/R4/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/R4/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.hasMember",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Observation",
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship"
-					}
-				]
-			},
-			{
-				"id": "Observation.derivedFrom",
-				"path": "Observation.derivedFrom",
-				"short": "Related measurements the observation is made from",
-				"definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
-				"comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/R4/observation.html#obsgrouping) below.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.derivedFrom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/DocumentReference",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy",
-							"http://hl7.org/fhir/StructureDefinition/Media",
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/Observation",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": ".targetObservation"
-					}
-				]
-			},
-			{
-				"id": "Observation.component",
-				"path": "Observation.component",
-				"short": "Component results",
-				"definition": "Some observations have multiple component observations.  These component observations are expressed as separate code value pairs that share the same attributes.  Examples include systolic and diastolic component observations for blood pressure measurement and multiple component observations for genetics observations.",
-				"comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/R4/observation.html#notes) below.",
-				"requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "containment by OBX-4?"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=COMP]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.id",
-				"path": "Observation.component.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.extension",
-				"path": "Observation.component.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.modifierExtension",
-				"path": "Observation.component.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.code",
-				"path": "Observation.component.code",
-				"short": "Type of component observation (code / type)",
-				"definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
-				"comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCode"
-						}
-					],
-					"strength": "example",
-					"description": "Codes identifying names of simple observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-codes"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.value[x]",
-				"path": "Observation.component.value[x]",
-				"short": "Actual component result",
-				"definition": "The information determined as a result of making the observation, if the information has a simple value.",
-				"comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/R4/observation.html#notes) below.",
-				"requirements": "An observation exists to have a value, though it might not if it is in error, or if it represents a group of observations.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.dataAbsentReason",
-				"path": "Observation.component.dataAbsentReason",
-				"short": "Why the component result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
-				"comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.interpretation",
-				"path": "Observation.component.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.referenceRange",
-				"path": "Observation.component.referenceRange",
-				"short": "Provides guide for interpretation of component result",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"contentReference": "#Observation.referenceRange",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"definition": "This profile is  created to meet the 2015 Edition Common Clinical Data Set 'Laboratory test(s) and Laboratory value(s)/result(s)' requirements.",
-				"constraint": [
-					{
-						"key": "us-core-2",
-						"severity": "error",
-						"human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present",
-						"expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
-						"xpath": "exists(f:component) or exists(f:hasMember) or exists(f:*[starts-with(local-name(.), 'value')]) or exists(f:dataAbsentReason)"
-					}
-				],
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation"
-					}
-				]
-			},
-			{
-				"id": "Observation.status",
-				"path": "Observation.status",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-status"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.status"
-					}
-				]
-			},
-			{
-				"id": "Observation.category",
-				"path": "Observation.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "$this"
-						}
-					],
-					"rules": "open"
-				},
-				"min": 1,
-				"max": "*",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.category"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:Laboratory",
-				"path": "Observation.category",
-				"sliceName": "Laboratory",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://terminology.hl7.org/CodeSystem/observation-category",
-							"code": "laboratory"
-						}
-					]
-				},
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.category"
-					}
-				]
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Laboratory Test Name",
-				"definition": "The test that was performed.  A LOINC **SHALL** be used if the concept is present in LOINC.",
-				"comment": "The typical patterns for codes are:  1)  a LOINC code either as a  translation from a \"local\" code or as a primary code, or 2)  a local code only if no suitable LOINC exists,  or 3)  both the local and the LOINC translation.   Systems SHALL be capable of sending the local code if one exists.  When using LOINC , Use either the SHORTNAME or LONG_COMMON_NAME field for the display.",
-				"alias": [
-					"Test Name",
-					"Observation Identifer"
-				],
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "LOINC codes",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-codes"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.subject",
-				"path": "Observation.subject",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.effective[x]",
-				"path": "Observation.effective[x]",
-				"definition": "For lab tests this is the specimen collection date.  For Ask at Order Entry Questions (AOE)'s this is the date the question was asked.",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"us-core-1"
-				],
-				"constraint": [
-					{
-						"key": "us-core-1",
-						"severity": "error",
-						"human": "Datetime must be at least to day.",
-						"expression": "($this as dateTime).toString().length() >= 8",
-						"xpath": "f:matches(effectiveDateTime,/\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z)/)"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.effective[x]"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]",
-				"path": "Observation.value[x]",
-				"short": "Result Value",
-				"definition": "The Laboratory result value.  If a coded value,  the valueCodeableConcept.code **SHOULD**  be selected from [SNOMED CT](http://hl7.org/fhir/ValueSet/uslab-obs-codedresults).  If a numeric value, valueQuantity.code **SHALL** be selected from [UCUM](http://unitsofmeasure.org).  A FHIR [UCUM Codes value set](http://hl7.org/fhir/STU3/valueset-ucum-units.html) that defines all UCUM codes is in the FHIR specification.",
-				"min": 0,
-				"max": "1",
-				"condition": [
-					"us-core-2",
-					"us-core-3",
-					"us-core-4"
-				],
-				"constraint": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							}
-						],
-						"key": "us-core-4",
-						"severity": "warning",
-						"human": "SHOULD use Snomed CT for coded Results",
-						"expression": "valueCodeableConcept.coding.system.empty() or valueCodeableConcept.coding.system = 'http://snomed.info/sct'",
-						"xpath": "not(exists(f:valueCodeableConcept/f:coding/f:system) ) or  f:valueCodeableConcept/f:coding/f:system[@value='http://snomed.info/sct']"
-					},
-					{
-						"key": "us-core-3",
-						"severity": "error",
-						"human": "SHALL use UCUM for coded quantity units.",
-						"expression": "valueQuantity.system.empty() or valueQuantity.system = 'http://unitsofmeasure.org'",
-						"xpath": "not(exists(f:valueQuantity/f:system) ) or  f:valueQuantity/f:system[@value='http://unitsofmeasure.org']"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.value[x]"
-					}
-				]
-			},
-			{
-				"id": "Observation.dataAbsentReason",
-				"path": "Observation.dataAbsentReason",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"us-core-2"
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.dataAbsentReason"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-observation-lab",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab",
+    "version": "3.1.1",
+    "name": "USCoreLaboratoryResultObservationProfile",
+    "title": "US Core Laboratory Result Observation Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-06-27",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.healthit.gov"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the Observation resource for the minimal set of data to query and retrieve laboratory test results",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "argonaut-dq-dstu2",
+            "uri": "http://unknown.org/Argonaut-DQ-DSTU2",
+            "name": "Argonaut-DQ-DSTU2"
+        },
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "sct-concept",
+            "uri": "http://snomed.info/conceptdomain",
+            "name": "SNOMED CT Concept Domain Binding"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "sct-attr",
+            "uri": "http://snomed.org/attributebinding",
+            "name": "SNOMED CT Attribute Binding"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Observation",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Observation",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "Measurements and simple assertions",
+                "definition": "This profile is  created to meet the 2015 Edition Common Clinical Data Set 'Laboratory test(s) and Laboratory value(s)/result(s)' requirements.",
+                "comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
+                "alias": [
+                    "Vital Signs",
+                    "Measurement",
+                    "Results",
+                    "Tests"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "obs-6",
+                        "severity": "error",
+                        "human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
+                        "expression": "dataAbsentReason.empty() or value.empty()",
+                        "xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "obs-7",
+                        "severity": "error",
+                        "human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
+                        "expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
+                        "xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "us-core-2",
+                        "severity": "error",
+                        "human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present",
+                        "expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
+                        "xpath": "exists(f:component) or exists(f:hasMember) or exists(f:*[starts-with(local-name(.), 'value')]) or exists(f:dataAbsentReason)"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation[classCode=OBS, moodCode=EVN]"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.id",
+                "path": "Observation.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.meta",
+                "path": "Observation.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.implicitRules",
+                "path": "Observation.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Observation.language",
+                "path": "Observation.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Observation.text",
+                "path": "Observation.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.contained",
+                "path": "Observation.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.extension",
+                "path": "Observation.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.modifierExtension",
+                "path": "Observation.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.identifier",
+                "path": "Observation.identifier",
+                "short": "Business Identifier for observation",
+                "definition": "A unique identifier assigned to this observation.",
+                "requirements": "Allows observations to be distinguished and referenced.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "id"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.basedOn",
+                "path": "Observation.basedOn",
+                "short": "Fulfills plan, proposal or order",
+                "definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
+                "requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
+                "alias": [
+                    "Fulfills"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceRequest",
+                            "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+                            "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.basedOn"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.partOf",
+                "path": "Observation.partOf",
+                "short": "Part of referenced event",
+                "definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
+                "comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/R4/observation.html#obsgrouping) below for guidance on referencing another Observation.",
+                "alias": [
+                    "Container"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.partOf",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationDispense",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationStatement",
+                            "http://hl7.org/fhir/StructureDefinition/Procedure",
+                            "http://hl7.org/fhir/StructureDefinition/Immunization",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.partOf"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "Varies by domain"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=FLFS].target"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.status",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
+                        "valueString": "default: final"
+                    }
+                ],
+                "path": "Observation.status",
+                "short": "registered | preliminary | final | amended +",
+                "definition": "The status of the result value.",
+                "comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
+                "requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 445584004 |Report by finality status|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-11"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.status"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category",
+                "path": "Observation.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "$this"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.category"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:Laboratory",
+                "path": "Observation.category",
+                "sliceName": "Laboratory",
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.category"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Laboratory Test Name",
+                "definition": "The test that was performed.  A LOINC **SHALL** be used if the concept is present in LOINC.",
+                "comment": "The typical patterns for codes are:  1)  a LOINC code either as a  translation from a \"local\" code or as a primary code, or 2)  a local code only if no suitable LOINC exists,  or 3)  both the local and the LOINC translation.   Systems SHALL be capable of sending the local code if one exists.  When using LOINC , Use either the SHORTNAME or LONG_COMMON_NAME field for the display.",
+                "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+                "alias": [
+                    "Name",
+                    "Test Name",
+                    "Observation Identifer"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "LOINC codes",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-codes"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "116680003 |Is a|"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.subject",
+                "path": "Observation.subject",
+                "short": "Who and/or what the observation is about",
+                "definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
+                "comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
+                "requirements": "Observations have no value if you don't know who or what they're about.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=RTGT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.focus",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+                        "valueCode": "trial-use"
+                    }
+                ],
+                "path": "Observation.focus",
+                "short": "What the observation is about, when it is not about the subject of record",
+                "definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
+                "comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/R4/extension-observation-focuscode.html).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.focus",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SBJ]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.encounter",
+                "path": "Observation.encounter",
+                "short": "Healthcare event during which this observation is made",
+                "definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
+                "comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
+                "requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
+                "alias": [
+                    "Context"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.effective[x]",
+                "path": "Observation.effective[x]",
+                "short": "Clinically relevant time/time-period for observation",
+                "definition": "For lab tests this is the specimen collection date.  For Ask at Order Entry Questions (AOE)'s this is the date the question was asked.",
+                "comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/R4/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
+                "requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
+                "alias": [
+                    "Occurrence"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.effective[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "us-core-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "us-core-1",
+                        "severity": "error",
+                        "human": "Datetime must be at least to day.",
+                        "expression": "($this as dateTime).toString().length() >= 8",
+                        "xpath": "f:matches(effectiveDateTime,/\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z)/)"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.effective[x]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.issued",
+                "path": "Observation.issued",
+                "short": "Date/Time this version was made available",
+                "definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
+                "comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/R4/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.issued",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.performer",
+                "path": "Observation.performer",
+                "short": "Who is responsible for the observation",
+                "definition": "Who was responsible for asserting the observed value as \"true\".",
+                "requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.performer",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=PRF]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]",
+                "path": "Observation.value[x]",
+                "short": "Result Value",
+                "definition": "The Laboratory result value.  If a coded value,  the valueCodeableConcept.code **SHOULD**  be selected from [SNOMED CT](http://hl7.org/fhir/ValueSet/uslab-obs-codedresults).  If a numeric value, valueQuantity.code **SHALL** be selected from [UCUM](http://unitsofmeasure.org).  A FHIR [UCUM Codes value set](http://hl7.org/fhir/STU3/valueset-ucum-units.html) that defines all UCUM codes is in the FHIR specification.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/R4/observation.html#notes) below.",
+                "requirements": "An observation exists to have a value, though it might not if it is in error, or if it represents a group of observations.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "us-core-2",
+                    "us-core-3",
+                    "us-core-4"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "key": "us-core-4",
+                        "severity": "warning",
+                        "human": "SHOULD use Snomed CT for coded Results",
+                        "expression": "valueCodeableConcept.coding.system.empty() or valueCodeableConcept.coding.system = 'http://snomed.info/sct'",
+                        "xpath": "not(exists(f:valueCodeableConcept/f:coding/f:system) ) or  f:valueCodeableConcept/f:coding/f:system[@value='http://snomed.info/sct']"
+                    },
+                    {
+                        "key": "us-core-3",
+                        "severity": "error",
+                        "human": "SHALL use UCUM for coded quantity units.",
+                        "expression": "valueQuantity.system.empty() or valueQuantity.system = 'http://unitsofmeasure.org'",
+                        "xpath": "not(exists(f:valueQuantity/f:system) ) or  f:valueQuantity/f:system[@value='http://unitsofmeasure.org']"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.value[x]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.dataAbsentReason",
+                "path": "Observation.dataAbsentReason",
+                "short": "Why the result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
+                "comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "us-core-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.dataAbsentReason"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.interpretation",
+                "path": "Observation.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.note",
+                "path": "Observation.note",
+                "short": "Comments about the observation",
+                "definition": "Comments about the observation or the results.",
+                "comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
+                "requirements": "Need to be able to provide free text additional information.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "subjectOf.observationEvent[code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.bodySite",
+                "path": "Observation.bodySite",
+                "short": "Observed body part",
+                "definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
+                "comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/R4/extension-bodysite.html).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.bodySite",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "BodySite"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing anatomical locations. May include laterality.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/body-site"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123037004 |Body structure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-20"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "targetSiteCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "718497002 |Inherent location|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.method",
+                "path": "Observation.method",
+                "short": "How it was done",
+                "definition": "Indicates the mechanism used to perform the observation.",
+                "comment": "Only used if not implicit in code for Observation.code.",
+                "requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.method",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationMethod"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Methods for simple observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "methodCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.specimen",
+                "path": "Observation.specimen",
+                "short": "Specimen used for this observation",
+                "definition": "The specimen that was used when this observation was made.",
+                "comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.specimen",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Specimen"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123038009 |Specimen|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "SPM segment"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SPC].specimen"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "704319004 |Inherent in|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.device",
+                "path": "Observation.device",
+                "short": "(Measurement) Device",
+                "definition": "The device used to generate the observation data.",
+                "comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.device",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceMetric"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 49062001 |Device|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17 / PRT -10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=DEV]"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "424226004 |Using device|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange",
+                "path": "Observation.referenceRange",
+                "short": "Provides guide for interpretation",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "obs-3",
+                        "severity": "error",
+                        "human": "Must have at least a low or a high or text",
+                        "expression": "low.exists() or high.exists() or text.exists()",
+                        "xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.id",
+                "path": "Observation.referenceRange.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.extension",
+                "path": "Observation.referenceRange.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.modifierExtension",
+                "path": "Observation.referenceRange.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.low",
+                "path": "Observation.referenceRange.low",
+                "short": "Low Range, if relevant",
+                "definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.low",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.low"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.high",
+                "path": "Observation.referenceRange.high",
+                "short": "High Range, if relevant",
+                "definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.high",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.high"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.type",
+                "path": "Observation.referenceRange.type",
+                "short": "Reference range qualifier",
+                "definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
+                "requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeMeaning"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Code for the meaning of a reference range.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.appliesTo",
+                "path": "Observation.referenceRange.appliesTo",
+                "short": "Reference range population",
+                "definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
+                "requirements": "Need to be able to identify the target population for proper interpretation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange.appliesTo",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes identifying the population the reference range applies to.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.age",
+                "path": "Observation.referenceRange.age",
+                "short": "Applicable age range, if relevant",
+                "definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
+                "requirements": "Some analytes vary greatly over age.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.age",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Range"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.text",
+                "path": "Observation.referenceRange.text",
+                "short": "Text based reference range in an observation",
+                "definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:ST"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.hasMember",
+                "path": "Observation.hasMember",
+                "short": "Related resource that belongs to the Observation group",
+                "definition": "This observation is a group observation (e.g. a battery, a panel of tests, a set of vital sign measurements) that includes the target as a member of the group.",
+                "comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/R4/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/R4/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.hasMember",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Observation",
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.derivedFrom",
+                "path": "Observation.derivedFrom",
+                "short": "Related measurements the observation is made from",
+                "definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
+                "comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/R4/observation.html#obsgrouping) below.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.derivedFrom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/DocumentReference",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy",
+                            "http://hl7.org/fhir/StructureDefinition/Media",
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/Observation",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".targetObservation"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component",
+                "path": "Observation.component",
+                "short": "Component results",
+                "definition": "Some observations have multiple component observations.  These component observations are expressed as separate code value pairs that share the same attributes.  Examples include systolic and diastolic component observations for blood pressure measurement and multiple component observations for genetics observations.",
+                "comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/R4/observation.html#notes) below.",
+                "requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "containment by OBX-4?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=COMP]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.id",
+                "path": "Observation.component.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.extension",
+                "path": "Observation.component.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.modifierExtension",
+                "path": "Observation.component.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.code",
+                "path": "Observation.component.code",
+                "short": "Type of component observation (code / type)",
+                "definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
+                "comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCode"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes identifying names of simple observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-codes"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.value[x]",
+                "path": "Observation.component.value[x]",
+                "short": "Actual component result",
+                "definition": "The information determined as a result of making the observation, if the information has a simple value.",
+                "comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/R4/observation.html#notes) below.",
+                "requirements": "An observation exists to have a value, though it might not if it is in error, or if it represents a group of observations.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.dataAbsentReason",
+                "path": "Observation.component.dataAbsentReason",
+                "short": "Why the component result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
+                "comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.interpretation",
+                "path": "Observation.component.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.referenceRange",
+                "path": "Observation.component.referenceRange",
+                "short": "Provides guide for interpretation of component result",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "contentReference": "#Observation.referenceRange",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "definition": "This profile is  created to meet the 2015 Edition Common Clinical Data Set 'Laboratory test(s) and Laboratory value(s)/result(s)' requirements.",
+                "constraint": [
+                    {
+                        "key": "us-core-2",
+                        "severity": "error",
+                        "human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present",
+                        "expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
+                        "xpath": "exists(f:component) or exists(f:hasMember) or exists(f:*[starts-with(local-name(.), 'value')]) or exists(f:dataAbsentReason)"
+                    }
+                ],
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.status",
+                "path": "Observation.status",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.status"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category",
+                "path": "Observation.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "$this"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "min": 1,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.category"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:Laboratory",
+                "path": "Observation.category",
+                "sliceName": "Laboratory",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                },
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.category"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Laboratory Test Name",
+                "definition": "The test that was performed.  A LOINC **SHALL** be used if the concept is present in LOINC.",
+                "comment": "The typical patterns for codes are:  1)  a LOINC code either as a  translation from a \"local\" code or as a primary code, or 2)  a local code only if no suitable LOINC exists,  or 3)  both the local and the LOINC translation.   Systems SHALL be capable of sending the local code if one exists.  When using LOINC , Use either the SHORTNAME or LONG_COMMON_NAME field for the display.",
+                "alias": [
+                    "Test Name",
+                    "Observation Identifer"
+                ],
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "LOINC codes",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-codes"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.subject",
+                "path": "Observation.subject",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.effective[x]",
+                "path": "Observation.effective[x]",
+                "definition": "For lab tests this is the specimen collection date.  For Ask at Order Entry Questions (AOE)'s this is the date the question was asked.",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "us-core-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "us-core-1",
+                        "severity": "error",
+                        "human": "Datetime must be at least to day.",
+                        "expression": "($this as dateTime).toString().length() >= 8",
+                        "xpath": "f:matches(effectiveDateTime,/\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z)/)"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.effective[x]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]",
+                "path": "Observation.value[x]",
+                "short": "Result Value",
+                "definition": "The Laboratory result value.  If a coded value,  the valueCodeableConcept.code **SHOULD**  be selected from [SNOMED CT](http://hl7.org/fhir/ValueSet/uslab-obs-codedresults).  If a numeric value, valueQuantity.code **SHALL** be selected from [UCUM](http://unitsofmeasure.org).  A FHIR [UCUM Codes value set](http://hl7.org/fhir/STU3/valueset-ucum-units.html) that defines all UCUM codes is in the FHIR specification.",
+                "min": 0,
+                "max": "1",
+                "condition": [
+                    "us-core-2",
+                    "us-core-3",
+                    "us-core-4"
+                ],
+                "constraint": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "key": "us-core-4",
+                        "severity": "warning",
+                        "human": "SHOULD use Snomed CT for coded Results",
+                        "expression": "valueCodeableConcept.coding.system.empty() or valueCodeableConcept.coding.system = 'http://snomed.info/sct'",
+                        "xpath": "not(exists(f:valueCodeableConcept/f:coding/f:system) ) or  f:valueCodeableConcept/f:coding/f:system[@value='http://snomed.info/sct']"
+                    },
+                    {
+                        "key": "us-core-3",
+                        "severity": "error",
+                        "human": "SHALL use UCUM for coded quantity units.",
+                        "expression": "valueQuantity.system.empty() or valueQuantity.system = 'http://unitsofmeasure.org'",
+                        "xpath": "not(exists(f:valueQuantity/f:system) ) or  f:valueQuantity/f:system[@value='http://unitsofmeasure.org']"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.value[x]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.dataAbsentReason",
+                "path": "Observation.dataAbsentReason",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "us-core-2"
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.dataAbsentReason"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-organization.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-organization.json
@@ -1,2739 +1,2739 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-organization",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-organization-definitions.html#Organization\">Organization</a><a name=\"Organization\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/organization.html\">Organization</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">A grouping of people or organizations with a common purpose</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck13.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Definition\" class=\"hierarchy\"/> <a style=\"font-style: italic\" href=\"StructureDefinition-us-core-organization-definitions.html#Organization.identifier\">identifier</a><a name=\"Organization.identifier\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red; font-style: italic\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"font-style: italic\"/><span style=\"font-style: italic\">0</span><span style=\"font-style: italic\">..</span><span style=\"font-style: italic\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"font-style: italic\" href=\"http://hl7.org/fhir/R4/profiling.html#slicing\">(Slice Definition)</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5; font-style: italic\">Identifies this organization  across multiple systems</span><br style=\"font-style: italic\"/><span style=\"font-weight:bold; font-style: italic\">Slice: </span><span style=\"font-style: italic\">Unordered, Open by pattern:$this</span><br style=\"font-style: italic\"/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck133.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> identifier:All Slices<a name=\"Organization.identifier\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Content/Rules for all slices</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1330.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-organization-definitions.html#Organization.identifier.system\">system</a><a name=\"Organization.identifier.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The namespace for the identifier value</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1320.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-organization-definitions.html#Organization.identifier.value\">value</a><a name=\"Organization.identifier.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The value that is unique</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck135.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-organization-definitions.html#Organization.identifier:NPI\" title=\"Slice NPI\">identifier:NPI</a><a name=\"Organization.identifier\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Identifier\">Identifier</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">National Provider Identifier (NPI)<br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1340.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Identifier.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">The namespace for the identifier value<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">http://hl7.org/fhir/sid/us-npi</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck125.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-organization-definitions.html#Organization.identifier:CLIA\" title=\"Slice CLIA\">identifier:CLIA</a><a name=\"Organization.identifier\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Identifier\">Identifier</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Clinical Laboratory Improvement Amendments (CLIA) Number for laboratories<br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1240.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Identifier.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">The namespace for the identifier value<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">urn:oid:2.16.840.1.113883.4.7</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-organization-definitions.html#Organization.active\">active</a><a name=\"Organization.active\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#boolean\">boolean</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Whether the organization's record is still in active use</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-organization-definitions.html#Organization.name\">name</a><a name=\"Organization.name\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Name used for the organization</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-organization-definitions.html#Organization.telecom\">telecom</a><a name=\"Organization.telecom\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#ContactPoint\">ContactPoint</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">A contact detail for the organization</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-organization-definitions.html#Organization.address\">address</a><a name=\"Organization.address\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Address\">Address</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">An address for the organization</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-organization-definitions.html#Organization.address.line\">line</a><a name=\"Organization.address.line\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..4</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Street name, number, direction &amp; P.O. Box etc.</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-organization-definitions.html#Organization.address.city\">city</a><a name=\"Organization.address.city\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Name of city, town etc.</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-organization-definitions.html#Organization.address.state\">state</a><a name=\"Organization.address.state\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Sub-unit of country (abbreviations ok)</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-usps-state.html\">USPS Two Letter Alphabetic Codes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-organization-definitions.html#Organization.address.postalCode\">postalCode</a><a name=\"Organization.address.postalCode\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">US Zip Codes</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-organization-definitions.html#Organization.address.country\">country</a><a name=\"Organization.address.country\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Country (e.g. can be ISO 3166 2 or 3 letter code)</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
-	"version": "3.1.1",
-	"name": "USCoreOrganizationProfile",
-	"title": "US Core Organization Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-06-29",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.healthit.gov"
-				}
-			]
-		}
-	],
-	"description": "Defines basic constraints and extensions on the Organization resource for use with other US Core resources",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "servd",
-			"uri": "http://www.omg.org/spec/ServD/1.0/",
-			"name": "ServD"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Organization",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Organization",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Organization",
-				"path": "Organization",
-				"short": "A grouping of people or organizations with a common purpose",
-				"definition": "A formally or informally recognized grouping of people or organizations formed for the purpose of achieving some form of collective action.  Includes companies, institutions, corporations, departments, community groups, healthcare practice groups, payer/insurer, etc.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Organization",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "org-1",
-						"severity": "error",
-						"human": "The organization SHALL at least have a name or an identifier, and possibly more than one",
-						"expression": "(identifier.count() + name.count()) > 0",
-						"xpath": "count(f:identifier | f:name) > 0",
-						"source": "http://hl7.org/fhir/StructureDefinition/Organization"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "v2",
-						"map": "(also see master files messages)"
-					},
-					{
-						"identity": "rim",
-						"map": "Organization(classCode=ORG, determinerCode=INST)"
-					},
-					{
-						"identity": "servd",
-						"map": "Organization"
-					}
-				]
-			},
-			{
-				"id": "Organization.id",
-				"path": "Organization.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Organization.meta",
-				"path": "Organization.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Organization.implicitRules",
-				"path": "Organization.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Organization.language",
-				"path": "Organization.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Organization.text",
-				"path": "Organization.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Organization.contained",
-				"path": "Organization.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Organization.extension",
-				"path": "Organization.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Organization.modifierExtension",
-				"path": "Organization.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Organization.identifier",
-				"path": "Organization.identifier",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "$this"
-						}
-					],
-					"rules": "open"
-				},
-				"short": "Identifies this organization  across multiple systems",
-				"definition": "Identifier for the organization that is used to identify the organization across multiple disparate systems.",
-				"comment": "NPI preferred.",
-				"requirements": "Organizations are known by a variety of ids. Some institutions maintain several, and most collect identifiers for exchange with other organizations concerning the organization.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Organization.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"condition": [
-					"org-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "XON.10 / XON.3"
-					},
-					{
-						"identity": "rim",
-						"map": ".scopes[Role](classCode=IDENT)"
-					},
-					{
-						"identity": "servd",
-						"map": "./Identifiers"
-					},
-					{
-						"identity": "servd",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.identifier.id",
-				"path": "Organization.identifier.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.identifier.extension",
-				"path": "Organization.identifier.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.identifier.use",
-				"path": "Organization.identifier.use",
-				"short": "usual | official | temp | secondary | old (If known)",
-				"definition": "The purpose of this identifier.",
-				"comment": "Applications can assume that an identifier is permanent unless it explicitly says that it is temporary.",
-				"requirements": "Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.use",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary id for a permanent one.",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "IdentifierUse"
-						}
-					],
-					"strength": "required",
-					"description": "Identifies the purpose for this identifier, if known .",
-					"valueSet": "http://hl7.org/fhir/ValueSet/identifier-use|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "Role.code or implied by context"
-					}
-				]
-			},
-			{
-				"id": "Organization.identifier.type",
-				"path": "Organization.identifier.type",
-				"short": "Description of identifier",
-				"definition": "A coded type for the identifier that can be used to determine which identifier to use for a specific purpose.",
-				"comment": "This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage.   Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type.",
-				"requirements": "Allows users to make use of identifiers when the identifier system is not known.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "IdentifierType"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "extensible",
-					"description": "A coded type for an identifier that can be used to determine which identifier to use for a specific purpose.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/identifier-type"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.5"
-					},
-					{
-						"identity": "rim",
-						"map": "Role.code or implied by context"
-					}
-				]
-			},
-			{
-				"id": "Organization.identifier.system",
-				"path": "Organization.identifier.system",
-				"short": "The namespace for the identifier value",
-				"definition": "Establishes the namespace for the value - that is, a URL that describes a set values that are unique.",
-				"comment": "Identifier.system is always case sensitive.",
-				"requirements": "There are many sets  of identifiers.  To perform matching of two identifiers, we need to know what set we're dealing with. The system identifies a particular set of unique identifiers.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueUri": "http://www.acme.com/identifiers/patient"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.4 / EI-2-4"
-					},
-					{
-						"identity": "rim",
-						"map": "II.root or Role.id.root"
-					},
-					{
-						"identity": "servd",
-						"map": "./IdentifierType"
-					}
-				]
-			},
-			{
-				"id": "Organization.identifier.value",
-				"path": "Organization.identifier.value",
-				"short": "The value that is unique",
-				"definition": "The portion of the identifier typically relevant to the user and which is unique within the context of the system.",
-				"comment": "If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986.  The value's primary purpose is computational mapping.  As a result, it may be normalized for comparison purposes (e.g. removing non-significant whitespace, dashes, etc.)  A value formatted for human display can be conveyed using the [Rendered Value extension](http://hl7.org/fhir/R4/extension-rendered-value.html). Identifier.value is to be treated as case sensitive unless knowledge of the Identifier.system allows the processer to be confident that non-case-sensitive processing is safe.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "123456"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.1 / EI.1"
-					},
-					{
-						"identity": "rim",
-						"map": "II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)"
-					},
-					{
-						"identity": "servd",
-						"map": "./Value"
-					}
-				]
-			},
-			{
-				"id": "Organization.identifier.period",
-				"path": "Organization.identifier.period",
-				"short": "Time period when id is/was valid for use",
-				"definition": "Time period during which identifier is/was valid for use.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.7 + CX.8"
-					},
-					{
-						"identity": "rim",
-						"map": "Role.effectiveTime or implied by context"
-					},
-					{
-						"identity": "servd",
-						"map": "./StartDate and ./EndDate"
-					}
-				]
-			},
-			{
-				"id": "Organization.identifier.assigner",
-				"path": "Organization.identifier.assigner",
-				"short": "Organization that issued id (may be just text)",
-				"definition": "Organization that issued/manages the identifier.",
-				"comment": "The Identifier.assigner may omit the .reference element and only contain a .display element reflecting the name or other textual information about the assigning organization.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.assigner",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.4 / (CX.4,CX.9,CX.10)"
-					},
-					{
-						"identity": "rim",
-						"map": "II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper"
-					},
-					{
-						"identity": "servd",
-						"map": "./IdentifierIssuingAuthority"
-					}
-				]
-			},
-			{
-				"id": "Organization.identifier:NPI",
-				"path": "Organization.identifier",
-				"sliceName": "NPI",
-				"short": "National Provider Identifier (NPI)",
-				"definition": "Identifier for the organization that is used to identify the organization across multiple disparate systems.",
-				"requirements": "Organizations are known by a variety of ids. Some institutions maintain several, and most collect identifiers for exchange with other organizations concerning the organization.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Organization.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"patternIdentifier": {
-					"system": "http://hl7.org/fhir/sid/us-npi"
-				},
-				"condition": [
-					"org-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "XON.10 / XON.3"
-					},
-					{
-						"identity": "rim",
-						"map": ".scopes[Role](classCode=IDENT)"
-					},
-					{
-						"identity": "servd",
-						"map": "./Identifiers"
-					},
-					{
-						"identity": "servd",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.identifier:CLIA",
-				"path": "Organization.identifier",
-				"sliceName": "CLIA",
-				"short": "Clinical Laboratory Improvement Amendments (CLIA) Number for laboratories",
-				"definition": "Identifier for the organization that is used to identify the organization across multiple disparate systems.",
-				"requirements": "Organizations are known by a variety of ids. Some institutions maintain several, and most collect identifiers for exchange with other organizations concerning the organization.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Organization.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"patternIdentifier": {
-					"system": "urn:oid:2.16.840.1.113883.4.7"
-				},
-				"condition": [
-					"org-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "XON.10 / XON.3"
-					},
-					{
-						"identity": "rim",
-						"map": ".scopes[Role](classCode=IDENT)"
-					},
-					{
-						"identity": "servd",
-						"map": "./Identifiers"
-					},
-					{
-						"identity": "servd",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.active",
-				"path": "Organization.active",
-				"short": "Whether the organization's record is still in active use",
-				"definition": "Whether the organization's record is still in active use.",
-				"comment": "This active flag is not intended to be used to mark an organization as temporarily closed or under construction. Instead the Location(s) within the Organization should have the suspended status. If further details of the reason for the suspension are required, then an extension on this element should be used.\n\nThis element is labeled as a modifier because it may be used to mark that the resource was created in error.",
-				"requirements": "Need a flag to indicate a record is no longer to be used and should generally be hidden for the user in the UI.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Organization.active",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"meaningWhenMissing": "This resource is generally assumed to be active if no value is provided for the active element",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labelled as a modifier because it is a status element that can indicate that a record should not be treated as valid",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "v2",
-						"map": "No equivalent in HL7 v2"
-					},
-					{
-						"identity": "rim",
-						"map": ".status"
-					},
-					{
-						"identity": "servd",
-						"map": "./Status (however this concept in ServD more covers why the organization is active or not, could be delisted, deregistered, not operational yet) this could alternatively be derived from ./StartDate and ./EndDate and given a context date."
-					}
-				]
-			},
-			{
-				"id": "Organization.type",
-				"path": "Organization.type",
-				"short": "Kind of organization",
-				"definition": "The kind(s) of organization that this is.",
-				"comment": "Organizations can be corporations, wards, sections, clinical teams, government departments, etc. Note that code is generally a classifier of the type of organization; in many applications, codes are used to identity a particular organization (say, ward) as opposed to another of the same type - these are identifiers, not codes\n\nWhen considering if multiple types are appropriate, you should evaluate if child organizations would be a more appropriate use of the concept, as different types likely are in different sub-areas of the organization. This is most likely to be used where type values have orthogonal values, such as a religious, academic and medical center.\n\nWe expect that some jurisdictions will profile this optionality to be a single cardinality.",
-				"requirements": "Need to be able to track the kind of organization that this is - different organization types have different uses.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Organization.type",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "OrganizationType"
-						}
-					],
-					"strength": "example",
-					"description": "Used to categorize the organization.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/organization-type"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "v2",
-						"map": "No equivalent in v2"
-					},
-					{
-						"identity": "rim",
-						"map": ".code"
-					},
-					{
-						"identity": "servd",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.name",
-				"path": "Organization.name",
-				"short": "Name used for the organization",
-				"definition": "A name associated with the organization.",
-				"comment": "If the name of an organization changes, consider putting the old name in the alias column so that it can still be located through searches.",
-				"requirements": "Need to use the name as the label of the organization.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Organization.name",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"condition": [
-					"org-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XON.1"
-					},
-					{
-						"identity": "rim",
-						"map": ".name"
-					},
-					{
-						"identity": "servd",
-						"map": ".PreferredName/Name"
-					},
-					{
-						"identity": "servd",
-						"map": "./PrimaryAddress and ./OtherAddresses"
-					}
-				]
-			},
-			{
-				"id": "Organization.alias",
-				"path": "Organization.alias",
-				"short": "A list of alternate names that the organization is known as, or was known as in the past",
-				"definition": "A list of alternate names that the organization is known as, or was known as in the past.",
-				"comment": "There are no dates associated with the alias/historic names, as this is not intended to track when names were used, but to assist in searching so that older names can still result in identifying the organization.",
-				"requirements": "Over time locations and organizations go through many changes and can be known by different names.\n\nFor searching knowing previous names that the organization was known by can be very useful.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Organization.alias",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".name"
-					}
-				]
-			},
-			{
-				"id": "Organization.telecom",
-				"path": "Organization.telecom",
-				"short": "A contact detail for the organization",
-				"definition": "A contact detail for the organization.",
-				"comment": "The use code 'home' is not to be used. Note that these contacts are not the contact details of people who are employed by or represent the organization, but official contacts for the organization itself.",
-				"requirements": "Human contact for the organization.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Organization.telecom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "ContactPoint"
-					}
-				],
-				"condition": [
-					"org-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "org-3",
-						"severity": "error",
-						"human": "The telecom of an organization can never be of use 'home'",
-						"expression": "where(use = 'home').empty()",
-						"xpath": "count(f:use[@value='home']) = 0",
-						"source": "http://hl7.org/fhir/StructureDefinition/Organization"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "ORC-22?"
-					},
-					{
-						"identity": "rim",
-						"map": ".telecom"
-					},
-					{
-						"identity": "servd",
-						"map": "./ContactPoints"
-					}
-				]
-			},
-			{
-				"id": "Organization.address",
-				"path": "Organization.address",
-				"short": "An address for the organization",
-				"definition": "An address for the organization.",
-				"comment": "Organization may have multiple addresses with different uses or applicable periods. The use code 'home' is not to be used.",
-				"requirements": "May need to keep track of the organization's addresses for contacting, billing or reporting requirements.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Organization.address",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Address"
-					}
-				],
-				"condition": [
-					"org-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "org-2",
-						"severity": "error",
-						"human": "An address of an organization can never be of use 'home'",
-						"expression": "where(use = 'home').empty()",
-						"xpath": "count(f:use[@value='home']) = 0",
-						"source": "http://hl7.org/fhir/StructureDefinition/Organization"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "ORC-23?"
-					},
-					{
-						"identity": "rim",
-						"map": ".address"
-					},
-					{
-						"identity": "servd",
-						"map": "./PrimaryAddress and ./OtherAddresses"
-					},
-					{
-						"identity": "servd",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.address.id",
-				"path": "Organization.address.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.address.extension",
-				"path": "Organization.address.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.address.use",
-				"path": "Organization.address.use",
-				"short": "home | work | temp | old | billing - purpose of this address",
-				"definition": "The purpose of this address.",
-				"comment": "Applications can assume that an address is current unless it explicitly says that it is temporary or old.",
-				"requirements": "Allows an appropriate address to be chosen from a list of many.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.use",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueCode": "home"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old address etc.for a current/permanent one",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AddressUse"
-						}
-					],
-					"strength": "required",
-					"description": "The use of an address.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/address-use|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.7"
-					},
-					{
-						"identity": "rim",
-						"map": "unique(./use)"
-					},
-					{
-						"identity": "servd",
-						"map": "./AddressPurpose"
-					}
-				]
-			},
-			{
-				"id": "Organization.address.type",
-				"path": "Organization.address.type",
-				"short": "postal | physical | both",
-				"definition": "Distinguishes between physical addresses (those you can visit) and mailing addresses (e.g. PO Boxes and care-of addresses). Most addresses are both.",
-				"comment": "The definition of Address states that \"address is intended to describe postal addresses, not physical locations\". However, many applications track whether an address has a dual purpose of being a location that can be visited as well as being a valid delivery destination, and Postal addresses are often used as proxies for physical locations (also see the [Location](http://hl7.org/fhir/R4/location.html#) resource).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueCode": "both"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AddressType"
-						}
-					],
-					"strength": "required",
-					"description": "The type of an address (physical / postal).",
-					"valueSet": "http://hl7.org/fhir/ValueSet/address-type|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.18"
-					},
-					{
-						"identity": "rim",
-						"map": "unique(./use)"
-					},
-					{
-						"identity": "vcard",
-						"map": "address type parameter"
-					}
-				]
-			},
-			{
-				"id": "Organization.address.text",
-				"path": "Organization.address.text",
-				"short": "Text representation of the address",
-				"definition": "Specifies the entire address as it should be displayed e.g. on a postal label. This may be provided instead of or as well as the specific parts.",
-				"comment": "Can provide both a text representation and parts. Applications updating an address SHALL ensure that  when both text and parts are present,  no content is included in the text that isn't found in a part.",
-				"requirements": "A renderable, unencoded form.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "137 Nowhere Street, Erewhon 9132"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.1 + XAD.2 + XAD.3 + XAD.4 + XAD.5 + XAD.6"
-					},
-					{
-						"identity": "rim",
-						"map": "./formatted"
-					},
-					{
-						"identity": "vcard",
-						"map": "address label parameter"
-					}
-				]
-			},
-			{
-				"id": "Organization.address.line",
-				"path": "Organization.address.line",
-				"short": "Street name, number, direction & P.O. Box etc.",
-				"definition": "This component contains the house number, apartment number, street name, street direction,  P.O. Box number, delivery hints, and similar address information.",
-				"min": 0,
-				"max": "4",
-				"base": {
-					"path": "Address.line",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"orderMeaning": "The order in which lines should appear in an address label",
-				"example": [
-					{
-						"label": "General",
-						"valueString": "137 Nowhere Street"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.1 + XAD.2 (note: XAD.1 and XAD.2 have different meanings for a company address than for a person address)"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = AL]"
-					},
-					{
-						"identity": "vcard",
-						"map": "street"
-					},
-					{
-						"identity": "servd",
-						"map": "./StreetAddress (newline delimitted)"
-					}
-				]
-			},
-			{
-				"id": "Organization.address.city",
-				"path": "Organization.address.city",
-				"short": "Name of city, town etc.",
-				"definition": "The name of the city, town, suburb, village or other community or delivery center.",
-				"alias": [
-					"Municpality"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.city",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "Erewhon"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.3"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = CTY]"
-					},
-					{
-						"identity": "vcard",
-						"map": "locality"
-					},
-					{
-						"identity": "servd",
-						"map": "./Jurisdiction"
-					}
-				]
-			},
-			{
-				"id": "Organization.address.district",
-				"path": "Organization.address.district",
-				"short": "District name (aka county)",
-				"definition": "The name of the administrative area (county).",
-				"comment": "District is sometimes known as county, but in some regions 'county' is used in place of city (municipality), so county name should be conveyed in city instead.",
-				"alias": [
-					"County"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.district",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "Madison"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.9"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = CNT | CPA]"
-					}
-				]
-			},
-			{
-				"id": "Organization.address.state",
-				"path": "Organization.address.state",
-				"short": "Sub-unit of country (abbreviations ok)",
-				"definition": "Sub-unit of a country with limited sovereignty in a federally organized country. A code may be used if codes are in common use (e.g. US 2 letter state codes).",
-				"alias": [
-					"Province",
-					"Territory"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.state",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Two letter USPS alphabetic codes.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.4"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = STA]"
-					},
-					{
-						"identity": "vcard",
-						"map": "region"
-					},
-					{
-						"identity": "servd",
-						"map": "./Region"
-					},
-					{
-						"identity": "servd",
-						"map": "./Sites"
-					}
-				]
-			},
-			{
-				"id": "Organization.address.postalCode",
-				"path": "Organization.address.postalCode",
-				"short": "US Zip Codes",
-				"definition": "A postal code designating a region defined by the postal service.",
-				"alias": [
-					"Zip"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.postalCode",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "9132"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.5"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = ZIP]"
-					},
-					{
-						"identity": "vcard",
-						"map": "code"
-					},
-					{
-						"identity": "servd",
-						"map": "./PostalIdentificationCode"
-					}
-				]
-			},
-			{
-				"id": "Organization.address.country",
-				"path": "Organization.address.country",
-				"short": "Country (e.g. can be ISO 3166 2 or 3 letter code)",
-				"definition": "Country - a nation as commonly understood or generally accepted.",
-				"comment": "ISO 3166 3 letter codes can be used in place of a human readable country name.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.country",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.6"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = CNT]"
-					},
-					{
-						"identity": "vcard",
-						"map": "country"
-					},
-					{
-						"identity": "servd",
-						"map": "./Country"
-					}
-				]
-			},
-			{
-				"id": "Organization.address.period",
-				"path": "Organization.address.period",
-				"short": "Time period when address was/is in use",
-				"definition": "Time period when address was/is in use.",
-				"requirements": "Allows addresses to be placed in historical context.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valuePeriod": {
-							"start": "2010-03-23",
-							"end": "2010-07-01"
-						}
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.12 / XAD.13 + XAD.14"
-					},
-					{
-						"identity": "rim",
-						"map": "./usablePeriod[type=\"IVL<TS>\"]"
-					},
-					{
-						"identity": "servd",
-						"map": "./StartDate and ./EndDate"
-					}
-				]
-			},
-			{
-				"id": "Organization.partOf",
-				"path": "Organization.partOf",
-				"short": "The organization of which this organization forms a part",
-				"definition": "The organization of which this organization forms a part.",
-				"requirements": "Need to be able to track the hierarchy of organizations within an organization.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Organization.partOf",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-hierarchy",
-								"valueBoolean": true
-							}
-						],
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "No equivalent in HL7 v2"
-					},
-					{
-						"identity": "rim",
-						"map": ".playedBy[classCode=Part].scoper"
-					},
-					{
-						"identity": "servd",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.contact",
-				"path": "Organization.contact",
-				"short": "Contact for the organization for a certain purpose",
-				"definition": "Contact for the organization for a certain purpose.",
-				"comment": "Where multiple contacts for the same purpose are provided there is a standard extension that can be used to determine which one is the preferred contact to use.",
-				"requirements": "Need to keep track of assigned contact points within bigger organization.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Organization.contact",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".contactParty"
-					}
-				]
-			},
-			{
-				"id": "Organization.contact.id",
-				"path": "Organization.contact.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.contact.extension",
-				"path": "Organization.contact.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.contact.modifierExtension",
-				"path": "Organization.contact.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Organization.contact.purpose",
-				"path": "Organization.contact.purpose",
-				"short": "The type of contact",
-				"definition": "Indicates a purpose for which the contact can be reached.",
-				"requirements": "Need to distinguish between multiple contact persons.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Organization.contact.purpose",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ContactPartyType"
-						}
-					],
-					"strength": "extensible",
-					"description": "The purpose for which you would contact a contact party.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/contactentity-type"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "./type"
-					}
-				]
-			},
-			{
-				"id": "Organization.contact.name",
-				"path": "Organization.contact.name",
-				"short": "A name associated with the contact",
-				"definition": "A name associated with the contact.",
-				"requirements": "Need to be able to track the person by name.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Organization.contact.name",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "HumanName"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PID-5, PID-9"
-					},
-					{
-						"identity": "rim",
-						"map": "./name"
-					}
-				]
-			},
-			{
-				"id": "Organization.contact.telecom",
-				"path": "Organization.contact.telecom",
-				"short": "Contact details (telephone, email, etc.)  for a contact",
-				"definition": "A contact detail (e.g. a telephone number or an email address) by which the party may be contacted.",
-				"requirements": "People have (primary) ways to contact them in some way such as phone, email.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Organization.contact.telecom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "ContactPoint"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PID-13, PID-14"
-					},
-					{
-						"identity": "rim",
-						"map": "./telecom"
-					}
-				]
-			},
-			{
-				"id": "Organization.contact.address",
-				"path": "Organization.contact.address",
-				"short": "Visiting or postal addresses for the contact",
-				"definition": "Visiting or postal addresses for the contact.",
-				"requirements": "May need to keep track of a contact party's address for contacting, billing or reporting requirements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Organization.contact.address",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Address"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PID-11"
-					},
-					{
-						"identity": "rim",
-						"map": "./addr"
-					}
-				]
-			},
-			{
-				"id": "Organization.endpoint",
-				"path": "Organization.endpoint",
-				"short": "Technical endpoints providing access to services operated for the organization",
-				"definition": "Technical endpoints providing access to services operated for the organization.",
-				"requirements": "Organizations have multiple systems that provide various services and need to be able to define the technical connection details for how to connect to them, and for what purpose.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Organization.endpoint",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Endpoint"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Organization",
-				"path": "Organization",
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "servd",
-						"map": "Organization"
-					}
-				]
-			},
-			{
-				"id": "Organization.identifier",
-				"path": "Organization.identifier",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "$this"
-						}
-					],
-					"rules": "open"
-				},
-				"comment": "NPI preferred.",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "servd",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.identifier.system",
-				"path": "Organization.identifier.system",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Organization.identifier.value",
-				"path": "Organization.identifier.value",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Organization.identifier:NPI",
-				"path": "Organization.identifier",
-				"sliceName": "NPI",
-				"short": "National Provider Identifier (NPI)",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"patternIdentifier": {
-					"system": "http://hl7.org/fhir/sid/us-npi"
-				},
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "servd",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.identifier:CLIA",
-				"path": "Organization.identifier",
-				"sliceName": "CLIA",
-				"short": "Clinical Laboratory Improvement Amendments (CLIA) Number for laboratories",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"patternIdentifier": {
-					"system": "urn:oid:2.16.840.1.113883.4.7"
-				},
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "servd",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.active",
-				"path": "Organization.active",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Organization.name",
-				"path": "Organization.name",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "servd",
-						"map": "./PrimaryAddress and ./OtherAddresses"
-					}
-				]
-			},
-			{
-				"id": "Organization.telecom",
-				"path": "Organization.telecom",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "ContactPoint"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Organization.address",
-				"path": "Organization.address",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "Address"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "servd",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.address.line",
-				"path": "Organization.address.line",
-				"min": 0,
-				"max": "4",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Organization.address.city",
-				"path": "Organization.address.city",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Organization.address.state",
-				"path": "Organization.address.state",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Two letter USPS alphabetic codes.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "servd",
-						"map": "./Sites"
-					}
-				]
-			},
-			{
-				"id": "Organization.address.postalCode",
-				"path": "Organization.address.postalCode",
-				"short": "US Zip Codes",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Organization.address.country",
-				"path": "Organization.address.country",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-organization",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
+    "version": "3.1.1",
+    "name": "USCoreOrganizationProfile",
+    "title": "US Core Organization Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-06-29",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.healthit.gov"
+                }
+            ]
+        }
+    ],
+    "description": "Defines basic constraints and extensions on the Organization resource for use with other US Core resources",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "servd",
+            "uri": "http://www.omg.org/spec/ServD/1.0/",
+            "name": "ServD"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Organization",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Organization",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Organization",
+                "path": "Organization",
+                "short": "A grouping of people or organizations with a common purpose",
+                "definition": "A formally or informally recognized grouping of people or organizations formed for the purpose of achieving some form of collective action.  Includes companies, institutions, corporations, departments, community groups, healthcare practice groups, payer/insurer, etc.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Organization",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "org-1",
+                        "severity": "error",
+                        "human": "The organization SHALL at least have a name or an identifier, and possibly more than one",
+                        "expression": "(identifier.count() + name.count()) > 0",
+                        "xpath": "count(f:identifier | f:name) > 0",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Organization"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "(also see master files messages)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Organization(classCode=ORG, determinerCode=INST)"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "Organization"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.id",
+                "path": "Organization.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Organization.meta",
+                "path": "Organization.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Organization.implicitRules",
+                "path": "Organization.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Organization.language",
+                "path": "Organization.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Organization.text",
+                "path": "Organization.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.contained",
+                "path": "Organization.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.extension",
+                "path": "Organization.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.modifierExtension",
+                "path": "Organization.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.identifier",
+                "path": "Organization.identifier",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "$this"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "short": "Identifies this organization  across multiple systems",
+                "definition": "Identifier for the organization that is used to identify the organization across multiple disparate systems.",
+                "comment": "NPI preferred.",
+                "requirements": "Organizations are known by a variety of ids. Some institutions maintain several, and most collect identifiers for exchange with other organizations concerning the organization.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Organization.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "condition": [
+                    "org-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "XON.10 / XON.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".scopes[Role](classCode=IDENT)"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Identifiers"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.identifier.id",
+                "path": "Organization.identifier.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.identifier.extension",
+                "path": "Organization.identifier.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.identifier.use",
+                "path": "Organization.identifier.use",
+                "short": "usual | official | temp | secondary | old (If known)",
+                "definition": "The purpose of this identifier.",
+                "comment": "Applications can assume that an identifier is permanent unless it explicitly says that it is temporary.",
+                "requirements": "Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.use",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary id for a permanent one.",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "IdentifierUse"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Identifies the purpose for this identifier, if known .",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/identifier-use|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Role.code or implied by context"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.identifier.type",
+                "path": "Organization.identifier.type",
+                "short": "Description of identifier",
+                "definition": "A coded type for the identifier that can be used to determine which identifier to use for a specific purpose.",
+                "comment": "This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage.   Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type.",
+                "requirements": "Allows users to make use of identifiers when the identifier system is not known.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "IdentifierType"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "A coded type for an identifier that can be used to determine which identifier to use for a specific purpose.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/identifier-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Role.code or implied by context"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.identifier.system",
+                "path": "Organization.identifier.system",
+                "short": "The namespace for the identifier value",
+                "definition": "Establishes the namespace for the value - that is, a URL that describes a set values that are unique.",
+                "comment": "Identifier.system is always case sensitive.",
+                "requirements": "There are many sets  of identifiers.  To perform matching of two identifiers, we need to know what set we're dealing with. The system identifies a particular set of unique identifiers.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueUri": "http://www.acme.com/identifiers/patient"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.4 / EI-2-4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "II.root or Role.id.root"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./IdentifierType"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.identifier.value",
+                "path": "Organization.identifier.value",
+                "short": "The value that is unique",
+                "definition": "The portion of the identifier typically relevant to the user and which is unique within the context of the system.",
+                "comment": "If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986.  The value's primary purpose is computational mapping.  As a result, it may be normalized for comparison purposes (e.g. removing non-significant whitespace, dashes, etc.)  A value formatted for human display can be conveyed using the [Rendered Value extension](http://hl7.org/fhir/R4/extension-rendered-value.html). Identifier.value is to be treated as case sensitive unless knowledge of the Identifier.system allows the processer to be confident that non-case-sensitive processing is safe.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "123456"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.1 / EI.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Value"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.identifier.period",
+                "path": "Organization.identifier.period",
+                "short": "Time period when id is/was valid for use",
+                "definition": "Time period during which identifier is/was valid for use.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.7 + CX.8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Role.effectiveTime or implied by context"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./StartDate and ./EndDate"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.identifier.assigner",
+                "path": "Organization.identifier.assigner",
+                "short": "Organization that issued id (may be just text)",
+                "definition": "Organization that issued/manages the identifier.",
+                "comment": "The Identifier.assigner may omit the .reference element and only contain a .display element reflecting the name or other textual information about the assigning organization.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.assigner",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.4 / (CX.4,CX.9,CX.10)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./IdentifierIssuingAuthority"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.identifier:NPI",
+                "path": "Organization.identifier",
+                "sliceName": "NPI",
+                "short": "National Provider Identifier (NPI)",
+                "definition": "Identifier for the organization that is used to identify the organization across multiple disparate systems.",
+                "requirements": "Organizations are known by a variety of ids. Some institutions maintain several, and most collect identifiers for exchange with other organizations concerning the organization.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Organization.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "patternIdentifier": {
+                    "system": "http://hl7.org/fhir/sid/us-npi"
+                },
+                "condition": [
+                    "org-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "XON.10 / XON.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".scopes[Role](classCode=IDENT)"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Identifiers"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.identifier:CLIA",
+                "path": "Organization.identifier",
+                "sliceName": "CLIA",
+                "short": "Clinical Laboratory Improvement Amendments (CLIA) Number for laboratories",
+                "definition": "Identifier for the organization that is used to identify the organization across multiple disparate systems.",
+                "requirements": "Organizations are known by a variety of ids. Some institutions maintain several, and most collect identifiers for exchange with other organizations concerning the organization.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Organization.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "patternIdentifier": {
+                    "system": "urn:oid:2.16.840.1.113883.4.7"
+                },
+                "condition": [
+                    "org-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "XON.10 / XON.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".scopes[Role](classCode=IDENT)"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Identifiers"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.active",
+                "path": "Organization.active",
+                "short": "Whether the organization's record is still in active use",
+                "definition": "Whether the organization's record is still in active use.",
+                "comment": "This active flag is not intended to be used to mark an organization as temporarily closed or under construction. Instead the Location(s) within the Organization should have the suspended status. If further details of the reason for the suspension are required, then an extension on this element should be used.\n\nThis element is labeled as a modifier because it may be used to mark that the resource was created in error.",
+                "requirements": "Need a flag to indicate a record is no longer to be used and should generally be hidden for the user in the UI.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Organization.active",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "meaningWhenMissing": "This resource is generally assumed to be active if no value is provided for the active element",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labelled as a modifier because it is a status element that can indicate that a record should not be treated as valid",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "No equivalent in HL7 v2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".status"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Status (however this concept in ServD more covers why the organization is active or not, could be delisted, deregistered, not operational yet) this could alternatively be derived from ./StartDate and ./EndDate and given a context date."
+                    }
+                ]
+            },
+            {
+                "id": "Organization.type",
+                "path": "Organization.type",
+                "short": "Kind of organization",
+                "definition": "The kind(s) of organization that this is.",
+                "comment": "Organizations can be corporations, wards, sections, clinical teams, government departments, etc. Note that code is generally a classifier of the type of organization; in many applications, codes are used to identity a particular organization (say, ward) as opposed to another of the same type - these are identifiers, not codes\n\nWhen considering if multiple types are appropriate, you should evaluate if child organizations would be a more appropriate use of the concept, as different types likely are in different sub-areas of the organization. This is most likely to be used where type values have orthogonal values, such as a religious, academic and medical center.\n\nWe expect that some jurisdictions will profile this optionality to be a single cardinality.",
+                "requirements": "Need to be able to track the kind of organization that this is - different organization types have different uses.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Organization.type",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "OrganizationType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Used to categorize the organization.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/organization-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "No equivalent in v2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".code"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.name",
+                "path": "Organization.name",
+                "short": "Name used for the organization",
+                "definition": "A name associated with the organization.",
+                "comment": "If the name of an organization changes, consider putting the old name in the alias column so that it can still be located through searches.",
+                "requirements": "Need to use the name as the label of the organization.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Organization.name",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "condition": [
+                    "org-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XON.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".name"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": ".PreferredName/Name"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./PrimaryAddress and ./OtherAddresses"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.alias",
+                "path": "Organization.alias",
+                "short": "A list of alternate names that the organization is known as, or was known as in the past",
+                "definition": "A list of alternate names that the organization is known as, or was known as in the past.",
+                "comment": "There are no dates associated with the alias/historic names, as this is not intended to track when names were used, but to assist in searching so that older names can still result in identifying the organization.",
+                "requirements": "Over time locations and organizations go through many changes and can be known by different names.\n\nFor searching knowing previous names that the organization was known by can be very useful.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Organization.alias",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".name"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.telecom",
+                "path": "Organization.telecom",
+                "short": "A contact detail for the organization",
+                "definition": "A contact detail for the organization.",
+                "comment": "The use code 'home' is not to be used. Note that these contacts are not the contact details of people who are employed by or represent the organization, but official contacts for the organization itself.",
+                "requirements": "Human contact for the organization.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Organization.telecom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "ContactPoint"
+                    }
+                ],
+                "condition": [
+                    "org-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "org-3",
+                        "severity": "error",
+                        "human": "The telecom of an organization can never be of use 'home'",
+                        "expression": "where(use = 'home').empty()",
+                        "xpath": "count(f:use[@value='home']) = 0",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Organization"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "ORC-22?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".telecom"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./ContactPoints"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.address",
+                "path": "Organization.address",
+                "short": "An address for the organization",
+                "definition": "An address for the organization.",
+                "comment": "Organization may have multiple addresses with different uses or applicable periods. The use code 'home' is not to be used.",
+                "requirements": "May need to keep track of the organization's addresses for contacting, billing or reporting requirements.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Organization.address",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Address"
+                    }
+                ],
+                "condition": [
+                    "org-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "org-2",
+                        "severity": "error",
+                        "human": "An address of an organization can never be of use 'home'",
+                        "expression": "where(use = 'home').empty()",
+                        "xpath": "count(f:use[@value='home']) = 0",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Organization"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "ORC-23?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".address"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./PrimaryAddress and ./OtherAddresses"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.address.id",
+                "path": "Organization.address.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.address.extension",
+                "path": "Organization.address.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.address.use",
+                "path": "Organization.address.use",
+                "short": "home | work | temp | old | billing - purpose of this address",
+                "definition": "The purpose of this address.",
+                "comment": "Applications can assume that an address is current unless it explicitly says that it is temporary or old.",
+                "requirements": "Allows an appropriate address to be chosen from a list of many.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.use",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueCode": "home"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old address etc.for a current/permanent one",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AddressUse"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The use of an address.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/address-use|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "unique(./use)"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./AddressPurpose"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.address.type",
+                "path": "Organization.address.type",
+                "short": "postal | physical | both",
+                "definition": "Distinguishes between physical addresses (those you can visit) and mailing addresses (e.g. PO Boxes and care-of addresses). Most addresses are both.",
+                "comment": "The definition of Address states that \"address is intended to describe postal addresses, not physical locations\". However, many applications track whether an address has a dual purpose of being a location that can be visited as well as being a valid delivery destination, and Postal addresses are often used as proxies for physical locations (also see the [Location](http://hl7.org/fhir/R4/location.html#) resource).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueCode": "both"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AddressType"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The type of an address (physical / postal).",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/address-type|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.18"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "unique(./use)"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "address type parameter"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.address.text",
+                "path": "Organization.address.text",
+                "short": "Text representation of the address",
+                "definition": "Specifies the entire address as it should be displayed e.g. on a postal label. This may be provided instead of or as well as the specific parts.",
+                "comment": "Can provide both a text representation and parts. Applications updating an address SHALL ensure that  when both text and parts are present,  no content is included in the text that isn't found in a part.",
+                "requirements": "A renderable, unencoded form.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "137 Nowhere Street, Erewhon 9132"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.1 + XAD.2 + XAD.3 + XAD.4 + XAD.5 + XAD.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./formatted"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "address label parameter"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.address.line",
+                "path": "Organization.address.line",
+                "short": "Street name, number, direction & P.O. Box etc.",
+                "definition": "This component contains the house number, apartment number, street name, street direction,  P.O. Box number, delivery hints, and similar address information.",
+                "min": 0,
+                "max": "4",
+                "base": {
+                    "path": "Address.line",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "orderMeaning": "The order in which lines should appear in an address label",
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "137 Nowhere Street"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.1 + XAD.2 (note: XAD.1 and XAD.2 have different meanings for a company address than for a person address)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = AL]"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "street"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./StreetAddress (newline delimitted)"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.address.city",
+                "path": "Organization.address.city",
+                "short": "Name of city, town etc.",
+                "definition": "The name of the city, town, suburb, village or other community or delivery center.",
+                "alias": [
+                    "Municpality"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.city",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "Erewhon"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = CTY]"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "locality"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Jurisdiction"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.address.district",
+                "path": "Organization.address.district",
+                "short": "District name (aka county)",
+                "definition": "The name of the administrative area (county).",
+                "comment": "District is sometimes known as county, but in some regions 'county' is used in place of city (municipality), so county name should be conveyed in city instead.",
+                "alias": [
+                    "County"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.district",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "Madison"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.9"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = CNT | CPA]"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.address.state",
+                "path": "Organization.address.state",
+                "short": "Sub-unit of country (abbreviations ok)",
+                "definition": "Sub-unit of a country with limited sovereignty in a federally organized country. A code may be used if codes are in common use (e.g. US 2 letter state codes).",
+                "alias": [
+                    "Province",
+                    "Territory"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.state",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Two letter USPS alphabetic codes.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = STA]"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "region"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Region"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Sites"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.address.postalCode",
+                "path": "Organization.address.postalCode",
+                "short": "US Zip Codes",
+                "definition": "A postal code designating a region defined by the postal service.",
+                "alias": [
+                    "Zip"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.postalCode",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "9132"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = ZIP]"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "code"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./PostalIdentificationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.address.country",
+                "path": "Organization.address.country",
+                "short": "Country (e.g. can be ISO 3166 2 or 3 letter code)",
+                "definition": "Country - a nation as commonly understood or generally accepted.",
+                "comment": "ISO 3166 3 letter codes can be used in place of a human readable country name.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.country",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = CNT]"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "country"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Country"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.address.period",
+                "path": "Organization.address.period",
+                "short": "Time period when address was/is in use",
+                "definition": "Time period when address was/is in use.",
+                "requirements": "Allows addresses to be placed in historical context.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valuePeriod": {
+                            "start": "2010-03-23",
+                            "end": "2010-07-01"
+                        }
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.12 / XAD.13 + XAD.14"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./usablePeriod[type=\"IVL<TS>\"]"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./StartDate and ./EndDate"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.partOf",
+                "path": "Organization.partOf",
+                "short": "The organization of which this organization forms a part",
+                "definition": "The organization of which this organization forms a part.",
+                "requirements": "Need to be able to track the hierarchy of organizations within an organization.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Organization.partOf",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-hierarchy",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "No equivalent in HL7 v2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".playedBy[classCode=Part].scoper"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.contact",
+                "path": "Organization.contact",
+                "short": "Contact for the organization for a certain purpose",
+                "definition": "Contact for the organization for a certain purpose.",
+                "comment": "Where multiple contacts for the same purpose are provided there is a standard extension that can be used to determine which one is the preferred contact to use.",
+                "requirements": "Need to keep track of assigned contact points within bigger organization.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Organization.contact",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".contactParty"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.contact.id",
+                "path": "Organization.contact.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.contact.extension",
+                "path": "Organization.contact.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.contact.modifierExtension",
+                "path": "Organization.contact.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.contact.purpose",
+                "path": "Organization.contact.purpose",
+                "short": "The type of contact",
+                "definition": "Indicates a purpose for which the contact can be reached.",
+                "requirements": "Need to distinguish between multiple contact persons.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Organization.contact.purpose",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ContactPartyType"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "The purpose for which you would contact a contact party.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/contactentity-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "./type"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.contact.name",
+                "path": "Organization.contact.name",
+                "short": "A name associated with the contact",
+                "definition": "A name associated with the contact.",
+                "requirements": "Need to be able to track the person by name.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Organization.contact.name",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "HumanName"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PID-5, PID-9"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./name"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.contact.telecom",
+                "path": "Organization.contact.telecom",
+                "short": "Contact details (telephone, email, etc.)  for a contact",
+                "definition": "A contact detail (e.g. a telephone number or an email address) by which the party may be contacted.",
+                "requirements": "People have (primary) ways to contact them in some way such as phone, email.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Organization.contact.telecom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "ContactPoint"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PID-13, PID-14"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./telecom"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.contact.address",
+                "path": "Organization.contact.address",
+                "short": "Visiting or postal addresses for the contact",
+                "definition": "Visiting or postal addresses for the contact.",
+                "requirements": "May need to keep track of a contact party's address for contacting, billing or reporting requirements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Organization.contact.address",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Address"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PID-11"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./addr"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.endpoint",
+                "path": "Organization.endpoint",
+                "short": "Technical endpoints providing access to services operated for the organization",
+                "definition": "Technical endpoints providing access to services operated for the organization.",
+                "requirements": "Organizations have multiple systems that provide various services and need to be able to define the technical connection details for how to connect to them, and for what purpose.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Organization.endpoint",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Endpoint"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Organization",
+                "path": "Organization",
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "servd",
+                        "map": "Organization"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.identifier",
+                "path": "Organization.identifier",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "$this"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "comment": "NPI preferred.",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "servd",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.identifier.system",
+                "path": "Organization.identifier.system",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Organization.identifier.value",
+                "path": "Organization.identifier.value",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Organization.identifier:NPI",
+                "path": "Organization.identifier",
+                "sliceName": "NPI",
+                "short": "National Provider Identifier (NPI)",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "patternIdentifier": {
+                    "system": "http://hl7.org/fhir/sid/us-npi"
+                },
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "servd",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.identifier:CLIA",
+                "path": "Organization.identifier",
+                "sliceName": "CLIA",
+                "short": "Clinical Laboratory Improvement Amendments (CLIA) Number for laboratories",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "patternIdentifier": {
+                    "system": "urn:oid:2.16.840.1.113883.4.7"
+                },
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "servd",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.active",
+                "path": "Organization.active",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Organization.name",
+                "path": "Organization.name",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "servd",
+                        "map": "./PrimaryAddress and ./OtherAddresses"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.telecom",
+                "path": "Organization.telecom",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "ContactPoint"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Organization.address",
+                "path": "Organization.address",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "Address"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "servd",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.address.line",
+                "path": "Organization.address.line",
+                "min": 0,
+                "max": "4",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Organization.address.city",
+                "path": "Organization.address.city",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Organization.address.state",
+                "path": "Organization.address.state",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Two letter USPS alphabetic codes.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "servd",
+                        "map": "./Sites"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.address.postalCode",
+                "path": "Organization.address.postalCode",
+                "short": "US Zip Codes",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Organization.address.country",
+                "path": "Organization.address.country",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-patient.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-patient.json
@@ -1,4720 +1,4720 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-patient",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient\" title=\"The US Core Patient Profile is based upon the core FHIR Patient Resource and designed to meet the applicable patient demographic data elements from the 2015 Edition Common Clinical Data Set.\">Patient</a><a name=\"Patient\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/patient.html\">Patient</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Information about an individual or animal receiving health care services</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck14.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.extension:race\" title=\"Extension URL = http://hl7.org/fhir/us/core/StructureDefinition/us-core-race\">us-core-race</a><a name=\"Patient.extension\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">(Complex)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">US Core Race Extension</span><br/><span style=\"font-weight:bold\">URL: </span><a href=\"http://hl7.org/fhir/R4/StructureDefinition-us-core-race.html\">http://hl7.org/fhir/us/core/StructureDefinition/us-core-race</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck14.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.extension:ethnicity\" title=\"Extension URL = http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity\">us-core-ethnicity</a><a name=\"Patient.extension\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">(Complex)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">US Core ethnicity Extension</span><br/><span style=\"font-weight:bold\">URL: </span><a href=\"http://hl7.org/fhir/R4/StructureDefinition-us-core-ethnicity.html\">http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck14.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.extension:birthsex\" title=\"Extension URL = http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex\">us-core-birthsex</a><a name=\"Patient.extension\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Extension</span><br/><span style=\"font-weight:bold\">URL: </span><a href=\"http://hl7.org/fhir/R4/StructureDefinition-us-core-birthsex.html\">http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex</a><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-birthsex.html\">Birth Sex</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.identifier\">identifier</a><a name=\"Patient.identifier\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Identifier\">Identifier</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">An identifier for this patient</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.identifier.system\">system</a><a name=\"Patient.identifier.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The namespace for the identifier value</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.identifier.value\">value</a><a name=\"Patient.identifier.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">The value that is unique within the system.</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.name\">name</a><a name=\"Patient.name\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-8)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#HumanName\">HumanName</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">A name associated with the patient</span><br/><span style=\"font-weight:bold\">us-core-8: </span>Either Patient.name.given and/or Patient.name.family SHALL be present or a Data Absent Reason Extension SHALL be present.<br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.name.family\">family</a><a name=\"Patient.name.family\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-8)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Family name (often called 'Surname')</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.name.given\">given</a><a name=\"Patient.name.given\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-8)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Given names (not always 'first'). Includes middle names</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.telecom\">telecom</a><a name=\"Patient.telecom\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#ContactPoint\">ContactPoint</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">A contact detail for the individual</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.telecom.system\">system</a><a name=\"Patient.telecom.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">phone | fax | email | pager | url | sms | other</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-contact-point-system.html\">ContactPointSystem</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.telecom.value\">value</a><a name=\"Patient.telecom.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The actual contact point details</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.telecom.use\">use</a><a name=\"Patient.telecom.use\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">home | work | temp | old | mobile - purpose of this contact point</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-contact-point-use.html\">ContactPointUse</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.gender\">gender</a><a name=\"Patient.gender\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">male | female | other | unknown</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-administrative-gender.html\">AdministrativeGender</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.birthDate\">birthDate</a><a name=\"Patient.birthDate\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#date\">date</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The date of birth for the individual</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.address\">address</a><a name=\"Patient.address\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Address\">Address</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">An address for the individual</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.address.line\">line</a><a name=\"Patient.address.line\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Street name, number, direction &amp; P.O. Box etc.</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.address.city\">city</a><a name=\"Patient.address.city\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Name of city, town etc.</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.address.state\">state</a><a name=\"Patient.address.state\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Sub-unit of country (abbreviations ok)</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-usps-state.html\">USPS Two Letter Alphabetic Codes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.address.postalCode\">postalCode</a><a name=\"Patient.address.postalCode\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">US Zip Codes</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.address.period\">period</a><a name=\"Patient.address.period\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Period\">Period</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Time period when address was/is in use</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.communication\">communication</a><a name=\"Patient.communication\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">A language which may be used to communicate with the patient about his or her health</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.communication.language\">language</a><a name=\"Patient.communication.language\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The language which can be used to communicate with the patient about his or her health</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-simple-language.html\">Language codes with language and optionally a region modifier</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)</td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
-	"version": "3.1.1",
-	"name": "USCorePatientProfile",
-	"title": "US Core Patient Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-06-27",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.healthit.gov"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the patient resource for the minimal set of data to query and retrieve patient demographic information.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "cda",
-			"uri": "http://hl7.org/v3/cda",
-			"name": "CDA (R2)"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "loinc",
-			"uri": "http://loinc.org",
-			"name": "LOINC code for the element"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Patient",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Patient",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Patient",
-				"path": "Patient",
-				"short": "Information about an individual or animal receiving health care services",
-				"definition": "The US Core Patient Profile is based upon the core FHIR Patient Resource and designed to meet the applicable patient demographic data elements from the 2015 Edition Common Clinical Data Set.",
-				"alias": [
-					"SubjectOfCare Client Resident"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Patient",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "rim",
-						"map": "Patient[classCode=PAT]"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument.recordTarget.patientRole"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient"
-					}
-				]
-			},
-			{
-				"id": "Patient.id",
-				"path": "Patient.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Patient.meta",
-				"path": "Patient.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Patient.implicitRules",
-				"path": "Patient.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Patient.language",
-				"path": "Patient.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Patient.text",
-				"path": "Patient.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Patient.contained",
-				"path": "Patient.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Patient.extension",
-				"path": "Patient.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"ordered": false,
-					"rules": "open"
-				},
-				"short": "Extension",
-				"definition": "An Extension",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Patient.extension:race",
-				"path": "Patient.extension",
-				"sliceName": "race",
-				"short": "US Core Race Extension",
-				"definition": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\n   - American Indian or Alaska Native\n   - Asian\n   - Black or African American\n   - Native Hawaiian or Other Pacific Islander\n   - White.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension",
-						"profile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-race|3.1.1"
-						]
-					}
-				],
-				"condition": [
-					"ele-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.extension"
-					}
-				]
-			},
-			{
-				"id": "Patient.extension:ethnicity",
-				"path": "Patient.extension",
-				"sliceName": "ethnicity",
-				"short": "US Core ethnicity Extension",
-				"definition": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension",
-						"profile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity|3.1.1"
-						]
-					}
-				],
-				"condition": [
-					"ele-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.extension"
-					}
-				]
-			},
-			{
-				"id": "Patient.extension:birthsex",
-				"path": "Patient.extension",
-				"sliceName": "birthsex",
-				"short": "Extension",
-				"definition": "A code classifying the person's sex assigned at birth  as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc).",
-				"comment": "The codes required are intended to present birth sex (i.e., the sex recorded on the patient’s birth certificate) and not gender identity or reassigned sex.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension",
-						"profile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex|3.1.1"
-						]
-					}
-				],
-				"condition": [
-					"ele-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender"
-					},
-					{
-						"identity": "iso11179",
-						"map": ".patient.administrativeGenderCode"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.extension"
-					}
-				]
-			},
-			{
-				"id": "Patient.modifierExtension",
-				"path": "Patient.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Patient.identifier",
-				"path": "Patient.identifier",
-				"short": "An identifier for this patient",
-				"definition": "An identifier for this patient.",
-				"requirements": "Patients are almost always assigned specific numerical identifiers.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Patient.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": "id"
-					},
-					{
-						"identity": "cda",
-						"map": ".id"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.identifier"
-					}
-				]
-			},
-			{
-				"id": "Patient.identifier.id",
-				"path": "Patient.identifier.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.identifier.extension",
-				"path": "Patient.identifier.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.identifier.use",
-				"path": "Patient.identifier.use",
-				"short": "usual | official | temp | secondary | old (If known)",
-				"definition": "The purpose of this identifier.",
-				"comment": "Applications can assume that an identifier is permanent unless it explicitly says that it is temporary.",
-				"requirements": "Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.use",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary id for a permanent one.",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "IdentifierUse"
-						}
-					],
-					"strength": "required",
-					"description": "Identifies the purpose for this identifier, if known .",
-					"valueSet": "http://hl7.org/fhir/ValueSet/identifier-use|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "Role.code or implied by context"
-					}
-				]
-			},
-			{
-				"id": "Patient.identifier.type",
-				"path": "Patient.identifier.type",
-				"short": "Description of identifier",
-				"definition": "A coded type for the identifier that can be used to determine which identifier to use for a specific purpose.",
-				"comment": "This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage.   Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type.",
-				"requirements": "Allows users to make use of identifiers when the identifier system is not known.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "IdentifierType"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "extensible",
-					"description": "A coded type for an identifier that can be used to determine which identifier to use for a specific purpose.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/identifier-type"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.5"
-					},
-					{
-						"identity": "rim",
-						"map": "Role.code or implied by context"
-					}
-				]
-			},
-			{
-				"id": "Patient.identifier.system",
-				"path": "Patient.identifier.system",
-				"short": "The namespace for the identifier value",
-				"definition": "Establishes the namespace for the value - that is, a URL that describes a set values that are unique.",
-				"comment": "Identifier.system is always case sensitive.",
-				"requirements": "There are many sets  of identifiers.  To perform matching of two identifiers, we need to know what set we're dealing with. The system identifies a particular set of unique identifiers.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Identifier.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueUri": "http://www.acme.com/identifiers/patient"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.4 / EI-2-4"
-					},
-					{
-						"identity": "rim",
-						"map": "II.root or Role.id.root"
-					},
-					{
-						"identity": "servd",
-						"map": "./IdentifierType"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.identifier.system"
-					}
-				]
-			},
-			{
-				"id": "Patient.identifier.value",
-				"path": "Patient.identifier.value",
-				"short": "The value that is unique within the system.",
-				"definition": "The portion of the identifier typically relevant to the user and which is unique within the context of the system.",
-				"comment": "If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986.  The value's primary purpose is computational mapping.  As a result, it may be normalized for comparison purposes (e.g. removing non-significant whitespace, dashes, etc.)  A value formatted for human display can be conveyed using the [Rendered Value extension](http://hl7.org/fhir/R4/extension-rendered-value.html). Identifier.value is to be treated as case sensitive unless knowledge of the Identifier.system allows the processer to be confident that non-case-sensitive processing is safe.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Identifier.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "123456"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.1 / EI.1"
-					},
-					{
-						"identity": "rim",
-						"map": "II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)"
-					},
-					{
-						"identity": "servd",
-						"map": "./Value"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.identifier.value"
-					}
-				]
-			},
-			{
-				"id": "Patient.identifier.period",
-				"path": "Patient.identifier.period",
-				"short": "Time period when id is/was valid for use",
-				"definition": "Time period during which identifier is/was valid for use.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.7 + CX.8"
-					},
-					{
-						"identity": "rim",
-						"map": "Role.effectiveTime or implied by context"
-					},
-					{
-						"identity": "servd",
-						"map": "./StartDate and ./EndDate"
-					}
-				]
-			},
-			{
-				"id": "Patient.identifier.assigner",
-				"path": "Patient.identifier.assigner",
-				"short": "Organization that issued id (may be just text)",
-				"definition": "Organization that issued/manages the identifier.",
-				"comment": "The Identifier.assigner may omit the .reference element and only contain a .display element reflecting the name or other textual information about the assigning organization.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.assigner",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.4 / (CX.4,CX.9,CX.10)"
-					},
-					{
-						"identity": "rim",
-						"map": "II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper"
-					},
-					{
-						"identity": "servd",
-						"map": "./IdentifierIssuingAuthority"
-					}
-				]
-			},
-			{
-				"id": "Patient.active",
-				"path": "Patient.active",
-				"short": "Whether this patient's record is in active use",
-				"definition": "Whether this patient record is in active use. \nMany systems use this property to mark as non-current patients, such as those that have not been seen for a period of time based on an organization's business rules.\n\nIt is often used to filter patient lists to exclude inactive patients\n\nDeceased patients may also be marked as inactive for the same reasons, but may be active for some time after death.",
-				"comment": "If a record is inactive, and linked to an active record, then future patient/record updates should occur on the other patient.",
-				"requirements": "Need to be able to mark a patient record as not to be used because it was created in error.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Patient.active",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"meaningWhenMissing": "This resource is generally assumed to be active if no value is provided for the active element",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labelled as a modifier because it is a status element that can indicate that a record should not be treated as valid",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "rim",
-						"map": "statusCode"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.name",
-				"path": "Patient.name",
-				"short": "A name associated with the patient",
-				"definition": "A name associated with the individual.",
-				"comment": "A patient may have multiple names with different uses or applicable periods. For animals, the name is a \"HumanName\" in the sense that is assigned and used by humans and has the same patterns.",
-				"requirements": "Need to be able to track the patient by multiple names. Examples are your official name and a partner name.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Patient.name",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "HumanName"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "us-core-8",
-						"severity": "error",
-						"human": "Either Patient.name.given and/or Patient.name.family SHALL be present or a Data Absent Reason Extension SHALL be present.",
-						"expression": "(family.exists() or given.exists()) xor extension.where(url='http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()",
-						"xpath": "(/f:extension/@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason' and not(/f:family or /f:given)) or (not(/f:extension/@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason') and (/f:family or /f:given))"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PID-5, PID-9"
-					},
-					{
-						"identity": "rim",
-						"map": "name"
-					},
-					{
-						"identity": "cda",
-						"map": ".patient.name"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.name"
-					}
-				]
-			},
-			{
-				"id": "Patient.name.id",
-				"path": "Patient.name.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.name.extension",
-				"path": "Patient.name.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.name.use",
-				"path": "Patient.name.use",
-				"short": "usual | official | temp | nickname | anonymous | old | maiden",
-				"definition": "Identifies the purpose for this name.",
-				"comment": "Applications can assume that a name is current unless it explicitly says that it is temporary or old.",
-				"requirements": "Allows the appropriate name for a particular context of use to be selected from among a set of names.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "HumanName.use",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old name etc.for a current/permanent one",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "NameUse"
-						}
-					],
-					"strength": "required",
-					"description": "The use of a human name.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/name-use|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XPN.7, but often indicated by which field contains the name"
-					},
-					{
-						"identity": "rim",
-						"map": "unique(./use)"
-					},
-					{
-						"identity": "servd",
-						"map": "./NamePurpose"
-					}
-				]
-			},
-			{
-				"id": "Patient.name.text",
-				"path": "Patient.name.text",
-				"short": "Text representation of the full name",
-				"definition": "Specifies the entire name as it should be displayed e.g. on an application UI. This may be provided instead of or as well as the specific parts.",
-				"comment": "Can provide both a text representation and parts. Applications updating a name SHALL ensure that when both text and parts are present,  no content is included in the text that isn't found in a part.",
-				"requirements": "A renderable, unencoded form.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "HumanName.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "implied by XPN.11"
-					},
-					{
-						"identity": "rim",
-						"map": "./formatted"
-					}
-				]
-			},
-			{
-				"id": "Patient.name.family",
-				"path": "Patient.name.family",
-				"short": "Family name (often called 'Surname')",
-				"definition": "The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father.",
-				"comment": "Family Name may be decomposed into specific parts using extensions (de, nl, es related cultures).",
-				"alias": [
-					"surname"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "HumanName.family",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"condition": [
-					"us-core-8"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XPN.1/FN.1"
-					},
-					{
-						"identity": "rim",
-						"map": "./part[partType = FAM]"
-					},
-					{
-						"identity": "servd",
-						"map": "./FamilyName"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.name.family"
-					}
-				]
-			},
-			{
-				"id": "Patient.name.given",
-				"path": "Patient.name.given",
-				"short": "Given names (not always 'first'). Includes middle names",
-				"definition": "Given name.",
-				"comment": "If only initials are recorded, they may be used in place of the full name parts. Initials may be separated into multiple given names but often aren't due to paractical limitations.  This element is not called \"first name\" since given names do not always come first.",
-				"alias": [
-					"first name",
-					"middle name"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "HumanName.given",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"orderMeaning": "Given Names appear in the correct order for presenting the name",
-				"condition": [
-					"us-core-8"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XPN.2 + XPN.3"
-					},
-					{
-						"identity": "rim",
-						"map": "./part[partType = GIV]"
-					},
-					{
-						"identity": "servd",
-						"map": "./GivenNames"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.name.given"
-					}
-				]
-			},
-			{
-				"id": "Patient.name.prefix",
-				"path": "Patient.name.prefix",
-				"short": "Parts that come before the name",
-				"definition": "Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "HumanName.prefix",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"orderMeaning": "Prefixes appear in the correct order for presenting the name",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XPN.5"
-					},
-					{
-						"identity": "rim",
-						"map": "./part[partType = PFX]"
-					},
-					{
-						"identity": "servd",
-						"map": "./TitleCode"
-					}
-				]
-			},
-			{
-				"id": "Patient.name.suffix",
-				"path": "Patient.name.suffix",
-				"short": "Parts that come after the name",
-				"definition": "Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "HumanName.suffix",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"orderMeaning": "Suffixes appear in the correct order for presenting the name",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XPN/4"
-					},
-					{
-						"identity": "rim",
-						"map": "./part[partType = SFX]"
-					}
-				]
-			},
-			{
-				"id": "Patient.name.period",
-				"path": "Patient.name.period",
-				"short": "Time period when name was/is in use",
-				"definition": "Indicates the period of time when this name was valid for the named person.",
-				"requirements": "Allows names to be placed in historical context.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "HumanName.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XPN.13 + XPN.14"
-					},
-					{
-						"identity": "rim",
-						"map": "./usablePeriod[type=\"IVL<TS>\"]"
-					},
-					{
-						"identity": "servd",
-						"map": "./StartDate and ./EndDate"
-					}
-				]
-			},
-			{
-				"id": "Patient.telecom",
-				"path": "Patient.telecom",
-				"short": "A contact detail for the individual",
-				"definition": "A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted.",
-				"comment": "A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address might not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner's phone).",
-				"requirements": "People have (primary) ways to contact them in some way such as phone, email.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Patient.telecom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "ContactPoint"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PID-13, PID-14, PID-40"
-					},
-					{
-						"identity": "rim",
-						"map": "telecom"
-					},
-					{
-						"identity": "cda",
-						"map": ".telecom"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.telecom.id",
-				"path": "Patient.telecom.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.telecom.extension",
-				"path": "Patient.telecom.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.telecom.system",
-				"path": "Patient.telecom.system",
-				"short": "phone | fax | email | pager | url | sms | other",
-				"definition": "Telecommunications form for contact point - what communications system is required to make use of the contact.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "ContactPoint.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"condition": [
-					"cpt-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"description": "Telecommunications form for contact point.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/contact-point-system"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XTN.3"
-					},
-					{
-						"identity": "rim",
-						"map": "./scheme"
-					},
-					{
-						"identity": "servd",
-						"map": "./ContactPointType"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.telecom.value",
-				"path": "Patient.telecom.value",
-				"short": "The actual contact point details",
-				"definition": "The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address).",
-				"comment": "Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value.",
-				"requirements": "Need to support legacy numbers that are not in a tightly controlled format.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "ContactPoint.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XTN.1 (or XTN.12)"
-					},
-					{
-						"identity": "rim",
-						"map": "./url"
-					},
-					{
-						"identity": "servd",
-						"map": "./Value"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.telecom.use",
-				"path": "Patient.telecom.use",
-				"short": "home | work | temp | old | mobile - purpose of this contact point",
-				"definition": "Identifies the purpose for the contact point.",
-				"comment": "Applications can assume that a contact is current unless it explicitly says that it is temporary or old.",
-				"requirements": "Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "ContactPoint.use",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old contact etc.for a current/permanent one",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/contact-point-use"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XTN.2 - but often indicated by field"
-					},
-					{
-						"identity": "rim",
-						"map": "unique(./use)"
-					},
-					{
-						"identity": "servd",
-						"map": "./ContactPointPurpose"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.telecom.rank",
-				"path": "Patient.telecom.rank",
-				"short": "Specify preferred order of use (1 = highest)",
-				"definition": "Specifies a preferred order in which to use a set of contacts. ContactPoints with lower rank values are more preferred than those with higher rank values.",
-				"comment": "Note that rank does not necessarily follow the order in which the contacts are represented in the instance.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "ContactPoint.rank",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "positiveInt"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "n/a"
-					},
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.telecom.period",
-				"path": "Patient.telecom.period",
-				"short": "Time period when the contact point was/is in use",
-				"definition": "Time period when the contact point was/is in use.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "ContactPoint.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "./usablePeriod[type=\"IVL<TS>\"]"
-					},
-					{
-						"identity": "servd",
-						"map": "./StartDate and ./EndDate"
-					}
-				]
-			},
-			{
-				"id": "Patient.gender",
-				"path": "Patient.gender",
-				"short": "male | female | other | unknown",
-				"definition": "Administrative Gender - the gender that the patient is considered to have for administration and record keeping purposes.",
-				"comment": "The gender might not match the biological sex as determined by genetics or the individual's preferred identification. Note that for both humans and particularly animals, there are other legitimate possibilities than male and female, though the vast majority of systems and contexts only support male and female.  Systems providing decision support or enforcing business rules should ideally do this on the basis of Observations dealing with the specific sex or gender aspect of interest (anatomical, chromosomal, social, etc.)  However, because these observations are infrequently recorded, defaulting to the administrative gender is common practice.  Where such defaulting occurs, rule enforcement should allow for the variation between administrative and biological, chromosomal and other gender aspects.  For example, an alert about a hysterectomy on a male should be handled as a warning or overridable error, not a \"hard\" error.  See the Patient Gender and Sex section for additional information about communicating patient gender and sex.",
-				"requirements": "Needed for identification of the individual, in combination with (at least) name and birth date.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Patient.gender",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/administrative-gender"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PID-8"
-					},
-					{
-						"identity": "rim",
-						"map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender"
-					},
-					{
-						"identity": "cda",
-						"map": ".patient.administrativeGenderCode"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.gender"
-					}
-				]
-			},
-			{
-				"id": "Patient.birthDate",
-				"path": "Patient.birthDate",
-				"short": "The date of birth for the individual",
-				"definition": "The date of birth for the individual.",
-				"comment": "At least an estimated year should be provided as a guess if the real DOB is unknown  There is a standard extension \"patient-birthTime\" available that should be used where Time is required (such as in maternity/infant care systems).",
-				"requirements": "Age of the individual drives many clinical processes.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Patient.birthDate",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "date"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PID-7"
-					},
-					{
-						"identity": "rim",
-						"map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/birthTime"
-					},
-					{
-						"identity": "cda",
-						"map": ".patient.birthTime"
-					},
-					{
-						"identity": "loinc",
-						"map": "21112-8"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.birthDate"
-					}
-				]
-			},
-			{
-				"id": "Patient.deceased[x]",
-				"path": "Patient.deceased[x]",
-				"short": "Indicates if the individual is deceased or not",
-				"definition": "Indicates if the individual is deceased or not.",
-				"comment": "If there's no value in the instance, it means there is no statement on whether or not the individual is deceased. Most systems will interpret the absence of a value as a sign of the person being alive.",
-				"requirements": "The fact that a patient is deceased influences the clinical process. Also, in human communication and relation management it is necessary to know whether the person is alive.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Patient.deceased[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because once a patient is marked as deceased, the actions that are appropriate to perform on the patient may be significantly different.",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PID-30  (bool) and PID-29 (datetime)"
-					},
-					{
-						"identity": "rim",
-						"map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedInd, player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedTime"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.address",
-				"path": "Patient.address",
-				"short": "An address for the individual",
-				"definition": "An address for the individual.",
-				"comment": "Patient may have multiple addresses with different uses or applicable periods.",
-				"requirements": "May need to keep track of patient addresses for contacting, billing or reporting requirements and also to help with identification.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Patient.address",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Address"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PID-11"
-					},
-					{
-						"identity": "rim",
-						"map": "addr"
-					},
-					{
-						"identity": "cda",
-						"map": ".addr"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.birthDate"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.id",
-				"path": "Patient.address.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.extension",
-				"path": "Patient.address.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.use",
-				"path": "Patient.address.use",
-				"short": "home | work | temp | old | billing - purpose of this address",
-				"definition": "The purpose of this address.",
-				"comment": "Applications can assume that an address is current unless it explicitly says that it is temporary or old.",
-				"requirements": "Allows an appropriate address to be chosen from a list of many.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.use",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueCode": "home"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old address etc.for a current/permanent one",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AddressUse"
-						}
-					],
-					"strength": "required",
-					"description": "The use of an address.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/address-use|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.7"
-					},
-					{
-						"identity": "rim",
-						"map": "unique(./use)"
-					},
-					{
-						"identity": "servd",
-						"map": "./AddressPurpose"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.type",
-				"path": "Patient.address.type",
-				"short": "postal | physical | both",
-				"definition": "Distinguishes between physical addresses (those you can visit) and mailing addresses (e.g. PO Boxes and care-of addresses). Most addresses are both.",
-				"comment": "The definition of Address states that \"address is intended to describe postal addresses, not physical locations\". However, many applications track whether an address has a dual purpose of being a location that can be visited as well as being a valid delivery destination, and Postal addresses are often used as proxies for physical locations (also see the [Location](http://hl7.org/fhir/R4/location.html#) resource).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueCode": "both"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AddressType"
-						}
-					],
-					"strength": "required",
-					"description": "The type of an address (physical / postal).",
-					"valueSet": "http://hl7.org/fhir/ValueSet/address-type|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.18"
-					},
-					{
-						"identity": "rim",
-						"map": "unique(./use)"
-					},
-					{
-						"identity": "vcard",
-						"map": "address type parameter"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.text",
-				"path": "Patient.address.text",
-				"short": "Text representation of the address",
-				"definition": "Specifies the entire address as it should be displayed e.g. on a postal label. This may be provided instead of or as well as the specific parts.",
-				"comment": "Can provide both a text representation and parts. Applications updating an address SHALL ensure that  when both text and parts are present,  no content is included in the text that isn't found in a part.",
-				"requirements": "A renderable, unencoded form.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "137 Nowhere Street, Erewhon 9132"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.1 + XAD.2 + XAD.3 + XAD.4 + XAD.5 + XAD.6"
-					},
-					{
-						"identity": "rim",
-						"map": "./formatted"
-					},
-					{
-						"identity": "vcard",
-						"map": "address label parameter"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.line",
-				"path": "Patient.address.line",
-				"short": "Street name, number, direction & P.O. Box etc.",
-				"definition": "This component contains the house number, apartment number, street name, street direction,  P.O. Box number, delivery hints, and similar address information.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Address.line",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"orderMeaning": "The order in which lines should appear in an address label",
-				"example": [
-					{
-						"label": "General",
-						"valueString": "137 Nowhere Street"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.1 + XAD.2 (note: XAD.1 and XAD.2 have different meanings for a company address than for a person address)"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = AL]"
-					},
-					{
-						"identity": "vcard",
-						"map": "street"
-					},
-					{
-						"identity": "servd",
-						"map": "./StreetAddress (newline delimitted)"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.city",
-				"path": "Patient.address.city",
-				"short": "Name of city, town etc.",
-				"definition": "The name of the city, town, suburb, village or other community or delivery center.",
-				"alias": [
-					"Municpality"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.city",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "Erewhon"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.3"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = CTY]"
-					},
-					{
-						"identity": "vcard",
-						"map": "locality"
-					},
-					{
-						"identity": "servd",
-						"map": "./Jurisdiction"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.district",
-				"path": "Patient.address.district",
-				"short": "District name (aka county)",
-				"definition": "The name of the administrative area (county).",
-				"comment": "District is sometimes known as county, but in some regions 'county' is used in place of city (municipality), so county name should be conveyed in city instead.",
-				"alias": [
-					"County"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.district",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "Madison"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.9"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = CNT | CPA]"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.state",
-				"path": "Patient.address.state",
-				"short": "Sub-unit of country (abbreviations ok)",
-				"definition": "Sub-unit of a country with limited sovereignty in a federally organized country. A code may be used if codes are in common use (e.g. US 2 letter state codes).",
-				"alias": [
-					"Province",
-					"Territory"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.state",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Two Letter USPS alphabetic codes.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.4"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = STA]"
-					},
-					{
-						"identity": "vcard",
-						"map": "region"
-					},
-					{
-						"identity": "servd",
-						"map": "./Region"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.postalCode",
-				"path": "Patient.address.postalCode",
-				"short": "US Zip Codes",
-				"definition": "A postal code designating a region defined by the postal service.",
-				"alias": [
-					"Zip",
-					"Zip Code"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.postalCode",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "9132"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.5"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = ZIP]"
-					},
-					{
-						"identity": "vcard",
-						"map": "code"
-					},
-					{
-						"identity": "servd",
-						"map": "./PostalIdentificationCode"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.country",
-				"path": "Patient.address.country",
-				"short": "Country (e.g. can be ISO 3166 2 or 3 letter code)",
-				"definition": "Country - a nation as commonly understood or generally accepted.",
-				"comment": "ISO 3166 3 letter codes can be used in place of a human readable country name.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.country",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.6"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = CNT]"
-					},
-					{
-						"identity": "vcard",
-						"map": "country"
-					},
-					{
-						"identity": "servd",
-						"map": "./Country"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.period",
-				"path": "Patient.address.period",
-				"short": "Time period when address was/is in use",
-				"definition": "Time period when address was/is in use.",
-				"requirements": "Allows addresses to be placed in historical context.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valuePeriod": {
-							"start": "2010-03-23",
-							"end": "2010-07-01"
-						}
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.12 / XAD.13 + XAD.14"
-					},
-					{
-						"identity": "rim",
-						"map": "./usablePeriod[type=\"IVL<TS>\"]"
-					},
-					{
-						"identity": "servd",
-						"map": "./StartDate and ./EndDate"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.maritalStatus",
-				"path": "Patient.maritalStatus",
-				"short": "Marital (civil) status of a patient",
-				"definition": "This field contains a patient's most recent marital (civil) status.",
-				"requirements": "Most, if not all systems capture it.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Patient.maritalStatus",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "MaritalStatus"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "extensible",
-					"description": "The domestic partnership status of a person.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/marital-status"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PID-16"
-					},
-					{
-						"identity": "rim",
-						"map": "player[classCode=PSN]/maritalStatusCode"
-					},
-					{
-						"identity": "cda",
-						"map": ".patient.maritalStatusCode"
-					}
-				]
-			},
-			{
-				"id": "Patient.multipleBirth[x]",
-				"path": "Patient.multipleBirth[x]",
-				"short": "Whether patient is part of a multiple birth",
-				"definition": "Indicates whether the patient is part of a multiple (boolean) or indicates the actual birth order (integer).",
-				"comment": "Where the valueInteger is provided, the number is the birth number in the sequence. E.g. The middle birth in triplets would be valueInteger=2 and the third born would have valueInteger=3 If a boolean value was provided for this triplets example, then all 3 patient records would have valueBoolean=true (the ordering is not indicated).",
-				"requirements": "For disambiguation of multiple-birth children, especially relevant where the care provider doesn't meet the patient, such as labs.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Patient.multipleBirth[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PID-24 (bool), PID-25 (integer)"
-					},
-					{
-						"identity": "rim",
-						"map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/multipleBirthInd,  player[classCode=PSN|ANM and determinerCode=INSTANCE]/multipleBirthOrderNumber"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.photo",
-				"path": "Patient.photo",
-				"short": "Image of the patient",
-				"definition": "Image of the patient.",
-				"comment": "Guidelines:\n* Use id photos, not clinical photos.\n* Limit dimensions to thumbnail.\n* Keep byte count low to ease resource updates.",
-				"requirements": "Many EHR systems have the capability to capture an image of the patient. Fits with newer social media usage too.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Patient.photo",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Attachment"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-5 - needs a profile"
-					},
-					{
-						"identity": "rim",
-						"map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/desc"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.contact",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name",
-						"valueString": "Contact"
-					}
-				],
-				"path": "Patient.contact",
-				"short": "A contact party (e.g. guardian, partner, friend) for the patient",
-				"definition": "A contact party (e.g. guardian, partner, friend) for the patient.",
-				"comment": "Contact covers all kinds of contact parties: family members, business contacts, guardians, caregivers. Not applicable to register pedigree and family ties beyond use of having contact.",
-				"requirements": "Need to track people you can contact about the patient.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Patient.contact",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "pat-1",
-						"severity": "error",
-						"human": "SHALL at least contain a contact's details or a reference to an organization",
-						"expression": "name.exists() or telecom.exists() or address.exists() or organization.exists()",
-						"xpath": "exists(f:name) or exists(f:telecom) or exists(f:address) or exists(f:organization)"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/scopedRole[classCode=CON]"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.contact.id",
-				"path": "Patient.contact.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.contact.extension",
-				"path": "Patient.contact.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.contact.modifierExtension",
-				"path": "Patient.contact.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Patient.contact.relationship",
-				"path": "Patient.contact.relationship",
-				"short": "The kind of relationship",
-				"definition": "The nature of the relationship between the patient and the contact person.",
-				"requirements": "Used to determine which contact person is the most relevant to approach, depending on circumstances.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Patient.contact.relationship",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ContactRelationship"
-						}
-					],
-					"strength": "extensible",
-					"description": "The nature of the relationship between a patient and a contact person for that patient.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/patient-contactrelationship"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NK1-7, NK1-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.contact.name",
-				"path": "Patient.contact.name",
-				"short": "A name associated with the contact person",
-				"definition": "A name associated with the contact person.",
-				"requirements": "Contact persons need to be identified by name, but it is uncommon to need details about multiple other names for that contact person.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Patient.contact.name",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "HumanName"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NK1-2"
-					},
-					{
-						"identity": "rim",
-						"map": "name"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.contact.telecom",
-				"path": "Patient.contact.telecom",
-				"short": "A contact detail for the person",
-				"definition": "A contact detail for the person, e.g. a telephone number or an email address.",
-				"comment": "Contact may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently, and also to help with identification.",
-				"requirements": "People have (primary) ways to contact them in some way such as phone, email.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Patient.contact.telecom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "ContactPoint"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NK1-5, NK1-6, NK1-40"
-					},
-					{
-						"identity": "rim",
-						"map": "telecom"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.contact.address",
-				"path": "Patient.contact.address",
-				"short": "Address for the contact person",
-				"definition": "Address for the contact person.",
-				"requirements": "Need to keep track where the contact person can be contacted per postal mail or visited.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Patient.contact.address",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Address"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NK1-4"
-					},
-					{
-						"identity": "rim",
-						"map": "addr"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.contact.gender",
-				"path": "Patient.contact.gender",
-				"short": "male | female | other | unknown",
-				"definition": "Administrative Gender - the gender that the contact person is considered to have for administration and record keeping purposes.",
-				"requirements": "Needed to address the person correctly.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Patient.contact.gender",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AdministrativeGender"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "required",
-					"description": "The gender of a person used for administrative purposes.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/administrative-gender|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NK1-15"
-					},
-					{
-						"identity": "rim",
-						"map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.contact.organization",
-				"path": "Patient.contact.organization",
-				"short": "Organization that is associated with the contact",
-				"definition": "Organization on behalf of which the contact is acting or for which the contact is working.",
-				"requirements": "For guardians or business related contacts, the organization is relevant.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Patient.contact.organization",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"condition": [
-					"pat-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NK1-13, NK1-30, NK1-31, NK1-32, NK1-41"
-					},
-					{
-						"identity": "rim",
-						"map": "scoper"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.contact.period",
-				"path": "Patient.contact.period",
-				"short": "The period during which this contact person or organization is valid to be contacted relating to this patient",
-				"definition": "The period during which this contact person or organization is valid to be contacted relating to this patient.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Patient.contact.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "effectiveTime"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.communication",
-				"path": "Patient.communication",
-				"short": "A language which may be used to communicate with the patient about his or her health",
-				"definition": "A language which may be used to communicate with the patient about his or her health.",
-				"comment": "If no language is specified, this *implies* that the default local language is spoken.  If you need to convey proficiency for multiple modes, then you need multiple Patient.Communication associations.   For animals, language is not a relevant field, and should be absent from the instance. If the Patient does not speak the default local language, then the Interpreter Required Standard can be used to explicitly declare that an interpreter is required.",
-				"requirements": "If a patient does not speak the local language, interpreters may be required, so languages spoken and proficiency are important things to keep track of both for patient and other persons of interest.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Patient.communication",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "LanguageCommunication"
-					},
-					{
-						"identity": "cda",
-						"map": "patient.languageCommunication"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.communication"
-					}
-				]
-			},
-			{
-				"id": "Patient.communication.id",
-				"path": "Patient.communication.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.communication.extension",
-				"path": "Patient.communication.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.communication.modifierExtension",
-				"path": "Patient.communication.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Patient.communication.language",
-				"path": "Patient.communication.language",
-				"short": "The language which can be used to communicate with the patient about his or her health",
-				"definition": "The ISO-639-1 alpha 2 code in lower case for the language, optionally followed by a hyphen and the ISO-3166-1 alpha 2 code for the region in upper case; e.g. \"en\" for English, or \"en-US\" for American English versus \"en-EN\" for England English.",
-				"comment": "The structure aa-BB with this exact casing is one the most widely used notations for locale. However not all systems actually code this but instead have it as free text. Hence CodeableConcept instead of code as the data type.",
-				"requirements": "Most systems in multilingual countries will want to convey language. Not all systems actually need the regional dialect.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Patient.communication.language",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/simple-language|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PID-15, LAN-2"
-					},
-					{
-						"identity": "rim",
-						"map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/languageCommunication/code"
-					},
-					{
-						"identity": "cda",
-						"map": ".languageCode"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.communication.language"
-					}
-				]
-			},
-			{
-				"id": "Patient.communication.preferred",
-				"path": "Patient.communication.preferred",
-				"short": "Language preference indicator",
-				"definition": "Indicates whether or not the patient prefers this language (over other languages he masters up a certain level).",
-				"comment": "This language is specifically identified for communicating healthcare information.",
-				"requirements": "People that master multiple languages up to certain level may prefer one or more, i.e. feel more confident in communicating in a particular language making other languages sort of a fall back method.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Patient.communication.preferred",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PID-15"
-					},
-					{
-						"identity": "rim",
-						"map": "preferenceInd"
-					},
-					{
-						"identity": "cda",
-						"map": ".preferenceInd"
-					}
-				]
-			},
-			{
-				"id": "Patient.generalPractitioner",
-				"path": "Patient.generalPractitioner",
-				"short": "Patient's nominated primary care provider",
-				"definition": "Patient's nominated care provider.",
-				"comment": "This may be the primary care provider (in a GP context), or it may be a patient nominated care manager in a community/disability setting, or even organization that will provide people to perform the care provider roles.  It is not to be used to record Care Teams, these should be in a CareTeam resource that may be linked to the CarePlan or EpisodeOfCare resources.\nMultiple GPs may be recorded against the patient for various reasons, such as a student that has his home GP listed along with the GP at university during the school semesters, or a \"fly-in/fly-out\" worker that has the onsite GP also included with his home GP to remain aware of medical issues.\n\nJurisdictions may decide that they can profile this down to 1 if desired, or 1 per type.",
-				"alias": [
-					"careProvider"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Patient.generalPractitioner",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PD1-4"
-					},
-					{
-						"identity": "rim",
-						"map": "subjectOf.CareEvent.performer.AssignedEntity"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.managingOrganization",
-				"path": "Patient.managingOrganization",
-				"short": "Organization that is the custodian of the patient record",
-				"definition": "Organization that is the custodian of the patient record.",
-				"comment": "There is only one managing organization for a specific patient record. Other organizations will have their own Patient record, and may use the Link property to join the records together (or a Person resource which can include confidence ratings for the association).",
-				"requirements": "Need to know who recognizes this patient record, manages and updates it.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Patient.managingOrganization",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "scoper"
-					},
-					{
-						"identity": "cda",
-						"map": ".providerOrganization"
-					}
-				]
-			},
-			{
-				"id": "Patient.link",
-				"path": "Patient.link",
-				"short": "Link to another patient resource that concerns the same actual person",
-				"definition": "Link to another patient resource that concerns the same actual patient.",
-				"comment": "There is no assumption that linked patient records have mutual links.",
-				"requirements": "There are multiple use cases:   \n\n* Duplicate patient records due to the clerical errors associated with the difficulties of identifying humans consistently, and \n* Distribution of patient information across multiple servers.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Patient.link",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it might not be the main Patient resource, and the referenced patient should be used instead of this Patient record. This is when the link.type value is 'replaced-by'",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outboundLink"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.link.id",
-				"path": "Patient.link.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.link.extension",
-				"path": "Patient.link.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.link.modifierExtension",
-				"path": "Patient.link.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Patient.link.other",
-				"path": "Patient.link.other",
-				"short": "The other patient or related person resource that the link refers to",
-				"definition": "The other patient resource that the link refers to.",
-				"comment": "Referencing a RelatedPerson here removes the need to use a Person record to associate a Patient and RelatedPerson as the same individual.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Patient.link.other",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-hierarchy",
-								"valueBoolean": false
-							}
-						],
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PID-3, MRG-1"
-					},
-					{
-						"identity": "rim",
-						"map": "id"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.link.type",
-				"path": "Patient.link.type",
-				"short": "replaced-by | replaces | refer | seealso",
-				"definition": "The type of link between this patient resource and another patient resource.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Patient.link.type",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "LinkType"
-						}
-					],
-					"strength": "required",
-					"description": "The type of link between this patient resource and another patient resource.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/link-type|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "typeCode"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Patient",
-				"path": "Patient",
-				"definition": "The US Core Patient Profile is based upon the core FHIR Patient Resource and designed to meet the applicable patient demographic data elements from the 2015 Edition Common Clinical Data Set.",
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient"
-					}
-				]
-			},
-			{
-				"id": "Patient.extension:race",
-				"path": "Patient.extension",
-				"sliceName": "race",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Extension",
-						"profile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-race|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.extension"
-					}
-				]
-			},
-			{
-				"id": "Patient.extension:ethnicity",
-				"path": "Patient.extension",
-				"sliceName": "ethnicity",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Extension",
-						"profile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.extension"
-					}
-				]
-			},
-			{
-				"id": "Patient.extension:birthsex",
-				"path": "Patient.extension",
-				"sliceName": "birthsex",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Extension",
-						"profile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"description": "Code for sex assigned at birth",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/birthsex|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.extension"
-					}
-				]
-			},
-			{
-				"id": "Patient.identifier",
-				"path": "Patient.identifier",
-				"min": 1,
-				"max": "*",
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.identifier"
-					}
-				]
-			},
-			{
-				"id": "Patient.identifier.system",
-				"path": "Patient.identifier.system",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.identifier.system"
-					}
-				]
-			},
-			{
-				"id": "Patient.identifier.value",
-				"path": "Patient.identifier.value",
-				"short": "The value that is unique within the system.",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.identifier.value"
-					}
-				]
-			},
-			{
-				"id": "Patient.name",
-				"path": "Patient.name",
-				"min": 1,
-				"max": "*",
-				"type": [
-					{
-						"code": "HumanName"
-					}
-				],
-				"constraint": [
-					{
-						"key": "us-core-8",
-						"severity": "error",
-						"human": "Either Patient.name.given and/or Patient.name.family SHALL be present or a Data Absent Reason Extension SHALL be present.",
-						"expression": "(family.exists() or given.exists()) xor extension.where(url='http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()",
-						"xpath": "(/f:extension/@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason' and not(/f:family or /f:given)) or (not(/f:extension/@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason') and (/f:family or /f:given))"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.name"
-					}
-				]
-			},
-			{
-				"id": "Patient.name.family",
-				"path": "Patient.name.family",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"condition": [
-					"us-core-8"
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.name.family"
-					}
-				]
-			},
-			{
-				"id": "Patient.name.given",
-				"path": "Patient.name.given",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"condition": [
-					"us-core-8"
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.name.given"
-					}
-				]
-			},
-			{
-				"id": "Patient.telecom",
-				"path": "Patient.telecom",
-				"min": 0,
-				"max": "*",
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.telecom.system",
-				"path": "Patient.telecom.system",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"description": "Telecommunications form for contact point.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/contact-point-system"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.telecom.value",
-				"path": "Patient.telecom.value",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.telecom.use",
-				"path": "Patient.telecom.use",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/contact-point-use"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.gender",
-				"path": "Patient.gender",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/administrative-gender"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.gender"
-					}
-				]
-			},
-			{
-				"id": "Patient.birthDate",
-				"path": "Patient.birthDate",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "date"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.birthDate"
-					}
-				]
-			},
-			{
-				"id": "Patient.address",
-				"path": "Patient.address",
-				"min": 0,
-				"max": "*",
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.birthDate"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.line",
-				"path": "Patient.address.line",
-				"min": 0,
-				"max": "*",
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.city",
-				"path": "Patient.address.city",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.state",
-				"path": "Patient.address.state",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Two Letter USPS alphabetic codes.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.postalCode",
-				"path": "Patient.address.postalCode",
-				"short": "US Zip Codes",
-				"alias": [
-					"Zip Code"
-				],
-				"min": 0,
-				"max": "1",
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.period",
-				"path": "Patient.address.period",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.communication",
-				"path": "Patient.communication",
-				"min": 0,
-				"max": "*",
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.communication"
-					}
-				]
-			},
-			{
-				"id": "Patient.communication.language",
-				"path": "Patient.communication.language",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/simple-language|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.communication.language"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-patient",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
+    "version": "3.1.1",
+    "name": "USCorePatientProfile",
+    "title": "US Core Patient Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-06-27",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.healthit.gov"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the patient resource for the minimal set of data to query and retrieve patient demographic information.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "cda",
+            "uri": "http://hl7.org/v3/cda",
+            "name": "CDA (R2)"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "loinc",
+            "uri": "http://loinc.org",
+            "name": "LOINC code for the element"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Patient",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Patient",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Patient",
+                "path": "Patient",
+                "short": "Information about an individual or animal receiving health care services",
+                "definition": "The US Core Patient Profile is based upon the core FHIR Patient Resource and designed to meet the applicable patient demographic data elements from the 2015 Edition Common Clinical Data Set.",
+                "alias": [
+                    "SubjectOfCare Client Resident"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Patient",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Patient[classCode=PAT]"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument.recordTarget.patientRole"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.id",
+                "path": "Patient.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Patient.meta",
+                "path": "Patient.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Patient.implicitRules",
+                "path": "Patient.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Patient.language",
+                "path": "Patient.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Patient.text",
+                "path": "Patient.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.contained",
+                "path": "Patient.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.extension",
+                "path": "Patient.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "open"
+                },
+                "short": "Extension",
+                "definition": "An Extension",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Patient.extension:race",
+                "path": "Patient.extension",
+                "sliceName": "race",
+                "short": "US Core Race Extension",
+                "definition": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\n   - American Indian or Alaska Native\n   - Asian\n   - Black or African American\n   - Native Hawaiian or Other Pacific Islander\n   - White.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension",
+                        "profile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race|3.1.1"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "ele-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.extension"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.extension:ethnicity",
+                "path": "Patient.extension",
+                "sliceName": "ethnicity",
+                "short": "US Core ethnicity Extension",
+                "definition": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension",
+                        "profile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity|3.1.1"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "ele-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.extension"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.extension:birthsex",
+                "path": "Patient.extension",
+                "sliceName": "birthsex",
+                "short": "Extension",
+                "definition": "A code classifying the person's sex assigned at birth  as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc).",
+                "comment": "The codes required are intended to present birth sex (i.e., the sex recorded on the patient’s birth certificate) and not gender identity or reassigned sex.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension",
+                        "profile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex|3.1.1"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "ele-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender"
+                    },
+                    {
+                        "identity": "iso11179",
+                        "map": ".patient.administrativeGenderCode"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.extension"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.modifierExtension",
+                "path": "Patient.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.identifier",
+                "path": "Patient.identifier",
+                "short": "An identifier for this patient",
+                "definition": "An identifier for this patient.",
+                "requirements": "Patients are almost always assigned specific numerical identifiers.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Patient.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "id"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": ".id"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.identifier"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.identifier.id",
+                "path": "Patient.identifier.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.identifier.extension",
+                "path": "Patient.identifier.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.identifier.use",
+                "path": "Patient.identifier.use",
+                "short": "usual | official | temp | secondary | old (If known)",
+                "definition": "The purpose of this identifier.",
+                "comment": "Applications can assume that an identifier is permanent unless it explicitly says that it is temporary.",
+                "requirements": "Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.use",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary id for a permanent one.",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "IdentifierUse"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Identifies the purpose for this identifier, if known .",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/identifier-use|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Role.code or implied by context"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.identifier.type",
+                "path": "Patient.identifier.type",
+                "short": "Description of identifier",
+                "definition": "A coded type for the identifier that can be used to determine which identifier to use for a specific purpose.",
+                "comment": "This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage.   Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type.",
+                "requirements": "Allows users to make use of identifiers when the identifier system is not known.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "IdentifierType"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "A coded type for an identifier that can be used to determine which identifier to use for a specific purpose.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/identifier-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Role.code or implied by context"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.identifier.system",
+                "path": "Patient.identifier.system",
+                "short": "The namespace for the identifier value",
+                "definition": "Establishes the namespace for the value - that is, a URL that describes a set values that are unique.",
+                "comment": "Identifier.system is always case sensitive.",
+                "requirements": "There are many sets  of identifiers.  To perform matching of two identifiers, we need to know what set we're dealing with. The system identifies a particular set of unique identifiers.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueUri": "http://www.acme.com/identifiers/patient"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.4 / EI-2-4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "II.root or Role.id.root"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./IdentifierType"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.identifier.system"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.identifier.value",
+                "path": "Patient.identifier.value",
+                "short": "The value that is unique within the system.",
+                "definition": "The portion of the identifier typically relevant to the user and which is unique within the context of the system.",
+                "comment": "If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986.  The value's primary purpose is computational mapping.  As a result, it may be normalized for comparison purposes (e.g. removing non-significant whitespace, dashes, etc.)  A value formatted for human display can be conveyed using the [Rendered Value extension](http://hl7.org/fhir/R4/extension-rendered-value.html). Identifier.value is to be treated as case sensitive unless knowledge of the Identifier.system allows the processer to be confident that non-case-sensitive processing is safe.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "123456"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.1 / EI.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Value"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.identifier.value"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.identifier.period",
+                "path": "Patient.identifier.period",
+                "short": "Time period when id is/was valid for use",
+                "definition": "Time period during which identifier is/was valid for use.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.7 + CX.8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Role.effectiveTime or implied by context"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./StartDate and ./EndDate"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.identifier.assigner",
+                "path": "Patient.identifier.assigner",
+                "short": "Organization that issued id (may be just text)",
+                "definition": "Organization that issued/manages the identifier.",
+                "comment": "The Identifier.assigner may omit the .reference element and only contain a .display element reflecting the name or other textual information about the assigning organization.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.assigner",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.4 / (CX.4,CX.9,CX.10)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./IdentifierIssuingAuthority"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.active",
+                "path": "Patient.active",
+                "short": "Whether this patient's record is in active use",
+                "definition": "Whether this patient record is in active use. \nMany systems use this property to mark as non-current patients, such as those that have not been seen for a period of time based on an organization's business rules.\n\nIt is often used to filter patient lists to exclude inactive patients\n\nDeceased patients may also be marked as inactive for the same reasons, but may be active for some time after death.",
+                "comment": "If a record is inactive, and linked to an active record, then future patient/record updates should occur on the other patient.",
+                "requirements": "Need to be able to mark a patient record as not to be used because it was created in error.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Patient.active",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "meaningWhenMissing": "This resource is generally assumed to be active if no value is provided for the active element",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labelled as a modifier because it is a status element that can indicate that a record should not be treated as valid",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "statusCode"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.name",
+                "path": "Patient.name",
+                "short": "A name associated with the patient",
+                "definition": "A name associated with the individual.",
+                "comment": "A patient may have multiple names with different uses or applicable periods. For animals, the name is a \"HumanName\" in the sense that is assigned and used by humans and has the same patterns.",
+                "requirements": "Need to be able to track the patient by multiple names. Examples are your official name and a partner name.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Patient.name",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "HumanName"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "us-core-8",
+                        "severity": "error",
+                        "human": "Either Patient.name.given and/or Patient.name.family SHALL be present or a Data Absent Reason Extension SHALL be present.",
+                        "expression": "(family.exists() or given.exists()) xor extension.where(url='http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()",
+                        "xpath": "(/f:extension/@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason' and not(/f:family or /f:given)) or (not(/f:extension/@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason') and (/f:family or /f:given))"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PID-5, PID-9"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "name"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": ".patient.name"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.name"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.name.id",
+                "path": "Patient.name.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.name.extension",
+                "path": "Patient.name.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.name.use",
+                "path": "Patient.name.use",
+                "short": "usual | official | temp | nickname | anonymous | old | maiden",
+                "definition": "Identifies the purpose for this name.",
+                "comment": "Applications can assume that a name is current unless it explicitly says that it is temporary or old.",
+                "requirements": "Allows the appropriate name for a particular context of use to be selected from among a set of names.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "HumanName.use",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old name etc.for a current/permanent one",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "NameUse"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The use of a human name.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/name-use|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XPN.7, but often indicated by which field contains the name"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "unique(./use)"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./NamePurpose"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.name.text",
+                "path": "Patient.name.text",
+                "short": "Text representation of the full name",
+                "definition": "Specifies the entire name as it should be displayed e.g. on an application UI. This may be provided instead of or as well as the specific parts.",
+                "comment": "Can provide both a text representation and parts. Applications updating a name SHALL ensure that when both text and parts are present,  no content is included in the text that isn't found in a part.",
+                "requirements": "A renderable, unencoded form.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "HumanName.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "implied by XPN.11"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./formatted"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.name.family",
+                "path": "Patient.name.family",
+                "short": "Family name (often called 'Surname')",
+                "definition": "The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father.",
+                "comment": "Family Name may be decomposed into specific parts using extensions (de, nl, es related cultures).",
+                "alias": [
+                    "surname"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "HumanName.family",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "condition": [
+                    "us-core-8"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XPN.1/FN.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./part[partType = FAM]"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./FamilyName"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.name.family"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.name.given",
+                "path": "Patient.name.given",
+                "short": "Given names (not always 'first'). Includes middle names",
+                "definition": "Given name.",
+                "comment": "If only initials are recorded, they may be used in place of the full name parts. Initials may be separated into multiple given names but often aren't due to paractical limitations.  This element is not called \"first name\" since given names do not always come first.",
+                "alias": [
+                    "first name",
+                    "middle name"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "HumanName.given",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "orderMeaning": "Given Names appear in the correct order for presenting the name",
+                "condition": [
+                    "us-core-8"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XPN.2 + XPN.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./part[partType = GIV]"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./GivenNames"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.name.given"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.name.prefix",
+                "path": "Patient.name.prefix",
+                "short": "Parts that come before the name",
+                "definition": "Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "HumanName.prefix",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "orderMeaning": "Prefixes appear in the correct order for presenting the name",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XPN.5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./part[partType = PFX]"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./TitleCode"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.name.suffix",
+                "path": "Patient.name.suffix",
+                "short": "Parts that come after the name",
+                "definition": "Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "HumanName.suffix",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "orderMeaning": "Suffixes appear in the correct order for presenting the name",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XPN/4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./part[partType = SFX]"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.name.period",
+                "path": "Patient.name.period",
+                "short": "Time period when name was/is in use",
+                "definition": "Indicates the period of time when this name was valid for the named person.",
+                "requirements": "Allows names to be placed in historical context.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "HumanName.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XPN.13 + XPN.14"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./usablePeriod[type=\"IVL<TS>\"]"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./StartDate and ./EndDate"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.telecom",
+                "path": "Patient.telecom",
+                "short": "A contact detail for the individual",
+                "definition": "A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted.",
+                "comment": "A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address might not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner's phone).",
+                "requirements": "People have (primary) ways to contact them in some way such as phone, email.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Patient.telecom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "ContactPoint"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PID-13, PID-14, PID-40"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "telecom"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": ".telecom"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.telecom.id",
+                "path": "Patient.telecom.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.telecom.extension",
+                "path": "Patient.telecom.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.telecom.system",
+                "path": "Patient.telecom.system",
+                "short": "phone | fax | email | pager | url | sms | other",
+                "definition": "Telecommunications form for contact point - what communications system is required to make use of the contact.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "ContactPoint.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "condition": [
+                    "cpt-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "description": "Telecommunications form for contact point.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/contact-point-system"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XTN.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./scheme"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./ContactPointType"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.telecom.value",
+                "path": "Patient.telecom.value",
+                "short": "The actual contact point details",
+                "definition": "The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address).",
+                "comment": "Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value.",
+                "requirements": "Need to support legacy numbers that are not in a tightly controlled format.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "ContactPoint.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XTN.1 (or XTN.12)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./url"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Value"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.telecom.use",
+                "path": "Patient.telecom.use",
+                "short": "home | work | temp | old | mobile - purpose of this contact point",
+                "definition": "Identifies the purpose for the contact point.",
+                "comment": "Applications can assume that a contact is current unless it explicitly says that it is temporary or old.",
+                "requirements": "Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "ContactPoint.use",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old contact etc.for a current/permanent one",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/contact-point-use"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XTN.2 - but often indicated by field"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "unique(./use)"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./ContactPointPurpose"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.telecom.rank",
+                "path": "Patient.telecom.rank",
+                "short": "Specify preferred order of use (1 = highest)",
+                "definition": "Specifies a preferred order in which to use a set of contacts. ContactPoints with lower rank values are more preferred than those with higher rank values.",
+                "comment": "Note that rank does not necessarily follow the order in which the contacts are represented in the instance.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "ContactPoint.rank",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "positiveInt"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "n/a"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.telecom.period",
+                "path": "Patient.telecom.period",
+                "short": "Time period when the contact point was/is in use",
+                "definition": "Time period when the contact point was/is in use.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "ContactPoint.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./usablePeriod[type=\"IVL<TS>\"]"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./StartDate and ./EndDate"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.gender",
+                "path": "Patient.gender",
+                "short": "male | female | other | unknown",
+                "definition": "Administrative Gender - the gender that the patient is considered to have for administration and record keeping purposes.",
+                "comment": "The gender might not match the biological sex as determined by genetics or the individual's preferred identification. Note that for both humans and particularly animals, there are other legitimate possibilities than male and female, though the vast majority of systems and contexts only support male and female.  Systems providing decision support or enforcing business rules should ideally do this on the basis of Observations dealing with the specific sex or gender aspect of interest (anatomical, chromosomal, social, etc.)  However, because these observations are infrequently recorded, defaulting to the administrative gender is common practice.  Where such defaulting occurs, rule enforcement should allow for the variation between administrative and biological, chromosomal and other gender aspects.  For example, an alert about a hysterectomy on a male should be handled as a warning or overridable error, not a \"hard\" error.  See the Patient Gender and Sex section for additional information about communicating patient gender and sex.",
+                "requirements": "Needed for identification of the individual, in combination with (at least) name and birth date.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Patient.gender",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/administrative-gender"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PID-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": ".patient.administrativeGenderCode"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.gender"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.birthDate",
+                "path": "Patient.birthDate",
+                "short": "The date of birth for the individual",
+                "definition": "The date of birth for the individual.",
+                "comment": "At least an estimated year should be provided as a guess if the real DOB is unknown  There is a standard extension \"patient-birthTime\" available that should be used where Time is required (such as in maternity/infant care systems).",
+                "requirements": "Age of the individual drives many clinical processes.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Patient.birthDate",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "date"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PID-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/birthTime"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": ".patient.birthTime"
+                    },
+                    {
+                        "identity": "loinc",
+                        "map": "21112-8"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.birthDate"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.deceased[x]",
+                "path": "Patient.deceased[x]",
+                "short": "Indicates if the individual is deceased or not",
+                "definition": "Indicates if the individual is deceased or not.",
+                "comment": "If there's no value in the instance, it means there is no statement on whether or not the individual is deceased. Most systems will interpret the absence of a value as a sign of the person being alive.",
+                "requirements": "The fact that a patient is deceased influences the clinical process. Also, in human communication and relation management it is necessary to know whether the person is alive.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Patient.deceased[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because once a patient is marked as deceased, the actions that are appropriate to perform on the patient may be significantly different.",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PID-30  (bool) and PID-29 (datetime)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedInd, player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedTime"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address",
+                "path": "Patient.address",
+                "short": "An address for the individual",
+                "definition": "An address for the individual.",
+                "comment": "Patient may have multiple addresses with different uses or applicable periods.",
+                "requirements": "May need to keep track of patient addresses for contacting, billing or reporting requirements and also to help with identification.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Patient.address",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Address"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PID-11"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "addr"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": ".addr"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.birthDate"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.id",
+                "path": "Patient.address.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.extension",
+                "path": "Patient.address.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.use",
+                "path": "Patient.address.use",
+                "short": "home | work | temp | old | billing - purpose of this address",
+                "definition": "The purpose of this address.",
+                "comment": "Applications can assume that an address is current unless it explicitly says that it is temporary or old.",
+                "requirements": "Allows an appropriate address to be chosen from a list of many.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.use",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueCode": "home"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old address etc.for a current/permanent one",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AddressUse"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The use of an address.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/address-use|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "unique(./use)"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./AddressPurpose"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.type",
+                "path": "Patient.address.type",
+                "short": "postal | physical | both",
+                "definition": "Distinguishes between physical addresses (those you can visit) and mailing addresses (e.g. PO Boxes and care-of addresses). Most addresses are both.",
+                "comment": "The definition of Address states that \"address is intended to describe postal addresses, not physical locations\". However, many applications track whether an address has a dual purpose of being a location that can be visited as well as being a valid delivery destination, and Postal addresses are often used as proxies for physical locations (also see the [Location](http://hl7.org/fhir/R4/location.html#) resource).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueCode": "both"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AddressType"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The type of an address (physical / postal).",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/address-type|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.18"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "unique(./use)"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "address type parameter"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.text",
+                "path": "Patient.address.text",
+                "short": "Text representation of the address",
+                "definition": "Specifies the entire address as it should be displayed e.g. on a postal label. This may be provided instead of or as well as the specific parts.",
+                "comment": "Can provide both a text representation and parts. Applications updating an address SHALL ensure that  when both text and parts are present,  no content is included in the text that isn't found in a part.",
+                "requirements": "A renderable, unencoded form.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "137 Nowhere Street, Erewhon 9132"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.1 + XAD.2 + XAD.3 + XAD.4 + XAD.5 + XAD.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./formatted"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "address label parameter"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.line",
+                "path": "Patient.address.line",
+                "short": "Street name, number, direction & P.O. Box etc.",
+                "definition": "This component contains the house number, apartment number, street name, street direction,  P.O. Box number, delivery hints, and similar address information.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Address.line",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "orderMeaning": "The order in which lines should appear in an address label",
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "137 Nowhere Street"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.1 + XAD.2 (note: XAD.1 and XAD.2 have different meanings for a company address than for a person address)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = AL]"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "street"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./StreetAddress (newline delimitted)"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.city",
+                "path": "Patient.address.city",
+                "short": "Name of city, town etc.",
+                "definition": "The name of the city, town, suburb, village or other community or delivery center.",
+                "alias": [
+                    "Municpality"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.city",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "Erewhon"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = CTY]"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "locality"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Jurisdiction"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.district",
+                "path": "Patient.address.district",
+                "short": "District name (aka county)",
+                "definition": "The name of the administrative area (county).",
+                "comment": "District is sometimes known as county, but in some regions 'county' is used in place of city (municipality), so county name should be conveyed in city instead.",
+                "alias": [
+                    "County"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.district",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "Madison"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.9"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = CNT | CPA]"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.state",
+                "path": "Patient.address.state",
+                "short": "Sub-unit of country (abbreviations ok)",
+                "definition": "Sub-unit of a country with limited sovereignty in a federally organized country. A code may be used if codes are in common use (e.g. US 2 letter state codes).",
+                "alias": [
+                    "Province",
+                    "Territory"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.state",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Two Letter USPS alphabetic codes.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = STA]"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "region"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Region"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.postalCode",
+                "path": "Patient.address.postalCode",
+                "short": "US Zip Codes",
+                "definition": "A postal code designating a region defined by the postal service.",
+                "alias": [
+                    "Zip",
+                    "Zip Code"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.postalCode",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "9132"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = ZIP]"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "code"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./PostalIdentificationCode"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.country",
+                "path": "Patient.address.country",
+                "short": "Country (e.g. can be ISO 3166 2 or 3 letter code)",
+                "definition": "Country - a nation as commonly understood or generally accepted.",
+                "comment": "ISO 3166 3 letter codes can be used in place of a human readable country name.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.country",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = CNT]"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "country"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Country"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.period",
+                "path": "Patient.address.period",
+                "short": "Time period when address was/is in use",
+                "definition": "Time period when address was/is in use.",
+                "requirements": "Allows addresses to be placed in historical context.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valuePeriod": {
+                            "start": "2010-03-23",
+                            "end": "2010-07-01"
+                        }
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.12 / XAD.13 + XAD.14"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./usablePeriod[type=\"IVL<TS>\"]"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./StartDate and ./EndDate"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.maritalStatus",
+                "path": "Patient.maritalStatus",
+                "short": "Marital (civil) status of a patient",
+                "definition": "This field contains a patient's most recent marital (civil) status.",
+                "requirements": "Most, if not all systems capture it.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Patient.maritalStatus",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "MaritalStatus"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "The domestic partnership status of a person.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/marital-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PID-16"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "player[classCode=PSN]/maritalStatusCode"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": ".patient.maritalStatusCode"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.multipleBirth[x]",
+                "path": "Patient.multipleBirth[x]",
+                "short": "Whether patient is part of a multiple birth",
+                "definition": "Indicates whether the patient is part of a multiple (boolean) or indicates the actual birth order (integer).",
+                "comment": "Where the valueInteger is provided, the number is the birth number in the sequence. E.g. The middle birth in triplets would be valueInteger=2 and the third born would have valueInteger=3 If a boolean value was provided for this triplets example, then all 3 patient records would have valueBoolean=true (the ordering is not indicated).",
+                "requirements": "For disambiguation of multiple-birth children, especially relevant where the care provider doesn't meet the patient, such as labs.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Patient.multipleBirth[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PID-24 (bool), PID-25 (integer)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/multipleBirthInd,  player[classCode=PSN|ANM and determinerCode=INSTANCE]/multipleBirthOrderNumber"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.photo",
+                "path": "Patient.photo",
+                "short": "Image of the patient",
+                "definition": "Image of the patient.",
+                "comment": "Guidelines:\n* Use id photos, not clinical photos.\n* Limit dimensions to thumbnail.\n* Keep byte count low to ease resource updates.",
+                "requirements": "Many EHR systems have the capability to capture an image of the patient. Fits with newer social media usage too.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Patient.photo",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Attachment"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-5 - needs a profile"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/desc"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.contact",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name",
+                        "valueString": "Contact"
+                    }
+                ],
+                "path": "Patient.contact",
+                "short": "A contact party (e.g. guardian, partner, friend) for the patient",
+                "definition": "A contact party (e.g. guardian, partner, friend) for the patient.",
+                "comment": "Contact covers all kinds of contact parties: family members, business contacts, guardians, caregivers. Not applicable to register pedigree and family ties beyond use of having contact.",
+                "requirements": "Need to track people you can contact about the patient.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Patient.contact",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "pat-1",
+                        "severity": "error",
+                        "human": "SHALL at least contain a contact's details or a reference to an organization",
+                        "expression": "name.exists() or telecom.exists() or address.exists() or organization.exists()",
+                        "xpath": "exists(f:name) or exists(f:telecom) or exists(f:address) or exists(f:organization)"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/scopedRole[classCode=CON]"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.contact.id",
+                "path": "Patient.contact.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.contact.extension",
+                "path": "Patient.contact.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.contact.modifierExtension",
+                "path": "Patient.contact.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.contact.relationship",
+                "path": "Patient.contact.relationship",
+                "short": "The kind of relationship",
+                "definition": "The nature of the relationship between the patient and the contact person.",
+                "requirements": "Used to determine which contact person is the most relevant to approach, depending on circumstances.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Patient.contact.relationship",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ContactRelationship"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "The nature of the relationship between a patient and a contact person for that patient.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/patient-contactrelationship"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NK1-7, NK1-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.contact.name",
+                "path": "Patient.contact.name",
+                "short": "A name associated with the contact person",
+                "definition": "A name associated with the contact person.",
+                "requirements": "Contact persons need to be identified by name, but it is uncommon to need details about multiple other names for that contact person.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Patient.contact.name",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "HumanName"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NK1-2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "name"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.contact.telecom",
+                "path": "Patient.contact.telecom",
+                "short": "A contact detail for the person",
+                "definition": "A contact detail for the person, e.g. a telephone number or an email address.",
+                "comment": "Contact may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently, and also to help with identification.",
+                "requirements": "People have (primary) ways to contact them in some way such as phone, email.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Patient.contact.telecom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "ContactPoint"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NK1-5, NK1-6, NK1-40"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "telecom"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.contact.address",
+                "path": "Patient.contact.address",
+                "short": "Address for the contact person",
+                "definition": "Address for the contact person.",
+                "requirements": "Need to keep track where the contact person can be contacted per postal mail or visited.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Patient.contact.address",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Address"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NK1-4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "addr"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.contact.gender",
+                "path": "Patient.contact.gender",
+                "short": "male | female | other | unknown",
+                "definition": "Administrative Gender - the gender that the contact person is considered to have for administration and record keeping purposes.",
+                "requirements": "Needed to address the person correctly.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Patient.contact.gender",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AdministrativeGender"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The gender of a person used for administrative purposes.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/administrative-gender|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NK1-15"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.contact.organization",
+                "path": "Patient.contact.organization",
+                "short": "Organization that is associated with the contact",
+                "definition": "Organization on behalf of which the contact is acting or for which the contact is working.",
+                "requirements": "For guardians or business related contacts, the organization is relevant.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Patient.contact.organization",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "pat-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NK1-13, NK1-30, NK1-31, NK1-32, NK1-41"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "scoper"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.contact.period",
+                "path": "Patient.contact.period",
+                "short": "The period during which this contact person or organization is valid to be contacted relating to this patient",
+                "definition": "The period during which this contact person or organization is valid to be contacted relating to this patient.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Patient.contact.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.communication",
+                "path": "Patient.communication",
+                "short": "A language which may be used to communicate with the patient about his or her health",
+                "definition": "A language which may be used to communicate with the patient about his or her health.",
+                "comment": "If no language is specified, this *implies* that the default local language is spoken.  If you need to convey proficiency for multiple modes, then you need multiple Patient.Communication associations.   For animals, language is not a relevant field, and should be absent from the instance. If the Patient does not speak the default local language, then the Interpreter Required Standard can be used to explicitly declare that an interpreter is required.",
+                "requirements": "If a patient does not speak the local language, interpreters may be required, so languages spoken and proficiency are important things to keep track of both for patient and other persons of interest.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Patient.communication",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "LanguageCommunication"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "patient.languageCommunication"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.communication"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.communication.id",
+                "path": "Patient.communication.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.communication.extension",
+                "path": "Patient.communication.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.communication.modifierExtension",
+                "path": "Patient.communication.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.communication.language",
+                "path": "Patient.communication.language",
+                "short": "The language which can be used to communicate with the patient about his or her health",
+                "definition": "The ISO-639-1 alpha 2 code in lower case for the language, optionally followed by a hyphen and the ISO-3166-1 alpha 2 code for the region in upper case; e.g. \"en\" for English, or \"en-US\" for American English versus \"en-EN\" for England English.",
+                "comment": "The structure aa-BB with this exact casing is one the most widely used notations for locale. However not all systems actually code this but instead have it as free text. Hence CodeableConcept instead of code as the data type.",
+                "requirements": "Most systems in multilingual countries will want to convey language. Not all systems actually need the regional dialect.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Patient.communication.language",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/simple-language|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PID-15, LAN-2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/languageCommunication/code"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": ".languageCode"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.communication.language"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.communication.preferred",
+                "path": "Patient.communication.preferred",
+                "short": "Language preference indicator",
+                "definition": "Indicates whether or not the patient prefers this language (over other languages he masters up a certain level).",
+                "comment": "This language is specifically identified for communicating healthcare information.",
+                "requirements": "People that master multiple languages up to certain level may prefer one or more, i.e. feel more confident in communicating in a particular language making other languages sort of a fall back method.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Patient.communication.preferred",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PID-15"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "preferenceInd"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": ".preferenceInd"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.generalPractitioner",
+                "path": "Patient.generalPractitioner",
+                "short": "Patient's nominated primary care provider",
+                "definition": "Patient's nominated care provider.",
+                "comment": "This may be the primary care provider (in a GP context), or it may be a patient nominated care manager in a community/disability setting, or even organization that will provide people to perform the care provider roles.  It is not to be used to record Care Teams, these should be in a CareTeam resource that may be linked to the CarePlan or EpisodeOfCare resources.\nMultiple GPs may be recorded against the patient for various reasons, such as a student that has his home GP listed along with the GP at university during the school semesters, or a \"fly-in/fly-out\" worker that has the onsite GP also included with his home GP to remain aware of medical issues.\n\nJurisdictions may decide that they can profile this down to 1 if desired, or 1 per type.",
+                "alias": [
+                    "careProvider"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Patient.generalPractitioner",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PD1-4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "subjectOf.CareEvent.performer.AssignedEntity"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.managingOrganization",
+                "path": "Patient.managingOrganization",
+                "short": "Organization that is the custodian of the patient record",
+                "definition": "Organization that is the custodian of the patient record.",
+                "comment": "There is only one managing organization for a specific patient record. Other organizations will have their own Patient record, and may use the Link property to join the records together (or a Person resource which can include confidence ratings for the association).",
+                "requirements": "Need to know who recognizes this patient record, manages and updates it.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Patient.managingOrganization",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "scoper"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": ".providerOrganization"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.link",
+                "path": "Patient.link",
+                "short": "Link to another patient resource that concerns the same actual person",
+                "definition": "Link to another patient resource that concerns the same actual patient.",
+                "comment": "There is no assumption that linked patient records have mutual links.",
+                "requirements": "There are multiple use cases:   \n\n* Duplicate patient records due to the clerical errors associated with the difficulties of identifying humans consistently, and \n* Distribution of patient information across multiple servers.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Patient.link",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it might not be the main Patient resource, and the referenced patient should be used instead of this Patient record. This is when the link.type value is 'replaced-by'",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outboundLink"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.link.id",
+                "path": "Patient.link.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.link.extension",
+                "path": "Patient.link.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.link.modifierExtension",
+                "path": "Patient.link.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.link.other",
+                "path": "Patient.link.other",
+                "short": "The other patient or related person resource that the link refers to",
+                "definition": "The other patient resource that the link refers to.",
+                "comment": "Referencing a RelatedPerson here removes the need to use a Person record to associate a Patient and RelatedPerson as the same individual.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Patient.link.other",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-hierarchy",
+                                "valueBoolean": false
+                            }
+                        ],
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PID-3, MRG-1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "id"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.link.type",
+                "path": "Patient.link.type",
+                "short": "replaced-by | replaces | refer | seealso",
+                "definition": "The type of link between this patient resource and another patient resource.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Patient.link.type",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "LinkType"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The type of link between this patient resource and another patient resource.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/link-type|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "typeCode"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Patient",
+                "path": "Patient",
+                "definition": "The US Core Patient Profile is based upon the core FHIR Patient Resource and designed to meet the applicable patient demographic data elements from the 2015 Edition Common Clinical Data Set.",
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.extension:race",
+                "path": "Patient.extension",
+                "sliceName": "race",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Extension",
+                        "profile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.extension"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.extension:ethnicity",
+                "path": "Patient.extension",
+                "sliceName": "ethnicity",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Extension",
+                        "profile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.extension"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.extension:birthsex",
+                "path": "Patient.extension",
+                "sliceName": "birthsex",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Extension",
+                        "profile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "description": "Code for sex assigned at birth",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/birthsex|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.extension"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.identifier",
+                "path": "Patient.identifier",
+                "min": 1,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.identifier"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.identifier.system",
+                "path": "Patient.identifier.system",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.identifier.system"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.identifier.value",
+                "path": "Patient.identifier.value",
+                "short": "The value that is unique within the system.",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.identifier.value"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.name",
+                "path": "Patient.name",
+                "min": 1,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "HumanName"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "us-core-8",
+                        "severity": "error",
+                        "human": "Either Patient.name.given and/or Patient.name.family SHALL be present or a Data Absent Reason Extension SHALL be present.",
+                        "expression": "(family.exists() or given.exists()) xor extension.where(url='http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()",
+                        "xpath": "(/f:extension/@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason' and not(/f:family or /f:given)) or (not(/f:extension/@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason') and (/f:family or /f:given))"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.name"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.name.family",
+                "path": "Patient.name.family",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "condition": [
+                    "us-core-8"
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.name.family"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.name.given",
+                "path": "Patient.name.given",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "condition": [
+                    "us-core-8"
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.name.given"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.telecom",
+                "path": "Patient.telecom",
+                "min": 0,
+                "max": "*",
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.telecom.system",
+                "path": "Patient.telecom.system",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "description": "Telecommunications form for contact point.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/contact-point-system"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.telecom.value",
+                "path": "Patient.telecom.value",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.telecom.use",
+                "path": "Patient.telecom.use",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/contact-point-use"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.gender",
+                "path": "Patient.gender",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/administrative-gender"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.gender"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.birthDate",
+                "path": "Patient.birthDate",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "date"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.birthDate"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address",
+                "path": "Patient.address",
+                "min": 0,
+                "max": "*",
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.birthDate"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.line",
+                "path": "Patient.address.line",
+                "min": 0,
+                "max": "*",
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.city",
+                "path": "Patient.address.city",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.state",
+                "path": "Patient.address.state",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Two Letter USPS alphabetic codes.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.postalCode",
+                "path": "Patient.address.postalCode",
+                "short": "US Zip Codes",
+                "alias": [
+                    "Zip Code"
+                ],
+                "min": 0,
+                "max": "1",
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.period",
+                "path": "Patient.address.period",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.communication",
+                "path": "Patient.communication",
+                "min": 0,
+                "max": "*",
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.communication"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.communication.language",
+                "path": "Patient.communication.language",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/simple-language|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.communication.language"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-practitioner.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-practitioner.json
@@ -1,2253 +1,2253 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-practitioner",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitioner-definitions.html#Practitioner\" title=\"This is basic constraint on provider for use in US Core resources.\">Practitioner</a><a name=\"Practitioner\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/practitioner.html\">Practitioner</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">A person with a  formal responsibility in the provisioning of healthcare or related services</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck13.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Definition\" class=\"hierarchy\"/> <a style=\"font-style: italic\" href=\"StructureDefinition-us-core-practitioner-definitions.html#Practitioner.identifier\">identifier</a><a name=\"Practitioner.identifier\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red; font-style: italic\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"font-style: italic\"/><span style=\"font-style: italic\">1</span><span style=\"font-style: italic\">..</span><span style=\"font-style: italic\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"font-style: italic\" href=\"http://hl7.org/fhir/R4/profiling.html#slicing\">(Slice Definition)</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5; font-style: italic\">An identifier for the person as this agent</span><br style=\"font-style: italic\"/><span style=\"font-weight:bold; font-style: italic\">Slice: </span><span style=\"font-style: italic\">Unordered, Open by pattern:$this</span><br style=\"font-style: italic\"/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck133.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> identifier:All Slices<a name=\"Practitioner.identifier\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Content/Rules for all slices</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1330.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitioner-definitions.html#Practitioner.identifier.system\">system</a><a name=\"Practitioner.identifier.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The namespace for the identifier value</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1320.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitioner-definitions.html#Practitioner.identifier.value\">value</a><a name=\"Practitioner.identifier.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The value that is unique</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck125.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitioner-definitions.html#Practitioner.identifier:NPI\" title=\"Slice NPI\">identifier:NPI</a><a name=\"Practitioner.identifier\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Identifier\">Identifier</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">An identifier for the person as this agent</span><br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1240.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Identifier.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">The namespace for the identifier value<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">http://hl7.org/fhir/sid/us-npi</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitioner-definitions.html#Practitioner.name\">name</a><a name=\"Practitioner.name\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#HumanName\">HumanName</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The name(s) associated with the practitioner</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitioner-definitions.html#Practitioner.name.family\">family</a><a name=\"Practitioner.name.family\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Family name (often called 'Surname')</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
-	"version": "3.1.1",
-	"name": "USCorePractitionerProfile",
-	"title": "US Core Practitioner Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2019-09-02",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.healthit.gov"
-				}
-			]
-		}
-	],
-	"description": "The practitioner(s) referenced in US Core profiles.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "servd",
-			"uri": "http://www.omg.org/spec/ServD/1.0/",
-			"name": "ServD"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Practitioner",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Practitioner",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Practitioner",
-				"path": "Practitioner",
-				"short": "A person with a  formal responsibility in the provisioning of healthcare or related services",
-				"definition": "This is basic constraint on provider for use in US Core resources.",
-				"alias": [
-					"Provider"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Practitioner",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "v2",
-						"map": "PRD (as one example)"
-					},
-					{
-						"identity": "rim",
-						"map": "Role"
-					},
-					{
-						"identity": "servd",
-						"map": "Provider"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.id",
-				"path": "Practitioner.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Practitioner.meta",
-				"path": "Practitioner.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Practitioner.implicitRules",
-				"path": "Practitioner.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Practitioner.language",
-				"path": "Practitioner.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Practitioner.text",
-				"path": "Practitioner.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.contained",
-				"path": "Practitioner.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.extension",
-				"path": "Practitioner.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.modifierExtension",
-				"path": "Practitioner.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.identifier",
-				"path": "Practitioner.identifier",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "$this"
-						}
-					],
-					"rules": "open"
-				},
-				"short": "An identifier for the person as this agent",
-				"definition": "An identifier that applies to this person in this role.",
-				"comment": "NPI must be supported as the identifier system in the US, Tax id is allowed, Local id is allowed in addition to an another identifier supplied by a jurisdictional authority such as a practitioner's *Drug Enforcement Administration (DEA)* number.",
-				"requirements": "Often, specific identities are assigned for the agent.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Practitioner.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "PRD-7 (or XCN.1)"
-					},
-					{
-						"identity": "rim",
-						"map": "./id"
-					},
-					{
-						"identity": "servd",
-						"map": "./Identifiers"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.identifier.id",
-				"path": "Practitioner.identifier.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.identifier.extension",
-				"path": "Practitioner.identifier.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.identifier.use",
-				"path": "Practitioner.identifier.use",
-				"short": "usual | official | temp | secondary | old (If known)",
-				"definition": "The purpose of this identifier.",
-				"comment": "Applications can assume that an identifier is permanent unless it explicitly says that it is temporary.",
-				"requirements": "Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.use",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary id for a permanent one.",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "IdentifierUse"
-						}
-					],
-					"strength": "required",
-					"description": "Identifies the purpose for this identifier, if known .",
-					"valueSet": "http://hl7.org/fhir/ValueSet/identifier-use|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "Role.code or implied by context"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.identifier.type",
-				"path": "Practitioner.identifier.type",
-				"short": "Description of identifier",
-				"definition": "A coded type for the identifier that can be used to determine which identifier to use for a specific purpose.",
-				"comment": "This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage.   Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type.",
-				"requirements": "Allows users to make use of identifiers when the identifier system is not known.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "IdentifierType"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "extensible",
-					"description": "A coded type for an identifier that can be used to determine which identifier to use for a specific purpose.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/identifier-type"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.5"
-					},
-					{
-						"identity": "rim",
-						"map": "Role.code or implied by context"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.identifier.system",
-				"path": "Practitioner.identifier.system",
-				"short": "The namespace for the identifier value",
-				"definition": "Establishes the namespace for the value - that is, a URL that describes a set values that are unique.",
-				"comment": "Identifier.system is always case sensitive.",
-				"requirements": "There are many sets  of identifiers.  To perform matching of two identifiers, we need to know what set we're dealing with. The system identifies a particular set of unique identifiers.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Identifier.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueUri": "http://www.acme.com/identifiers/patient"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.4 / EI-2-4"
-					},
-					{
-						"identity": "rim",
-						"map": "II.root or Role.id.root"
-					},
-					{
-						"identity": "servd",
-						"map": "./IdentifierType"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.identifier.value",
-				"path": "Practitioner.identifier.value",
-				"short": "The value that is unique",
-				"definition": "The portion of the identifier typically relevant to the user and which is unique within the context of the system.",
-				"comment": "If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986.  The value's primary purpose is computational mapping.  As a result, it may be normalized for comparison purposes (e.g. removing non-significant whitespace, dashes, etc.)  A value formatted for human display can be conveyed using the [Rendered Value extension](http://hl7.org/fhir/R4/extension-rendered-value.html). Identifier.value is to be treated as case sensitive unless knowledge of the Identifier.system allows the processer to be confident that non-case-sensitive processing is safe.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Identifier.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "123456"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.1 / EI.1"
-					},
-					{
-						"identity": "rim",
-						"map": "II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)"
-					},
-					{
-						"identity": "servd",
-						"map": "./Value"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.identifier.period",
-				"path": "Practitioner.identifier.period",
-				"short": "Time period when id is/was valid for use",
-				"definition": "Time period during which identifier is/was valid for use.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.7 + CX.8"
-					},
-					{
-						"identity": "rim",
-						"map": "Role.effectiveTime or implied by context"
-					},
-					{
-						"identity": "servd",
-						"map": "./StartDate and ./EndDate"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.identifier.assigner",
-				"path": "Practitioner.identifier.assigner",
-				"short": "Organization that issued id (may be just text)",
-				"definition": "Organization that issued/manages the identifier.",
-				"comment": "The Identifier.assigner may omit the .reference element and only contain a .display element reflecting the name or other textual information about the assigning organization.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.assigner",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.4 / (CX.4,CX.9,CX.10)"
-					},
-					{
-						"identity": "rim",
-						"map": "II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper"
-					},
-					{
-						"identity": "servd",
-						"map": "./IdentifierIssuingAuthority"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.identifier:NPI",
-				"path": "Practitioner.identifier",
-				"sliceName": "NPI",
-				"short": "An identifier for the person as this agent",
-				"definition": "An identifier that applies to this person in this role.",
-				"requirements": "Often, specific identities are assigned for the agent.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Practitioner.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"patternIdentifier": {
-					"system": "http://hl7.org/fhir/sid/us-npi"
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "PRD-7 (or XCN.1)"
-					},
-					{
-						"identity": "rim",
-						"map": "./id"
-					},
-					{
-						"identity": "servd",
-						"map": "./Identifiers"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.active",
-				"path": "Practitioner.active",
-				"short": "Whether this practitioner's record is in active use",
-				"definition": "Whether this practitioner's record is in active use.",
-				"comment": "If the practitioner is not in use by one organization, then it should mark the period on the PractitonerRole with an end date (even if they are active) as they may be active in another role.",
-				"requirements": "Need to be able to mark a practitioner record as not to be used because it was created in error.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Practitioner.active",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"meaningWhenMissing": "This resource is generally assumed to be active if no value is provided for the active element",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "rim",
-						"map": "./statusCode"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.name",
-				"path": "Practitioner.name",
-				"short": "The name(s) associated with the practitioner",
-				"definition": "The name(s) associated with the practitioner.",
-				"comment": "The selection of the use property should ensure that there is a single usual name specified, and others use the nickname (alias), old, or other values as appropriate.  \r\rIn general, select the value to be used in the ResourceReference.display based on this:\r\r1. There is more than 1 name\r2. Use = usual\r3. Period is current to the date of the usage\r4. Use = official\r5. Other order as decided by internal business rules.",
-				"requirements": "The name(s) that a Practitioner is known by. Where there are multiple, the name that the practitioner is usually known as should be used in the display.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Practitioner.name",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "HumanName"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XCN Components"
-					},
-					{
-						"identity": "rim",
-						"map": "./name"
-					},
-					{
-						"identity": "servd",
-						"map": "./PreferredName (GivenNames, FamilyName, TitleCode)"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.name.id",
-				"path": "Practitioner.name.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.name.extension",
-				"path": "Practitioner.name.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.name.use",
-				"path": "Practitioner.name.use",
-				"short": "usual | official | temp | nickname | anonymous | old | maiden",
-				"definition": "Identifies the purpose for this name.",
-				"comment": "Applications can assume that a name is current unless it explicitly says that it is temporary or old.",
-				"requirements": "Allows the appropriate name for a particular context of use to be selected from among a set of names.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "HumanName.use",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old name etc.for a current/permanent one",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "NameUse"
-						}
-					],
-					"strength": "required",
-					"description": "The use of a human name.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/name-use|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XPN.7, but often indicated by which field contains the name"
-					},
-					{
-						"identity": "rim",
-						"map": "unique(./use)"
-					},
-					{
-						"identity": "servd",
-						"map": "./NamePurpose"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.name.text",
-				"path": "Practitioner.name.text",
-				"short": "Text representation of the full name",
-				"definition": "Specifies the entire name as it should be displayed e.g. on an application UI. This may be provided instead of or as well as the specific parts.",
-				"comment": "Can provide both a text representation and parts. Applications updating a name SHALL ensure that when both text and parts are present,  no content is included in the text that isn't found in a part.",
-				"requirements": "A renderable, unencoded form.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "HumanName.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "implied by XPN.11"
-					},
-					{
-						"identity": "rim",
-						"map": "./formatted"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.name.family",
-				"path": "Practitioner.name.family",
-				"short": "Family name (often called 'Surname')",
-				"definition": "The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father.",
-				"comment": "Family Name may be decomposed into specific parts using extensions (de, nl, es related cultures).",
-				"alias": [
-					"surname"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "HumanName.family",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XPN.1/FN.1"
-					},
-					{
-						"identity": "rim",
-						"map": "./part[partType = FAM]"
-					},
-					{
-						"identity": "servd",
-						"map": "./FamilyName"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.name.given",
-				"path": "Practitioner.name.given",
-				"short": "Given names (not always 'first'). Includes middle names",
-				"definition": "Given name.",
-				"comment": "If only initials are recorded, they may be used in place of the full name parts. Initials may be separated into multiple given names but often aren't due to paractical limitations.  This element is not called \"first name\" since given names do not always come first.",
-				"alias": [
-					"first name",
-					"middle name"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "HumanName.given",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"orderMeaning": "Given Names appear in the correct order for presenting the name",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XPN.2 + XPN.3"
-					},
-					{
-						"identity": "rim",
-						"map": "./part[partType = GIV]"
-					},
-					{
-						"identity": "servd",
-						"map": "./GivenNames"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.name.prefix",
-				"path": "Practitioner.name.prefix",
-				"short": "Parts that come before the name",
-				"definition": "Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "HumanName.prefix",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"orderMeaning": "Prefixes appear in the correct order for presenting the name",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XPN.5"
-					},
-					{
-						"identity": "rim",
-						"map": "./part[partType = PFX]"
-					},
-					{
-						"identity": "servd",
-						"map": "./TitleCode"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.name.suffix",
-				"path": "Practitioner.name.suffix",
-				"short": "Parts that come after the name",
-				"definition": "Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "HumanName.suffix",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"orderMeaning": "Suffixes appear in the correct order for presenting the name",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XPN/4"
-					},
-					{
-						"identity": "rim",
-						"map": "./part[partType = SFX]"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.name.period",
-				"path": "Practitioner.name.period",
-				"short": "Time period when name was/is in use",
-				"definition": "Indicates the period of time when this name was valid for the named person.",
-				"requirements": "Allows names to be placed in historical context.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "HumanName.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XPN.13 + XPN.14"
-					},
-					{
-						"identity": "rim",
-						"map": "./usablePeriod[type=\"IVL<TS>\"]"
-					},
-					{
-						"identity": "servd",
-						"map": "./StartDate and ./EndDate"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.telecom",
-				"path": "Practitioner.telecom",
-				"short": "A contact detail for the practitioner (that apply to all roles)",
-				"definition": "A contact detail for the practitioner, e.g. a telephone number or an email address.",
-				"comment": "Person may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and to help with identification.  These typically will have home numbers, or mobile numbers that are not role specific.",
-				"requirements": "Need to know how to reach a practitioner independent to any roles the practitioner may have.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Practitioner.telecom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "ContactPoint"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PRT-15, STF-10, ROL-12"
-					},
-					{
-						"identity": "rim",
-						"map": "./telecom"
-					},
-					{
-						"identity": "servd",
-						"map": "./ContactPoints"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.address",
-				"path": "Practitioner.address",
-				"short": "Address(es) of the practitioner that are not role specific (typically home address)",
-				"definition": "Address(es) of the practitioner that are not role specific (typically home address). \rWork addresses are not typically entered in this property as they are usually role dependent.",
-				"comment": "The PractitionerRole does not have an address value on it, as it is expected that the location property be used for this purpose (which has an address).",
-				"requirements": "The home/mailing address of the practitioner is often required for employee administration purposes, and also for some rostering services where the start point (practitioners home) can be used in calculations.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Practitioner.address",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Address"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "ORC-24, STF-11, ROL-11, PRT-14"
-					},
-					{
-						"identity": "rim",
-						"map": "./addr"
-					},
-					{
-						"identity": "servd",
-						"map": "./Addresses"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.gender",
-				"path": "Practitioner.gender",
-				"short": "male | female | other | unknown",
-				"definition": "Administrative Gender - the gender that the person is considered to have for administration and record keeping purposes.",
-				"requirements": "Needed to address the person correctly.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Practitioner.gender",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AdministrativeGender"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "required",
-					"description": "The gender of a person used for administrative purposes.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/administrative-gender|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "STF-5"
-					},
-					{
-						"identity": "rim",
-						"map": "./administrativeGender"
-					},
-					{
-						"identity": "servd",
-						"map": "./GenderCode"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.birthDate",
-				"path": "Practitioner.birthDate",
-				"short": "The date  on which the practitioner was born",
-				"definition": "The date of birth for the practitioner.",
-				"requirements": "Needed for identification.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Practitioner.birthDate",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "date"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "STF-6"
-					},
-					{
-						"identity": "rim",
-						"map": "./birthTime"
-					},
-					{
-						"identity": "servd",
-						"map": "(not represented in ServD)"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.photo",
-				"path": "Practitioner.photo",
-				"short": "Image of the person",
-				"definition": "Image of the person.",
-				"requirements": "Many EHR systems have the capability to capture an image of patients and personnel. Fits with newer social media usage too.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Practitioner.photo",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Attachment"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "./subjectOf/ObservationEvent[code=\"photo\"]/value"
-					},
-					{
-						"identity": "servd",
-						"map": "./ImageURI (only supports the URI reference)"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.qualification",
-				"path": "Practitioner.qualification",
-				"short": "Certification, licenses, or training pertaining to the provision of care",
-				"definition": "The official certifications, training, and licenses that authorize or otherwise pertain to the provision of care by the practitioner.  For example, a medical license issued by a medical board authorizing the practitioner to practice medicine within a certian locality.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Practitioner.qualification",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CER?"
-					},
-					{
-						"identity": "rim",
-						"map": ".playingEntity.playingRole[classCode=QUAL].code"
-					},
-					{
-						"identity": "servd",
-						"map": "./Qualifications"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.qualification.id",
-				"path": "Practitioner.qualification.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.qualification.extension",
-				"path": "Practitioner.qualification.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.qualification.modifierExtension",
-				"path": "Practitioner.qualification.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.qualification.identifier",
-				"path": "Practitioner.qualification.identifier",
-				"short": "An identifier for this qualification for the practitioner",
-				"definition": "An identifier that applies to this person's qualification in this role.",
-				"requirements": "Often, specific identities are assigned for the qualification.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Practitioner.qualification.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".playingEntity.playingRole[classCode=QUAL].id"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.qualification.code",
-				"path": "Practitioner.qualification.code",
-				"short": "Coded representation of the qualification",
-				"definition": "Coded representation of the qualification.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Practitioner.qualification.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Qualification"
-						}
-					],
-					"strength": "example",
-					"description": "Specific qualification the practitioner has to provide a service.",
-					"valueSet": "http://terminology.hl7.org/ValueSet/v2-2.7-0360"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".playingEntity.playingRole[classCode=QUAL].code"
-					},
-					{
-						"identity": "servd",
-						"map": "./Qualifications.Value"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.qualification.period",
-				"path": "Practitioner.qualification.period",
-				"short": "Period during which the qualification is valid",
-				"definition": "Period during which the qualification is valid.",
-				"requirements": "Qualifications are often for a limited period of time, and can be revoked.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Practitioner.qualification.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".playingEntity.playingRole[classCode=QUAL].effectiveTime"
-					},
-					{
-						"identity": "servd",
-						"map": "./Qualifications.StartDate and ./Qualifications.EndDate"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.qualification.issuer",
-				"path": "Practitioner.qualification.issuer",
-				"short": "Organization that regulates and issues the qualification",
-				"definition": "Organization that regulates and issues the qualification.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Practitioner.qualification.issuer",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".playingEntity.playingRole[classCode=QUAL].scoper"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.communication",
-				"path": "Practitioner.communication",
-				"short": "A language the practitioner can use in patient communication",
-				"definition": "A language the practitioner can use in patient communication.",
-				"comment": "The structure aa-BB with this exact casing is one the most widely used notations for locale. However not all systems code this but instead have it as free text. Hence CodeableConcept instead of code as the data type.",
-				"requirements": "Knowing which language a practitioner speaks can help in facilitating communication with patients.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Practitioner.communication",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PID-15, NK1-20, LAN-2"
-					},
-					{
-						"identity": "rim",
-						"map": "./languageCommunication"
-					},
-					{
-						"identity": "servd",
-						"map": "./Languages.LanguageSpokenCode"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Practitioner",
-				"path": "Practitioner",
-				"definition": "This is basic constraint on provider for use in US Core resources.",
-				"alias": [
-					"Provider"
-				],
-				"mustSupport": false
-			},
-			{
-				"id": "Practitioner.identifier",
-				"path": "Practitioner.identifier",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "$this"
-						}
-					],
-					"rules": "open"
-				},
-				"comment": "NPI must be supported as the identifier system in the US, Tax id is allowed, Local id is allowed in addition to an another identifier supplied by a jurisdictional authority such as a practitioner's *Drug Enforcement Administration (DEA)* number.",
-				"min": 1,
-				"max": "*",
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Practitioner.identifier.system",
-				"path": "Practitioner.identifier.system",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Practitioner.identifier.value",
-				"path": "Practitioner.identifier.value",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Practitioner.identifier:NPI",
-				"path": "Practitioner.identifier",
-				"sliceName": "NPI",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"patternIdentifier": {
-					"system": "http://hl7.org/fhir/sid/us-npi"
-				},
-				"mustSupport": true
-			},
-			{
-				"id": "Practitioner.name",
-				"path": "Practitioner.name",
-				"min": 1,
-				"max": "*",
-				"type": [
-					{
-						"code": "HumanName"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Practitioner.name.family",
-				"path": "Practitioner.name.family",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-practitioner",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
+    "version": "3.1.1",
+    "name": "USCorePractitionerProfile",
+    "title": "US Core Practitioner Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2019-09-02",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.healthit.gov"
+                }
+            ]
+        }
+    ],
+    "description": "The practitioner(s) referenced in US Core profiles.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "servd",
+            "uri": "http://www.omg.org/spec/ServD/1.0/",
+            "name": "ServD"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Practitioner",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Practitioner",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Practitioner",
+                "path": "Practitioner",
+                "short": "A person with a  formal responsibility in the provisioning of healthcare or related services",
+                "definition": "This is basic constraint on provider for use in US Core resources.",
+                "alias": [
+                    "Provider"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Practitioner",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRD (as one example)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Role"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "Provider"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.id",
+                "path": "Practitioner.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Practitioner.meta",
+                "path": "Practitioner.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Practitioner.implicitRules",
+                "path": "Practitioner.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Practitioner.language",
+                "path": "Practitioner.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Practitioner.text",
+                "path": "Practitioner.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.contained",
+                "path": "Practitioner.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.extension",
+                "path": "Practitioner.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.modifierExtension",
+                "path": "Practitioner.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.identifier",
+                "path": "Practitioner.identifier",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "$this"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "short": "An identifier for the person as this agent",
+                "definition": "An identifier that applies to this person in this role.",
+                "comment": "NPI must be supported as the identifier system in the US, Tax id is allowed, Local id is allowed in addition to an another identifier supplied by a jurisdictional authority such as a practitioner's *Drug Enforcement Administration (DEA)* number.",
+                "requirements": "Often, specific identities are assigned for the agent.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Practitioner.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRD-7 (or XCN.1)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./id"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Identifiers"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.identifier.id",
+                "path": "Practitioner.identifier.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.identifier.extension",
+                "path": "Practitioner.identifier.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.identifier.use",
+                "path": "Practitioner.identifier.use",
+                "short": "usual | official | temp | secondary | old (If known)",
+                "definition": "The purpose of this identifier.",
+                "comment": "Applications can assume that an identifier is permanent unless it explicitly says that it is temporary.",
+                "requirements": "Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.use",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary id for a permanent one.",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "IdentifierUse"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Identifies the purpose for this identifier, if known .",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/identifier-use|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Role.code or implied by context"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.identifier.type",
+                "path": "Practitioner.identifier.type",
+                "short": "Description of identifier",
+                "definition": "A coded type for the identifier that can be used to determine which identifier to use for a specific purpose.",
+                "comment": "This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage.   Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type.",
+                "requirements": "Allows users to make use of identifiers when the identifier system is not known.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "IdentifierType"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "A coded type for an identifier that can be used to determine which identifier to use for a specific purpose.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/identifier-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Role.code or implied by context"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.identifier.system",
+                "path": "Practitioner.identifier.system",
+                "short": "The namespace for the identifier value",
+                "definition": "Establishes the namespace for the value - that is, a URL that describes a set values that are unique.",
+                "comment": "Identifier.system is always case sensitive.",
+                "requirements": "There are many sets  of identifiers.  To perform matching of two identifiers, we need to know what set we're dealing with. The system identifies a particular set of unique identifiers.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueUri": "http://www.acme.com/identifiers/patient"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.4 / EI-2-4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "II.root or Role.id.root"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./IdentifierType"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.identifier.value",
+                "path": "Practitioner.identifier.value",
+                "short": "The value that is unique",
+                "definition": "The portion of the identifier typically relevant to the user and which is unique within the context of the system.",
+                "comment": "If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986.  The value's primary purpose is computational mapping.  As a result, it may be normalized for comparison purposes (e.g. removing non-significant whitespace, dashes, etc.)  A value formatted for human display can be conveyed using the [Rendered Value extension](http://hl7.org/fhir/R4/extension-rendered-value.html). Identifier.value is to be treated as case sensitive unless knowledge of the Identifier.system allows the processer to be confident that non-case-sensitive processing is safe.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "123456"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.1 / EI.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Value"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.identifier.period",
+                "path": "Practitioner.identifier.period",
+                "short": "Time period when id is/was valid for use",
+                "definition": "Time period during which identifier is/was valid for use.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.7 + CX.8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Role.effectiveTime or implied by context"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./StartDate and ./EndDate"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.identifier.assigner",
+                "path": "Practitioner.identifier.assigner",
+                "short": "Organization that issued id (may be just text)",
+                "definition": "Organization that issued/manages the identifier.",
+                "comment": "The Identifier.assigner may omit the .reference element and only contain a .display element reflecting the name or other textual information about the assigning organization.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.assigner",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.4 / (CX.4,CX.9,CX.10)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./IdentifierIssuingAuthority"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.identifier:NPI",
+                "path": "Practitioner.identifier",
+                "sliceName": "NPI",
+                "short": "An identifier for the person as this agent",
+                "definition": "An identifier that applies to this person in this role.",
+                "requirements": "Often, specific identities are assigned for the agent.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Practitioner.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "patternIdentifier": {
+                    "system": "http://hl7.org/fhir/sid/us-npi"
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRD-7 (or XCN.1)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./id"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Identifiers"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.active",
+                "path": "Practitioner.active",
+                "short": "Whether this practitioner's record is in active use",
+                "definition": "Whether this practitioner's record is in active use.",
+                "comment": "If the practitioner is not in use by one organization, then it should mark the period on the PractitonerRole with an end date (even if they are active) as they may be active in another role.",
+                "requirements": "Need to be able to mark a practitioner record as not to be used because it was created in error.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Practitioner.active",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "meaningWhenMissing": "This resource is generally assumed to be active if no value is provided for the active element",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./statusCode"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.name",
+                "path": "Practitioner.name",
+                "short": "The name(s) associated with the practitioner",
+                "definition": "The name(s) associated with the practitioner.",
+                "comment": "The selection of the use property should ensure that there is a single usual name specified, and others use the nickname (alias), old, or other values as appropriate.  \r\rIn general, select the value to be used in the ResourceReference.display based on this:\r\r1. There is more than 1 name\r2. Use = usual\r3. Period is current to the date of the usage\r4. Use = official\r5. Other order as decided by internal business rules.",
+                "requirements": "The name(s) that a Practitioner is known by. Where there are multiple, the name that the practitioner is usually known as should be used in the display.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Practitioner.name",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "HumanName"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XCN Components"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./name"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./PreferredName (GivenNames, FamilyName, TitleCode)"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.name.id",
+                "path": "Practitioner.name.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.name.extension",
+                "path": "Practitioner.name.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.name.use",
+                "path": "Practitioner.name.use",
+                "short": "usual | official | temp | nickname | anonymous | old | maiden",
+                "definition": "Identifies the purpose for this name.",
+                "comment": "Applications can assume that a name is current unless it explicitly says that it is temporary or old.",
+                "requirements": "Allows the appropriate name for a particular context of use to be selected from among a set of names.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "HumanName.use",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old name etc.for a current/permanent one",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "NameUse"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The use of a human name.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/name-use|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XPN.7, but often indicated by which field contains the name"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "unique(./use)"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./NamePurpose"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.name.text",
+                "path": "Practitioner.name.text",
+                "short": "Text representation of the full name",
+                "definition": "Specifies the entire name as it should be displayed e.g. on an application UI. This may be provided instead of or as well as the specific parts.",
+                "comment": "Can provide both a text representation and parts. Applications updating a name SHALL ensure that when both text and parts are present,  no content is included in the text that isn't found in a part.",
+                "requirements": "A renderable, unencoded form.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "HumanName.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "implied by XPN.11"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./formatted"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.name.family",
+                "path": "Practitioner.name.family",
+                "short": "Family name (often called 'Surname')",
+                "definition": "The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father.",
+                "comment": "Family Name may be decomposed into specific parts using extensions (de, nl, es related cultures).",
+                "alias": [
+                    "surname"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "HumanName.family",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XPN.1/FN.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./part[partType = FAM]"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./FamilyName"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.name.given",
+                "path": "Practitioner.name.given",
+                "short": "Given names (not always 'first'). Includes middle names",
+                "definition": "Given name.",
+                "comment": "If only initials are recorded, they may be used in place of the full name parts. Initials may be separated into multiple given names but often aren't due to paractical limitations.  This element is not called \"first name\" since given names do not always come first.",
+                "alias": [
+                    "first name",
+                    "middle name"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "HumanName.given",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "orderMeaning": "Given Names appear in the correct order for presenting the name",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XPN.2 + XPN.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./part[partType = GIV]"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./GivenNames"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.name.prefix",
+                "path": "Practitioner.name.prefix",
+                "short": "Parts that come before the name",
+                "definition": "Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "HumanName.prefix",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "orderMeaning": "Prefixes appear in the correct order for presenting the name",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XPN.5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./part[partType = PFX]"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./TitleCode"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.name.suffix",
+                "path": "Practitioner.name.suffix",
+                "short": "Parts that come after the name",
+                "definition": "Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "HumanName.suffix",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "orderMeaning": "Suffixes appear in the correct order for presenting the name",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XPN/4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./part[partType = SFX]"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.name.period",
+                "path": "Practitioner.name.period",
+                "short": "Time period when name was/is in use",
+                "definition": "Indicates the period of time when this name was valid for the named person.",
+                "requirements": "Allows names to be placed in historical context.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "HumanName.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XPN.13 + XPN.14"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./usablePeriod[type=\"IVL<TS>\"]"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./StartDate and ./EndDate"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.telecom",
+                "path": "Practitioner.telecom",
+                "short": "A contact detail for the practitioner (that apply to all roles)",
+                "definition": "A contact detail for the practitioner, e.g. a telephone number or an email address.",
+                "comment": "Person may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and to help with identification.  These typically will have home numbers, or mobile numbers that are not role specific.",
+                "requirements": "Need to know how to reach a practitioner independent to any roles the practitioner may have.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Practitioner.telecom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "ContactPoint"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PRT-15, STF-10, ROL-12"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./telecom"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./ContactPoints"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.address",
+                "path": "Practitioner.address",
+                "short": "Address(es) of the practitioner that are not role specific (typically home address)",
+                "definition": "Address(es) of the practitioner that are not role specific (typically home address). \rWork addresses are not typically entered in this property as they are usually role dependent.",
+                "comment": "The PractitionerRole does not have an address value on it, as it is expected that the location property be used for this purpose (which has an address).",
+                "requirements": "The home/mailing address of the practitioner is often required for employee administration purposes, and also for some rostering services where the start point (practitioners home) can be used in calculations.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Practitioner.address",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Address"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "ORC-24, STF-11, ROL-11, PRT-14"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./addr"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Addresses"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.gender",
+                "path": "Practitioner.gender",
+                "short": "male | female | other | unknown",
+                "definition": "Administrative Gender - the gender that the person is considered to have for administration and record keeping purposes.",
+                "requirements": "Needed to address the person correctly.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Practitioner.gender",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AdministrativeGender"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The gender of a person used for administrative purposes.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/administrative-gender|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "STF-5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./administrativeGender"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./GenderCode"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.birthDate",
+                "path": "Practitioner.birthDate",
+                "short": "The date  on which the practitioner was born",
+                "definition": "The date of birth for the practitioner.",
+                "requirements": "Needed for identification.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Practitioner.birthDate",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "date"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "STF-6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./birthTime"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "(not represented in ServD)"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.photo",
+                "path": "Practitioner.photo",
+                "short": "Image of the person",
+                "definition": "Image of the person.",
+                "requirements": "Many EHR systems have the capability to capture an image of patients and personnel. Fits with newer social media usage too.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Practitioner.photo",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Attachment"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "./subjectOf/ObservationEvent[code=\"photo\"]/value"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./ImageURI (only supports the URI reference)"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.qualification",
+                "path": "Practitioner.qualification",
+                "short": "Certification, licenses, or training pertaining to the provision of care",
+                "definition": "The official certifications, training, and licenses that authorize or otherwise pertain to the provision of care by the practitioner.  For example, a medical license issued by a medical board authorizing the practitioner to practice medicine within a certian locality.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Practitioner.qualification",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CER?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".playingEntity.playingRole[classCode=QUAL].code"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Qualifications"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.qualification.id",
+                "path": "Practitioner.qualification.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.qualification.extension",
+                "path": "Practitioner.qualification.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.qualification.modifierExtension",
+                "path": "Practitioner.qualification.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.qualification.identifier",
+                "path": "Practitioner.qualification.identifier",
+                "short": "An identifier for this qualification for the practitioner",
+                "definition": "An identifier that applies to this person's qualification in this role.",
+                "requirements": "Often, specific identities are assigned for the qualification.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Practitioner.qualification.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".playingEntity.playingRole[classCode=QUAL].id"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.qualification.code",
+                "path": "Practitioner.qualification.code",
+                "short": "Coded representation of the qualification",
+                "definition": "Coded representation of the qualification.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Practitioner.qualification.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Qualification"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Specific qualification the practitioner has to provide a service.",
+                    "valueSet": "http://terminology.hl7.org/ValueSet/v2-2.7-0360"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".playingEntity.playingRole[classCode=QUAL].code"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Qualifications.Value"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.qualification.period",
+                "path": "Practitioner.qualification.period",
+                "short": "Period during which the qualification is valid",
+                "definition": "Period during which the qualification is valid.",
+                "requirements": "Qualifications are often for a limited period of time, and can be revoked.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Practitioner.qualification.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".playingEntity.playingRole[classCode=QUAL].effectiveTime"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Qualifications.StartDate and ./Qualifications.EndDate"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.qualification.issuer",
+                "path": "Practitioner.qualification.issuer",
+                "short": "Organization that regulates and issues the qualification",
+                "definition": "Organization that regulates and issues the qualification.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Practitioner.qualification.issuer",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".playingEntity.playingRole[classCode=QUAL].scoper"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.communication",
+                "path": "Practitioner.communication",
+                "short": "A language the practitioner can use in patient communication",
+                "definition": "A language the practitioner can use in patient communication.",
+                "comment": "The structure aa-BB with this exact casing is one the most widely used notations for locale. However not all systems code this but instead have it as free text. Hence CodeableConcept instead of code as the data type.",
+                "requirements": "Knowing which language a practitioner speaks can help in facilitating communication with patients.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Practitioner.communication",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PID-15, NK1-20, LAN-2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./languageCommunication"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Languages.LanguageSpokenCode"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Practitioner",
+                "path": "Practitioner",
+                "definition": "This is basic constraint on provider for use in US Core resources.",
+                "alias": [
+                    "Provider"
+                ],
+                "mustSupport": false
+            },
+            {
+                "id": "Practitioner.identifier",
+                "path": "Practitioner.identifier",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "$this"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "comment": "NPI must be supported as the identifier system in the US, Tax id is allowed, Local id is allowed in addition to an another identifier supplied by a jurisdictional authority such as a practitioner's *Drug Enforcement Administration (DEA)* number.",
+                "min": 1,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Practitioner.identifier.system",
+                "path": "Practitioner.identifier.system",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Practitioner.identifier.value",
+                "path": "Practitioner.identifier.value",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Practitioner.identifier:NPI",
+                "path": "Practitioner.identifier",
+                "sliceName": "NPI",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "patternIdentifier": {
+                    "system": "http://hl7.org/fhir/sid/us-npi"
+                },
+                "mustSupport": true
+            },
+            {
+                "id": "Practitioner.name",
+                "path": "Practitioner.name",
+                "min": 1,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "HumanName"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Practitioner.name.family",
+                "path": "Practitioner.name.family",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-practitionerrole.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-practitionerrole.json
@@ -1,2080 +1,2080 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-practitionerrole",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitionerrole-definitions.html#PractitionerRole\" title=\"This is basic constraint on PractitionerRole for use in US Core resources.\">PractitionerRole</a><a name=\"PractitionerRole\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (pd-1)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/practitionerrole.html\">PractitionerRole</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Roles/organizations the practitioner is associated with</span><br/><span style=\"font-weight:bold\">pd-1: </span>SHALL have contact information or a reference to an Endpoint</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitionerrole-definitions.html#PractitionerRole.practitioner\">practitioner</a><a name=\"PractitionerRole.practitioner\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-practitioner.html\">US Core Practitioner Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Practitioner that is able to provide the defined services for the organization</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitionerrole-definitions.html#PractitionerRole.organization\">organization</a><a name=\"PractitionerRole.organization\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-organization.html\">US Core Organization Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Organization where the roles are available</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitionerrole-definitions.html#PractitionerRole.code\">code</a><a name=\"PractitionerRole.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Roles which this practitioner may perform</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-provider-role.html\">US Core Provider Role (NUCC)</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)<br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitionerrole-definitions.html#PractitionerRole.specialty\">specialty</a><a name=\"PractitionerRole.specialty\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Specific specialty of the practitioner</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-provider-specialty.html\">US Core Provider Speciality (NUCC)</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)<br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitionerrole-definitions.html#PractitionerRole.location\">location</a><a name=\"PractitionerRole.location\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"http://hl7.org/fhir/R4/location.html\">Location</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The location(s) at which this practitioner provides care</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitionerrole-definitions.html#PractitionerRole.telecom\">telecom</a><a name=\"PractitionerRole.telecom\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (pd-1)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#ContactPoint\">ContactPoint</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Contact details that are specific to the role/location/service</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitionerrole-definitions.html#PractitionerRole.telecom.system\">system</a><a name=\"PractitionerRole.telecom.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">phone | fax | email | pager | url | sms | other</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitionerrole-definitions.html#PractitionerRole.telecom.value\">value</a><a name=\"PractitionerRole.telecom.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The actual contact point details</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck00.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitionerrole-definitions.html#PractitionerRole.endpoint\">endpoint</a><a name=\"PractitionerRole.endpoint\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (pd-1)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/endpoint.html\">Endpoint</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Technical endpoints providing access to services operated for the practitioner with this role</span><br/></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
-	"version": "3.1.1",
-	"name": "USCorePractitionerRoleProfile",
-	"title": "US Core PractitionerRole Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2019-08-11",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.healthit.gov"
-				}
-			]
-		}
-	],
-	"description": "The practitioner roles referenced in the US Core profiles.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "servd",
-			"uri": "http://www.omg.org/spec/ServD/1.0/",
-			"name": "ServD"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "PractitionerRole",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "PractitionerRole",
-				"path": "PractitionerRole",
-				"short": "Roles/organizations the practitioner is associated with",
-				"definition": "This is basic constraint on PractitionerRole for use in US Core resources.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "PractitionerRole",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "pd-1",
-						"severity": "error",
-						"human": "SHALL have contact information or a reference to an Endpoint",
-						"expression": "telecom or endpoint",
-						"xpath": "exists(f:telecom) or exists(f:endpoint)"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "v2",
-						"map": "PRD (as one example)"
-					},
-					{
-						"identity": "rim",
-						"map": "Role"
-					},
-					{
-						"identity": "servd",
-						"map": "ServiceSiteProvider"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.id",
-				"path": "PractitionerRole.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "PractitionerRole.meta",
-				"path": "PractitionerRole.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "PractitionerRole.implicitRules",
-				"path": "PractitionerRole.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "PractitionerRole.language",
-				"path": "PractitionerRole.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "PractitionerRole.text",
-				"path": "PractitionerRole.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.contained",
-				"path": "PractitionerRole.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.extension",
-				"path": "PractitionerRole.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.modifierExtension",
-				"path": "PractitionerRole.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.identifier",
-				"path": "PractitionerRole.identifier",
-				"short": "Business Identifiers that are specific to a role/location",
-				"definition": "Business Identifiers that are specific to a role/location.",
-				"requirements": "Often, specific identities are assigned for the agent.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "PractitionerRole.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "PRD-7 (or XCN.1)"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					},
-					{
-						"identity": "servd",
-						"map": "./Identifiers"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.active",
-				"path": "PractitionerRole.active",
-				"short": "Whether this practitioner role record is in active use",
-				"definition": "Whether this practitioner role record is in active use.",
-				"comment": "If this value is false, you may refer to the period to see when the role was in active use. If there is no period specified, no inference can be made about when it was active.",
-				"requirements": "Need to be able to mark a practitioner role record as not to be used because it was created in error, or otherwise no longer in active use.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "PractitionerRole.active",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"meaningWhenMissing": "This resource is generally assumed to be active if no value is provided for the active element",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "v2",
-						"map": "STF-7"
-					},
-					{
-						"identity": "rim",
-						"map": ".statusCode"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.period",
-				"path": "PractitionerRole.period",
-				"short": "The period during which the practitioner is authorized to perform in these role(s)",
-				"definition": "The period during which the person is authorized to act as a practitioner in these role(s) for the organization.",
-				"requirements": "Even after the agencies is revoked, the fact that it existed must still be recorded.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "PractitionerRole.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PRD-8/9 / PRA-5.4"
-					},
-					{
-						"identity": "rim",
-						"map": ".performance[@typeCode <= 'PPRF'].ActDefinitionOrEvent.effectiveTime"
-					},
-					{
-						"identity": "servd",
-						"map": "(ServD maps Practitioners and Organizations via another entity, so this concept is not available)"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.practitioner",
-				"path": "PractitionerRole.practitioner",
-				"short": "Practitioner that is able to provide the defined services for the organization",
-				"definition": "Practitioner that is able to provide the defined services for the organization.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "PractitionerRole.practitioner",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".player"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.organization",
-				"path": "PractitionerRole.organization",
-				"short": "Organization where the roles are available",
-				"definition": "The organization where the Practitioner performs the roles associated.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "PractitionerRole.organization",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".scoper"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.code",
-				"path": "PractitionerRole.code",
-				"short": "Roles which this practitioner may perform",
-				"definition": "Roles which this practitioner is authorized to perform for the organization.",
-				"comment": "A person may have more than one role.",
-				"requirements": "Need to know what authority the practitioner has - what can they do?",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "PractitionerRole.code",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Provider role codes consisting of NUCC Health Care Provider Taxonomy Code Set for providers.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-provider-role|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PRD-1 / STF-18  / PRA-3  / PRT-4  / ROL-3 / ORC-12 / OBR-16 / PV1-7 / PV1-8 / PV1-9 / PV1-17"
-					},
-					{
-						"identity": "rim",
-						"map": ".code"
-					},
-					{
-						"identity": "servd",
-						"map": "(ServD maps Practitioners and Organizations via another entity, so this concept is not available)"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.specialty",
-				"path": "PractitionerRole.specialty",
-				"short": "Specific specialty of the practitioner",
-				"definition": "Specific specialty of the practitioner.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "PractitionerRole.specialty",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Provider specialty codes consist of NUCC Health Care Provider Taxonomy Code Set for providers.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-provider-specialty|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PRA-5"
-					},
-					{
-						"identity": "rim",
-						"map": ".player.HealthCareProvider[@classCode = 'PROV'].code"
-					},
-					{
-						"identity": "servd",
-						"map": "./Specialty"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.location",
-				"path": "PractitionerRole.location",
-				"short": "The location(s) at which this practitioner provides care",
-				"definition": "The location(s) at which this practitioner provides care.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "PractitionerRole.location",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Location"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.where[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".performance.ActDefinitionOrEvent.ServiceDeliveryLocation[@classCode = 'SDLOC']"
-					},
-					{
-						"identity": "servd",
-						"map": "(ServD maps Practitioners and Organizations via another entity, so this concept is not available)<br/> However these are accessed via the Site.ServiceSite.ServiceSiteProvider record. (The Site has the location)"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.healthcareService",
-				"path": "PractitionerRole.healthcareService",
-				"short": "The list of healthcare services that this worker provides for this role's Organization/Location(s)",
-				"definition": "The list of healthcare services that this worker provides for this role's Organization/Location(s).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "PractitionerRole.healthcareService",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/HealthcareService"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "EDU-2 / AFF-3"
-					},
-					{
-						"identity": "rim",
-						"map": ".player.QualifiedEntity[@classCode = 'QUAL'].code"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.telecom",
-				"path": "PractitionerRole.telecom",
-				"short": "Contact details that are specific to the role/location/service",
-				"definition": "Contact details that are specific to the role/location/service.",
-				"requirements": "Often practitioners have a dedicated line for each location (or service) that they work at, and need to be able to define separate contact details for each of these.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "PractitionerRole.telecom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "ContactPoint"
-					}
-				],
-				"condition": [
-					"pd-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".telecom"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.telecom.id",
-				"path": "PractitionerRole.telecom.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.telecom.extension",
-				"path": "PractitionerRole.telecom.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.telecom.system",
-				"path": "PractitionerRole.telecom.system",
-				"short": "phone | fax | email | pager | url | sms | other",
-				"definition": "Telecommunications form for contact point - what communications system is required to make use of the contact.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "ContactPoint.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"condition": [
-					"cpt-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ContactPointSystem"
-						}
-					],
-					"strength": "required",
-					"description": "Telecommunications form for contact point.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/contact-point-system|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XTN.3"
-					},
-					{
-						"identity": "rim",
-						"map": "./scheme"
-					},
-					{
-						"identity": "servd",
-						"map": "./ContactPointType"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.telecom.value",
-				"path": "PractitionerRole.telecom.value",
-				"short": "The actual contact point details",
-				"definition": "The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address).",
-				"comment": "Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value.",
-				"requirements": "Need to support legacy numbers that are not in a tightly controlled format.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "ContactPoint.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XTN.1 (or XTN.12)"
-					},
-					{
-						"identity": "rim",
-						"map": "./url"
-					},
-					{
-						"identity": "servd",
-						"map": "./Value"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.telecom.use",
-				"path": "PractitionerRole.telecom.use",
-				"short": "home | work | temp | old | mobile - purpose of this contact point",
-				"definition": "Identifies the purpose for the contact point.",
-				"comment": "Applications can assume that a contact is current unless it explicitly says that it is temporary or old.",
-				"requirements": "Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "ContactPoint.use",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old contact etc.for a current/permanent one",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ContactPointUse"
-						}
-					],
-					"strength": "required",
-					"description": "Use of contact point.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/contact-point-use|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XTN.2 - but often indicated by field"
-					},
-					{
-						"identity": "rim",
-						"map": "unique(./use)"
-					},
-					{
-						"identity": "servd",
-						"map": "./ContactPointPurpose"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.telecom.rank",
-				"path": "PractitionerRole.telecom.rank",
-				"short": "Specify preferred order of use (1 = highest)",
-				"definition": "Specifies a preferred order in which to use a set of contacts. ContactPoints with lower rank values are more preferred than those with higher rank values.",
-				"comment": "Note that rank does not necessarily follow the order in which the contacts are represented in the instance.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "ContactPoint.rank",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "positiveInt"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "n/a"
-					},
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.telecom.period",
-				"path": "PractitionerRole.telecom.period",
-				"short": "Time period when the contact point was/is in use",
-				"definition": "Time period when the contact point was/is in use.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "ContactPoint.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "./usablePeriod[type=\"IVL<TS>\"]"
-					},
-					{
-						"identity": "servd",
-						"map": "./StartDate and ./EndDate"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.availableTime",
-				"path": "PractitionerRole.availableTime",
-				"short": "Times the Service Site is available",
-				"definition": "A collection of times the practitioner is available or performing this role at the location and/or healthcareservice.",
-				"comment": "More detailed availability information may be provided in associated Schedule/Slot resources.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "PractitionerRole.availableTime",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.availableTime.id",
-				"path": "PractitionerRole.availableTime.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.availableTime.extension",
-				"path": "PractitionerRole.availableTime.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.availableTime.modifierExtension",
-				"path": "PractitionerRole.availableTime.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.availableTime.daysOfWeek",
-				"path": "PractitionerRole.availableTime.daysOfWeek",
-				"short": "mon | tue | wed | thu | fri | sat | sun",
-				"definition": "Indicates which days of the week are available between the start and end Times.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "PractitionerRole.availableTime.daysOfWeek",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "DaysOfWeek"
-						}
-					],
-					"strength": "required",
-					"description": "The days of the week.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/days-of-week|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.availableTime.allDay",
-				"path": "PractitionerRole.availableTime.allDay",
-				"short": "Always available? e.g. 24 hour service",
-				"definition": "Is this always available? (hence times are irrelevant) e.g. 24 hour service.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "PractitionerRole.availableTime.allDay",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.availableTime.availableStartTime",
-				"path": "PractitionerRole.availableTime.availableStartTime",
-				"short": "Opening time of day (ignored if allDay = true)",
-				"definition": "The opening time of day. Note: If the AllDay flag is set, then this time is ignored.",
-				"comment": "The timezone is expected to be for where this HealthcareService is provided at.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "PractitionerRole.availableTime.availableStartTime",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "time"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.availableTime.availableEndTime",
-				"path": "PractitionerRole.availableTime.availableEndTime",
-				"short": "Closing time of day (ignored if allDay = true)",
-				"definition": "The closing time of day. Note: If the AllDay flag is set, then this time is ignored.",
-				"comment": "The timezone is expected to be for where this HealthcareService is provided at.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "PractitionerRole.availableTime.availableEndTime",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "time"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.notAvailable",
-				"path": "PractitionerRole.notAvailable",
-				"short": "Not available during this time due to provided reason",
-				"definition": "The practitioner is not available or performing this role during this period of time due to the provided reason.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "PractitionerRole.notAvailable",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.notAvailable.id",
-				"path": "PractitionerRole.notAvailable.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.notAvailable.extension",
-				"path": "PractitionerRole.notAvailable.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.notAvailable.modifierExtension",
-				"path": "PractitionerRole.notAvailable.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.notAvailable.description",
-				"path": "PractitionerRole.notAvailable.description",
-				"short": "Reason presented to the user explaining why time not available",
-				"definition": "The reason that can be presented to the user as to why this time is not available.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "PractitionerRole.notAvailable.description",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.notAvailable.during",
-				"path": "PractitionerRole.notAvailable.during",
-				"short": "Service not available from this date",
-				"definition": "Service is not available (seasonally or for a public holiday) from this date.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "PractitionerRole.notAvailable.during",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.availabilityExceptions",
-				"path": "PractitionerRole.availabilityExceptions",
-				"short": "Description of availability exceptions",
-				"definition": "A description of site availability exceptions, e.g. public holiday availability. Succinctly describing all possible exceptions to normal site availability as details in the available Times and not available Times.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "PractitionerRole.availabilityExceptions",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.endpoint",
-				"path": "PractitionerRole.endpoint",
-				"short": "Technical endpoints providing access to services operated for the practitioner with this role",
-				"definition": "Technical endpoints providing access to services operated for the practitioner with this role.",
-				"requirements": "Organizations have multiple systems that provide various services and ,ay also be different for practitioners too.\r\rSo the endpoint satisfies the need to be able to define the technical connection details for how to connect to them, and for what purpose.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "PractitionerRole.endpoint",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Endpoint"
-						]
-					}
-				],
-				"condition": [
-					"pd-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "PractitionerRole",
-				"path": "PractitionerRole",
-				"definition": "This is basic constraint on PractitionerRole for use in US Core resources.",
-				"constraint": [
-					{
-						"key": "pd-1",
-						"severity": "error",
-						"human": "SHALL have contact information or a reference to an Endpoint",
-						"expression": "telecom or endpoint",
-						"xpath": "exists(f:telecom) or exists(f:endpoint)"
-					}
-				],
-				"mustSupport": false
-			},
-			{
-				"id": "PractitionerRole.practitioner",
-				"path": "PractitionerRole.practitioner",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "PractitionerRole.organization",
-				"path": "PractitionerRole.organization",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "PractitionerRole.code",
-				"path": "PractitionerRole.code",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Provider role codes consisting of NUCC Health Care Provider Taxonomy Code Set for providers.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-provider-role|3.1.1"
-				}
-			},
-			{
-				"id": "PractitionerRole.specialty",
-				"path": "PractitionerRole.specialty",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Provider specialty codes consist of NUCC Health Care Provider Taxonomy Code Set for providers.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-provider-specialty|3.1.1"
-				}
-			},
-			{
-				"id": "PractitionerRole.location",
-				"path": "PractitionerRole.location",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Location"
-						]
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "PractitionerRole.telecom",
-				"path": "PractitionerRole.telecom",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "ContactPoint"
-					}
-				],
-				"condition": [
-					"pd-1"
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "PractitionerRole.telecom.system",
-				"path": "PractitionerRole.telecom.system",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "PractitionerRole.telecom.value",
-				"path": "PractitionerRole.telecom.value",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "PractitionerRole.endpoint",
-				"path": "PractitionerRole.endpoint",
-				"min": 0,
-				"max": "*",
-				"condition": [
-					"pd-1"
-				],
-				"mustSupport": true
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-practitionerrole",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
+    "version": "3.1.1",
+    "name": "USCorePractitionerRoleProfile",
+    "title": "US Core PractitionerRole Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2019-08-11",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.healthit.gov"
+                }
+            ]
+        }
+    ],
+    "description": "The practitioner roles referenced in the US Core profiles.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "servd",
+            "uri": "http://www.omg.org/spec/ServD/1.0/",
+            "name": "ServD"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "PractitionerRole",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "PractitionerRole",
+                "path": "PractitionerRole",
+                "short": "Roles/organizations the practitioner is associated with",
+                "definition": "This is basic constraint on PractitionerRole for use in US Core resources.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "PractitionerRole",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "pd-1",
+                        "severity": "error",
+                        "human": "SHALL have contact information or a reference to an Endpoint",
+                        "expression": "telecom or endpoint",
+                        "xpath": "exists(f:telecom) or exists(f:endpoint)"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRD (as one example)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Role"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "ServiceSiteProvider"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.id",
+                "path": "PractitionerRole.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "PractitionerRole.meta",
+                "path": "PractitionerRole.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "PractitionerRole.implicitRules",
+                "path": "PractitionerRole.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "PractitionerRole.language",
+                "path": "PractitionerRole.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "PractitionerRole.text",
+                "path": "PractitionerRole.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.contained",
+                "path": "PractitionerRole.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.extension",
+                "path": "PractitionerRole.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.modifierExtension",
+                "path": "PractitionerRole.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.identifier",
+                "path": "PractitionerRole.identifier",
+                "short": "Business Identifiers that are specific to a role/location",
+                "definition": "Business Identifiers that are specific to a role/location.",
+                "requirements": "Often, specific identities are assigned for the agent.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "PractitionerRole.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRD-7 (or XCN.1)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Identifiers"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.active",
+                "path": "PractitionerRole.active",
+                "short": "Whether this practitioner role record is in active use",
+                "definition": "Whether this practitioner role record is in active use.",
+                "comment": "If this value is false, you may refer to the period to see when the role was in active use. If there is no period specified, no inference can be made about when it was active.",
+                "requirements": "Need to be able to mark a practitioner role record as not to be used because it was created in error, or otherwise no longer in active use.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "PractitionerRole.active",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "meaningWhenMissing": "This resource is generally assumed to be active if no value is provided for the active element",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "STF-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".statusCode"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.period",
+                "path": "PractitionerRole.period",
+                "short": "The period during which the practitioner is authorized to perform in these role(s)",
+                "definition": "The period during which the person is authorized to act as a practitioner in these role(s) for the organization.",
+                "requirements": "Even after the agencies is revoked, the fact that it existed must still be recorded.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "PractitionerRole.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRD-8/9 / PRA-5.4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".performance[@typeCode <= 'PPRF'].ActDefinitionOrEvent.effectiveTime"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "(ServD maps Practitioners and Organizations via another entity, so this concept is not available)"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.practitioner",
+                "path": "PractitionerRole.practitioner",
+                "short": "Practitioner that is able to provide the defined services for the organization",
+                "definition": "Practitioner that is able to provide the defined services for the organization.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "PractitionerRole.practitioner",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".player"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.organization",
+                "path": "PractitionerRole.organization",
+                "short": "Organization where the roles are available",
+                "definition": "The organization where the Practitioner performs the roles associated.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "PractitionerRole.organization",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".scoper"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.code",
+                "path": "PractitionerRole.code",
+                "short": "Roles which this practitioner may perform",
+                "definition": "Roles which this practitioner is authorized to perform for the organization.",
+                "comment": "A person may have more than one role.",
+                "requirements": "Need to know what authority the practitioner has - what can they do?",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "PractitionerRole.code",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Provider role codes consisting of NUCC Health Care Provider Taxonomy Code Set for providers.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-provider-role|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PRD-1 / STF-18  / PRA-3  / PRT-4  / ROL-3 / ORC-12 / OBR-16 / PV1-7 / PV1-8 / PV1-9 / PV1-17"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".code"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "(ServD maps Practitioners and Organizations via another entity, so this concept is not available)"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.specialty",
+                "path": "PractitionerRole.specialty",
+                "short": "Specific specialty of the practitioner",
+                "definition": "Specific specialty of the practitioner.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "PractitionerRole.specialty",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Provider specialty codes consist of NUCC Health Care Provider Taxonomy Code Set for providers.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-provider-specialty|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PRA-5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".player.HealthCareProvider[@classCode = 'PROV'].code"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Specialty"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.location",
+                "path": "PractitionerRole.location",
+                "short": "The location(s) at which this practitioner provides care",
+                "definition": "The location(s) at which this practitioner provides care.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "PractitionerRole.location",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Location"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.where[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".performance.ActDefinitionOrEvent.ServiceDeliveryLocation[@classCode = 'SDLOC']"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "(ServD maps Practitioners and Organizations via another entity, so this concept is not available)<br/> However these are accessed via the Site.ServiceSite.ServiceSiteProvider record. (The Site has the location)"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.healthcareService",
+                "path": "PractitionerRole.healthcareService",
+                "short": "The list of healthcare services that this worker provides for this role's Organization/Location(s)",
+                "definition": "The list of healthcare services that this worker provides for this role's Organization/Location(s).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "PractitionerRole.healthcareService",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/HealthcareService"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "EDU-2 / AFF-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".player.QualifiedEntity[@classCode = 'QUAL'].code"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.telecom",
+                "path": "PractitionerRole.telecom",
+                "short": "Contact details that are specific to the role/location/service",
+                "definition": "Contact details that are specific to the role/location/service.",
+                "requirements": "Often practitioners have a dedicated line for each location (or service) that they work at, and need to be able to define separate contact details for each of these.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "PractitionerRole.telecom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "ContactPoint"
+                    }
+                ],
+                "condition": [
+                    "pd-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".telecom"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.telecom.id",
+                "path": "PractitionerRole.telecom.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.telecom.extension",
+                "path": "PractitionerRole.telecom.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.telecom.system",
+                "path": "PractitionerRole.telecom.system",
+                "short": "phone | fax | email | pager | url | sms | other",
+                "definition": "Telecommunications form for contact point - what communications system is required to make use of the contact.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "ContactPoint.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "condition": [
+                    "cpt-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ContactPointSystem"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Telecommunications form for contact point.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/contact-point-system|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XTN.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./scheme"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./ContactPointType"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.telecom.value",
+                "path": "PractitionerRole.telecom.value",
+                "short": "The actual contact point details",
+                "definition": "The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address).",
+                "comment": "Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value.",
+                "requirements": "Need to support legacy numbers that are not in a tightly controlled format.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "ContactPoint.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XTN.1 (or XTN.12)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./url"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Value"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.telecom.use",
+                "path": "PractitionerRole.telecom.use",
+                "short": "home | work | temp | old | mobile - purpose of this contact point",
+                "definition": "Identifies the purpose for the contact point.",
+                "comment": "Applications can assume that a contact is current unless it explicitly says that it is temporary or old.",
+                "requirements": "Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "ContactPoint.use",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old contact etc.for a current/permanent one",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ContactPointUse"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Use of contact point.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/contact-point-use|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XTN.2 - but often indicated by field"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "unique(./use)"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./ContactPointPurpose"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.telecom.rank",
+                "path": "PractitionerRole.telecom.rank",
+                "short": "Specify preferred order of use (1 = highest)",
+                "definition": "Specifies a preferred order in which to use a set of contacts. ContactPoints with lower rank values are more preferred than those with higher rank values.",
+                "comment": "Note that rank does not necessarily follow the order in which the contacts are represented in the instance.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "ContactPoint.rank",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "positiveInt"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "n/a"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.telecom.period",
+                "path": "PractitionerRole.telecom.period",
+                "short": "Time period when the contact point was/is in use",
+                "definition": "Time period when the contact point was/is in use.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "ContactPoint.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./usablePeriod[type=\"IVL<TS>\"]"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./StartDate and ./EndDate"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.availableTime",
+                "path": "PractitionerRole.availableTime",
+                "short": "Times the Service Site is available",
+                "definition": "A collection of times the practitioner is available or performing this role at the location and/or healthcareservice.",
+                "comment": "More detailed availability information may be provided in associated Schedule/Slot resources.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "PractitionerRole.availableTime",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.availableTime.id",
+                "path": "PractitionerRole.availableTime.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.availableTime.extension",
+                "path": "PractitionerRole.availableTime.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.availableTime.modifierExtension",
+                "path": "PractitionerRole.availableTime.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.availableTime.daysOfWeek",
+                "path": "PractitionerRole.availableTime.daysOfWeek",
+                "short": "mon | tue | wed | thu | fri | sat | sun",
+                "definition": "Indicates which days of the week are available between the start and end Times.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "PractitionerRole.availableTime.daysOfWeek",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "DaysOfWeek"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The days of the week.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/days-of-week|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.availableTime.allDay",
+                "path": "PractitionerRole.availableTime.allDay",
+                "short": "Always available? e.g. 24 hour service",
+                "definition": "Is this always available? (hence times are irrelevant) e.g. 24 hour service.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "PractitionerRole.availableTime.allDay",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.availableTime.availableStartTime",
+                "path": "PractitionerRole.availableTime.availableStartTime",
+                "short": "Opening time of day (ignored if allDay = true)",
+                "definition": "The opening time of day. Note: If the AllDay flag is set, then this time is ignored.",
+                "comment": "The timezone is expected to be for where this HealthcareService is provided at.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "PractitionerRole.availableTime.availableStartTime",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "time"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.availableTime.availableEndTime",
+                "path": "PractitionerRole.availableTime.availableEndTime",
+                "short": "Closing time of day (ignored if allDay = true)",
+                "definition": "The closing time of day. Note: If the AllDay flag is set, then this time is ignored.",
+                "comment": "The timezone is expected to be for where this HealthcareService is provided at.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "PractitionerRole.availableTime.availableEndTime",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "time"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.notAvailable",
+                "path": "PractitionerRole.notAvailable",
+                "short": "Not available during this time due to provided reason",
+                "definition": "The practitioner is not available or performing this role during this period of time due to the provided reason.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "PractitionerRole.notAvailable",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.notAvailable.id",
+                "path": "PractitionerRole.notAvailable.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.notAvailable.extension",
+                "path": "PractitionerRole.notAvailable.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.notAvailable.modifierExtension",
+                "path": "PractitionerRole.notAvailable.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.notAvailable.description",
+                "path": "PractitionerRole.notAvailable.description",
+                "short": "Reason presented to the user explaining why time not available",
+                "definition": "The reason that can be presented to the user as to why this time is not available.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "PractitionerRole.notAvailable.description",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.notAvailable.during",
+                "path": "PractitionerRole.notAvailable.during",
+                "short": "Service not available from this date",
+                "definition": "Service is not available (seasonally or for a public holiday) from this date.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "PractitionerRole.notAvailable.during",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.availabilityExceptions",
+                "path": "PractitionerRole.availabilityExceptions",
+                "short": "Description of availability exceptions",
+                "definition": "A description of site availability exceptions, e.g. public holiday availability. Succinctly describing all possible exceptions to normal site availability as details in the available Times and not available Times.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "PractitionerRole.availabilityExceptions",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.endpoint",
+                "path": "PractitionerRole.endpoint",
+                "short": "Technical endpoints providing access to services operated for the practitioner with this role",
+                "definition": "Technical endpoints providing access to services operated for the practitioner with this role.",
+                "requirements": "Organizations have multiple systems that provide various services and ,ay also be different for practitioners too.\r\rSo the endpoint satisfies the need to be able to define the technical connection details for how to connect to them, and for what purpose.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "PractitionerRole.endpoint",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Endpoint"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "pd-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "PractitionerRole",
+                "path": "PractitionerRole",
+                "definition": "This is basic constraint on PractitionerRole for use in US Core resources.",
+                "constraint": [
+                    {
+                        "key": "pd-1",
+                        "severity": "error",
+                        "human": "SHALL have contact information or a reference to an Endpoint",
+                        "expression": "telecom or endpoint",
+                        "xpath": "exists(f:telecom) or exists(f:endpoint)"
+                    }
+                ],
+                "mustSupport": false
+            },
+            {
+                "id": "PractitionerRole.practitioner",
+                "path": "PractitionerRole.practitioner",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "PractitionerRole.organization",
+                "path": "PractitionerRole.organization",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "PractitionerRole.code",
+                "path": "PractitionerRole.code",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Provider role codes consisting of NUCC Health Care Provider Taxonomy Code Set for providers.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-provider-role|3.1.1"
+                }
+            },
+            {
+                "id": "PractitionerRole.specialty",
+                "path": "PractitionerRole.specialty",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Provider specialty codes consist of NUCC Health Care Provider Taxonomy Code Set for providers.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-provider-specialty|3.1.1"
+                }
+            },
+            {
+                "id": "PractitionerRole.location",
+                "path": "PractitionerRole.location",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Location"
+                        ]
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "PractitionerRole.telecom",
+                "path": "PractitionerRole.telecom",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "ContactPoint"
+                    }
+                ],
+                "condition": [
+                    "pd-1"
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "PractitionerRole.telecom.system",
+                "path": "PractitionerRole.telecom.system",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "PractitionerRole.telecom.value",
+                "path": "PractitionerRole.telecom.value",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "PractitionerRole.endpoint",
+                "path": "PractitionerRole.endpoint",
+                "min": 0,
+                "max": "*",
+                "condition": [
+                    "pd-1"
+                ],
+                "mustSupport": true
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-procedure.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-procedure.json
@@ -1,2452 +1,2452 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-procedure",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-procedure-definitions.html#Procedure\" title=\"The US Core Condition Profile is based upon the core FHIR Procedure Resource and created to meet the 2015 Edition Common Clinical Data Set 'Procedures' requirements.\">Procedure</a><a name=\"Procedure\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/procedure.html\">Procedure</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">An action that is being or was performed on a patient</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-procedure-definitions.html#Procedure.status\">status</a><a name=\"Procedure.status\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">preparation | in-progress | not-done | on-hold | stopped | completed | entered-in-error | unknown</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-event-status.html\">EventStatus</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-procedure-definitions.html#Procedure.code\">code</a><a name=\"Procedure.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Procedure codes from SNOMED CT, CPT, HCPCS II, ICD-10PC, or CDT<br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-procedure-code.html\">US Core Procedure Codes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-procedure-definitions.html#Procedure.subject\">subject</a><a name=\"Procedure.subject\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who the procedure was performed on</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_choice.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Choice of Types\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-procedure-definitions.html#Procedure.performed[x]\">performed[x]</a><a name=\"Procedure.performed_x_\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">When the procedure was performed</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for dateTime Type: A date, date-time or partial date (e.g. just year or year + month).  If hours and minutes are specified, a time zone SHALL be populated. The format is a union of the schema types gYear, gYearMonth, date and dateTime. Seconds must be provided due to schema type constraints but may be zero-filled and may be ignored.                 Dates SHALL be valid dates.\">performedDateTime</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#dateTime\">dateTime</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for Period Type: A time period defined by a start and end date and optionally time.\">performedPeriod</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Period\">Period</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure",
-	"version": "3.1.1",
-	"name": "USCoreProcedureProfile",
-	"title": "US Core Procedure Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-06-29",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.healthit.gov"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the Procedure resource for the minimal set of data to query and retrieve patient's procedure information.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "argonaut-dq-dstu2",
-			"uri": "http://unknown.org/Argonaut-DQ-DSTU2",
-			"name": "Argonaut-DQ-DSTU2"
-		},
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Procedure",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Procedure",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Procedure",
-				"path": "Procedure",
-				"short": "An action that is being or was performed on a patient",
-				"definition": "The US Core Condition Profile is based upon the core FHIR Procedure Resource and created to meet the 2015 Edition Common Clinical Data Set 'Procedures' requirements.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "rim",
-						"map": "Procedure[moodCode=EVN]"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Procedure"
-					}
-				]
-			},
-			{
-				"id": "Procedure.id",
-				"path": "Procedure.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Procedure.meta",
-				"path": "Procedure.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Procedure.implicitRules",
-				"path": "Procedure.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Procedure.language",
-				"path": "Procedure.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Procedure.text",
-				"path": "Procedure.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Procedure.contained",
-				"path": "Procedure.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Procedure.extension",
-				"path": "Procedure.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Procedure.modifierExtension",
-				"path": "Procedure.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Procedure.identifier",
-				"path": "Procedure.identifier",
-				"short": "External Identifiers for this procedure",
-				"definition": "Business identifiers assigned to this procedure by the performer or other systems which remain constant as the resource is updated and is propagated from server to server.",
-				"comment": "This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and Person resource instances might share the same social insurance number.",
-				"requirements": "Allows identification of the procedure as it is known by various participating systems and in a way that remains consistent across servers.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "Some combination of ORC-2 / ORC-3 / OBR-2 / OBR-3 / IPC-1 / IPC-2 / IPC-3 / IPC-4"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					}
-				]
-			},
-			{
-				"id": "Procedure.instantiatesCanonical",
-				"path": "Procedure.instantiatesCanonical",
-				"short": "Instantiates FHIR protocol or definition",
-				"definition": "The URL pointing to a FHIR-defined protocol, guideline, order set or other definition that is adhered to in whole or in part by this Procedure.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.instantiatesCanonical",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "canonical",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/PlanDefinition",
-							"http://hl7.org/fhir/StructureDefinition/ActivityDefinition",
-							"http://hl7.org/fhir/StructureDefinition/Measure",
-							"http://hl7.org/fhir/StructureDefinition/OperationDefinition",
-							"http://hl7.org/fhir/StructureDefinition/Questionnaire"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.instantiatesCanonical"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=DEFN].target"
-					}
-				]
-			},
-			{
-				"id": "Procedure.instantiatesUri",
-				"path": "Procedure.instantiatesUri",
-				"short": "Instantiates external protocol or definition",
-				"definition": "The URL pointing to an externally maintained protocol, guideline, order set or other definition that is adhered to in whole or in part by this Procedure.",
-				"comment": "This might be an HTML page, PDF, etc. or could just be a non-resolvable URI identifier.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.instantiatesUri",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.instantiatesUri"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=DEFN].target"
-					}
-				]
-			},
-			{
-				"id": "Procedure.basedOn",
-				"path": "Procedure.basedOn",
-				"short": "A request for this procedure",
-				"definition": "A reference to a resource that contains details of the request for this procedure.",
-				"alias": [
-					"fulfills"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.basedOn"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=FLFS].target[classCode=(various e.g. PROC, OBS, PCPR, ACT,  moodCode=RQO].code"
-					}
-				]
-			},
-			{
-				"id": "Procedure.partOf",
-				"path": "Procedure.partOf",
-				"short": "Part of referenced event",
-				"definition": "A larger event of which this particular procedure is a component or step.",
-				"comment": "The MedicationAdministration resource has a partOf reference to Procedure, but this is not a circular reference.   For example, the anesthesia MedicationAdministration is part of the surgical Procedure (MedicationAdministration.partOf = Procedure).  For example, the procedure to insert the IV port for an IV medication administration is part of the medication administration (Procedure.partOf = MedicationAdministration).",
-				"alias": [
-					"container"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.partOf",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Procedure",
-							"http://hl7.org/fhir/StructureDefinition/Observation",
-							"http://hl7.org/fhir/StructureDefinition/MedicationAdministration"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.partOf"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[classCode=SBADM or PROC or OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Procedure.status",
-				"path": "Procedure.status",
-				"short": "preparation | in-progress | not-done | on-hold | stopped | completed | entered-in-error | unknown",
-				"definition": "A code specifying the state of the procedure. Generally, this will be the in-progress or completed state.",
-				"comment": "The \"unknown\" code is not to be used to convey other statuses.  The \"unknown\" code should be used when one of the statuses applies, but the authoring system doesn't know the current state of the procedure.\n\nThis element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Procedure.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labelled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/event-status"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "rim",
-						"map": "statusCode"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Procedure.status"
-					}
-				]
-			},
-			{
-				"id": "Procedure.statusReason",
-				"path": "Procedure.statusReason",
-				"short": "Reason for current status",
-				"definition": "Captures the reason for the current state of the procedure.",
-				"comment": "This is generally only used for \"exception\" statuses such as \"not-done\", \"suspended\" or \"aborted\". The reason for performing the event at all is captured in reasonCode, not here.",
-				"alias": [
-					"Suspended Reason",
-					"Cancelled Reason"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Procedure.statusReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProcedureNegationReason"
-						}
-					],
-					"strength": "example",
-					"description": "A code that identifies the reason a procedure was not performed.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/procedure-not-performed-reason"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.statusReason"
-					},
-					{
-						"identity": "rim",
-						"map": ".reason.Observation.value"
-					}
-				]
-			},
-			{
-				"id": "Procedure.category",
-				"path": "Procedure.category",
-				"short": "Classification of the procedure",
-				"definition": "A code that classifies the procedure for searching, sorting and display purposes (e.g. \"Surgical Procedure\").",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Procedure.category",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProcedureCategory"
-						}
-					],
-					"strength": "example",
-					"description": "A code that classifies a procedure for searching, sorting and display purposes.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/procedure-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Procedure.code",
-				"path": "Procedure.code",
-				"short": "Procedure codes from SNOMED CT, CPT, HCPCS II, ICD-10PC, or CDT",
-				"definition": "The specific procedure that is performed. Use text if the exact nature of the procedure cannot be coded (e.g. \"Laparoscopic Appendectomy\").",
-				"requirements": "0..1 to account for primarily narrative only resources.",
-				"alias": [
-					"type"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Procedure.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Codes describing the type of  Procedure",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-code|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-44/OBR-45"
-					},
-					{
-						"identity": "rim",
-						"map": ".code"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Procedure.code"
-					}
-				]
-			},
-			{
-				"id": "Procedure.subject",
-				"path": "Procedure.subject",
-				"short": "Who the procedure was performed on",
-				"definition": "The person, animal or group on which the procedure was performed.",
-				"alias": [
-					"patient"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Procedure.subject",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=SBJ].role"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Procedure.subject"
-					}
-				]
-			},
-			{
-				"id": "Procedure.encounter",
-				"path": "Procedure.encounter",
-				"short": "Encounter created as part of",
-				"definition": "The Encounter during which this Procedure was created or performed or to which the creation of this record is tightly associated.",
-				"comment": "This will typically be the encounter the event occurred within, but some activities may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Procedure.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1-19"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Procedure.performed[x]",
-				"path": "Procedure.performed[x]",
-				"short": "When the procedure was performed",
-				"definition": "Estimated or actual date, date-time, period, or age when the procedure was performed.  Allows a period to support complex procedures that span more than one date, and also allows for the length of the procedure to be captured.",
-				"comment": "Age is generally used when the patient reports an age at which the procedure was performed. Range is generally used when the patient reports an age range when the procedure was performed, such as sometime between 20-25 years old.  dateTime supports a range of precision due to some procedures being reported as past procedures that might not have millisecond precision while other procedures performed and documented during the encounter might have more precise UTC timestamps with timezone.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Procedure.performed[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-7"
-					},
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Procedure.performed[x]"
-					}
-				]
-			},
-			{
-				"id": "Procedure.recorder",
-				"path": "Procedure.recorder",
-				"short": "Who recorded the procedure",
-				"definition": "Individual who recorded the record and takes responsibility for its content.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Procedure.recorder",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson",
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.author"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=AUT].role"
-					}
-				]
-			},
-			{
-				"id": "Procedure.asserter",
-				"path": "Procedure.asserter",
-				"short": "Person who asserts this procedure",
-				"definition": "Individual who is making the procedure statement.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Procedure.asserter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson",
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.source"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=INF].role"
-					}
-				]
-			},
-			{
-				"id": "Procedure.performer",
-				"path": "Procedure.performer",
-				"short": "The people who performed the procedure",
-				"definition": "Limited to \"real\" people rather than equipment.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.performer",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=PRF]"
-					}
-				]
-			},
-			{
-				"id": "Procedure.performer.id",
-				"path": "Procedure.performer.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Procedure.performer.extension",
-				"path": "Procedure.performer.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Procedure.performer.modifierExtension",
-				"path": "Procedure.performer.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Procedure.performer.function",
-				"path": "Procedure.performer.function",
-				"short": "Type of performance",
-				"definition": "Distinguishes the type of involvement of the performer in the procedure. For example, surgeon, anaesthetist, endoscopist.",
-				"requirements": "Allows disambiguation of the types of involvement of different performers.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Procedure.performer.function",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProcedurePerformerRole"
-						}
-					],
-					"strength": "example",
-					"description": "A code that identifies the role of a performer of the procedure.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/performer-role"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.function"
-					},
-					{
-						"identity": "v2",
-						"map": "Some combination of STF-18 / PRA-3 / PRT-4 / ROL-3 / ORC-12 / OBR-16 / PV1-7 / PV1-8 / PV1-9 / PV1-17 / OBX-25"
-					},
-					{
-						"identity": "rim",
-						"map": ".functionCode"
-					}
-				]
-			},
-			{
-				"id": "Procedure.performer.actor",
-				"path": "Procedure.performer.actor",
-				"short": "The reference to the practitioner",
-				"definition": "The practitioner who was involved in the procedure.",
-				"requirements": "A reference to Device supports use cases, such as pacemakers.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Procedure.performer.actor",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson",
-							"http://hl7.org/fhir/StructureDefinition/Device"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC-19/PRT-5"
-					},
-					{
-						"identity": "rim",
-						"map": ".role"
-					}
-				]
-			},
-			{
-				"id": "Procedure.performer.onBehalfOf",
-				"path": "Procedure.performer.onBehalfOf",
-				"short": "Organization the device or practitioner was acting for",
-				"definition": "The organization the device or practitioner was acting on behalf of.",
-				"requirements": "Practitioners and Devices can be associated with multiple organizations.  This element indicates which organization they were acting on behalf of when performing the action.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Procedure.performer.onBehalfOf",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".scoper"
-					}
-				]
-			},
-			{
-				"id": "Procedure.location",
-				"path": "Procedure.location",
-				"short": "Where the procedure happened",
-				"definition": "The location where the procedure actually happened.  E.g. a newborn at home, a tracheostomy at a restaurant.",
-				"requirements": "Ties a procedure to where the records are likely kept.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Procedure.location",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Location"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.where[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=LOC].role[classCode=SDLOC]"
-					}
-				]
-			},
-			{
-				"id": "Procedure.reasonCode",
-				"path": "Procedure.reasonCode",
-				"short": "Coded reason procedure performed",
-				"definition": "The coded reason why the procedure was performed. This may be a coded entity of some type, or may simply be present as text.",
-				"comment": "Use Procedure.reasonCode when a code sufficiently describes the reason.  Use Procedure.reasonReference when referencing a resource, which allows more information to be conveyed, such as onset date. Procedure.reasonCode and Procedure.reasonReference are not meant to be duplicative.  For a single reason, either Procedure.reasonCode or Procedure.reasonReference can be used.  Procedure.reasonCode may be a summary code, or Procedure.reasonReference may be used to reference a very precise definition of the reason using Condition | Observation | Procedure | DiagnosticReport | DocumentReference.  Both Procedure.reasonCode and Procedure.reasonReference can be used if they are describing different reasons for the procedure.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.reasonCode",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProcedureReason"
-						}
-					],
-					"strength": "example",
-					"description": "A code that identifies the reason a procedure is  required.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/procedure-reason"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.reasonCode"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.why[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".reasonCode"
-					}
-				]
-			},
-			{
-				"id": "Procedure.reasonReference",
-				"path": "Procedure.reasonReference",
-				"short": "The justification that the procedure was performed",
-				"definition": "The justification of why the procedure was performed.",
-				"comment": "It is possible for a procedure to be a reason (such as C-Section) for another procedure (such as an epidural). Other examples include endoscopy for dilatation and biopsy (a combination of diagnostic and therapeutic use). \nUse Procedure.reasonCode when a code sufficiently describes the reason.  Use Procedure.reasonReference when referencing a resource, which allows more information to be conveyed, such as onset date. Procedure.reasonCode and Procedure.reasonReference are not meant to be duplicative.  For a single reason, either Procedure.reasonCode or Procedure.reasonReference can be used.  Procedure.reasonCode may be a summary code, or Procedure.reasonReference may be used to reference a very precise definition of the reason using Condition | Observation | Procedure | DiagnosticReport | DocumentReference.  Both Procedure.reasonCode and Procedure.reasonReference can be used if they are describing different reasons for the procedure.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.reasonReference",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Condition",
-							"http://hl7.org/fhir/StructureDefinition/Observation",
-							"http://hl7.org/fhir/StructureDefinition/Procedure",
-							"http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
-							"http://hl7.org/fhir/StructureDefinition/DocumentReference"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.reasonReference"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.why[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".reasonCode"
-					}
-				]
-			},
-			{
-				"id": "Procedure.bodySite",
-				"path": "Procedure.bodySite",
-				"short": "Target body sites",
-				"definition": "Detailed and structured anatomical location information. Multiple locations are allowed - e.g. multiple punch biopsies of a lesion.",
-				"comment": "If the use case requires attributes from the BodySite resource (e.g. to identify and track separately) then use the standard extension [procedure-targetbodystructure](http://hl7.org/fhir/R4/extension-procedure-targetbodystructure.html).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.bodySite",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "BodySite"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing anatomical locations. May include laterality.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/body-site"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-20"
-					},
-					{
-						"identity": "rim",
-						"map": ".targetSiteCode"
-					}
-				]
-			},
-			{
-				"id": "Procedure.outcome",
-				"path": "Procedure.outcome",
-				"short": "The result of procedure",
-				"definition": "The outcome of the procedure - did it resolve the reasons for the procedure being performed?",
-				"comment": "If outcome contains narrative text only, it can be captured using the CodeableConcept.text.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Procedure.outcome",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProcedureOutcome"
-						}
-					],
-					"strength": "example",
-					"description": "An outcome of a procedure - whether it was resolved or otherwise.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/procedure-outcome"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=OUT].target.text"
-					}
-				]
-			},
-			{
-				"id": "Procedure.report",
-				"path": "Procedure.report",
-				"short": "Any report resulting from the procedure",
-				"definition": "This could be a histology result, pathology report, surgical report, etc.",
-				"comment": "There could potentially be multiple reports - e.g. if this was a procedure which took multiple biopsies resulting in a number of anatomical pathology reports.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.report",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
-							"http://hl7.org/fhir/StructureDefinition/DocumentReference",
-							"http://hl7.org/fhir/StructureDefinition/Composition"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Procedure.complication",
-				"path": "Procedure.complication",
-				"short": "Complication following the procedure",
-				"definition": "Any complications that occurred during the procedure, or in the immediate post-performance period. These are generally tracked separately from the notes, which will typically describe the procedure itself rather than any 'post procedure' issues.",
-				"comment": "If complications are only expressed by the narrative text, they can be captured using the CodeableConcept.text.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.complication",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProcedureComplication"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing complications that resulted from a procedure.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/condition-code"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=OUTC].target[classCode=OBS, code=\"complication\", moodCode=EVN].value"
-					}
-				]
-			},
-			{
-				"id": "Procedure.complicationDetail",
-				"path": "Procedure.complicationDetail",
-				"short": "A condition that is a result of the procedure",
-				"definition": "Any complications that occurred during the procedure, or in the immediate post-performance period.",
-				"requirements": "This is used to document a condition that is a result of the procedure, not the condition that was the reason for the procedure.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.complicationDetail",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Condition"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=OUTC].target[classCode=OBS, code=\"complication\", moodCode=EVN].value"
-					}
-				]
-			},
-			{
-				"id": "Procedure.followUp",
-				"path": "Procedure.followUp",
-				"short": "Instructions for follow up",
-				"definition": "If the procedure required specific follow up - e.g. removal of sutures. The follow up may be represented as a simple note or could potentially be more complex, in which case the CarePlan resource can be used.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.followUp",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProcedureFollowUp"
-						}
-					],
-					"strength": "example",
-					"description": "Specific follow up required for a procedure e.g. removal of sutures.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/procedure-followup"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=COMP].target[classCode=ACT, moodCode=INT].code"
-					}
-				]
-			},
-			{
-				"id": "Procedure.note",
-				"path": "Procedure.note",
-				"short": "Additional information about the procedure",
-				"definition": "Any other notes and comments about the procedure.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.note"
-					},
-					{
-						"identity": "v2",
-						"map": "NTE"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "Procedure.focalDevice",
-				"path": "Procedure.focalDevice",
-				"short": "Manipulated, implanted, or removed device",
-				"definition": "A device that is implanted, removed or otherwise manipulated (calibration, battery replacement, fitting a prosthesis, attaching a wound-vac, etc.) as a focal portion of the Procedure.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.focalDevice",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=DEV].role[classCode=MANU]"
-					}
-				]
-			},
-			{
-				"id": "Procedure.focalDevice.id",
-				"path": "Procedure.focalDevice.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Procedure.focalDevice.extension",
-				"path": "Procedure.focalDevice.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Procedure.focalDevice.modifierExtension",
-				"path": "Procedure.focalDevice.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Procedure.focalDevice.action",
-				"path": "Procedure.focalDevice.action",
-				"short": "Kind of change to device",
-				"definition": "The kind of change that happened to the device during the procedure.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Procedure.focalDevice.action",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "DeviceActionKind"
-						}
-					],
-					"strength": "preferred",
-					"description": "A kind of change that happened to the device during the procedure.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/device-action"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"procedure device action\"].value=:procedure device action codes"
-					}
-				]
-			},
-			{
-				"id": "Procedure.focalDevice.manipulated",
-				"path": "Procedure.focalDevice.manipulated",
-				"short": "Device that was changed",
-				"definition": "The device that was manipulated (changed) during the procedure.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Procedure.focalDevice.manipulated",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Device"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=DEV].role[classCode=SDLOC]"
-					}
-				]
-			},
-			{
-				"id": "Procedure.usedReference",
-				"path": "Procedure.usedReference",
-				"short": "Items used during procedure",
-				"definition": "Identifies medications, devices and any other substance used as part of the procedure.",
-				"comment": "For devices actually implanted or removed, use Procedure.device.",
-				"requirements": "Used for tracking contamination, etc.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.usedReference",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/Medication",
-							"http://hl7.org/fhir/StructureDefinition/Substance"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=DEV].role[classCode=MANU] or\n.participation[typeCode=CSM].role[classCode=ADMM] (for Medication or Substance)"
-					}
-				]
-			},
-			{
-				"id": "Procedure.usedCode",
-				"path": "Procedure.usedCode",
-				"short": "Coded items used during the procedure",
-				"definition": "Identifies coded items that were used as part of the procedure.",
-				"comment": "For devices actually implanted or removed, use Procedure.device.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.usedCode",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProcedureUsed"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing items used during a procedure.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/device-kind"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=Dev].role[classCode=MANU]"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Procedure",
-				"path": "Procedure",
-				"definition": "The US Core Condition Profile is based upon the core FHIR Procedure Resource and created to meet the 2015 Edition Common Clinical Data Set 'Procedures' requirements.",
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Procedure"
-					}
-				]
-			},
-			{
-				"id": "Procedure.status",
-				"path": "Procedure.status",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/event-status"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Procedure.status"
-					}
-				]
-			},
-			{
-				"id": "Procedure.code",
-				"path": "Procedure.code",
-				"short": "Procedure codes from SNOMED CT, CPT, HCPCS II, ICD-10PC, or CDT",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Codes describing the type of  Procedure",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-code|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Procedure.code"
-					}
-				]
-			},
-			{
-				"id": "Procedure.subject",
-				"path": "Procedure.subject",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Procedure.subject"
-					}
-				]
-			},
-			{
-				"id": "Procedure.performed[x]",
-				"path": "Procedure.performed[x]",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Procedure.performed[x]"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-procedure",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure",
+    "version": "3.1.1",
+    "name": "USCoreProcedureProfile",
+    "title": "US Core Procedure Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-06-29",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.healthit.gov"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the Procedure resource for the minimal set of data to query and retrieve patient's procedure information.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "argonaut-dq-dstu2",
+            "uri": "http://unknown.org/Argonaut-DQ-DSTU2",
+            "name": "Argonaut-DQ-DSTU2"
+        },
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Procedure",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Procedure",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Procedure",
+                "path": "Procedure",
+                "short": "An action that is being or was performed on a patient",
+                "definition": "The US Core Condition Profile is based upon the core FHIR Procedure Resource and created to meet the 2015 Edition Common Clinical Data Set 'Procedures' requirements.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Procedure[moodCode=EVN]"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Procedure"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.id",
+                "path": "Procedure.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Procedure.meta",
+                "path": "Procedure.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Procedure.implicitRules",
+                "path": "Procedure.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Procedure.language",
+                "path": "Procedure.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Procedure.text",
+                "path": "Procedure.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.contained",
+                "path": "Procedure.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.extension",
+                "path": "Procedure.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.modifierExtension",
+                "path": "Procedure.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.identifier",
+                "path": "Procedure.identifier",
+                "short": "External Identifiers for this procedure",
+                "definition": "Business identifiers assigned to this procedure by the performer or other systems which remain constant as the resource is updated and is propagated from server to server.",
+                "comment": "This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and Person resource instances might share the same social insurance number.",
+                "requirements": "Allows identification of the procedure as it is known by various participating systems and in a way that remains consistent across servers.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "Some combination of ORC-2 / ORC-3 / OBR-2 / OBR-3 / IPC-1 / IPC-2 / IPC-3 / IPC-4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.instantiatesCanonical",
+                "path": "Procedure.instantiatesCanonical",
+                "short": "Instantiates FHIR protocol or definition",
+                "definition": "The URL pointing to a FHIR-defined protocol, guideline, order set or other definition that is adhered to in whole or in part by this Procedure.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.instantiatesCanonical",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "canonical",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/PlanDefinition",
+                            "http://hl7.org/fhir/StructureDefinition/ActivityDefinition",
+                            "http://hl7.org/fhir/StructureDefinition/Measure",
+                            "http://hl7.org/fhir/StructureDefinition/OperationDefinition",
+                            "http://hl7.org/fhir/StructureDefinition/Questionnaire"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.instantiatesCanonical"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=DEFN].target"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.instantiatesUri",
+                "path": "Procedure.instantiatesUri",
+                "short": "Instantiates external protocol or definition",
+                "definition": "The URL pointing to an externally maintained protocol, guideline, order set or other definition that is adhered to in whole or in part by this Procedure.",
+                "comment": "This might be an HTML page, PDF, etc. or could just be a non-resolvable URI identifier.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.instantiatesUri",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.instantiatesUri"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=DEFN].target"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.basedOn",
+                "path": "Procedure.basedOn",
+                "short": "A request for this procedure",
+                "definition": "A reference to a resource that contains details of the request for this procedure.",
+                "alias": [
+                    "fulfills"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.basedOn"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=FLFS].target[classCode=(various e.g. PROC, OBS, PCPR, ACT,  moodCode=RQO].code"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.partOf",
+                "path": "Procedure.partOf",
+                "short": "Part of referenced event",
+                "definition": "A larger event of which this particular procedure is a component or step.",
+                "comment": "The MedicationAdministration resource has a partOf reference to Procedure, but this is not a circular reference.   For example, the anesthesia MedicationAdministration is part of the surgical Procedure (MedicationAdministration.partOf = Procedure).  For example, the procedure to insert the IV port for an IV medication administration is part of the medication administration (Procedure.partOf = MedicationAdministration).",
+                "alias": [
+                    "container"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.partOf",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Procedure",
+                            "http://hl7.org/fhir/StructureDefinition/Observation",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationAdministration"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.partOf"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[classCode=SBADM or PROC or OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.status",
+                "path": "Procedure.status",
+                "short": "preparation | in-progress | not-done | on-hold | stopped | completed | entered-in-error | unknown",
+                "definition": "A code specifying the state of the procedure. Generally, this will be the in-progress or completed state.",
+                "comment": "The \"unknown\" code is not to be used to convey other statuses.  The \"unknown\" code should be used when one of the statuses applies, but the authoring system doesn't know the current state of the procedure.\n\nThis element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labelled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/event-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "statusCode"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Procedure.status"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.statusReason",
+                "path": "Procedure.statusReason",
+                "short": "Reason for current status",
+                "definition": "Captures the reason for the current state of the procedure.",
+                "comment": "This is generally only used for \"exception\" statuses such as \"not-done\", \"suspended\" or \"aborted\". The reason for performing the event at all is captured in reasonCode, not here.",
+                "alias": [
+                    "Suspended Reason",
+                    "Cancelled Reason"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.statusReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProcedureNegationReason"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "A code that identifies the reason a procedure was not performed.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/procedure-not-performed-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.statusReason"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".reason.Observation.value"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.category",
+                "path": "Procedure.category",
+                "short": "Classification of the procedure",
+                "definition": "A code that classifies the procedure for searching, sorting and display purposes (e.g. \"Surgical Procedure\").",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.category",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProcedureCategory"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "A code that classifies a procedure for searching, sorting and display purposes.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/procedure-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.code",
+                "path": "Procedure.code",
+                "short": "Procedure codes from SNOMED CT, CPT, HCPCS II, ICD-10PC, or CDT",
+                "definition": "The specific procedure that is performed. Use text if the exact nature of the procedure cannot be coded (e.g. \"Laparoscopic Appendectomy\").",
+                "requirements": "0..1 to account for primarily narrative only resources.",
+                "alias": [
+                    "type"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Codes describing the type of  Procedure",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-code|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-44/OBR-45"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".code"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Procedure.code"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.subject",
+                "path": "Procedure.subject",
+                "short": "Who the procedure was performed on",
+                "definition": "The person, animal or group on which the procedure was performed.",
+                "alias": [
+                    "patient"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.subject",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=SBJ].role"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Procedure.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.encounter",
+                "path": "Procedure.encounter",
+                "short": "Encounter created as part of",
+                "definition": "The Encounter during which this Procedure was created or performed or to which the creation of this record is tightly associated.",
+                "comment": "This will typically be the encounter the event occurred within, but some activities may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1-19"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.performed[x]",
+                "path": "Procedure.performed[x]",
+                "short": "When the procedure was performed",
+                "definition": "Estimated or actual date, date-time, period, or age when the procedure was performed.  Allows a period to support complex procedures that span more than one date, and also allows for the length of the procedure to be captured.",
+                "comment": "Age is generally used when the patient reports an age at which the procedure was performed. Range is generally used when the patient reports an age range when the procedure was performed, such as sometime between 20-25 years old.  dateTime supports a range of precision due to some procedures being reported as past procedures that might not have millisecond precision while other procedures performed and documented during the encounter might have more precise UTC timestamps with timezone.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.performed[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Procedure.performed[x]"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.recorder",
+                "path": "Procedure.recorder",
+                "short": "Who recorded the procedure",
+                "definition": "Individual who recorded the record and takes responsibility for its content.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.recorder",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.author"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=AUT].role"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.asserter",
+                "path": "Procedure.asserter",
+                "short": "Person who asserts this procedure",
+                "definition": "Individual who is making the procedure statement.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.asserter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.source"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=INF].role"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.performer",
+                "path": "Procedure.performer",
+                "short": "The people who performed the procedure",
+                "definition": "Limited to \"real\" people rather than equipment.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.performer",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=PRF]"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.performer.id",
+                "path": "Procedure.performer.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.performer.extension",
+                "path": "Procedure.performer.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.performer.modifierExtension",
+                "path": "Procedure.performer.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.performer.function",
+                "path": "Procedure.performer.function",
+                "short": "Type of performance",
+                "definition": "Distinguishes the type of involvement of the performer in the procedure. For example, surgeon, anaesthetist, endoscopist.",
+                "requirements": "Allows disambiguation of the types of involvement of different performers.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.performer.function",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProcedurePerformerRole"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "A code that identifies the role of a performer of the procedure.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/performer-role"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.function"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "Some combination of STF-18 / PRA-3 / PRT-4 / ROL-3 / ORC-12 / OBR-16 / PV1-7 / PV1-8 / PV1-9 / PV1-17 / OBX-25"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".functionCode"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.performer.actor",
+                "path": "Procedure.performer.actor",
+                "short": "The reference to the practitioner",
+                "definition": "The practitioner who was involved in the procedure.",
+                "requirements": "A reference to Device supports use cases, such as pacemakers.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.performer.actor",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+                            "http://hl7.org/fhir/StructureDefinition/Device"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC-19/PRT-5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".role"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.performer.onBehalfOf",
+                "path": "Procedure.performer.onBehalfOf",
+                "short": "Organization the device or practitioner was acting for",
+                "definition": "The organization the device or practitioner was acting on behalf of.",
+                "requirements": "Practitioners and Devices can be associated with multiple organizations.  This element indicates which organization they were acting on behalf of when performing the action.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.performer.onBehalfOf",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".scoper"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.location",
+                "path": "Procedure.location",
+                "short": "Where the procedure happened",
+                "definition": "The location where the procedure actually happened.  E.g. a newborn at home, a tracheostomy at a restaurant.",
+                "requirements": "Ties a procedure to where the records are likely kept.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.location",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Location"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.where[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=LOC].role[classCode=SDLOC]"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.reasonCode",
+                "path": "Procedure.reasonCode",
+                "short": "Coded reason procedure performed",
+                "definition": "The coded reason why the procedure was performed. This may be a coded entity of some type, or may simply be present as text.",
+                "comment": "Use Procedure.reasonCode when a code sufficiently describes the reason.  Use Procedure.reasonReference when referencing a resource, which allows more information to be conveyed, such as onset date. Procedure.reasonCode and Procedure.reasonReference are not meant to be duplicative.  For a single reason, either Procedure.reasonCode or Procedure.reasonReference can be used.  Procedure.reasonCode may be a summary code, or Procedure.reasonReference may be used to reference a very precise definition of the reason using Condition | Observation | Procedure | DiagnosticReport | DocumentReference.  Both Procedure.reasonCode and Procedure.reasonReference can be used if they are describing different reasons for the procedure.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.reasonCode",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProcedureReason"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "A code that identifies the reason a procedure is  required.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/procedure-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.reasonCode"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.why[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".reasonCode"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.reasonReference",
+                "path": "Procedure.reasonReference",
+                "short": "The justification that the procedure was performed",
+                "definition": "The justification of why the procedure was performed.",
+                "comment": "It is possible for a procedure to be a reason (such as C-Section) for another procedure (such as an epidural). Other examples include endoscopy for dilatation and biopsy (a combination of diagnostic and therapeutic use). \nUse Procedure.reasonCode when a code sufficiently describes the reason.  Use Procedure.reasonReference when referencing a resource, which allows more information to be conveyed, such as onset date. Procedure.reasonCode and Procedure.reasonReference are not meant to be duplicative.  For a single reason, either Procedure.reasonCode or Procedure.reasonReference can be used.  Procedure.reasonCode may be a summary code, or Procedure.reasonReference may be used to reference a very precise definition of the reason using Condition | Observation | Procedure | DiagnosticReport | DocumentReference.  Both Procedure.reasonCode and Procedure.reasonReference can be used if they are describing different reasons for the procedure.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.reasonReference",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Condition",
+                            "http://hl7.org/fhir/StructureDefinition/Observation",
+                            "http://hl7.org/fhir/StructureDefinition/Procedure",
+                            "http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
+                            "http://hl7.org/fhir/StructureDefinition/DocumentReference"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.reasonReference"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.why[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".reasonCode"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.bodySite",
+                "path": "Procedure.bodySite",
+                "short": "Target body sites",
+                "definition": "Detailed and structured anatomical location information. Multiple locations are allowed - e.g. multiple punch biopsies of a lesion.",
+                "comment": "If the use case requires attributes from the BodySite resource (e.g. to identify and track separately) then use the standard extension [procedure-targetbodystructure](http://hl7.org/fhir/R4/extension-procedure-targetbodystructure.html).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.bodySite",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "BodySite"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing anatomical locations. May include laterality.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/body-site"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-20"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".targetSiteCode"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.outcome",
+                "path": "Procedure.outcome",
+                "short": "The result of procedure",
+                "definition": "The outcome of the procedure - did it resolve the reasons for the procedure being performed?",
+                "comment": "If outcome contains narrative text only, it can be captured using the CodeableConcept.text.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.outcome",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProcedureOutcome"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "An outcome of a procedure - whether it was resolved or otherwise.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/procedure-outcome"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=OUT].target.text"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.report",
+                "path": "Procedure.report",
+                "short": "Any report resulting from the procedure",
+                "definition": "This could be a histology result, pathology report, surgical report, etc.",
+                "comment": "There could potentially be multiple reports - e.g. if this was a procedure which took multiple biopsies resulting in a number of anatomical pathology reports.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.report",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
+                            "http://hl7.org/fhir/StructureDefinition/DocumentReference",
+                            "http://hl7.org/fhir/StructureDefinition/Composition"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.complication",
+                "path": "Procedure.complication",
+                "short": "Complication following the procedure",
+                "definition": "Any complications that occurred during the procedure, or in the immediate post-performance period. These are generally tracked separately from the notes, which will typically describe the procedure itself rather than any 'post procedure' issues.",
+                "comment": "If complications are only expressed by the narrative text, they can be captured using the CodeableConcept.text.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.complication",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProcedureComplication"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing complications that resulted from a procedure.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/condition-code"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=OUTC].target[classCode=OBS, code=\"complication\", moodCode=EVN].value"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.complicationDetail",
+                "path": "Procedure.complicationDetail",
+                "short": "A condition that is a result of the procedure",
+                "definition": "Any complications that occurred during the procedure, or in the immediate post-performance period.",
+                "requirements": "This is used to document a condition that is a result of the procedure, not the condition that was the reason for the procedure.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.complicationDetail",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Condition"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=OUTC].target[classCode=OBS, code=\"complication\", moodCode=EVN].value"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.followUp",
+                "path": "Procedure.followUp",
+                "short": "Instructions for follow up",
+                "definition": "If the procedure required specific follow up - e.g. removal of sutures. The follow up may be represented as a simple note or could potentially be more complex, in which case the CarePlan resource can be used.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.followUp",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProcedureFollowUp"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Specific follow up required for a procedure e.g. removal of sutures.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/procedure-followup"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=COMP].target[classCode=ACT, moodCode=INT].code"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.note",
+                "path": "Procedure.note",
+                "short": "Additional information about the procedure",
+                "definition": "Any other notes and comments about the procedure.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.note"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "NTE"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.focalDevice",
+                "path": "Procedure.focalDevice",
+                "short": "Manipulated, implanted, or removed device",
+                "definition": "A device that is implanted, removed or otherwise manipulated (calibration, battery replacement, fitting a prosthesis, attaching a wound-vac, etc.) as a focal portion of the Procedure.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.focalDevice",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=DEV].role[classCode=MANU]"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.focalDevice.id",
+                "path": "Procedure.focalDevice.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.focalDevice.extension",
+                "path": "Procedure.focalDevice.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.focalDevice.modifierExtension",
+                "path": "Procedure.focalDevice.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.focalDevice.action",
+                "path": "Procedure.focalDevice.action",
+                "short": "Kind of change to device",
+                "definition": "The kind of change that happened to the device during the procedure.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.focalDevice.action",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "DeviceActionKind"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A kind of change that happened to the device during the procedure.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/device-action"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"procedure device action\"].value=:procedure device action codes"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.focalDevice.manipulated",
+                "path": "Procedure.focalDevice.manipulated",
+                "short": "Device that was changed",
+                "definition": "The device that was manipulated (changed) during the procedure.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.focalDevice.manipulated",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Device"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=DEV].role[classCode=SDLOC]"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.usedReference",
+                "path": "Procedure.usedReference",
+                "short": "Items used during procedure",
+                "definition": "Identifies medications, devices and any other substance used as part of the procedure.",
+                "comment": "For devices actually implanted or removed, use Procedure.device.",
+                "requirements": "Used for tracking contamination, etc.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.usedReference",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/Medication",
+                            "http://hl7.org/fhir/StructureDefinition/Substance"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=DEV].role[classCode=MANU] or\n.participation[typeCode=CSM].role[classCode=ADMM] (for Medication or Substance)"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.usedCode",
+                "path": "Procedure.usedCode",
+                "short": "Coded items used during the procedure",
+                "definition": "Identifies coded items that were used as part of the procedure.",
+                "comment": "For devices actually implanted or removed, use Procedure.device.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.usedCode",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProcedureUsed"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing items used during a procedure.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/device-kind"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=Dev].role[classCode=MANU]"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Procedure",
+                "path": "Procedure",
+                "definition": "The US Core Condition Profile is based upon the core FHIR Procedure Resource and created to meet the 2015 Edition Common Clinical Data Set 'Procedures' requirements.",
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Procedure"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.status",
+                "path": "Procedure.status",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/event-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Procedure.status"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.code",
+                "path": "Procedure.code",
+                "short": "Procedure codes from SNOMED CT, CPT, HCPCS II, ICD-10PC, or CDT",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Codes describing the type of  Procedure",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-code|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Procedure.code"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.subject",
+                "path": "Procedure.subject",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Procedure.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.performed[x]",
+                "path": "Procedure.performed[x]",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Procedure.performed[x]"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-provenance.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-provenance.json
@@ -1,2616 +1,2616 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-provenance",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-provenance-definitions.html#Provenance\" title=\"The US Core Provenance Profile is based upon the Argonaut Data Query requirements.\">Provenance</a><a name=\"Provenance\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/provenance.html\">Provenance</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">US Core Provenance</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-provenance-definitions.html#Provenance.target\">target</a><a name=\"Provenance.target\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"http://hl7.org/fhir/R4/resource.html\">Resource</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">The Resource this Provenance record supports<br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-provenance-definitions.html#Provenance.recorded\" title=\"The instant of time at which the activity was recorded.\">recorded</a><a name=\"Provenance.recorded\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#instant\">instant</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Timestamp when the activity was recorded / updated</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck03.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Definition\" class=\"hierarchy\"/> <a style=\"font-style: italic\" href=\"StructureDefinition-us-core-provenance-definitions.html#Provenance.agent\">agent</a><a name=\"Provenance.agent\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red; font-style: italic\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"font-style: italic\"/><span style=\"font-style: italic\">1</span><span style=\"font-style: italic\">..</span><span style=\"font-style: italic\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"font-style: italic\" href=\"http://hl7.org/fhir/R4/profiling.html#slicing\">(Slice Definition)</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5; font-style: italic\">Actor involved</span><br style=\"font-style: italic\"/><span style=\"font-weight:bold; font-style: italic\">Slice: </span><span style=\"font-style: italic\">Unordered, Open by pattern:type</span><br style=\"font-style: italic\"/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck033.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> agent:All Slices<a name=\"Provenance.agent\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Content/Rules for all slices</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0330.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-provenance-definitions.html#Provenance.agent.type\">type</a><a name=\"Provenance.agent.type\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">How the agent participated</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-provenance-participant-type.html\">US Core Provenance Participant Type Codes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0330.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-provenance-definitions.html#Provenance.agent.who\">who</a><a name=\"Provenance.agent.who\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-practitioner.html\">US Core Practitioner Profile</a> | <a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a> | <a href=\"StructureDefinition-us-core-organization.html\">US Core Organization Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who participated</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0320.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-provenance-definitions.html#Provenance.agent.onBehalfOf\">onBehalfOf</a><a name=\"Provenance.agent.onBehalfOf\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (provenance-1)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-organization.html\">US Core Organization Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who the agent is representing</span><br/><span style=\"font-weight:bold\">provenance-1: </span>onBehalfOf SHALL be present when Provenance.agent.who is a Practitioner or Device</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck035.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-provenance-definitions.html#Provenance.agent:ProvenanceAuthor\" title=\"Slice ProvenanceAuthor\">agent:ProvenanceAuthor</a><a name=\"Provenance.agent\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Actor involved</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0341.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-provenance-definitions.html#Provenance.agent:ProvenanceAuthor.type\">type</a><a name=\"Provenance.agent.type\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">How the agent participated</span><br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck03401.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#CodeableConcept.coding\">coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Code defined by a terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">(complex)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck034010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"https://terminology.hl7.org/1.0.0//CodeSystem-provenance-participant-type.html\">http://terminology.hl7.org/CodeSystem/provenance-participant-type</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck034000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">author</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck025.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-provenance-definitions.html#Provenance.agent:ProvenanceTransmitter\" title=\"Slice ProvenanceTransmitter: The entity that provided the copy to your system.\">agent:ProvenanceTransmitter</a><a name=\"Provenance.agent\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Actor involved</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0241.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-provenance-definitions.html#Provenance.agent:ProvenanceTransmitter.type\">type</a><a name=\"Provenance.agent.type\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">How the agent participated</span><br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck02401.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#CodeableConcept.coding\">coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Code defined by a terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">(complex)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck024010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"CodeSystem-us-core-provenance-participant-type.html\">http://hl7.org/fhir/us/core/CodeSystem/us-core-provenance-participant-type</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck024000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">transmitter</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance",
-	"version": "3.1.1",
-	"name": "USCoreProvenance",
-	"title": "US Core Provenance Profile",
-	"status": "active",
-	"date": "2019-08-05",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.healthit.gov"
-				}
-			]
-		}
-	],
-	"description": "Draft set of requirements to satisfy Basic Provenance Requirements.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w3c.prov",
-			"uri": "http://www.w3.org/ns/prov",
-			"name": "W3C PROV"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "fhirauditevent",
-			"uri": "http://hl7.org/fhir/auditevent",
-			"name": "FHIR AuditEvent Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Provenance",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Provenance",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Provenance",
-				"path": "Provenance",
-				"short": "US Core Provenance",
-				"definition": "The US Core Provenance Profile is based upon the Argonaut Data Query requirements.",
-				"comment": "Some parties may be duplicated between the target resource and its provenance.  For instance, the prescriber is usually (but not always) the author of the prescription resource. This resource is defined with close consideration for W3C Provenance.",
-				"alias": [
-					"History",
-					"Event",
-					"Activity",
-					"Basic Provenance"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Provenance",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "rim",
-						"map": "ControlAct[isNormalAct() and subsumes(CACT, classCode) and moodCode=EVN]"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Activity"
-					}
-				]
-			},
-			{
-				"id": "Provenance.id",
-				"path": "Provenance.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Provenance.meta",
-				"path": "Provenance.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Provenance.implicitRules",
-				"path": "Provenance.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Provenance.language",
-				"path": "Provenance.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Provenance.text",
-				"path": "Provenance.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Provenance.contained",
-				"path": "Provenance.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Provenance.extension",
-				"path": "Provenance.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Provenance.modifierExtension",
-				"path": "Provenance.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Provenance.target",
-				"path": "Provenance.target",
-				"short": "The Resource this Provenance record supports",
-				"definition": "The Reference(s) that were generated or updated by  the activity described in this resource. A provenance can point to more than one target if multiple resources were created/updated by the same activity.",
-				"comment": "Target references are usually version specific, but might not be, if a version has not been assigned or if the provenance information is part of the set of resources being maintained (i.e. a document). When using the RESTful API, the identity of the resource might not be known (especially not the version specific one); the client may either submit the resource first, and then the provenance, or it may submit both using a single transaction. See the notes on transaction for further discussion.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Provenance.target",
-					"min": 1,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "rim",
-						"map": "./outboundRelationship[isNormalActRelationship() and typeCode=SUBJ]/target  OR  ./participation[isNormalParticipation() and typeCode=SBJ]/role  OR  ./participation[isNormalParticipation() and typeCode=SBJ]/role[isNormalRole()]/player"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.entity.reference"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Entity Created/Updated"
-					}
-				]
-			},
-			{
-				"id": "Provenance.occurred[x]",
-				"path": "Provenance.occurred[x]",
-				"short": "When the activity occurred",
-				"definition": "The period during which the activity occurred.",
-				"comment": "The period can be a little arbitrary; where possible, the time should correspond to human assessment of the activity time.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Provenance.occurred[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					},
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurred[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "rim",
-						"map": "./effectiveTime[type=IVL_TS]"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Activity.startTime & Activity.endTime"
-					}
-				]
-			},
-			{
-				"id": "Provenance.recorded",
-				"path": "Provenance.recorded",
-				"short": "Timestamp when the activity was recorded / updated",
-				"definition": "The instant of time at which the activity was recorded.",
-				"comment": "This can be a little different from the time stamp on the resource if there is a delay between recording the event and updating the provenance and target resource.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Provenance.recorded",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "rim",
-						"map": "unique(./participation[isNormalParticipation() and typeCode=AUT]/time[type=TS])"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.recorded"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Activity.when"
-					}
-				]
-			},
-			{
-				"id": "Provenance.policy",
-				"path": "Provenance.policy",
-				"short": "Policy or plan the activity was defined by",
-				"definition": "Policy or plan the activity was defined by. Typically, a single activity may have multiple applicable policy documents, such as patient consent, guarantor funding, etc.",
-				"comment": "For example: Where an OAuth token authorizes, the unique identifier from the OAuth token is placed into the policy element Where a policy engine (e.g. XACML) holds policy logic, the unique policy identifier is placed into the policy element.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Provenance.policy",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "./inboundRelationship[isNormalActRelationship() and typeCode=\"SUBJ\"]/source[isNormalAct and subsumes(POLICY, classCode) and moodCode=EVN]/text[typeCode='ED'/tel"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.agent.policy"
-					}
-				]
-			},
-			{
-				"id": "Provenance.location",
-				"path": "Provenance.location",
-				"short": "Where the activity occurred, if relevant",
-				"definition": "Where the activity occurred, if relevant.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Provenance.location",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Location"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.location"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.where[x]"
-					},
-					{
-						"identity": "rim",
-						"map": "unique(./participation[isNormalParticipation() and typeCode=LOC]/role[isNormalRole() and subsumes(SDLOC, classCode)]/player[isNormalEntity and classCode=\"LOC\" and determinerCode=\"INST\"]"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.agent.location"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Activity.location"
-					}
-				]
-			},
-			{
-				"id": "Provenance.reason",
-				"path": "Provenance.reason",
-				"short": "Reason the activity is occurring",
-				"definition": "The reason that the activity was taking place.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Provenance.reason",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProvenanceReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "The reason the activity took place.",
-					"valueSet": "http://terminology.hl7.org/ValueSet/v3-PurposeOfUse"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.reasonCode"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.why[x]"
-					},
-					{
-						"identity": "rim",
-						"map": "unique(./reasonCode)"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.purposeOfEvent"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Activity.Activity"
-					}
-				]
-			},
-			{
-				"id": "Provenance.activity",
-				"path": "Provenance.activity",
-				"short": "Activity that occurred",
-				"definition": "An activity is something that occurs over a period of time and acts upon or with entities; it may include consuming, processing, transforming, modifying, relocating, using, or generating entities.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Provenance.activity",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProvenanceActivity"
-						}
-					],
-					"strength": "extensible",
-					"description": "The activity that took place.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/provenance-activity-type"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.why[x]"
-					},
-					{
-						"identity": "rim",
-						"map": "Act.code"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Activity.Activity"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent",
-				"path": "Provenance.agent",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "type"
-						}
-					],
-					"rules": "open"
-				},
-				"short": "Actor involved",
-				"definition": "An actor taking a role in an activity  for which it can be assigned some degree of responsibility for the activity taking place.",
-				"comment": "Several agents may be associated (i.e. has some responsibility for an activity) with an activity and vice-versa.",
-				"requirements": "An agent can be a person, an organization, software, device, or other entities that may be ascribed responsibility.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Provenance.agent",
-					"min": 1,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.who"
-					},
-					{
-						"identity": "rim",
-						"map": "./participation[isNormalParticipation()]  OR  ./outboundRelationship[isNormalActRelationship() and typeCode='DRIV']"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.agent"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Agent"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent.id",
-				"path": "Provenance.agent.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent.extension",
-				"path": "Provenance.agent.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent.modifierExtension",
-				"path": "Provenance.agent.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent.type",
-				"path": "Provenance.agent.type",
-				"short": "How the agent participated",
-				"definition": "The participation the agent had with respect to the activity.",
-				"comment": "For example: author, performer, enterer, attester, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Provenance.agent.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-provenance-participant-type"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.function"
-					},
-					{
-						"identity": "rim",
-						"map": ".role"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.agent.type"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Agent.Attribution"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent.role",
-				"path": "Provenance.agent.role",
-				"short": "What the agents role was",
-				"definition": "The function of the agent with respect to the activity. The security role enabling the agent with respect to the activity.",
-				"comment": "For example: doctor, nurse, clerk, etc.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Provenance.agent.role",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProvenanceAgentRole"
-						}
-					],
-					"strength": "example",
-					"description": "The role that a provenance agent played with respect to the activity.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/security-role-type"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".typecode"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.agent.role"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent.who",
-				"path": "Provenance.agent.who",
-				"short": "Who participated",
-				"definition": "The individual, device or organization that participated in the event.",
-				"comment": "whoIdentity should be used when the agent is not a Resource type.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Provenance.agent.who",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent.onBehalfOf",
-				"path": "Provenance.agent.onBehalfOf",
-				"short": "Who the agent is representing",
-				"definition": "The individual, device, or organization for whom the change was made.",
-				"comment": "onBehalfOfIdentity should be used when the agent is not a Resource type.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Provenance.agent.onBehalfOf",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "provenance-1",
-						"severity": "error",
-						"human": "onBehalfOf SHALL be present when Provenance.agent.who is a Practitioner or Device",
-						"expression": "(($this.agent.who.resolve() is Practitioner) or ($this.agent.who.resolve() is Device)) implies exists()"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Person, Practitioner, Organization, Device :* .role [classCode = RoleClassMutualRelationship; role.code and * .scopes[Role](classCode=IDENT) and *.plays [Role.Code]"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceAuthor",
-				"path": "Provenance.agent",
-				"sliceName": "ProvenanceAuthor",
-				"short": "Actor involved",
-				"definition": "An actor taking a role in an activity  for which it can be assigned some degree of responsibility for the activity taking place.",
-				"comment": "Several agents may be associated (i.e. has some responsibility for an activity) with an activity and vice-versa.",
-				"requirements": "An agent can be a person, an organization, software, device, or other entities that may be ascribed responsibility.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Provenance.agent",
-					"min": 1,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.who"
-					},
-					{
-						"identity": "rim",
-						"map": "./participation[isNormalParticipation()]  OR  ./outboundRelationship[isNormalActRelationship() and typeCode='DRIV']"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.agent"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Agent"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceAuthor.id",
-				"path": "Provenance.agent.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceAuthor.extension",
-				"path": "Provenance.agent.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceAuthor.modifierExtension",
-				"path": "Provenance.agent.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceAuthor.type",
-				"path": "Provenance.agent.type",
-				"short": "How the agent participated",
-				"definition": "The participation the agent had with respect to the activity.",
-				"comment": "For example: author, performer, enterer, attester, etc.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Provenance.agent.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-							"code": "author"
-						}
-					]
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProvenanceAgentType"
-						}
-					],
-					"strength": "extensible",
-					"description": "The type of participation that a provenance agent played with respect to the activity.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/provenance-agent-type"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.function"
-					},
-					{
-						"identity": "rim",
-						"map": ".role"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.agent.type"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Agent.Attribution"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceAuthor.role",
-				"path": "Provenance.agent.role",
-				"short": "What the agents role was",
-				"definition": "The function of the agent with respect to the activity. The security role enabling the agent with respect to the activity.",
-				"comment": "For example: doctor, nurse, clerk, etc.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Provenance.agent.role",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProvenanceAgentRole"
-						}
-					],
-					"strength": "example",
-					"description": "The role that a provenance agent played with respect to the activity.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/security-role-type"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".typecode"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.agent.role"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceAuthor.who",
-				"path": "Provenance.agent.who",
-				"short": "Who participated",
-				"definition": "The individual, device or organization that participated in the event.",
-				"comment": "whoIdentity should be used when the agent is not a Resource type.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Provenance.agent.who",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceAuthor.onBehalfOf",
-				"path": "Provenance.agent.onBehalfOf",
-				"short": "Who the agent is representing",
-				"definition": "The individual, device, or organization for whom the change was made.",
-				"comment": "onBehalfOfIdentity should be used when the agent is not a Resource type.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Provenance.agent.onBehalfOf",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Person, Practitioner, Organization, Device :* .role [classCode = RoleClassMutualRelationship; role.code and * .scopes[Role](classCode=IDENT) and *.plays [Role.Code]"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceTransmitter",
-				"path": "Provenance.agent",
-				"sliceName": "ProvenanceTransmitter",
-				"short": "Actor involved",
-				"definition": "The entity that provided the copy to your system.",
-				"comment": "Several agents may be associated (i.e. has some responsibility for an activity) with an activity and vice-versa.",
-				"requirements": "An agent can be a person, an organization, software, device, or other entities that may be ascribed responsibility.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Provenance.agent",
-					"min": 1,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.who"
-					},
-					{
-						"identity": "rim",
-						"map": "./participation[isNormalParticipation()]  OR  ./outboundRelationship[isNormalActRelationship() and typeCode='DRIV']"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.agent"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Agent"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceTransmitter.id",
-				"path": "Provenance.agent.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceTransmitter.extension",
-				"path": "Provenance.agent.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceTransmitter.modifierExtension",
-				"path": "Provenance.agent.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceTransmitter.type",
-				"path": "Provenance.agent.type",
-				"short": "How the agent participated",
-				"definition": "The participation the agent had with respect to the activity.",
-				"comment": "For example: author, performer, enterer, attester, etc.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Provenance.agent.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-provenance-participant-type",
-							"code": "transmitter"
-						}
-					]
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProvenanceAgentType"
-						}
-					],
-					"strength": "extensible",
-					"description": "The type of participation that a provenance agent played with respect to the activity.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/provenance-agent-type"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.function"
-					},
-					{
-						"identity": "rim",
-						"map": ".role"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.agent.type"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Agent.Attribution"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceTransmitter.role",
-				"path": "Provenance.agent.role",
-				"short": "What the agents role was",
-				"definition": "The function of the agent with respect to the activity. The security role enabling the agent with respect to the activity.",
-				"comment": "For example: doctor, nurse, clerk, etc.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Provenance.agent.role",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProvenanceAgentRole"
-						}
-					],
-					"strength": "example",
-					"description": "The role that a provenance agent played with respect to the activity.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/security-role-type"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".typecode"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.agent.role"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceTransmitter.who",
-				"path": "Provenance.agent.who",
-				"short": "Who participated",
-				"definition": "The individual, device or organization that participated in the event.",
-				"comment": "whoIdentity should be used when the agent is not a Resource type.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Provenance.agent.who",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceTransmitter.onBehalfOf",
-				"path": "Provenance.agent.onBehalfOf",
-				"short": "Who the agent is representing",
-				"definition": "The individual, device, or organization for whom the change was made.",
-				"comment": "onBehalfOfIdentity should be used when the agent is not a Resource type.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Provenance.agent.onBehalfOf",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Person, Practitioner, Organization, Device :* .role [classCode = RoleClassMutualRelationship; role.code and * .scopes[Role](classCode=IDENT) and *.plays [Role.Code]"
-					}
-				]
-			},
-			{
-				"id": "Provenance.entity",
-				"path": "Provenance.entity",
-				"short": "An entity used in this activity",
-				"definition": "An entity used in this activity.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Provenance.entity",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "./subjectOf"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.entity"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Entity"
-					}
-				]
-			},
-			{
-				"id": "Provenance.entity.id",
-				"path": "Provenance.entity.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Provenance.entity.extension",
-				"path": "Provenance.entity.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Provenance.entity.modifierExtension",
-				"path": "Provenance.entity.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Provenance.entity.role",
-				"path": "Provenance.entity.role",
-				"short": "derivation | revision | quotation | source | removal",
-				"definition": "How the entity was used during the activity.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Provenance.entity.role",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProvenanceEntityRole"
-						}
-					],
-					"strength": "required",
-					"description": "How an entity was used in an activity.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/provenance-entity-role|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "./typeCode"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.entity.lifecycle"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Entity.role"
-					}
-				]
-			},
-			{
-				"id": "Provenance.entity.what",
-				"path": "Provenance.entity.what",
-				"short": "Identity of entity",
-				"definition": "Identity of the  Entity used. May be a logical or physical uri and maybe absolute or relative.",
-				"comment": "whatIdentity should be used for entities that are not a Resource type.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Provenance.entity.what",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "./text/reference"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.entity.reference"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Entity.Identity"
-					}
-				]
-			},
-			{
-				"id": "Provenance.entity.agent",
-				"path": "Provenance.entity.agent",
-				"short": "Entity is attributed to this agent",
-				"definition": "The entity is attributed to an agent to express the agent's responsibility for that entity, possibly along with other agents. This description can be understood as shorthand for saying that the agent was responsible for the activity which generated the entity.",
-				"comment": "A usecase where one Provenance.entity.agent is used where the Entity that was used in the creation/updating of the Target, is not in the context of the same custodianship as the Target, and thus the meaning of Provenance.entity.agent is to say that the entity referenced is managed elsewhere and that this Agent provided access to it.  This would be similar to where the Entity being referenced is managed outside FHIR, such as through HL7 v2, v3, or XDS. This might be where the Entity being referenced is managed in another FHIR resource server. Thus it explains the Provenance of that Entity's use in the context of this Provenance activity.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Provenance.entity.agent",
-					"min": 0,
-					"max": "*"
-				},
-				"contentReference": "#Provenance.agent:ProvenanceTransmitter",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "./author/role"
-					}
-				]
-			},
-			{
-				"id": "Provenance.signature",
-				"path": "Provenance.signature",
-				"short": "Signature on target",
-				"definition": "A digital signature on the target Reference(s). The signer should match a Provenance.agent. The purpose of the signature is indicated.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Provenance.signature",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Signature"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "./signatureText"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Provenance",
-				"path": "Provenance",
-				"short": "US Core Provenance",
-				"definition": "The US Core Provenance Profile is based upon the Argonaut Data Query requirements.",
-				"alias": [
-					"Basic Provenance"
-				],
-				"mustSupport": false,
-				"isModifier": false
-			},
-			{
-				"id": "Provenance.target",
-				"path": "Provenance.target",
-				"short": "The Resource this Provenance record supports",
-				"min": 1,
-				"max": "*",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "Provenance.recorded",
-				"path": "Provenance.recorded",
-				"short": "Timestamp when the activity was recorded / updated",
-				"definition": "The instant of time at which the activity was recorded.",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "Provenance.agent",
-				"path": "Provenance.agent",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "type"
-						}
-					],
-					"rules": "open"
-				},
-				"min": 1,
-				"max": "*",
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "Provenance.agent.type",
-				"path": "Provenance.agent.type",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-provenance-participant-type|3.1.1"
-				}
-			},
-			{
-				"id": "Provenance.agent.who",
-				"path": "Provenance.agent.who",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "Provenance.agent.onBehalfOf",
-				"path": "Provenance.agent.onBehalfOf",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "provenance-1",
-						"severity": "error",
-						"human": "onBehalfOf SHALL be present when Provenance.agent.who is a Practitioner or Device",
-						"expression": "(($this.agent.who.resolve() is Practitioner) or ($this.agent.who.resolve() is Device)) implies exists()"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "Provenance.agent:ProvenanceAuthor",
-				"path": "Provenance.agent",
-				"sliceName": "ProvenanceAuthor",
-				"min": 0,
-				"max": "*",
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "Provenance.agent:ProvenanceAuthor.type",
-				"path": "Provenance.agent.type",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-							"code": "author"
-						}
-					]
-				},
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "Provenance.agent:ProvenanceTransmitter",
-				"path": "Provenance.agent",
-				"sliceName": "ProvenanceTransmitter",
-				"definition": "The entity that provided the copy to your system.",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "Provenance.agent:ProvenanceTransmitter.type",
-				"path": "Provenance.agent.type",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-provenance-participant-type",
-							"code": "transmitter"
-						}
-					]
-				},
-				"mustSupport": true,
-				"isModifier": false
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-provenance",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance",
+    "version": "3.1.1",
+    "name": "USCoreProvenance",
+    "title": "US Core Provenance Profile",
+    "status": "active",
+    "date": "2019-08-05",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.healthit.gov"
+                }
+            ]
+        }
+    ],
+    "description": "Draft set of requirements to satisfy Basic Provenance Requirements.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w3c.prov",
+            "uri": "http://www.w3.org/ns/prov",
+            "name": "W3C PROV"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "fhirauditevent",
+            "uri": "http://hl7.org/fhir/auditevent",
+            "name": "FHIR AuditEvent Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Provenance",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Provenance",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Provenance",
+                "path": "Provenance",
+                "short": "US Core Provenance",
+                "definition": "The US Core Provenance Profile is based upon the Argonaut Data Query requirements.",
+                "comment": "Some parties may be duplicated between the target resource and its provenance.  For instance, the prescriber is usually (but not always) the author of the prescription resource. This resource is defined with close consideration for W3C Provenance.",
+                "alias": [
+                    "History",
+                    "Event",
+                    "Activity",
+                    "Basic Provenance"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Provenance",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "ControlAct[isNormalAct() and subsumes(CACT, classCode) and moodCode=EVN]"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Activity"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.id",
+                "path": "Provenance.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Provenance.meta",
+                "path": "Provenance.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Provenance.implicitRules",
+                "path": "Provenance.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Provenance.language",
+                "path": "Provenance.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Provenance.text",
+                "path": "Provenance.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.contained",
+                "path": "Provenance.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.extension",
+                "path": "Provenance.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.modifierExtension",
+                "path": "Provenance.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.target",
+                "path": "Provenance.target",
+                "short": "The Resource this Provenance record supports",
+                "definition": "The Reference(s) that were generated or updated by  the activity described in this resource. A provenance can point to more than one target if multiple resources were created/updated by the same activity.",
+                "comment": "Target references are usually version specific, but might not be, if a version has not been assigned or if the provenance information is part of the set of resources being maintained (i.e. a document). When using the RESTful API, the identity of the resource might not be known (especially not the version specific one); the client may either submit the resource first, and then the provenance, or it may submit both using a single transaction. See the notes on transaction for further discussion.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Provenance.target",
+                    "min": 1,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./outboundRelationship[isNormalActRelationship() and typeCode=SUBJ]/target  OR  ./participation[isNormalParticipation() and typeCode=SBJ]/role  OR  ./participation[isNormalParticipation() and typeCode=SBJ]/role[isNormalRole()]/player"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.entity.reference"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Entity Created/Updated"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.occurred[x]",
+                "path": "Provenance.occurred[x]",
+                "short": "When the activity occurred",
+                "definition": "The period during which the activity occurred.",
+                "comment": "The period can be a little arbitrary; where possible, the time should correspond to human assessment of the activity time.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.occurred[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    },
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurred[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./effectiveTime[type=IVL_TS]"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Activity.startTime & Activity.endTime"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.recorded",
+                "path": "Provenance.recorded",
+                "short": "Timestamp when the activity was recorded / updated",
+                "definition": "The instant of time at which the activity was recorded.",
+                "comment": "This can be a little different from the time stamp on the resource if there is a delay between recording the event and updating the provenance and target resource.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.recorded",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "unique(./participation[isNormalParticipation() and typeCode=AUT]/time[type=TS])"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.recorded"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Activity.when"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.policy",
+                "path": "Provenance.policy",
+                "short": "Policy or plan the activity was defined by",
+                "definition": "Policy or plan the activity was defined by. Typically, a single activity may have multiple applicable policy documents, such as patient consent, guarantor funding, etc.",
+                "comment": "For example: Where an OAuth token authorizes, the unique identifier from the OAuth token is placed into the policy element Where a policy engine (e.g. XACML) holds policy logic, the unique policy identifier is placed into the policy element.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Provenance.policy",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "./inboundRelationship[isNormalActRelationship() and typeCode=\"SUBJ\"]/source[isNormalAct and subsumes(POLICY, classCode) and moodCode=EVN]/text[typeCode='ED'/tel"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.agent.policy"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.location",
+                "path": "Provenance.location",
+                "short": "Where the activity occurred, if relevant",
+                "definition": "Where the activity occurred, if relevant.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.location",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Location"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.location"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.where[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "unique(./participation[isNormalParticipation() and typeCode=LOC]/role[isNormalRole() and subsumes(SDLOC, classCode)]/player[isNormalEntity and classCode=\"LOC\" and determinerCode=\"INST\"]"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.agent.location"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Activity.location"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.reason",
+                "path": "Provenance.reason",
+                "short": "Reason the activity is occurring",
+                "definition": "The reason that the activity was taking place.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Provenance.reason",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProvenanceReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "The reason the activity took place.",
+                    "valueSet": "http://terminology.hl7.org/ValueSet/v3-PurposeOfUse"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.reasonCode"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.why[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "unique(./reasonCode)"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.purposeOfEvent"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Activity.Activity"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.activity",
+                "path": "Provenance.activity",
+                "short": "Activity that occurred",
+                "definition": "An activity is something that occurs over a period of time and acts upon or with entities; it may include consuming, processing, transforming, modifying, relocating, using, or generating entities.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.activity",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProvenanceActivity"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "The activity that took place.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/provenance-activity-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.why[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Act.code"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Activity.Activity"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent",
+                "path": "Provenance.agent",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "type"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "short": "Actor involved",
+                "definition": "An actor taking a role in an activity  for which it can be assigned some degree of responsibility for the activity taking place.",
+                "comment": "Several agents may be associated (i.e. has some responsibility for an activity) with an activity and vice-versa.",
+                "requirements": "An agent can be a person, an organization, software, device, or other entities that may be ascribed responsibility.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Provenance.agent",
+                    "min": 1,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.who"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./participation[isNormalParticipation()]  OR  ./outboundRelationship[isNormalActRelationship() and typeCode='DRIV']"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.agent"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Agent"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent.id",
+                "path": "Provenance.agent.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent.extension",
+                "path": "Provenance.agent.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent.modifierExtension",
+                "path": "Provenance.agent.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent.type",
+                "path": "Provenance.agent.type",
+                "short": "How the agent participated",
+                "definition": "The participation the agent had with respect to the activity.",
+                "comment": "For example: author, performer, enterer, attester, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.agent.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-provenance-participant-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.function"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".role"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.agent.type"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Agent.Attribution"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent.role",
+                "path": "Provenance.agent.role",
+                "short": "What the agents role was",
+                "definition": "The function of the agent with respect to the activity. The security role enabling the agent with respect to the activity.",
+                "comment": "For example: doctor, nurse, clerk, etc.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Provenance.agent.role",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProvenanceAgentRole"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "The role that a provenance agent played with respect to the activity.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/security-role-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".typecode"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.agent.role"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent.who",
+                "path": "Provenance.agent.who",
+                "short": "Who participated",
+                "definition": "The individual, device or organization that participated in the event.",
+                "comment": "whoIdentity should be used when the agent is not a Resource type.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.agent.who",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent.onBehalfOf",
+                "path": "Provenance.agent.onBehalfOf",
+                "short": "Who the agent is representing",
+                "definition": "The individual, device, or organization for whom the change was made.",
+                "comment": "onBehalfOfIdentity should be used when the agent is not a Resource type.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.agent.onBehalfOf",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "provenance-1",
+                        "severity": "error",
+                        "human": "onBehalfOf SHALL be present when Provenance.agent.who is a Practitioner or Device",
+                        "expression": "(($this.agent.who.resolve() is Practitioner) or ($this.agent.who.resolve() is Device)) implies exists()"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Person, Practitioner, Organization, Device :* .role [classCode = RoleClassMutualRelationship; role.code and * .scopes[Role](classCode=IDENT) and *.plays [Role.Code]"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceAuthor",
+                "path": "Provenance.agent",
+                "sliceName": "ProvenanceAuthor",
+                "short": "Actor involved",
+                "definition": "An actor taking a role in an activity  for which it can be assigned some degree of responsibility for the activity taking place.",
+                "comment": "Several agents may be associated (i.e. has some responsibility for an activity) with an activity and vice-versa.",
+                "requirements": "An agent can be a person, an organization, software, device, or other entities that may be ascribed responsibility.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Provenance.agent",
+                    "min": 1,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.who"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./participation[isNormalParticipation()]  OR  ./outboundRelationship[isNormalActRelationship() and typeCode='DRIV']"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.agent"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Agent"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceAuthor.id",
+                "path": "Provenance.agent.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceAuthor.extension",
+                "path": "Provenance.agent.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceAuthor.modifierExtension",
+                "path": "Provenance.agent.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceAuthor.type",
+                "path": "Provenance.agent.type",
+                "short": "How the agent participated",
+                "definition": "The participation the agent had with respect to the activity.",
+                "comment": "For example: author, performer, enterer, attester, etc.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.agent.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                            "code": "author"
+                        }
+                    ]
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProvenanceAgentType"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "The type of participation that a provenance agent played with respect to the activity.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/provenance-agent-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.function"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".role"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.agent.type"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Agent.Attribution"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceAuthor.role",
+                "path": "Provenance.agent.role",
+                "short": "What the agents role was",
+                "definition": "The function of the agent with respect to the activity. The security role enabling the agent with respect to the activity.",
+                "comment": "For example: doctor, nurse, clerk, etc.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Provenance.agent.role",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProvenanceAgentRole"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "The role that a provenance agent played with respect to the activity.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/security-role-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".typecode"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.agent.role"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceAuthor.who",
+                "path": "Provenance.agent.who",
+                "short": "Who participated",
+                "definition": "The individual, device or organization that participated in the event.",
+                "comment": "whoIdentity should be used when the agent is not a Resource type.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.agent.who",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceAuthor.onBehalfOf",
+                "path": "Provenance.agent.onBehalfOf",
+                "short": "Who the agent is representing",
+                "definition": "The individual, device, or organization for whom the change was made.",
+                "comment": "onBehalfOfIdentity should be used when the agent is not a Resource type.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.agent.onBehalfOf",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Person, Practitioner, Organization, Device :* .role [classCode = RoleClassMutualRelationship; role.code and * .scopes[Role](classCode=IDENT) and *.plays [Role.Code]"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceTransmitter",
+                "path": "Provenance.agent",
+                "sliceName": "ProvenanceTransmitter",
+                "short": "Actor involved",
+                "definition": "The entity that provided the copy to your system.",
+                "comment": "Several agents may be associated (i.e. has some responsibility for an activity) with an activity and vice-versa.",
+                "requirements": "An agent can be a person, an organization, software, device, or other entities that may be ascribed responsibility.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.agent",
+                    "min": 1,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.who"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./participation[isNormalParticipation()]  OR  ./outboundRelationship[isNormalActRelationship() and typeCode='DRIV']"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.agent"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Agent"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceTransmitter.id",
+                "path": "Provenance.agent.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceTransmitter.extension",
+                "path": "Provenance.agent.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceTransmitter.modifierExtension",
+                "path": "Provenance.agent.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceTransmitter.type",
+                "path": "Provenance.agent.type",
+                "short": "How the agent participated",
+                "definition": "The participation the agent had with respect to the activity.",
+                "comment": "For example: author, performer, enterer, attester, etc.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.agent.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-provenance-participant-type",
+                            "code": "transmitter"
+                        }
+                    ]
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProvenanceAgentType"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "The type of participation that a provenance agent played with respect to the activity.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/provenance-agent-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.function"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".role"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.agent.type"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Agent.Attribution"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceTransmitter.role",
+                "path": "Provenance.agent.role",
+                "short": "What the agents role was",
+                "definition": "The function of the agent with respect to the activity. The security role enabling the agent with respect to the activity.",
+                "comment": "For example: doctor, nurse, clerk, etc.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Provenance.agent.role",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProvenanceAgentRole"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "The role that a provenance agent played with respect to the activity.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/security-role-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".typecode"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.agent.role"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceTransmitter.who",
+                "path": "Provenance.agent.who",
+                "short": "Who participated",
+                "definition": "The individual, device or organization that participated in the event.",
+                "comment": "whoIdentity should be used when the agent is not a Resource type.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.agent.who",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceTransmitter.onBehalfOf",
+                "path": "Provenance.agent.onBehalfOf",
+                "short": "Who the agent is representing",
+                "definition": "The individual, device, or organization for whom the change was made.",
+                "comment": "onBehalfOfIdentity should be used when the agent is not a Resource type.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.agent.onBehalfOf",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Person, Practitioner, Organization, Device :* .role [classCode = RoleClassMutualRelationship; role.code and * .scopes[Role](classCode=IDENT) and *.plays [Role.Code]"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.entity",
+                "path": "Provenance.entity",
+                "short": "An entity used in this activity",
+                "definition": "An entity used in this activity.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Provenance.entity",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "./subjectOf"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.entity"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Entity"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.entity.id",
+                "path": "Provenance.entity.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.entity.extension",
+                "path": "Provenance.entity.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.entity.modifierExtension",
+                "path": "Provenance.entity.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.entity.role",
+                "path": "Provenance.entity.role",
+                "short": "derivation | revision | quotation | source | removal",
+                "definition": "How the entity was used during the activity.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.entity.role",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProvenanceEntityRole"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "How an entity was used in an activity.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/provenance-entity-role|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "./typeCode"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.entity.lifecycle"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Entity.role"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.entity.what",
+                "path": "Provenance.entity.what",
+                "short": "Identity of entity",
+                "definition": "Identity of the  Entity used. May be a logical or physical uri and maybe absolute or relative.",
+                "comment": "whatIdentity should be used for entities that are not a Resource type.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.entity.what",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "./text/reference"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.entity.reference"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Entity.Identity"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.entity.agent",
+                "path": "Provenance.entity.agent",
+                "short": "Entity is attributed to this agent",
+                "definition": "The entity is attributed to an agent to express the agent's responsibility for that entity, possibly along with other agents. This description can be understood as shorthand for saying that the agent was responsible for the activity which generated the entity.",
+                "comment": "A usecase where one Provenance.entity.agent is used where the Entity that was used in the creation/updating of the Target, is not in the context of the same custodianship as the Target, and thus the meaning of Provenance.entity.agent is to say that the entity referenced is managed elsewhere and that this Agent provided access to it.  This would be similar to where the Entity being referenced is managed outside FHIR, such as through HL7 v2, v3, or XDS. This might be where the Entity being referenced is managed in another FHIR resource server. Thus it explains the Provenance of that Entity's use in the context of this Provenance activity.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Provenance.entity.agent",
+                    "min": 0,
+                    "max": "*"
+                },
+                "contentReference": "#Provenance.agent:ProvenanceTransmitter",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "./author/role"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.signature",
+                "path": "Provenance.signature",
+                "short": "Signature on target",
+                "definition": "A digital signature on the target Reference(s). The signer should match a Provenance.agent. The purpose of the signature is indicated.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Provenance.signature",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Signature"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "./signatureText"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Provenance",
+                "path": "Provenance",
+                "short": "US Core Provenance",
+                "definition": "The US Core Provenance Profile is based upon the Argonaut Data Query requirements.",
+                "alias": [
+                    "Basic Provenance"
+                ],
+                "mustSupport": false,
+                "isModifier": false
+            },
+            {
+                "id": "Provenance.target",
+                "path": "Provenance.target",
+                "short": "The Resource this Provenance record supports",
+                "min": 1,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "Provenance.recorded",
+                "path": "Provenance.recorded",
+                "short": "Timestamp when the activity was recorded / updated",
+                "definition": "The instant of time at which the activity was recorded.",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "Provenance.agent",
+                "path": "Provenance.agent",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "type"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "min": 1,
+                "max": "*",
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "Provenance.agent.type",
+                "path": "Provenance.agent.type",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-provenance-participant-type|3.1.1"
+                }
+            },
+            {
+                "id": "Provenance.agent.who",
+                "path": "Provenance.agent.who",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner|3.1.1",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "Provenance.agent.onBehalfOf",
+                "path": "Provenance.agent.onBehalfOf",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "provenance-1",
+                        "severity": "error",
+                        "human": "onBehalfOf SHALL be present when Provenance.agent.who is a Practitioner or Device",
+                        "expression": "(($this.agent.who.resolve() is Practitioner) or ($this.agent.who.resolve() is Device)) implies exists()"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "Provenance.agent:ProvenanceAuthor",
+                "path": "Provenance.agent",
+                "sliceName": "ProvenanceAuthor",
+                "min": 0,
+                "max": "*",
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "Provenance.agent:ProvenanceAuthor.type",
+                "path": "Provenance.agent.type",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                            "code": "author"
+                        }
+                    ]
+                },
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "Provenance.agent:ProvenanceTransmitter",
+                "path": "Provenance.agent",
+                "sliceName": "ProvenanceTransmitter",
+                "definition": "The entity that provided the copy to your system.",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "Provenance.agent:ProvenanceTransmitter.type",
+                "path": "Provenance.agent.type",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-provenance-participant-type",
+                            "code": "transmitter"
+                        }
+                    ]
+                },
+                "mustSupport": true,
+                "isModifier": false
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-pulse-oximetry.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-pulse-oximetry.json
@@ -1,6531 +1,6531 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-pulse-oximetry",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation\" title=\"This profile defines how to represent pulse oximetry and inspired oxygen concentration based on the FHIR Core Vitals Profile.\nINSPIRED OXYGEN CONCENTRATION observations in FHIR using a standard LOINC code and UCUM units of measure.\">Observation</a><a name=\"Observation\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/oxygensat.html\">observation-oxygensat</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">FHIR Oxygen Saturation Profile</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.code\">code</a><a name=\"Observation.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">1</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Oxygen Saturation by Pulse Oximetry</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck103.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Slice Definition\" class=\"hierarchy\"/> <a style=\"font-style: italic\" href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.code.coding\">coding</a><a name=\"Observation.code.coding\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red; font-style: italic\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"font-style: italic\"/><span style=\"opacity: 0.5; font-style: italic\">0</span><span style=\"opacity: 0.5; font-style: italic\">..</span><span style=\"opacity: 0.5; font-style: italic\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"font-style: italic\" href=\"http://hl7.org/fhir/R4/profiling.html#slicing\">(Slice Definition)</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5; font-style: italic\">Code defined by a terminology system</span><br style=\"font-style: italic\"/><span style=\"font-weight:bold; font-style: italic\">Slice: </span><span style=\"font-style: italic\">Unordered, Open by value:code, value:system</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1025.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.code.coding:PulseOx\" title=\"Slice PulseOx\">coding:PulseOx</a><a name=\"Observation.code.coding\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Code defined by a terminology system</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10250.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.code.coding:PulseOx.system\">system</a><a name=\"Observation.code.coding.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Identity of the terminology system</span><br/><span style=\"font-weight:bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/loinc.html\">http://loinc.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10240.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.code.coding:PulseOx.code\">code</a><a name=\"Observation.code.coding.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Symbol in syntax defined by the system</span><br/><span style=\"font-weight:bold\">Fixed Value: </span><span style=\"color: darkgreen\">59408-5</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck03.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Slice Definition\" class=\"hierarchy\"/> <a style=\"font-style: italic\" href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.component\">component</a><a name=\"Observation.component\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red; font-style: italic\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"font-style: italic\"/><span style=\"opacity: 0.5; font-style: italic\">0</span><span style=\"opacity: 0.5; font-style: italic\">..</span><span style=\"opacity: 0.5; font-style: italic\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"font-style: italic\" href=\"http://hl7.org/fhir/R4/profiling.html#slicing\">(Slice Definition)</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5; font-style: italic\">Used when reporting systolic and diastolic blood pressure.</span><br style=\"font-style: italic\"/><span style=\"font-weight:bold; font-style: italic\">Slice: </span><span style=\"font-style: italic\">Unordered, Open by pattern:code</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck035.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.component:FlowRate\" title=\"Slice FlowRate\">component:FlowRate</a><a name=\"Observation.component\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Inhaled oxygen flow rate</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0351.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.component:FlowRate.code\">code</a><a name=\"Observation.component.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">1</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Type of component observation (code / type)</span><br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck03501.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#CodeableConcept.coding\">coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Code defined by a terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">(complex)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck035010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/loinc.html\">http://loinc.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck035000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">3151-8</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0341.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.component:FlowRate.valueQuantity\">valueQuantity</a><a name=\"Observation.component.valueQuantity\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Quantity\">Quantity</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Vital Sign Value recorded with UCUM</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck03410.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.component:FlowRate.valueQuantity.value\">value</a><a name=\"Observation.component.valueQuantity.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#decimal\">decimal</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Numerical value (with implicit precision)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck03410.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.component:FlowRate.valueQuantity.unit\">unit</a><a name=\"Observation.component.valueQuantity.unit\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Unit representation</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck03410.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.component:FlowRate.valueQuantity.system\">system</a><a name=\"Observation.component.valueQuantity.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">System that defines coded unit form</span><br/><span style=\"font-weight:bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/ucum.html\">http://unitsofmeasure.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck03400.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.component:FlowRate.valueQuantity.code\">code</a><a name=\"Observation.component.valueQuantity.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Coded form of the unit</span><br/><span style=\"font-weight:bold\">Fixed Value: </span><span style=\"color: darkgreen\">L/min</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck025.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.component:Concentration\" title=\"Slice Concentration\">component:Concentration</a><a name=\"Observation.component\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Inhaled oxygen concentration</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0251.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.component:Concentration.code\">code</a><a name=\"Observation.component.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">1</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Type of component observation (code / type)</span><br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck02501.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#CodeableConcept.coding\">coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Code defined by a terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">(complex)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck025010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/loinc.html\">http://loinc.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck025000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">3150-0</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0241.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.component:Concentration.valueQuantity\">valueQuantity</a><a name=\"Observation.component.valueQuantity\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Quantity\">Quantity</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Vital Sign Value recorded with UCUM</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck02410.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.component:Concentration.valueQuantity.value\">value</a><a name=\"Observation.component.valueQuantity.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#decimal\">decimal</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Numerical value (with implicit precision)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck02410.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.component:Concentration.valueQuantity.unit\">unit</a><a name=\"Observation.component.valueQuantity.unit\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Unit representation</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck02410.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.component:Concentration.valueQuantity.system\">system</a><a name=\"Observation.component.valueQuantity.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">System that defines coded unit form</span><br/><span style=\"font-weight:bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/ucum.html\">http://unitsofmeasure.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck02400.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.component:Concentration.valueQuantity.code\">code</a><a name=\"Observation.component.valueQuantity.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Coded form of the unit</span><br/><span style=\"font-weight:bold\">Fixed Value: </span><span style=\"color: darkgreen\">%</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry",
-	"version": "3.1.1",
-	"name": "USCorePulseOximetryProfile",
-	"title": "US Core Pulse Oximetry Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-06-29",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.healthit.gov"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the Observation resource for use in querying and retrieving inspired O2 by pulse oximetry observations.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "sct-concept",
-			"uri": "http://snomed.info/conceptdomain",
-			"name": "SNOMED CT Concept Domain Binding"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "sct-attr",
-			"uri": "http://snomed.org/attributebinding",
-			"name": "SNOMED CT Attribute Binding"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Observation",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/oxygensat",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "FHIR Oxygen Saturation Profile",
-				"definition": "This profile defines how to represent pulse oximetry and inspired oxygen concentration based on the FHIR Core Vitals Profile.\nINSPIRED OXYGEN CONCENTRATION observations in FHIR using a standard LOINC code and UCUM units of measure.",
-				"comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
-				"alias": [
-					"Vital Signs",
-					"Measurement",
-					"Results",
-					"Tests"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "obs-6",
-						"severity": "error",
-						"human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
-						"expression": "dataAbsentReason.empty() or value.empty()",
-						"xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "obs-7",
-						"severity": "error",
-						"human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
-						"expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
-						"xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "vs-2",
-						"severity": "error",
-						"human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
-						"expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
-						"xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.id",
-				"path": "Observation.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.meta",
-				"path": "Observation.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.implicitRules",
-				"path": "Observation.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Observation.language",
-				"path": "Observation.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Observation.text",
-				"path": "Observation.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Observation.contained",
-				"path": "Observation.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.extension",
-				"path": "Observation.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.modifierExtension",
-				"path": "Observation.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.identifier",
-				"path": "Observation.identifier",
-				"short": "Business Identifier for observation",
-				"definition": "A unique identifier assigned to this observation.",
-				"requirements": "Allows observations to be distinguished and referenced.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
-					},
-					{
-						"identity": "rim",
-						"map": "id"
-					}
-				]
-			},
-			{
-				"id": "Observation.basedOn",
-				"path": "Observation.basedOn",
-				"short": "Fulfills plan, proposal or order",
-				"definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
-				"requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
-				"alias": [
-					"Fulfills"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan",
-							"http://hl7.org/fhir/StructureDefinition/DeviceRequest",
-							"http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
-							"http://hl7.org/fhir/StructureDefinition/MedicationRequest",
-							"http://hl7.org/fhir/StructureDefinition/NutritionOrder",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.basedOn"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.partOf",
-				"path": "Observation.partOf",
-				"short": "Part of referenced event",
-				"definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
-				"comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
-				"alias": [
-					"Container"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.partOf",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
-							"http://hl7.org/fhir/StructureDefinition/MedicationDispense",
-							"http://hl7.org/fhir/StructureDefinition/MedicationStatement",
-							"http://hl7.org/fhir/StructureDefinition/Procedure",
-							"http://hl7.org/fhir/StructureDefinition/Immunization",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.partOf"
-					},
-					{
-						"identity": "v2",
-						"map": "Varies by domain"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=FLFS].target"
-					}
-				]
-			},
-			{
-				"id": "Observation.status",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
-						"valueString": "default: final"
-					}
-				],
-				"path": "Observation.status",
-				"short": "registered | preliminary | final | amended +",
-				"definition": "The status of the result value.",
-				"comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
-				"requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Status"
-						}
-					],
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 445584004 |Report by finality status|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-11"
-					},
-					{
-						"identity": "rim",
-						"map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
-					}
-				]
-			},
-			{
-				"id": "Observation.category",
-				"path": "Observation.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "coding.code"
-						},
-						{
-							"type": "value",
-							"path": "coding.system"
-						}
-					],
-					"ordered": false,
-					"rules": "open"
-				},
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat",
-				"path": "Observation.category",
-				"sliceName": "VSCat",
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.id",
-				"path": "Observation.category.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.extension",
-				"path": "Observation.category.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding",
-				"path": "Observation.category.coding",
-				"short": "Code defined by a terminology system",
-				"definition": "A reference to a code defined by a terminology system.",
-				"comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
-				"requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "CodeableConcept.coding",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1-8, C*E.10-22"
-					},
-					{
-						"identity": "rim",
-						"map": "union(., ./translation)"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.id",
-				"path": "Observation.category.coding.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.extension",
-				"path": "Observation.category.coding.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.system",
-				"path": "Observation.category.coding.system",
-				"short": "Identity of the terminology system",
-				"definition": "The identification of the code system that defines the meaning of the symbol in the code.",
-				"comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
-				"requirements": "Need to be unambiguous about the source of the definition of the symbol.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.3"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystem"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.version",
-				"path": "Observation.category.coding.version",
-				"short": "Version of the system - if relevant",
-				"definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
-				"comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.version",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.7"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystemVersion"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.code",
-				"path": "Observation.category.coding.code",
-				"short": "Symbol in syntax defined by the system",
-				"definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
-				"requirements": "Need to refer to a particular code in the system.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "vital-signs",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1"
-					},
-					{
-						"identity": "rim",
-						"map": "./code"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.display",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.coding.display",
-				"short": "Representation defined by the system",
-				"definition": "A representation of the meaning of the code in the system, following the rules of the system.",
-				"requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.display",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.2 - but note this is not well followed"
-					},
-					{
-						"identity": "rim",
-						"map": "CV.displayName"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.userSelected",
-				"path": "Observation.category.coding.userSelected",
-				"short": "If this coding was chosen directly by the user",
-				"definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
-				"comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
-				"requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.userSelected",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Sometimes implied by being first"
-					},
-					{
-						"identity": "rim",
-						"map": "CD.codingRationale"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.text",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.text",
-				"short": "Plain text representation of the concept",
-				"definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
-				"comment": "Very often the text is the same as a displayName of one of the codings.",
-				"requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CodeableConcept.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.9. But note many systems use C*E.2 for this"
-					},
-					{
-						"identity": "rim",
-						"map": "./originalText[mediaType/code=\"text/plain\"]/data"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
-					}
-				]
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Oxygen Saturation by Pulse Oximetry",
-				"definition": "Oxygen Saturation.",
-				"comment": "The code (59408-5 Oxygen saturation in Arterial blood by Pulse oximetry) is included as an additional observation code to FHIR Core vital Oxygen Saturation code (2708-6 Oxygen saturation in Arterial blood -).",
-				"requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
-				"alias": [
-					"Name",
-					"Test"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "VitalSigns"
-						}
-					],
-					"strength": "extensible",
-					"description": "This identifies the vital sign result type.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-vitalsignresult"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "116680003 |Is a|"
-					}
-				]
-			},
-			{
-				"id": "Observation.code.id",
-				"path": "Observation.code.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.code.extension",
-				"path": "Observation.code.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.code.coding",
-				"path": "Observation.code.coding",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "code"
-						},
-						{
-							"type": "value",
-							"path": "system"
-						}
-					],
-					"ordered": false,
-					"rules": "open"
-				},
-				"short": "Code defined by a terminology system",
-				"definition": "A reference to a code defined by a terminology system.",
-				"comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
-				"requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CodeableConcept.coding",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1-8, C*E.10-22"
-					},
-					{
-						"identity": "rim",
-						"map": "union(., ./translation)"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
-					}
-				]
-			},
-			{
-				"id": "Observation.code.coding:OxygenSatCode",
-				"path": "Observation.code.coding",
-				"sliceName": "OxygenSatCode",
-				"short": "Code defined by a terminology system",
-				"definition": "A reference to a code defined by a terminology system.",
-				"comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
-				"requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "CodeableConcept.coding",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1-8, C*E.10-22"
-					},
-					{
-						"identity": "rim",
-						"map": "union(., ./translation)"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
-					}
-				]
-			},
-			{
-				"id": "Observation.code.coding:OxygenSatCode.id",
-				"path": "Observation.code.coding.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.code.coding:OxygenSatCode.extension",
-				"path": "Observation.code.coding.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.code.coding:OxygenSatCode.system",
-				"path": "Observation.code.coding.system",
-				"short": "Identity of the terminology system",
-				"definition": "The identification of the code system that defines the meaning of the symbol in the code.",
-				"comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
-				"requirements": "Need to be unambiguous about the source of the definition of the symbol.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://loinc.org",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.3"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystem"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.code.coding:OxygenSatCode.version",
-				"path": "Observation.code.coding.version",
-				"short": "Version of the system - if relevant",
-				"definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
-				"comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.version",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.7"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystemVersion"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
-					}
-				]
-			},
-			{
-				"id": "Observation.code.coding:OxygenSatCode.code",
-				"path": "Observation.code.coding.code",
-				"short": "Symbol in syntax defined by the system",
-				"definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
-				"requirements": "Need to refer to a particular code in the system.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "2708-6",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1"
-					},
-					{
-						"identity": "rim",
-						"map": "./code"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.code.coding:OxygenSatCode.display",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.code.coding.display",
-				"short": "Representation defined by the system",
-				"definition": "A representation of the meaning of the code in the system, following the rules of the system.",
-				"requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.display",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.2 - but note this is not well followed"
-					},
-					{
-						"identity": "rim",
-						"map": "CV.displayName"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
-					}
-				]
-			},
-			{
-				"id": "Observation.code.coding:OxygenSatCode.userSelected",
-				"path": "Observation.code.coding.userSelected",
-				"short": "If this coding was chosen directly by the user",
-				"definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
-				"comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
-				"requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.userSelected",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Sometimes implied by being first"
-					},
-					{
-						"identity": "rim",
-						"map": "CD.codingRationale"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
-					}
-				]
-			},
-			{
-				"id": "Observation.code.coding:PulseOx",
-				"path": "Observation.code.coding",
-				"sliceName": "PulseOx",
-				"short": "Code defined by a terminology system",
-				"definition": "A reference to a code defined by a terminology system.",
-				"comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
-				"requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "CodeableConcept.coding",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1-8, C*E.10-22"
-					},
-					{
-						"identity": "rim",
-						"map": "union(., ./translation)"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
-					}
-				]
-			},
-			{
-				"id": "Observation.code.coding:PulseOx.id",
-				"path": "Observation.code.coding.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.code.coding:PulseOx.extension",
-				"path": "Observation.code.coding.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.code.coding:PulseOx.system",
-				"path": "Observation.code.coding.system",
-				"short": "Identity of the terminology system",
-				"definition": "The identification of the code system that defines the meaning of the symbol in the code.",
-				"comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
-				"requirements": "Need to be unambiguous about the source of the definition of the symbol.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://loinc.org",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.3"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystem"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.code.coding:PulseOx.version",
-				"path": "Observation.code.coding.version",
-				"short": "Version of the system - if relevant",
-				"definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
-				"comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.version",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.7"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystemVersion"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
-					}
-				]
-			},
-			{
-				"id": "Observation.code.coding:PulseOx.code",
-				"path": "Observation.code.coding.code",
-				"short": "Symbol in syntax defined by the system",
-				"definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
-				"requirements": "Need to refer to a particular code in the system.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "59408-5",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1"
-					},
-					{
-						"identity": "rim",
-						"map": "./code"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.code.coding:PulseOx.display",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.code.coding.display",
-				"short": "Representation defined by the system",
-				"definition": "A representation of the meaning of the code in the system, following the rules of the system.",
-				"requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.display",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.2 - but note this is not well followed"
-					},
-					{
-						"identity": "rim",
-						"map": "CV.displayName"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
-					}
-				]
-			},
-			{
-				"id": "Observation.code.coding:PulseOx.userSelected",
-				"path": "Observation.code.coding.userSelected",
-				"short": "If this coding was chosen directly by the user",
-				"definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
-				"comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
-				"requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.userSelected",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Sometimes implied by being first"
-					},
-					{
-						"identity": "rim",
-						"map": "CD.codingRationale"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
-					}
-				]
-			},
-			{
-				"id": "Observation.code.text",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.code.text",
-				"short": "Plain text representation of the concept",
-				"definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
-				"comment": "Very often the text is the same as a displayName of one of the codings.",
-				"requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CodeableConcept.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.9. But note many systems use C*E.2 for this"
-					},
-					{
-						"identity": "rim",
-						"map": "./originalText[mediaType/code=\"text/plain\"]/data"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
-					}
-				]
-			},
-			{
-				"id": "Observation.subject",
-				"path": "Observation.subject",
-				"short": "Who and/or what the observation is about",
-				"definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
-				"comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
-				"requirements": "Observations have no value if you don't know who or what they're about.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Patient"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=RTGT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.focus",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
-						"valueCode": "trial-use"
-					}
-				],
-				"path": "Observation.focus",
-				"short": "What the observation is about, when it is not about the subject of record",
-				"definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
-				"comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.focus",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SBJ]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.encounter",
-				"path": "Observation.encounter",
-				"short": "Healthcare event during which this observation is made",
-				"definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
-				"comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
-				"requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
-				"alias": [
-					"Context"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.effective[x]",
-				"path": "Observation.effective[x]",
-				"short": "Often just a dateTime for Vital Signs",
-				"definition": "Often just a dateTime for Vital Signs.",
-				"comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
-				"requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
-				"alias": [
-					"Occurrence"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.effective[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-1",
-						"severity": "error",
-						"human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
-						"expression": "($this as dateTime).toString().length() >= 8",
-						"xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "Observation.issued",
-				"path": "Observation.issued",
-				"short": "Date/Time this version was made available",
-				"definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
-				"comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.issued",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=AUT].time"
-					}
-				]
-			},
-			{
-				"id": "Observation.performer",
-				"path": "Observation.performer",
-				"short": "Who is responsible for the observation",
-				"definition": "Who was responsible for asserting the observed value as \"true\".",
-				"requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.performer",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=PRF]"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]",
-				"path": "Observation.value[x]",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "type",
-							"path": "$this"
-						}
-					],
-					"ordered": false,
-					"rules": "closed"
-				},
-				"short": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
-				"definition": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity",
-				"path": "Observation.value[x]",
-				"sliceName": "valueQuantity",
-				"short": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
-				"definition": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.id",
-				"path": "Observation.value[x].id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.extension",
-				"path": "Observation.value[x].extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.value",
-				"path": "Observation.value[x].value",
-				"short": "Numerical value (with implicit precision)",
-				"definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
-				"comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
-				"requirements": "Precision is handled implicitly in almost all cases of measurement.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.2  / CQ - N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.comparator",
-				"path": "Observation.value[x].comparator",
-				"short": "< | <= | >= | > - how to understand the value",
-				"definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
-				"requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Quantity.comparator",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "QuantityComparator"
-						}
-					],
-					"strength": "required",
-					"description": "How the Quantity should be understood and represented.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.1  / CQ.1"
-					},
-					{
-						"identity": "rim",
-						"map": "IVL properties"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.unit",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.value[x].unit",
-				"short": "Unit representation",
-				"definition": "A human-readable form of the unit.",
-				"requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.unit",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.unit"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.system",
-				"path": "Observation.value[x].system",
-				"short": "System that defines coded unit form",
-				"definition": "The identification of the system that provides the coded form of the unit.",
-				"requirements": "Need to know the system that defines the coded form of the unit.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"condition": [
-					"qty-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "CO.codeSystem, PQ.translation.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.code",
-				"path": "Observation.value[x].code",
-				"short": "Coded responses from the common UCUM units for vital signs value set.",
-				"definition": "Coded responses from the common UCUM units for vital signs value set.",
-				"comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
-				"requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "%",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.code, MO.currency, PQ.translation.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.dataAbsentReason",
-				"path": "Observation.dataAbsentReason",
-				"short": "Why the result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
-				"comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.interpretation",
-				"path": "Observation.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.note",
-				"path": "Observation.note",
-				"short": "Comments about the observation",
-				"definition": "Comments about the observation or the results.",
-				"comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
-				"requirements": "Need to be able to provide free text additional information.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
-					},
-					{
-						"identity": "rim",
-						"map": "subjectOf.observationEvent[code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.bodySite",
-				"path": "Observation.bodySite",
-				"short": "Observed body part",
-				"definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
-				"comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.bodySite",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "BodySite"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing anatomical locations. May include laterality.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/body-site"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123037004 |Body structure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-20"
-					},
-					{
-						"identity": "rim",
-						"map": "targetSiteCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "718497002 |Inherent location|"
-					}
-				]
-			},
-			{
-				"id": "Observation.method",
-				"path": "Observation.method",
-				"short": "How it was done",
-				"definition": "Indicates the mechanism used to perform the observation.",
-				"comment": "Only used if not implicit in code for Observation.code.",
-				"requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.method",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationMethod"
-						}
-					],
-					"strength": "example",
-					"description": "Methods for simple observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-17"
-					},
-					{
-						"identity": "rim",
-						"map": "methodCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.specimen",
-				"path": "Observation.specimen",
-				"short": "Specimen used for this observation",
-				"definition": "The specimen that was used when this observation was made.",
-				"comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.specimen",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Specimen"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123038009 |Specimen|"
-					},
-					{
-						"identity": "v2",
-						"map": "SPM segment"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SPC].specimen"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "704319004 |Inherent in|"
-					}
-				]
-			},
-			{
-				"id": "Observation.device",
-				"path": "Observation.device",
-				"short": "(Measurement) Device",
-				"definition": "The device used to generate the observation data.",
-				"comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.device",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/DeviceMetric"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 49062001 |Device|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-17 / PRT -10"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=DEV]"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "424226004 |Using device|"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange",
-				"path": "Observation.referenceRange",
-				"short": "Provides guide for interpretation",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "obs-3",
-						"severity": "error",
-						"human": "Must have at least a low or a high or text",
-						"expression": "low.exists() or high.exists() or text.exists()",
-						"xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.id",
-				"path": "Observation.referenceRange.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.extension",
-				"path": "Observation.referenceRange.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.modifierExtension",
-				"path": "Observation.referenceRange.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.low",
-				"path": "Observation.referenceRange.low",
-				"short": "Low Range, if relevant",
-				"definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.low",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.low"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.high",
-				"path": "Observation.referenceRange.high",
-				"short": "High Range, if relevant",
-				"definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.high",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.high"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.type",
-				"path": "Observation.referenceRange.type",
-				"short": "Reference range qualifier",
-				"definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
-				"requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeMeaning"
-						}
-					],
-					"strength": "preferred",
-					"description": "Code for the meaning of a reference range.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.appliesTo",
-				"path": "Observation.referenceRange.appliesTo",
-				"short": "Reference range population",
-				"definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
-				"requirements": "Need to be able to identify the target population for proper interpretation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange.appliesTo",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeType"
-						}
-					],
-					"strength": "example",
-					"description": "Codes identifying the population the reference range applies to.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.age",
-				"path": "Observation.referenceRange.age",
-				"short": "Applicable age range, if relevant",
-				"definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
-				"requirements": "Some analytes vary greatly over age.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.age",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Range"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.text",
-				"path": "Observation.referenceRange.text",
-				"short": "Text based reference range in an observation",
-				"definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:ST"
-					}
-				]
-			},
-			{
-				"id": "Observation.hasMember",
-				"path": "Observation.hasMember",
-				"short": "Used when reporting vital signs panel components",
-				"definition": "Used when reporting vital signs panel components.",
-				"comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.hasMember",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship"
-					}
-				]
-			},
-			{
-				"id": "Observation.derivedFrom",
-				"path": "Observation.derivedFrom",
-				"short": "Related measurements the observation is made from",
-				"definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
-				"comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.derivedFrom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/DocumentReference",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy",
-							"http://hl7.org/fhir/StructureDefinition/Media",
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": ".targetObservation"
-					}
-				]
-			},
-			{
-				"id": "Observation.component",
-				"path": "Observation.component",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "code"
-						}
-					],
-					"rules": "open"
-				},
-				"short": "Used when reporting systolic and diastolic blood pressure.",
-				"definition": "Used when reporting systolic and diastolic blood pressure.",
-				"comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-3",
-						"severity": "error",
-						"human": "If there is no a value a data absent reason must be present",
-						"expression": "value.exists() or dataAbsentReason.exists()",
-						"xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/oxygensat"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "containment by OBX-4?"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=COMP]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.id",
-				"path": "Observation.component.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.extension",
-				"path": "Observation.component.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.modifierExtension",
-				"path": "Observation.component.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.code",
-				"path": "Observation.component.code",
-				"short": "Type of component observation (code / type)",
-				"definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
-				"comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "VitalSigns"
-						}
-					],
-					"strength": "extensible",
-					"description": "This identifies the vital sign result type.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-vitalsignresult"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.value[x]",
-				"path": "Observation.component.value[x]",
-				"short": "Vital Sign Value recorded with UCUM",
-				"definition": "Vital Sign Value recorded with UCUM.",
-				"comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "VitalSignsUnits"
-						}
-					],
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.dataAbsentReason",
-				"path": "Observation.component.dataAbsentReason",
-				"short": "Why the component result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
-				"comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.interpretation",
-				"path": "Observation.component.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.referenceRange",
-				"path": "Observation.component.referenceRange",
-				"short": "Provides guide for interpretation of component result",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"contentReference": "#Observation.referenceRange",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate",
-				"path": "Observation.component",
-				"sliceName": "FlowRate",
-				"short": "Inhaled oxygen flow rate",
-				"definition": "Used when reporting systolic and diastolic blood pressure.",
-				"comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-3",
-						"severity": "error",
-						"human": "If there is no a value a data absent reason must be present",
-						"expression": "value.exists() or dataAbsentReason.exists()",
-						"xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/oxygensat"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "containment by OBX-4?"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=COMP]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate.id",
-				"path": "Observation.component.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate.extension",
-				"path": "Observation.component.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate.modifierExtension",
-				"path": "Observation.component.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate.code",
-				"path": "Observation.component.code",
-				"short": "Type of component observation (code / type)",
-				"definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
-				"comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "3151-8"
-						}
-					]
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "VitalSigns"
-						}
-					],
-					"strength": "extensible",
-					"description": "This identifies the vital sign result type.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-vitalsignresult"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate.value[x]",
-				"path": "Observation.component.value[x]",
-				"short": "Vital Sign Value recorded with UCUM",
-				"definition": "Vital Sign Value recorded with UCUM.",
-				"comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "VitalSignsUnits"
-						}
-					],
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate.value[x].id",
-				"path": "Observation.component.value[x].id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate.value[x].extension",
-				"path": "Observation.component.value[x].extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate.value[x].value",
-				"path": "Observation.component.value[x].value",
-				"short": "Numerical value (with implicit precision)",
-				"definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
-				"comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
-				"requirements": "Precision is handled implicitly in almost all cases of measurement.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.2  / CQ - N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate.value[x].comparator",
-				"path": "Observation.component.value[x].comparator",
-				"short": "< | <= | >= | > - how to understand the value",
-				"definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
-				"requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Quantity.comparator",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "QuantityComparator"
-						}
-					],
-					"strength": "required",
-					"description": "How the Quantity should be understood and represented.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.1  / CQ.1"
-					},
-					{
-						"identity": "rim",
-						"map": "IVL properties"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate.value[x].unit",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.component.value[x].unit",
-				"short": "Unit representation",
-				"definition": "A human-readable form of the unit.",
-				"requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.unit",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.unit"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate.value[x].system",
-				"path": "Observation.component.value[x].system",
-				"short": "System that defines coded unit form",
-				"definition": "The identification of the system that provides the coded form of the unit.",
-				"requirements": "Need to know the system that defines the coded form of the unit.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"condition": [
-					"qty-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "CO.codeSystem, PQ.translation.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate.value[x].code",
-				"path": "Observation.component.value[x].code",
-				"short": "Coded form of the unit",
-				"definition": "A computer processable form of the unit in some unit representation system.",
-				"comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
-				"requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "L/min",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.code, MO.currency, PQ.translation.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate.dataAbsentReason",
-				"path": "Observation.component.dataAbsentReason",
-				"short": "Why the component result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
-				"comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate.interpretation",
-				"path": "Observation.component.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate.referenceRange",
-				"path": "Observation.component.referenceRange",
-				"short": "Provides guide for interpretation of component result",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"contentReference": "#Observation.referenceRange",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration",
-				"path": "Observation.component",
-				"sliceName": "Concentration",
-				"short": "Inhaled oxygen concentration",
-				"definition": "Used when reporting systolic and diastolic blood pressure.",
-				"comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-3",
-						"severity": "error",
-						"human": "If there is no a value a data absent reason must be present",
-						"expression": "value.exists() or dataAbsentReason.exists()",
-						"xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/oxygensat"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "containment by OBX-4?"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=COMP]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration.id",
-				"path": "Observation.component.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration.extension",
-				"path": "Observation.component.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration.modifierExtension",
-				"path": "Observation.component.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration.code",
-				"path": "Observation.component.code",
-				"short": "Type of component observation (code / type)",
-				"definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
-				"comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "3150-0"
-						}
-					]
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "VitalSigns"
-						}
-					],
-					"strength": "extensible",
-					"description": "This identifies the vital sign result type.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-vitalsignresult"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration.value[x]",
-				"path": "Observation.component.value[x]",
-				"short": "Vital Sign Value recorded with UCUM",
-				"definition": "Vital Sign Value recorded with UCUM.",
-				"comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "VitalSignsUnits"
-						}
-					],
-					"strength": "required",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration.value[x].id",
-				"path": "Observation.component.value[x].id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration.value[x].extension",
-				"path": "Observation.component.value[x].extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration.value[x].value",
-				"path": "Observation.component.value[x].value",
-				"short": "Numerical value (with implicit precision)",
-				"definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
-				"comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
-				"requirements": "Precision is handled implicitly in almost all cases of measurement.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.2  / CQ - N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration.value[x].comparator",
-				"path": "Observation.component.value[x].comparator",
-				"short": "< | <= | >= | > - how to understand the value",
-				"definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
-				"requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Quantity.comparator",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "QuantityComparator"
-						}
-					],
-					"strength": "required",
-					"description": "How the Quantity should be understood and represented.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.1  / CQ.1"
-					},
-					{
-						"identity": "rim",
-						"map": "IVL properties"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration.value[x].unit",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.component.value[x].unit",
-				"short": "Unit representation",
-				"definition": "A human-readable form of the unit.",
-				"requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.unit",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.unit"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration.value[x].system",
-				"path": "Observation.component.value[x].system",
-				"short": "System that defines coded unit form",
-				"definition": "The identification of the system that provides the coded form of the unit.",
-				"requirements": "Need to know the system that defines the coded form of the unit.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"condition": [
-					"qty-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "CO.codeSystem, PQ.translation.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration.value[x].code",
-				"path": "Observation.component.value[x].code",
-				"short": "Coded form of the unit",
-				"definition": "A computer processable form of the unit in some unit representation system.",
-				"comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
-				"requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "%",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.code, MO.currency, PQ.translation.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration.dataAbsentReason",
-				"path": "Observation.component.dataAbsentReason",
-				"short": "Why the component result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
-				"comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration.interpretation",
-				"path": "Observation.component.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration.referenceRange",
-				"path": "Observation.component.referenceRange",
-				"short": "Provides guide for interpretation of component result",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"contentReference": "#Observation.referenceRange",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"definition": "This profile defines how to represent pulse oximetry and inspired oxygen concentration based on the FHIR Core Vitals Profile.\nINSPIRED OXYGEN CONCENTRATION observations in FHIR using a standard LOINC code and UCUM units of measure.",
-				"mustSupport": false
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Oxygen Saturation by Pulse Oximetry",
-				"comment": "The code (59408-5 Oxygen saturation in Arterial blood by Pulse oximetry) is included as an additional observation code to FHIR Core vital Oxygen Saturation code (2708-6 Oxygen saturation in Arterial blood -).",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.code.coding",
-				"path": "Observation.code.coding",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "code"
-						},
-						{
-							"type": "value",
-							"path": "system"
-						}
-					],
-					"rules": "open"
-				},
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.code.coding:PulseOx",
-				"path": "Observation.code.coding",
-				"sliceName": "PulseOx",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.code.coding:PulseOx.system",
-				"path": "Observation.code.coding.system",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://loinc.org",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.code.coding:PulseOx.code",
-				"path": "Observation.code.coding.code",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "59408-5",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component",
-				"path": "Observation.component",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "code"
-						}
-					],
-					"rules": "open"
-				},
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:FlowRate",
-				"path": "Observation.component",
-				"sliceName": "FlowRate",
-				"short": "Inhaled oxygen flow rate",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:FlowRate.code",
-				"path": "Observation.component.code",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "3151-8"
-						}
-					]
-				},
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:FlowRate.valueQuantity",
-				"path": "Observation.component.valueQuantity",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:FlowRate.valueQuantity.value",
-				"path": "Observation.component.valueQuantity.value",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:FlowRate.valueQuantity.unit",
-				"path": "Observation.component.valueQuantity.unit",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:FlowRate.valueQuantity.system",
-				"path": "Observation.component.valueQuantity.system",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:FlowRate.valueQuantity.code",
-				"path": "Observation.component.valueQuantity.code",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "L/min",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:Concentration",
-				"path": "Observation.component",
-				"sliceName": "Concentration",
-				"short": "Inhaled oxygen concentration",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:Concentration.code",
-				"path": "Observation.component.code",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "3150-0"
-						}
-					]
-				},
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:Concentration.valueQuantity",
-				"path": "Observation.component.valueQuantity",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:Concentration.valueQuantity.value",
-				"path": "Observation.component.valueQuantity.value",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:Concentration.valueQuantity.unit",
-				"path": "Observation.component.valueQuantity.unit",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:Concentration.valueQuantity.system",
-				"path": "Observation.component.valueQuantity.system",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:Concentration.valueQuantity.code",
-				"path": "Observation.component.valueQuantity.code",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "%",
-				"mustSupport": true
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-pulse-oximetry",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry",
+    "version": "3.1.1",
+    "name": "USCorePulseOximetryProfile",
+    "title": "US Core Pulse Oximetry Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-06-29",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.healthit.gov"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the Observation resource for use in querying and retrieving inspired O2 by pulse oximetry observations.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "sct-concept",
+            "uri": "http://snomed.info/conceptdomain",
+            "name": "SNOMED CT Concept Domain Binding"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "sct-attr",
+            "uri": "http://snomed.org/attributebinding",
+            "name": "SNOMED CT Attribute Binding"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Observation",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/oxygensat",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "FHIR Oxygen Saturation Profile",
+                "definition": "This profile defines how to represent pulse oximetry and inspired oxygen concentration based on the FHIR Core Vitals Profile.\nINSPIRED OXYGEN CONCENTRATION observations in FHIR using a standard LOINC code and UCUM units of measure.",
+                "comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
+                "alias": [
+                    "Vital Signs",
+                    "Measurement",
+                    "Results",
+                    "Tests"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "obs-6",
+                        "severity": "error",
+                        "human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
+                        "expression": "dataAbsentReason.empty() or value.empty()",
+                        "xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "obs-7",
+                        "severity": "error",
+                        "human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
+                        "expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
+                        "xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "vs-2",
+                        "severity": "error",
+                        "human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
+                        "expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
+                        "xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.id",
+                "path": "Observation.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.meta",
+                "path": "Observation.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.implicitRules",
+                "path": "Observation.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Observation.language",
+                "path": "Observation.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Observation.text",
+                "path": "Observation.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.contained",
+                "path": "Observation.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.extension",
+                "path": "Observation.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.modifierExtension",
+                "path": "Observation.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.identifier",
+                "path": "Observation.identifier",
+                "short": "Business Identifier for observation",
+                "definition": "A unique identifier assigned to this observation.",
+                "requirements": "Allows observations to be distinguished and referenced.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "id"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.basedOn",
+                "path": "Observation.basedOn",
+                "short": "Fulfills plan, proposal or order",
+                "definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
+                "requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
+                "alias": [
+                    "Fulfills"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceRequest",
+                            "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+                            "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.basedOn"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.partOf",
+                "path": "Observation.partOf",
+                "short": "Part of referenced event",
+                "definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
+                "comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
+                "alias": [
+                    "Container"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.partOf",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationDispense",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationStatement",
+                            "http://hl7.org/fhir/StructureDefinition/Procedure",
+                            "http://hl7.org/fhir/StructureDefinition/Immunization",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.partOf"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "Varies by domain"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=FLFS].target"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.status",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
+                        "valueString": "default: final"
+                    }
+                ],
+                "path": "Observation.status",
+                "short": "registered | preliminary | final | amended +",
+                "definition": "The status of the result value.",
+                "comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
+                "requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Status"
+                        }
+                    ],
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 445584004 |Report by finality status|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-11"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category",
+                "path": "Observation.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "coding.code"
+                        },
+                        {
+                            "type": "value",
+                            "path": "coding.system"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "open"
+                },
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat",
+                "path": "Observation.category",
+                "sliceName": "VSCat",
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.id",
+                "path": "Observation.category.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.extension",
+                "path": "Observation.category.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding",
+                "path": "Observation.category.coding",
+                "short": "Code defined by a terminology system",
+                "definition": "A reference to a code defined by a terminology system.",
+                "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+                "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "CodeableConcept.coding",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1-8, C*E.10-22"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "union(., ./translation)"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.id",
+                "path": "Observation.category.coding.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.extension",
+                "path": "Observation.category.coding.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.system",
+                "path": "Observation.category.coding.system",
+                "short": "Identity of the terminology system",
+                "definition": "The identification of the code system that defines the meaning of the symbol in the code.",
+                "comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
+                "requirements": "Need to be unambiguous about the source of the definition of the symbol.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystem"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.version",
+                "path": "Observation.category.coding.version",
+                "short": "Version of the system - if relevant",
+                "definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
+                "comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.version",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystemVersion"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.code",
+                "path": "Observation.category.coding.code",
+                "short": "Symbol in syntax defined by the system",
+                "definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
+                "requirements": "Need to refer to a particular code in the system.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "vital-signs",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./code"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.display",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.coding.display",
+                "short": "Representation defined by the system",
+                "definition": "A representation of the meaning of the code in the system, following the rules of the system.",
+                "requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.display",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.2 - but note this is not well followed"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CV.displayName"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.userSelected",
+                "path": "Observation.category.coding.userSelected",
+                "short": "If this coding was chosen directly by the user",
+                "definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
+                "comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
+                "requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.userSelected",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Sometimes implied by being first"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CD.codingRationale"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.text",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.text",
+                "short": "Plain text representation of the concept",
+                "definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
+                "comment": "Very often the text is the same as a displayName of one of the codings.",
+                "requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CodeableConcept.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.9. But note many systems use C*E.2 for this"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./originalText[mediaType/code=\"text/plain\"]/data"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Oxygen Saturation by Pulse Oximetry",
+                "definition": "Oxygen Saturation.",
+                "comment": "The code (59408-5 Oxygen saturation in Arterial blood by Pulse oximetry) is included as an additional observation code to FHIR Core vital Oxygen Saturation code (2708-6 Oxygen saturation in Arterial blood -).",
+                "requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
+                "alias": [
+                    "Name",
+                    "Test"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "VitalSigns"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "This identifies the vital sign result type.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-vitalsignresult"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "116680003 |Is a|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code.id",
+                "path": "Observation.code.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code.extension",
+                "path": "Observation.code.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code.coding",
+                "path": "Observation.code.coding",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "code"
+                        },
+                        {
+                            "type": "value",
+                            "path": "system"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "open"
+                },
+                "short": "Code defined by a terminology system",
+                "definition": "A reference to a code defined by a terminology system.",
+                "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+                "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CodeableConcept.coding",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1-8, C*E.10-22"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "union(., ./translation)"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code.coding:OxygenSatCode",
+                "path": "Observation.code.coding",
+                "sliceName": "OxygenSatCode",
+                "short": "Code defined by a terminology system",
+                "definition": "A reference to a code defined by a terminology system.",
+                "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+                "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "CodeableConcept.coding",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1-8, C*E.10-22"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "union(., ./translation)"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code.coding:OxygenSatCode.id",
+                "path": "Observation.code.coding.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code.coding:OxygenSatCode.extension",
+                "path": "Observation.code.coding.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code.coding:OxygenSatCode.system",
+                "path": "Observation.code.coding.system",
+                "short": "Identity of the terminology system",
+                "definition": "The identification of the code system that defines the meaning of the symbol in the code.",
+                "comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
+                "requirements": "Need to be unambiguous about the source of the definition of the symbol.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://loinc.org",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystem"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code.coding:OxygenSatCode.version",
+                "path": "Observation.code.coding.version",
+                "short": "Version of the system - if relevant",
+                "definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
+                "comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.version",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystemVersion"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code.coding:OxygenSatCode.code",
+                "path": "Observation.code.coding.code",
+                "short": "Symbol in syntax defined by the system",
+                "definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
+                "requirements": "Need to refer to a particular code in the system.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "2708-6",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./code"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code.coding:OxygenSatCode.display",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.code.coding.display",
+                "short": "Representation defined by the system",
+                "definition": "A representation of the meaning of the code in the system, following the rules of the system.",
+                "requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.display",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.2 - but note this is not well followed"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CV.displayName"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code.coding:OxygenSatCode.userSelected",
+                "path": "Observation.code.coding.userSelected",
+                "short": "If this coding was chosen directly by the user",
+                "definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
+                "comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
+                "requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.userSelected",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Sometimes implied by being first"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CD.codingRationale"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code.coding:PulseOx",
+                "path": "Observation.code.coding",
+                "sliceName": "PulseOx",
+                "short": "Code defined by a terminology system",
+                "definition": "A reference to a code defined by a terminology system.",
+                "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+                "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "CodeableConcept.coding",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1-8, C*E.10-22"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "union(., ./translation)"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code.coding:PulseOx.id",
+                "path": "Observation.code.coding.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code.coding:PulseOx.extension",
+                "path": "Observation.code.coding.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code.coding:PulseOx.system",
+                "path": "Observation.code.coding.system",
+                "short": "Identity of the terminology system",
+                "definition": "The identification of the code system that defines the meaning of the symbol in the code.",
+                "comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
+                "requirements": "Need to be unambiguous about the source of the definition of the symbol.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://loinc.org",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystem"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code.coding:PulseOx.version",
+                "path": "Observation.code.coding.version",
+                "short": "Version of the system - if relevant",
+                "definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
+                "comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.version",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystemVersion"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code.coding:PulseOx.code",
+                "path": "Observation.code.coding.code",
+                "short": "Symbol in syntax defined by the system",
+                "definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
+                "requirements": "Need to refer to a particular code in the system.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "59408-5",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./code"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code.coding:PulseOx.display",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.code.coding.display",
+                "short": "Representation defined by the system",
+                "definition": "A representation of the meaning of the code in the system, following the rules of the system.",
+                "requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.display",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.2 - but note this is not well followed"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CV.displayName"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code.coding:PulseOx.userSelected",
+                "path": "Observation.code.coding.userSelected",
+                "short": "If this coding was chosen directly by the user",
+                "definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
+                "comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
+                "requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.userSelected",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Sometimes implied by being first"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CD.codingRationale"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code.text",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.code.text",
+                "short": "Plain text representation of the concept",
+                "definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
+                "comment": "Very often the text is the same as a displayName of one of the codings.",
+                "requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CodeableConcept.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.9. But note many systems use C*E.2 for this"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./originalText[mediaType/code=\"text/plain\"]/data"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.subject",
+                "path": "Observation.subject",
+                "short": "Who and/or what the observation is about",
+                "definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
+                "comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
+                "requirements": "Observations have no value if you don't know who or what they're about.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Patient"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=RTGT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.focus",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+                        "valueCode": "trial-use"
+                    }
+                ],
+                "path": "Observation.focus",
+                "short": "What the observation is about, when it is not about the subject of record",
+                "definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
+                "comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.focus",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SBJ]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.encounter",
+                "path": "Observation.encounter",
+                "short": "Healthcare event during which this observation is made",
+                "definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
+                "comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
+                "requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
+                "alias": [
+                    "Context"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.effective[x]",
+                "path": "Observation.effective[x]",
+                "short": "Often just a dateTime for Vital Signs",
+                "definition": "Often just a dateTime for Vital Signs.",
+                "comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
+                "requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
+                "alias": [
+                    "Occurrence"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.effective[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-1",
+                        "severity": "error",
+                        "human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
+                        "expression": "($this as dateTime).toString().length() >= 8",
+                        "xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.issued",
+                "path": "Observation.issued",
+                "short": "Date/Time this version was made available",
+                "definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
+                "comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.issued",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.performer",
+                "path": "Observation.performer",
+                "short": "Who is responsible for the observation",
+                "definition": "Who was responsible for asserting the observed value as \"true\".",
+                "requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.performer",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=PRF]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]",
+                "path": "Observation.value[x]",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "type",
+                            "path": "$this"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "closed"
+                },
+                "short": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
+                "definition": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity",
+                "path": "Observation.value[x]",
+                "sliceName": "valueQuantity",
+                "short": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
+                "definition": "Vital Signs value are recorded using the Quantity data type. For supporting observations such as Cuff size could use other datatypes such as CodeableConcept.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.id",
+                "path": "Observation.value[x].id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.extension",
+                "path": "Observation.value[x].extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.value",
+                "path": "Observation.value[x].value",
+                "short": "Numerical value (with implicit precision)",
+                "definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
+                "comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
+                "requirements": "Precision is handled implicitly in almost all cases of measurement.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.2  / CQ - N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.comparator",
+                "path": "Observation.value[x].comparator",
+                "short": "< | <= | >= | > - how to understand the value",
+                "definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
+                "requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.comparator",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "QuantityComparator"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "How the Quantity should be understood and represented.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.1  / CQ.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "IVL properties"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.unit",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.value[x].unit",
+                "short": "Unit representation",
+                "definition": "A human-readable form of the unit.",
+                "requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.unit",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.unit"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.system",
+                "path": "Observation.value[x].system",
+                "short": "System that defines coded unit form",
+                "definition": "The identification of the system that provides the coded form of the unit.",
+                "requirements": "Need to know the system that defines the coded form of the unit.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "condition": [
+                    "qty-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CO.codeSystem, PQ.translation.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.code",
+                "path": "Observation.value[x].code",
+                "short": "Coded responses from the common UCUM units for vital signs value set.",
+                "definition": "Coded responses from the common UCUM units for vital signs value set.",
+                "comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
+                "requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "%",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.code, MO.currency, PQ.translation.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.dataAbsentReason",
+                "path": "Observation.dataAbsentReason",
+                "short": "Why the result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
+                "comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.interpretation",
+                "path": "Observation.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.note",
+                "path": "Observation.note",
+                "short": "Comments about the observation",
+                "definition": "Comments about the observation or the results.",
+                "comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
+                "requirements": "Need to be able to provide free text additional information.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "subjectOf.observationEvent[code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.bodySite",
+                "path": "Observation.bodySite",
+                "short": "Observed body part",
+                "definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
+                "comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.bodySite",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "BodySite"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing anatomical locations. May include laterality.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/body-site"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123037004 |Body structure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-20"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "targetSiteCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "718497002 |Inherent location|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.method",
+                "path": "Observation.method",
+                "short": "How it was done",
+                "definition": "Indicates the mechanism used to perform the observation.",
+                "comment": "Only used if not implicit in code for Observation.code.",
+                "requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.method",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationMethod"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Methods for simple observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "methodCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.specimen",
+                "path": "Observation.specimen",
+                "short": "Specimen used for this observation",
+                "definition": "The specimen that was used when this observation was made.",
+                "comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.specimen",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Specimen"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123038009 |Specimen|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "SPM segment"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SPC].specimen"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "704319004 |Inherent in|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.device",
+                "path": "Observation.device",
+                "short": "(Measurement) Device",
+                "definition": "The device used to generate the observation data.",
+                "comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.device",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceMetric"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 49062001 |Device|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17 / PRT -10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=DEV]"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "424226004 |Using device|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange",
+                "path": "Observation.referenceRange",
+                "short": "Provides guide for interpretation",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "obs-3",
+                        "severity": "error",
+                        "human": "Must have at least a low or a high or text",
+                        "expression": "low.exists() or high.exists() or text.exists()",
+                        "xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.id",
+                "path": "Observation.referenceRange.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.extension",
+                "path": "Observation.referenceRange.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.modifierExtension",
+                "path": "Observation.referenceRange.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.low",
+                "path": "Observation.referenceRange.low",
+                "short": "Low Range, if relevant",
+                "definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.low",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.low"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.high",
+                "path": "Observation.referenceRange.high",
+                "short": "High Range, if relevant",
+                "definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.high",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.high"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.type",
+                "path": "Observation.referenceRange.type",
+                "short": "Reference range qualifier",
+                "definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
+                "requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeMeaning"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Code for the meaning of a reference range.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.appliesTo",
+                "path": "Observation.referenceRange.appliesTo",
+                "short": "Reference range population",
+                "definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
+                "requirements": "Need to be able to identify the target population for proper interpretation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange.appliesTo",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes identifying the population the reference range applies to.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.age",
+                "path": "Observation.referenceRange.age",
+                "short": "Applicable age range, if relevant",
+                "definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
+                "requirements": "Some analytes vary greatly over age.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.age",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Range"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.text",
+                "path": "Observation.referenceRange.text",
+                "short": "Text based reference range in an observation",
+                "definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:ST"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.hasMember",
+                "path": "Observation.hasMember",
+                "short": "Used when reporting vital signs panel components",
+                "definition": "Used when reporting vital signs panel components.",
+                "comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.hasMember",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.derivedFrom",
+                "path": "Observation.derivedFrom",
+                "short": "Related measurements the observation is made from",
+                "definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
+                "comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.derivedFrom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/DocumentReference",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy",
+                            "http://hl7.org/fhir/StructureDefinition/Media",
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".targetObservation"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component",
+                "path": "Observation.component",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "code"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "short": "Used when reporting systolic and diastolic blood pressure.",
+                "definition": "Used when reporting systolic and diastolic blood pressure.",
+                "comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-3",
+                        "severity": "error",
+                        "human": "If there is no a value a data absent reason must be present",
+                        "expression": "value.exists() or dataAbsentReason.exists()",
+                        "xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/oxygensat"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "containment by OBX-4?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=COMP]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.id",
+                "path": "Observation.component.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.extension",
+                "path": "Observation.component.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.modifierExtension",
+                "path": "Observation.component.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.code",
+                "path": "Observation.component.code",
+                "short": "Type of component observation (code / type)",
+                "definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
+                "comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "VitalSigns"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "This identifies the vital sign result type.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-vitalsignresult"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.value[x]",
+                "path": "Observation.component.value[x]",
+                "short": "Vital Sign Value recorded with UCUM",
+                "definition": "Vital Sign Value recorded with UCUM.",
+                "comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "VitalSignsUnits"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.dataAbsentReason",
+                "path": "Observation.component.dataAbsentReason",
+                "short": "Why the component result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
+                "comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.interpretation",
+                "path": "Observation.component.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.referenceRange",
+                "path": "Observation.component.referenceRange",
+                "short": "Provides guide for interpretation of component result",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "contentReference": "#Observation.referenceRange",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate",
+                "path": "Observation.component",
+                "sliceName": "FlowRate",
+                "short": "Inhaled oxygen flow rate",
+                "definition": "Used when reporting systolic and diastolic blood pressure.",
+                "comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-3",
+                        "severity": "error",
+                        "human": "If there is no a value a data absent reason must be present",
+                        "expression": "value.exists() or dataAbsentReason.exists()",
+                        "xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/oxygensat"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "containment by OBX-4?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=COMP]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate.id",
+                "path": "Observation.component.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate.extension",
+                "path": "Observation.component.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate.modifierExtension",
+                "path": "Observation.component.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate.code",
+                "path": "Observation.component.code",
+                "short": "Type of component observation (code / type)",
+                "definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
+                "comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "3151-8"
+                        }
+                    ]
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "VitalSigns"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "This identifies the vital sign result type.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-vitalsignresult"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate.value[x]",
+                "path": "Observation.component.value[x]",
+                "short": "Vital Sign Value recorded with UCUM",
+                "definition": "Vital Sign Value recorded with UCUM.",
+                "comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "VitalSignsUnits"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate.value[x].id",
+                "path": "Observation.component.value[x].id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate.value[x].extension",
+                "path": "Observation.component.value[x].extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate.value[x].value",
+                "path": "Observation.component.value[x].value",
+                "short": "Numerical value (with implicit precision)",
+                "definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
+                "comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
+                "requirements": "Precision is handled implicitly in almost all cases of measurement.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.2  / CQ - N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate.value[x].comparator",
+                "path": "Observation.component.value[x].comparator",
+                "short": "< | <= | >= | > - how to understand the value",
+                "definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
+                "requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.comparator",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "QuantityComparator"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "How the Quantity should be understood and represented.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.1  / CQ.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "IVL properties"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate.value[x].unit",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.component.value[x].unit",
+                "short": "Unit representation",
+                "definition": "A human-readable form of the unit.",
+                "requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.unit",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.unit"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate.value[x].system",
+                "path": "Observation.component.value[x].system",
+                "short": "System that defines coded unit form",
+                "definition": "The identification of the system that provides the coded form of the unit.",
+                "requirements": "Need to know the system that defines the coded form of the unit.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "condition": [
+                    "qty-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CO.codeSystem, PQ.translation.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate.value[x].code",
+                "path": "Observation.component.value[x].code",
+                "short": "Coded form of the unit",
+                "definition": "A computer processable form of the unit in some unit representation system.",
+                "comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
+                "requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "L/min",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.code, MO.currency, PQ.translation.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate.dataAbsentReason",
+                "path": "Observation.component.dataAbsentReason",
+                "short": "Why the component result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
+                "comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate.interpretation",
+                "path": "Observation.component.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate.referenceRange",
+                "path": "Observation.component.referenceRange",
+                "short": "Provides guide for interpretation of component result",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "contentReference": "#Observation.referenceRange",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration",
+                "path": "Observation.component",
+                "sliceName": "Concentration",
+                "short": "Inhaled oxygen concentration",
+                "definition": "Used when reporting systolic and diastolic blood pressure.",
+                "comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-3",
+                        "severity": "error",
+                        "human": "If there is no a value a data absent reason must be present",
+                        "expression": "value.exists() or dataAbsentReason.exists()",
+                        "xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/oxygensat"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "containment by OBX-4?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=COMP]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration.id",
+                "path": "Observation.component.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration.extension",
+                "path": "Observation.component.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration.modifierExtension",
+                "path": "Observation.component.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration.code",
+                "path": "Observation.component.code",
+                "short": "Type of component observation (code / type)",
+                "definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
+                "comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "3150-0"
+                        }
+                    ]
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "VitalSigns"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "This identifies the vital sign result type.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-vitalsignresult"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration.value[x]",
+                "path": "Observation.component.value[x]",
+                "short": "Vital Sign Value recorded with UCUM",
+                "definition": "Vital Sign Value recorded with UCUM.",
+                "comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "VitalSignsUnits"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration.value[x].id",
+                "path": "Observation.component.value[x].id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration.value[x].extension",
+                "path": "Observation.component.value[x].extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration.value[x].value",
+                "path": "Observation.component.value[x].value",
+                "short": "Numerical value (with implicit precision)",
+                "definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
+                "comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
+                "requirements": "Precision is handled implicitly in almost all cases of measurement.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.2  / CQ - N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration.value[x].comparator",
+                "path": "Observation.component.value[x].comparator",
+                "short": "< | <= | >= | > - how to understand the value",
+                "definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
+                "requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.comparator",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "QuantityComparator"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "How the Quantity should be understood and represented.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.1  / CQ.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "IVL properties"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration.value[x].unit",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.component.value[x].unit",
+                "short": "Unit representation",
+                "definition": "A human-readable form of the unit.",
+                "requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.unit",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.unit"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration.value[x].system",
+                "path": "Observation.component.value[x].system",
+                "short": "System that defines coded unit form",
+                "definition": "The identification of the system that provides the coded form of the unit.",
+                "requirements": "Need to know the system that defines the coded form of the unit.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "condition": [
+                    "qty-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CO.codeSystem, PQ.translation.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration.value[x].code",
+                "path": "Observation.component.value[x].code",
+                "short": "Coded form of the unit",
+                "definition": "A computer processable form of the unit in some unit representation system.",
+                "comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
+                "requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "%",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.code, MO.currency, PQ.translation.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration.dataAbsentReason",
+                "path": "Observation.component.dataAbsentReason",
+                "short": "Why the component result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
+                "comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration.interpretation",
+                "path": "Observation.component.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration.referenceRange",
+                "path": "Observation.component.referenceRange",
+                "short": "Provides guide for interpretation of component result",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "contentReference": "#Observation.referenceRange",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "definition": "This profile defines how to represent pulse oximetry and inspired oxygen concentration based on the FHIR Core Vitals Profile.\nINSPIRED OXYGEN CONCENTRATION observations in FHIR using a standard LOINC code and UCUM units of measure.",
+                "mustSupport": false
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Oxygen Saturation by Pulse Oximetry",
+                "comment": "The code (59408-5 Oxygen saturation in Arterial blood by Pulse oximetry) is included as an additional observation code to FHIR Core vital Oxygen Saturation code (2708-6 Oxygen saturation in Arterial blood -).",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.code.coding",
+                "path": "Observation.code.coding",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "code"
+                        },
+                        {
+                            "type": "value",
+                            "path": "system"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.code.coding:PulseOx",
+                "path": "Observation.code.coding",
+                "sliceName": "PulseOx",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.code.coding:PulseOx.system",
+                "path": "Observation.code.coding.system",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://loinc.org",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.code.coding:PulseOx.code",
+                "path": "Observation.code.coding.code",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "59408-5",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component",
+                "path": "Observation.component",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "code"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:FlowRate",
+                "path": "Observation.component",
+                "sliceName": "FlowRate",
+                "short": "Inhaled oxygen flow rate",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:FlowRate.code",
+                "path": "Observation.component.code",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "3151-8"
+                        }
+                    ]
+                },
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:FlowRate.valueQuantity",
+                "path": "Observation.component.valueQuantity",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:FlowRate.valueQuantity.value",
+                "path": "Observation.component.valueQuantity.value",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:FlowRate.valueQuantity.unit",
+                "path": "Observation.component.valueQuantity.unit",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:FlowRate.valueQuantity.system",
+                "path": "Observation.component.valueQuantity.system",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:FlowRate.valueQuantity.code",
+                "path": "Observation.component.valueQuantity.code",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "L/min",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:Concentration",
+                "path": "Observation.component",
+                "sliceName": "Concentration",
+                "short": "Inhaled oxygen concentration",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:Concentration.code",
+                "path": "Observation.component.code",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "3150-0"
+                        }
+                    ]
+                },
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:Concentration.valueQuantity",
+                "path": "Observation.component.valueQuantity",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:Concentration.valueQuantity.value",
+                "path": "Observation.component.valueQuantity.value",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:Concentration.valueQuantity.unit",
+                "path": "Observation.component.valueQuantity.unit",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:Concentration.valueQuantity.system",
+                "path": "Observation.component.valueQuantity.system",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:Concentration.valueQuantity.code",
+                "path": "Observation.component.valueQuantity.code",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "%",
+                "mustSupport": true
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-race.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-race.json
@@ -1,2274 +1,2274 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-race",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-race-definitions.html#Extension\" title=\"Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\n   - American Indian or Alaska Native\n   - Asian\n   - Black or African American\n   - Native Hawaiian or Other Pacific Islander\n   - White.\">Extension</a><a name=\"Extension\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/extensibility.html#Extension\">Extension</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">US Core Race Extension</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck15.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-race-definitions.html#Extension.extension:ombCategory\" title=\"Slice ombCategory: The 5 race category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).\">extension:ombCategory</a><a name=\"Extension.extension\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..5</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/extensibility.html#Extension\">Extension</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">American Indian or Alaska Native|Asian|Black or African American|Native Hawaiian or Other Pacific Islander|White</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck150.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-race-definitions.html#Extension.extension:ombCategory.url\">url</a><a name=\"Extension.extension.url\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"color: darkgreen\">&quot;ombCategory&quot;</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck140.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-race-definitions.html#Extension.extension:ombCategory.valueCoding\">valueCoding</a><a name=\"Extension.extension.valueCoding\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Value of extension</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-omb-race-category.html\">OMB Race Categories</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck15.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-race-definitions.html#Extension.extension:detailed\" title=\"Slice detailed: The 900+ CDC race codes that are grouped under one of the 5 OMB race category codes:.\">extension:detailed</a><a name=\"Extension.extension\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/extensibility.html#Extension\">Extension</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Extended race codes<br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck150.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-race-definitions.html#Extension.extension:detailed.url\">url</a><a name=\"Extension.extension.url\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"color: darkgreen\">&quot;detailed&quot;</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck140.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-race-definitions.html#Extension.extension:detailed.valueCoding\">valueCoding</a><a name=\"Extension.extension.valueCoding\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Value of extension</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-detailed-race.html\">Detailed Race</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck15.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-race-definitions.html#Extension.extension:text\" title=\"Slice text: Plain text representation of the race concept(s).\">extension:text</a><a name=\"Extension.extension\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/extensibility.html#Extension\">Extension</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Race Text</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck150.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-race-definitions.html#Extension.extension:text.url\">url</a><a name=\"Extension.extension.url\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"color: darkgreen\">&quot;text&quot;</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck140.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-race-definitions.html#Extension.extension:text.valueString\">valueString</a><a name=\"Extension.extension.valueString\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Value of extension</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-race-definitions.html#Extension.url\">url</a><a name=\"Extension.url\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"color: darkgreen\">&quot;http://hl7.org/fhir/us/core/StructureDefinition/us-core-race&quot;</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck00.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <span style=\"text-decoration:line-through\">value[x]</span><a name=\"Extension.value_x_\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"text-decoration:line-through\"/><span style=\"text-decoration:line-through\">0</span><span style=\"text-decoration:line-through\">..</span><span style=\"text-decoration:line-through\">0</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
-	"version": "3.1.1",
-	"name": "USCoreRaceExtension",
-	"title": "US Core Race Extension",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.healthit.gov"
-				}
-			]
-		}
-	],
-	"description": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\n - American Indian or Alaska Native\n - Asian\n - Black or African American\n - Native Hawaiian or Other Pacific Islander\n - White.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"purpose": "Complies with 2015 Edition Common Clinical Data Set for patient race.",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		}
-	],
-	"kind": "complex-type",
-	"abstract": false,
-	"context": [
-		{
-			"type": "element",
-			"expression": "Patient"
-		}
-	],
-	"type": "Extension",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Extension",
-				"path": "Extension",
-				"short": "US Core Race Extension",
-				"definition": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\n   - American Indian or Alaska Native\n   - Asian\n   - Black or African American\n   - Native Hawaiian or Other Pacific Islander\n   - White.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Extension",
-					"min": 0,
-					"max": "*"
-				},
-				"condition": [
-					"ele-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false
-			},
-			{
-				"id": "Extension.id",
-				"path": "Extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension",
-				"path": "Extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory",
-				"path": "Extension.extension",
-				"sliceName": "ombCategory",
-				"short": "American Indian or Alaska Native|Asian|Black or African American|Native Hawaiian or Other Pacific Islander|White",
-				"definition": "The 5 race category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
-				"min": 0,
-				"max": "5",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "iso11179",
-						"map": "/ClinicalDocument/recordTarget/patientRole/patient/raceCode"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.id",
-				"path": "Extension.extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.extension",
-				"path": "Extension.extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.extension.id",
-				"path": "Extension.extension.extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.extension.extension",
-				"path": "Extension.extension.extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.extension.url",
-				"path": "Extension.extension.extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "uri"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.extension.value[x]",
-				"path": "Extension.extension.extension.value[x]",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "base64Binary"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "canonical"
-					},
-					{
-						"code": "code"
-					},
-					{
-						"code": "date"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "decimal"
-					},
-					{
-						"code": "id"
-					},
-					{
-						"code": "instant"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "markdown"
-					},
-					{
-						"code": "oid"
-					},
-					{
-						"code": "positiveInt"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "unsignedInt"
-					},
-					{
-						"code": "uri"
-					},
-					{
-						"code": "url"
-					},
-					{
-						"code": "uuid"
-					},
-					{
-						"code": "Address"
-					},
-					{
-						"code": "Age"
-					},
-					{
-						"code": "Annotation"
-					},
-					{
-						"code": "Attachment"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "Coding"
-					},
-					{
-						"code": "ContactPoint"
-					},
-					{
-						"code": "Count"
-					},
-					{
-						"code": "Distance"
-					},
-					{
-						"code": "Duration"
-					},
-					{
-						"code": "HumanName"
-					},
-					{
-						"code": "Identifier"
-					},
-					{
-						"code": "Money"
-					},
-					{
-						"code": "Period"
-					},
-					{
-						"code": "Quantity"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "Reference"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "Signature"
-					},
-					{
-						"code": "Timing"
-					},
-					{
-						"code": "ContactDetail"
-					},
-					{
-						"code": "Contributor"
-					},
-					{
-						"code": "DataRequirement"
-					},
-					{
-						"code": "Expression"
-					},
-					{
-						"code": "ParameterDefinition"
-					},
-					{
-						"code": "RelatedArtifact"
-					},
-					{
-						"code": "TriggerDefinition"
-					},
-					{
-						"code": "UsageContext"
-					},
-					{
-						"code": "Dosage"
-					},
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.url",
-				"path": "Extension.extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "ombCategory",
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.value[x]",
-				"path": "Extension.extension.value[x]",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "type",
-							"path": "$this"
-						}
-					],
-					"ordered": false,
-					"rules": "closed"
-				},
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.value[x]:valueCoding",
-				"path": "Extension.extension.value[x]",
-				"sliceName": "valueCoding",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"strength": "required",
-					"description": "The 5 race category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/omb-race-category|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed",
-				"path": "Extension.extension",
-				"sliceName": "detailed",
-				"short": "Extended race codes",
-				"definition": "The 900+ CDC race codes that are grouped under one of the 5 OMB race category codes:.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "iso11179",
-						"map": "/ClinicalDocument/recordTarget/patientRole/patient/sdtc:raceCode"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.id",
-				"path": "Extension.extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.extension",
-				"path": "Extension.extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.extension.id",
-				"path": "Extension.extension.extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.extension.extension",
-				"path": "Extension.extension.extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.extension.url",
-				"path": "Extension.extension.extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "uri"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.extension.value[x]",
-				"path": "Extension.extension.extension.value[x]",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "base64Binary"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "canonical"
-					},
-					{
-						"code": "code"
-					},
-					{
-						"code": "date"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "decimal"
-					},
-					{
-						"code": "id"
-					},
-					{
-						"code": "instant"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "markdown"
-					},
-					{
-						"code": "oid"
-					},
-					{
-						"code": "positiveInt"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "unsignedInt"
-					},
-					{
-						"code": "uri"
-					},
-					{
-						"code": "url"
-					},
-					{
-						"code": "uuid"
-					},
-					{
-						"code": "Address"
-					},
-					{
-						"code": "Age"
-					},
-					{
-						"code": "Annotation"
-					},
-					{
-						"code": "Attachment"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "Coding"
-					},
-					{
-						"code": "ContactPoint"
-					},
-					{
-						"code": "Count"
-					},
-					{
-						"code": "Distance"
-					},
-					{
-						"code": "Duration"
-					},
-					{
-						"code": "HumanName"
-					},
-					{
-						"code": "Identifier"
-					},
-					{
-						"code": "Money"
-					},
-					{
-						"code": "Period"
-					},
-					{
-						"code": "Quantity"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "Reference"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "Signature"
-					},
-					{
-						"code": "Timing"
-					},
-					{
-						"code": "ContactDetail"
-					},
-					{
-						"code": "Contributor"
-					},
-					{
-						"code": "DataRequirement"
-					},
-					{
-						"code": "Expression"
-					},
-					{
-						"code": "ParameterDefinition"
-					},
-					{
-						"code": "RelatedArtifact"
-					},
-					{
-						"code": "TriggerDefinition"
-					},
-					{
-						"code": "UsageContext"
-					},
-					{
-						"code": "Dosage"
-					},
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.url",
-				"path": "Extension.extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "detailed",
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.value[x]",
-				"path": "Extension.extension.value[x]",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "type",
-							"path": "$this"
-						}
-					],
-					"ordered": false,
-					"rules": "closed"
-				},
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.value[x]:valueCoding",
-				"path": "Extension.extension.value[x]",
-				"sliceName": "valueCoding",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"strength": "required",
-					"description": "The [900+ CDC Race codes](http://www.cdc.gov/phin/resources/vocabulary/index.html) that are grouped under one of the 5 OMB race category codes.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/detailed-race|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text",
-				"path": "Extension.extension",
-				"sliceName": "text",
-				"short": "Race Text",
-				"definition": "Plain text representation of the race concept(s).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Extension.extension:text.id",
-				"path": "Extension.extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text.extension",
-				"path": "Extension.extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text.extension.id",
-				"path": "Extension.extension.extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text.extension.extension",
-				"path": "Extension.extension.extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text.extension.url",
-				"path": "Extension.extension.extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "uri"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text.extension.value[x]",
-				"path": "Extension.extension.extension.value[x]",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "base64Binary"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "canonical"
-					},
-					{
-						"code": "code"
-					},
-					{
-						"code": "date"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "decimal"
-					},
-					{
-						"code": "id"
-					},
-					{
-						"code": "instant"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "markdown"
-					},
-					{
-						"code": "oid"
-					},
-					{
-						"code": "positiveInt"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "unsignedInt"
-					},
-					{
-						"code": "uri"
-					},
-					{
-						"code": "url"
-					},
-					{
-						"code": "uuid"
-					},
-					{
-						"code": "Address"
-					},
-					{
-						"code": "Age"
-					},
-					{
-						"code": "Annotation"
-					},
-					{
-						"code": "Attachment"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "Coding"
-					},
-					{
-						"code": "ContactPoint"
-					},
-					{
-						"code": "Count"
-					},
-					{
-						"code": "Distance"
-					},
-					{
-						"code": "Duration"
-					},
-					{
-						"code": "HumanName"
-					},
-					{
-						"code": "Identifier"
-					},
-					{
-						"code": "Money"
-					},
-					{
-						"code": "Period"
-					},
-					{
-						"code": "Quantity"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "Reference"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "Signature"
-					},
-					{
-						"code": "Timing"
-					},
-					{
-						"code": "ContactDetail"
-					},
-					{
-						"code": "Contributor"
-					},
-					{
-						"code": "DataRequirement"
-					},
-					{
-						"code": "Expression"
-					},
-					{
-						"code": "ParameterDefinition"
-					},
-					{
-						"code": "RelatedArtifact"
-					},
-					{
-						"code": "TriggerDefinition"
-					},
-					{
-						"code": "UsageContext"
-					},
-					{
-						"code": "Dosage"
-					},
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text.url",
-				"path": "Extension.extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "text",
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text.value[x]",
-				"path": "Extension.extension.value[x]",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "type",
-							"path": "$this"
-						}
-					],
-					"ordered": false,
-					"rules": "closed"
-				},
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text.value[x]:valueString",
-				"path": "Extension.extension.value[x]",
-				"sliceName": "valueString",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.url",
-				"path": "Extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "uri"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.value[x]",
-				"path": "Extension.value[x]",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 0,
-				"max": "0",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "base64Binary"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "canonical"
-					},
-					{
-						"code": "code"
-					},
-					{
-						"code": "date"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "decimal"
-					},
-					{
-						"code": "id"
-					},
-					{
-						"code": "instant"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "markdown"
-					},
-					{
-						"code": "oid"
-					},
-					{
-						"code": "positiveInt"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "unsignedInt"
-					},
-					{
-						"code": "uri"
-					},
-					{
-						"code": "url"
-					},
-					{
-						"code": "uuid"
-					},
-					{
-						"code": "Address"
-					},
-					{
-						"code": "Age"
-					},
-					{
-						"code": "Annotation"
-					},
-					{
-						"code": "Attachment"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "Coding"
-					},
-					{
-						"code": "ContactPoint"
-					},
-					{
-						"code": "Count"
-					},
-					{
-						"code": "Distance"
-					},
-					{
-						"code": "Duration"
-					},
-					{
-						"code": "HumanName"
-					},
-					{
-						"code": "Identifier"
-					},
-					{
-						"code": "Money"
-					},
-					{
-						"code": "Period"
-					},
-					{
-						"code": "Quantity"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "Reference"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "Signature"
-					},
-					{
-						"code": "Timing"
-					},
-					{
-						"code": "ContactDetail"
-					},
-					{
-						"code": "Contributor"
-					},
-					{
-						"code": "DataRequirement"
-					},
-					{
-						"code": "Expression"
-					},
-					{
-						"code": "ParameterDefinition"
-					},
-					{
-						"code": "RelatedArtifact"
-					},
-					{
-						"code": "TriggerDefinition"
-					},
-					{
-						"code": "UsageContext"
-					},
-					{
-						"code": "Dosage"
-					},
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Extension",
-				"path": "Extension",
-				"short": "US Core Race Extension",
-				"definition": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\n   - American Indian or Alaska Native\n   - Asian\n   - Black or African American\n   - Native Hawaiian or Other Pacific Islander\n   - White.",
-				"min": 0,
-				"max": "1"
-			},
-			{
-				"id": "Extension.extension:ombCategory",
-				"path": "Extension.extension",
-				"sliceName": "ombCategory",
-				"short": "American Indian or Alaska Native|Asian|Black or African American|Native Hawaiian or Other Pacific Islander|White",
-				"definition": "The 5 race category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
-				"min": 0,
-				"max": "5",
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "iso11179",
-						"map": "/ClinicalDocument/recordTarget/patientRole/patient/raceCode"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.url",
-				"path": "Extension.extension.url",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "ombCategory"
-			},
-			{
-				"id": "Extension.extension:ombCategory.valueCoding",
-				"path": "Extension.extension.valueCoding",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"binding": {
-					"strength": "required",
-					"description": "The 5 race category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/omb-race-category|3.1.1"
-				}
-			},
-			{
-				"id": "Extension.extension:detailed",
-				"path": "Extension.extension",
-				"sliceName": "detailed",
-				"short": "Extended race codes",
-				"definition": "The 900+ CDC race codes that are grouped under one of the 5 OMB race category codes:.",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"mapping": [
-					{
-						"identity": "iso11179",
-						"map": "/ClinicalDocument/recordTarget/patientRole/patient/sdtc:raceCode"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.url",
-				"path": "Extension.extension.url",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "detailed"
-			},
-			{
-				"id": "Extension.extension:detailed.valueCoding",
-				"path": "Extension.extension.valueCoding",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"binding": {
-					"strength": "required",
-					"description": "The [900+ CDC Race codes](http://www.cdc.gov/phin/resources/vocabulary/index.html) that are grouped under one of the 5 OMB race category codes.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/detailed-race|3.1.1"
-				}
-			},
-			{
-				"id": "Extension.extension:text",
-				"path": "Extension.extension",
-				"sliceName": "text",
-				"short": "Race Text",
-				"definition": "Plain text representation of the race concept(s).",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Extension.extension:text.url",
-				"path": "Extension.extension.url",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "text"
-			},
-			{
-				"id": "Extension.extension:text.valueString",
-				"path": "Extension.extension.valueString",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				]
-			},
-			{
-				"id": "Extension.url",
-				"path": "Extension.url",
-				"min": 1,
-				"max": "1",
-				"fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
-			},
-			{
-				"id": "Extension.value[x]",
-				"path": "Extension.value[x]",
-				"min": 0,
-				"max": "0"
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-race",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+    "version": "3.1.1",
+    "name": "USCoreRaceExtension",
+    "title": "US Core Race Extension",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.healthit.gov"
+                }
+            ]
+        }
+    ],
+    "description": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\n - American Indian or Alaska Native\n - Asian\n - Black or African American\n - Native Hawaiian or Other Pacific Islander\n - White.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "purpose": "Complies with 2015 Edition Common Clinical Data Set for patient race.",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        }
+    ],
+    "kind": "complex-type",
+    "abstract": false,
+    "context": [
+        {
+            "type": "element",
+            "expression": "Patient"
+        }
+    ],
+    "type": "Extension",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Extension",
+                "path": "Extension",
+                "short": "US Core Race Extension",
+                "definition": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\n   - American Indian or Alaska Native\n   - Asian\n   - Black or African American\n   - Native Hawaiian or Other Pacific Islander\n   - White.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "condition": [
+                    "ele-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false
+            },
+            {
+                "id": "Extension.id",
+                "path": "Extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension",
+                "path": "Extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory",
+                "path": "Extension.extension",
+                "sliceName": "ombCategory",
+                "short": "American Indian or Alaska Native|Asian|Black or African American|Native Hawaiian or Other Pacific Islander|White",
+                "definition": "The 5 race category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
+                "min": 0,
+                "max": "5",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "iso11179",
+                        "map": "/ClinicalDocument/recordTarget/patientRole/patient/raceCode"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.id",
+                "path": "Extension.extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.extension",
+                "path": "Extension.extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.extension.id",
+                "path": "Extension.extension.extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.extension.extension",
+                "path": "Extension.extension.extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.extension.url",
+                "path": "Extension.extension.extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "uri"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.extension.value[x]",
+                "path": "Extension.extension.extension.value[x]",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "base64Binary"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "canonical"
+                    },
+                    {
+                        "code": "code"
+                    },
+                    {
+                        "code": "date"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "decimal"
+                    },
+                    {
+                        "code": "id"
+                    },
+                    {
+                        "code": "instant"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "markdown"
+                    },
+                    {
+                        "code": "oid"
+                    },
+                    {
+                        "code": "positiveInt"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "unsignedInt"
+                    },
+                    {
+                        "code": "uri"
+                    },
+                    {
+                        "code": "url"
+                    },
+                    {
+                        "code": "uuid"
+                    },
+                    {
+                        "code": "Address"
+                    },
+                    {
+                        "code": "Age"
+                    },
+                    {
+                        "code": "Annotation"
+                    },
+                    {
+                        "code": "Attachment"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "Coding"
+                    },
+                    {
+                        "code": "ContactPoint"
+                    },
+                    {
+                        "code": "Count"
+                    },
+                    {
+                        "code": "Distance"
+                    },
+                    {
+                        "code": "Duration"
+                    },
+                    {
+                        "code": "HumanName"
+                    },
+                    {
+                        "code": "Identifier"
+                    },
+                    {
+                        "code": "Money"
+                    },
+                    {
+                        "code": "Period"
+                    },
+                    {
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "Reference"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "Signature"
+                    },
+                    {
+                        "code": "Timing"
+                    },
+                    {
+                        "code": "ContactDetail"
+                    },
+                    {
+                        "code": "Contributor"
+                    },
+                    {
+                        "code": "DataRequirement"
+                    },
+                    {
+                        "code": "Expression"
+                    },
+                    {
+                        "code": "ParameterDefinition"
+                    },
+                    {
+                        "code": "RelatedArtifact"
+                    },
+                    {
+                        "code": "TriggerDefinition"
+                    },
+                    {
+                        "code": "UsageContext"
+                    },
+                    {
+                        "code": "Dosage"
+                    },
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.url",
+                "path": "Extension.extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "ombCategory",
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.value[x]",
+                "path": "Extension.extension.value[x]",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "type",
+                            "path": "$this"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "closed"
+                },
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.value[x]:valueCoding",
+                "path": "Extension.extension.value[x]",
+                "sliceName": "valueCoding",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "strength": "required",
+                    "description": "The 5 race category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/omb-race-category|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed",
+                "path": "Extension.extension",
+                "sliceName": "detailed",
+                "short": "Extended race codes",
+                "definition": "The 900+ CDC race codes that are grouped under one of the 5 OMB race category codes:.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "iso11179",
+                        "map": "/ClinicalDocument/recordTarget/patientRole/patient/sdtc:raceCode"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.id",
+                "path": "Extension.extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.extension",
+                "path": "Extension.extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.extension.id",
+                "path": "Extension.extension.extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.extension.extension",
+                "path": "Extension.extension.extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.extension.url",
+                "path": "Extension.extension.extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "uri"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.extension.value[x]",
+                "path": "Extension.extension.extension.value[x]",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "base64Binary"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "canonical"
+                    },
+                    {
+                        "code": "code"
+                    },
+                    {
+                        "code": "date"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "decimal"
+                    },
+                    {
+                        "code": "id"
+                    },
+                    {
+                        "code": "instant"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "markdown"
+                    },
+                    {
+                        "code": "oid"
+                    },
+                    {
+                        "code": "positiveInt"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "unsignedInt"
+                    },
+                    {
+                        "code": "uri"
+                    },
+                    {
+                        "code": "url"
+                    },
+                    {
+                        "code": "uuid"
+                    },
+                    {
+                        "code": "Address"
+                    },
+                    {
+                        "code": "Age"
+                    },
+                    {
+                        "code": "Annotation"
+                    },
+                    {
+                        "code": "Attachment"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "Coding"
+                    },
+                    {
+                        "code": "ContactPoint"
+                    },
+                    {
+                        "code": "Count"
+                    },
+                    {
+                        "code": "Distance"
+                    },
+                    {
+                        "code": "Duration"
+                    },
+                    {
+                        "code": "HumanName"
+                    },
+                    {
+                        "code": "Identifier"
+                    },
+                    {
+                        "code": "Money"
+                    },
+                    {
+                        "code": "Period"
+                    },
+                    {
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "Reference"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "Signature"
+                    },
+                    {
+                        "code": "Timing"
+                    },
+                    {
+                        "code": "ContactDetail"
+                    },
+                    {
+                        "code": "Contributor"
+                    },
+                    {
+                        "code": "DataRequirement"
+                    },
+                    {
+                        "code": "Expression"
+                    },
+                    {
+                        "code": "ParameterDefinition"
+                    },
+                    {
+                        "code": "RelatedArtifact"
+                    },
+                    {
+                        "code": "TriggerDefinition"
+                    },
+                    {
+                        "code": "UsageContext"
+                    },
+                    {
+                        "code": "Dosage"
+                    },
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.url",
+                "path": "Extension.extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "detailed",
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.value[x]",
+                "path": "Extension.extension.value[x]",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "type",
+                            "path": "$this"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "closed"
+                },
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.value[x]:valueCoding",
+                "path": "Extension.extension.value[x]",
+                "sliceName": "valueCoding",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "strength": "required",
+                    "description": "The [900+ CDC Race codes](http://www.cdc.gov/phin/resources/vocabulary/index.html) that are grouped under one of the 5 OMB race category codes.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/detailed-race|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text",
+                "path": "Extension.extension",
+                "sliceName": "text",
+                "short": "Race Text",
+                "definition": "Plain text representation of the race concept(s).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Extension.extension:text.id",
+                "path": "Extension.extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text.extension",
+                "path": "Extension.extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text.extension.id",
+                "path": "Extension.extension.extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text.extension.extension",
+                "path": "Extension.extension.extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text.extension.url",
+                "path": "Extension.extension.extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "uri"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text.extension.value[x]",
+                "path": "Extension.extension.extension.value[x]",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "base64Binary"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "canonical"
+                    },
+                    {
+                        "code": "code"
+                    },
+                    {
+                        "code": "date"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "decimal"
+                    },
+                    {
+                        "code": "id"
+                    },
+                    {
+                        "code": "instant"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "markdown"
+                    },
+                    {
+                        "code": "oid"
+                    },
+                    {
+                        "code": "positiveInt"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "unsignedInt"
+                    },
+                    {
+                        "code": "uri"
+                    },
+                    {
+                        "code": "url"
+                    },
+                    {
+                        "code": "uuid"
+                    },
+                    {
+                        "code": "Address"
+                    },
+                    {
+                        "code": "Age"
+                    },
+                    {
+                        "code": "Annotation"
+                    },
+                    {
+                        "code": "Attachment"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "Coding"
+                    },
+                    {
+                        "code": "ContactPoint"
+                    },
+                    {
+                        "code": "Count"
+                    },
+                    {
+                        "code": "Distance"
+                    },
+                    {
+                        "code": "Duration"
+                    },
+                    {
+                        "code": "HumanName"
+                    },
+                    {
+                        "code": "Identifier"
+                    },
+                    {
+                        "code": "Money"
+                    },
+                    {
+                        "code": "Period"
+                    },
+                    {
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "Reference"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "Signature"
+                    },
+                    {
+                        "code": "Timing"
+                    },
+                    {
+                        "code": "ContactDetail"
+                    },
+                    {
+                        "code": "Contributor"
+                    },
+                    {
+                        "code": "DataRequirement"
+                    },
+                    {
+                        "code": "Expression"
+                    },
+                    {
+                        "code": "ParameterDefinition"
+                    },
+                    {
+                        "code": "RelatedArtifact"
+                    },
+                    {
+                        "code": "TriggerDefinition"
+                    },
+                    {
+                        "code": "UsageContext"
+                    },
+                    {
+                        "code": "Dosage"
+                    },
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text.url",
+                "path": "Extension.extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "text",
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text.value[x]",
+                "path": "Extension.extension.value[x]",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "type",
+                            "path": "$this"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "closed"
+                },
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text.value[x]:valueString",
+                "path": "Extension.extension.value[x]",
+                "sliceName": "valueString",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.url",
+                "path": "Extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "uri"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.value[x]",
+                "path": "Extension.value[x]",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 0,
+                "max": "0",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "base64Binary"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "canonical"
+                    },
+                    {
+                        "code": "code"
+                    },
+                    {
+                        "code": "date"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "decimal"
+                    },
+                    {
+                        "code": "id"
+                    },
+                    {
+                        "code": "instant"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "markdown"
+                    },
+                    {
+                        "code": "oid"
+                    },
+                    {
+                        "code": "positiveInt"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "unsignedInt"
+                    },
+                    {
+                        "code": "uri"
+                    },
+                    {
+                        "code": "url"
+                    },
+                    {
+                        "code": "uuid"
+                    },
+                    {
+                        "code": "Address"
+                    },
+                    {
+                        "code": "Age"
+                    },
+                    {
+                        "code": "Annotation"
+                    },
+                    {
+                        "code": "Attachment"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "Coding"
+                    },
+                    {
+                        "code": "ContactPoint"
+                    },
+                    {
+                        "code": "Count"
+                    },
+                    {
+                        "code": "Distance"
+                    },
+                    {
+                        "code": "Duration"
+                    },
+                    {
+                        "code": "HumanName"
+                    },
+                    {
+                        "code": "Identifier"
+                    },
+                    {
+                        "code": "Money"
+                    },
+                    {
+                        "code": "Period"
+                    },
+                    {
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "Reference"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "Signature"
+                    },
+                    {
+                        "code": "Timing"
+                    },
+                    {
+                        "code": "ContactDetail"
+                    },
+                    {
+                        "code": "Contributor"
+                    },
+                    {
+                        "code": "DataRequirement"
+                    },
+                    {
+                        "code": "Expression"
+                    },
+                    {
+                        "code": "ParameterDefinition"
+                    },
+                    {
+                        "code": "RelatedArtifact"
+                    },
+                    {
+                        "code": "TriggerDefinition"
+                    },
+                    {
+                        "code": "UsageContext"
+                    },
+                    {
+                        "code": "Dosage"
+                    },
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Extension",
+                "path": "Extension",
+                "short": "US Core Race Extension",
+                "definition": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\n   - American Indian or Alaska Native\n   - Asian\n   - Black or African American\n   - Native Hawaiian or Other Pacific Islander\n   - White.",
+                "min": 0,
+                "max": "1"
+            },
+            {
+                "id": "Extension.extension:ombCategory",
+                "path": "Extension.extension",
+                "sliceName": "ombCategory",
+                "short": "American Indian or Alaska Native|Asian|Black or African American|Native Hawaiian or Other Pacific Islander|White",
+                "definition": "The 5 race category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
+                "min": 0,
+                "max": "5",
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "iso11179",
+                        "map": "/ClinicalDocument/recordTarget/patientRole/patient/raceCode"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.url",
+                "path": "Extension.extension.url",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "ombCategory"
+            },
+            {
+                "id": "Extension.extension:ombCategory.valueCoding",
+                "path": "Extension.extension.valueCoding",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "binding": {
+                    "strength": "required",
+                    "description": "The 5 race category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/omb-race-category|3.1.1"
+                }
+            },
+            {
+                "id": "Extension.extension:detailed",
+                "path": "Extension.extension",
+                "sliceName": "detailed",
+                "short": "Extended race codes",
+                "definition": "The 900+ CDC race codes that are grouped under one of the 5 OMB race category codes:.",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "mapping": [
+                    {
+                        "identity": "iso11179",
+                        "map": "/ClinicalDocument/recordTarget/patientRole/patient/sdtc:raceCode"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.url",
+                "path": "Extension.extension.url",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "detailed"
+            },
+            {
+                "id": "Extension.extension:detailed.valueCoding",
+                "path": "Extension.extension.valueCoding",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "binding": {
+                    "strength": "required",
+                    "description": "The [900+ CDC Race codes](http://www.cdc.gov/phin/resources/vocabulary/index.html) that are grouped under one of the 5 OMB race category codes.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/detailed-race|3.1.1"
+                }
+            },
+            {
+                "id": "Extension.extension:text",
+                "path": "Extension.extension",
+                "sliceName": "text",
+                "short": "Race Text",
+                "definition": "Plain text representation of the race concept(s).",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Extension.extension:text.url",
+                "path": "Extension.extension.url",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "text"
+            },
+            {
+                "id": "Extension.extension:text.valueString",
+                "path": "Extension.extension.valueString",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.url",
+                "path": "Extension.url",
+                "min": 1,
+                "max": "1",
+                "fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
+            },
+            {
+                "id": "Extension.value[x]",
+                "path": "Extension.value[x]",
+                "min": 0,
+                "max": "0"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-smokingstatus.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/StructureDefinition-us-core-smokingstatus.json
@@ -1,2887 +1,2887 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-smokingstatus",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-smokingstatus-definitions.html#Observation\" title=\"The US Core Smoking Status Observation Profile is based upon the core FHIR Observation Resource and created to meet the USCDI Data Set 'Smoking status' requirements.\">Observation</a><a name=\"Observation\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/observation.html\">Observation</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Measurements and simple assertions</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-smokingstatus-definitions.html#Observation.status\">status</a><a name=\"Observation.status\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">registered | preliminary | final | amended +</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-observation-smoking-status-status.html\">US Core Status for Smoking Status Observation</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-smokingstatus-definitions.html#Observation.code\">code</a><a name=\"Observation.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Smoking Status<br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-smoking-status-observation-codes.html\">US Core Smoking Status Observation Codes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-smokingstatus-definitions.html#Observation.subject\">subject</a><a name=\"Observation.subject\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who and/or what the observation is about</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-smokingstatus-definitions.html#Observation.issued\">issued</a><a name=\"Observation.issued\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#instant\">instant</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Date/Time this version was made available</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck00.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-smokingstatus-definitions.html#Observation.valueCodeableConcept\">valueCodeableConcept</a><a name=\"Observation.valueCodeableConcept\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Coded Responses from Smoking Status Value Set<br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-observation-smokingstatus.html\">US Core Smoking Status Preferred</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#preferred\" title=\"Instances are encouraged to draw from the specified codes for interoperability purposes but are not required to do so to be considered conformant.\">preferred</a>)<br/><a style=\"font-weight:bold\" href=\"http://hl7.org/fhir/R4/extension-elementdefinition-maxvalueset.html\" title=\"Max Value Set Extension\">Max Binding: </a><a href=\"ValueSet-us-core-observation-smokingstatus-max.html\">US Core Smoking Status Max-Binding</a></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus",
-	"version": "3.1.1",
-	"name": "USCoreSmokingStatusProfile",
-	"title": "US Core Smoking Status Observation Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2019-05-21T00:00:00+00:00",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.healthit.gov"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the Observation  resource for the minimal set of data to query and retrieve patient's Smoking Status information.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "sct-concept",
-			"uri": "http://snomed.info/conceptdomain",
-			"name": "SNOMED CT Concept Domain Binding"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "sct-attr",
-			"uri": "http://snomed.org/attributebinding",
-			"name": "SNOMED CT Attribute Binding"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Observation",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Observation",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "Measurements and simple assertions",
-				"definition": "The US Core Smoking Status Observation Profile is based upon the core FHIR Observation Resource and created to meet the USCDI Data Set 'Smoking status' requirements.",
-				"comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
-				"alias": [
-					"Vital Signs",
-					"Measurement",
-					"Results",
-					"Tests",
-					"Obs"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "obs-6",
-						"severity": "error",
-						"human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
-						"expression": "dataAbsentReason.empty() or value.empty()",
-						"xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "obs-7",
-						"severity": "error",
-						"human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
-						"expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
-						"xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation[classCode=OBS, moodCode=EVN]"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation"
-					}
-				]
-			},
-			{
-				"id": "Observation.id",
-				"path": "Observation.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.meta",
-				"path": "Observation.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.implicitRules",
-				"path": "Observation.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Observation.language",
-				"path": "Observation.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Observation.text",
-				"path": "Observation.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Observation.contained",
-				"path": "Observation.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.extension",
-				"path": "Observation.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.modifierExtension",
-				"path": "Observation.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.identifier",
-				"path": "Observation.identifier",
-				"short": "Business Identifier for observation",
-				"definition": "A unique identifier assigned to this observation.",
-				"requirements": "Allows observations to be distinguished and referenced.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
-					},
-					{
-						"identity": "rim",
-						"map": "id"
-					}
-				]
-			},
-			{
-				"id": "Observation.basedOn",
-				"path": "Observation.basedOn",
-				"short": "Fulfills plan, proposal or order",
-				"definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
-				"requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
-				"alias": [
-					"Fulfills"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan",
-							"http://hl7.org/fhir/StructureDefinition/DeviceRequest",
-							"http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
-							"http://hl7.org/fhir/StructureDefinition/MedicationRequest",
-							"http://hl7.org/fhir/StructureDefinition/NutritionOrder",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.basedOn"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.partOf",
-				"path": "Observation.partOf",
-				"short": "Part of referenced event",
-				"definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
-				"comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/R4/observation.html#obsgrouping) below for guidance on referencing another Observation.",
-				"alias": [
-					"Container"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.partOf",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
-							"http://hl7.org/fhir/StructureDefinition/MedicationDispense",
-							"http://hl7.org/fhir/StructureDefinition/MedicationStatement",
-							"http://hl7.org/fhir/StructureDefinition/Procedure",
-							"http://hl7.org/fhir/StructureDefinition/Immunization",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.partOf"
-					},
-					{
-						"identity": "v2",
-						"map": "Varies by domain"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=FLFS].target"
-					}
-				]
-			},
-			{
-				"id": "Observation.status",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
-						"valueString": "default: final"
-					}
-				],
-				"path": "Observation.status",
-				"short": "registered | preliminary | final | amended +",
-				"definition": "The status of the result value.",
-				"comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
-				"requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smoking-status-status|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 445584004 |Report by finality status|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-11"
-					},
-					{
-						"identity": "rim",
-						"map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.status"
-					}
-				]
-			},
-			{
-				"id": "Observation.category",
-				"path": "Observation.category",
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Smoking Status",
-				"definition": "Describes what was observed. Sometimes this is called the observation \"name\".",
-				"comment": "*All* code-value and, if present, component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
-				"alias": [
-					"Name"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-smoking-status-observation-codes|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "116680003 |Is a|"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.subject",
-				"path": "Observation.subject",
-				"short": "Who and/or what the observation is about",
-				"definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
-				"comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
-				"requirements": "Observations have no value if you don't know who or what they're about.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=RTGT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.focus",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
-						"valueCode": "trial-use"
-					}
-				],
-				"path": "Observation.focus",
-				"short": "What the observation is about, when it is not about the subject of record",
-				"definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
-				"comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/R4/extension-observation-focuscode.html).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.focus",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SBJ]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.encounter",
-				"path": "Observation.encounter",
-				"short": "Healthcare event during which this observation is made",
-				"definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
-				"comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
-				"requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
-				"alias": [
-					"Context"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.effective[x]",
-				"path": "Observation.effective[x]",
-				"short": "Clinically relevant time/time-period for observation",
-				"definition": "The time or time-period the observed value is asserted as being true. For biological subjects - e.g. human patients - this is usually called the \"physiologically relevant time\". This is usually either the time of the procedure or of specimen collection, but very often the source of the date/time is not known, only the date/time itself.",
-				"comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/R4/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
-				"requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
-				"alias": [
-					"Occurrence"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.effective[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					},
-					{
-						"code": "Timing"
-					},
-					{
-						"code": "instant"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "Observation.issued",
-				"path": "Observation.issued",
-				"short": "Date/Time this version was made available",
-				"definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
-				"comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/R4/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.issued",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=AUT].time"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.issued"
-					}
-				]
-			},
-			{
-				"id": "Observation.performer",
-				"path": "Observation.performer",
-				"short": "Who is responsible for the observation",
-				"definition": "Who was responsible for asserting the observed value as \"true\".",
-				"requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.performer",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=PRF]"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]",
-				"path": "Observation.value[x]",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "type",
-							"path": "$this"
-						}
-					],
-					"ordered": false,
-					"rules": "closed"
-				},
-				"short": "Actual result",
-				"definition": "The information determined as a result of making the observation, if the information has a simple value.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/R4/observation.html#notes) below.",
-				"requirements": "An observation exists to have a value, though it might not if it is in error, or if it represents a group of observations.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-7"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueCodeableConcept",
-				"path": "Observation.value[x]",
-				"sliceName": "valueCodeableConcept",
-				"short": "Coded Responses from Smoking Status Value Set",
-				"definition": "The information determined as a result of making the observation, if the information has a simple value.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/R4/observation.html#notes) below.",
-				"requirements": "An observation exists to have a value, though it might not if it is in error, or if it represents a group of observations.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-7"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smokingstatus-max|3.1.1"
-						}
-					],
-					"strength": "preferred",
-					"description": "This value set enumerates codes SNOMED CT codes historically used for the current smoking status of a patient with a maximum required binding to Snomed CT codes.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smokingstatus|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.valueCodeableConcept"
-					}
-				]
-			},
-			{
-				"id": "Observation.dataAbsentReason",
-				"path": "Observation.dataAbsentReason",
-				"short": "Why the result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
-				"comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.interpretation",
-				"path": "Observation.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.note",
-				"path": "Observation.note",
-				"short": "Comments about the observation",
-				"definition": "Comments about the observation or the results.",
-				"comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
-				"requirements": "Need to be able to provide free text additional information.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
-					},
-					{
-						"identity": "rim",
-						"map": "subjectOf.observationEvent[code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.bodySite",
-				"path": "Observation.bodySite",
-				"short": "Observed body part",
-				"definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
-				"comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/R4/extension-bodysite.html).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.bodySite",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "BodySite"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing anatomical locations. May include laterality.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/body-site"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123037004 |Body structure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-20"
-					},
-					{
-						"identity": "rim",
-						"map": "targetSiteCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "718497002 |Inherent location|"
-					}
-				]
-			},
-			{
-				"id": "Observation.method",
-				"path": "Observation.method",
-				"short": "How it was done",
-				"definition": "Indicates the mechanism used to perform the observation.",
-				"comment": "Only used if not implicit in code for Observation.code.",
-				"requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.method",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationMethod"
-						}
-					],
-					"strength": "example",
-					"description": "Methods for simple observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-17"
-					},
-					{
-						"identity": "rim",
-						"map": "methodCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.specimen",
-				"path": "Observation.specimen",
-				"short": "Specimen used for this observation",
-				"definition": "The specimen that was used when this observation was made.",
-				"comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.specimen",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Specimen"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123038009 |Specimen|"
-					},
-					{
-						"identity": "v2",
-						"map": "SPM segment"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SPC].specimen"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "704319004 |Inherent in|"
-					}
-				]
-			},
-			{
-				"id": "Observation.device",
-				"path": "Observation.device",
-				"short": "(Measurement) Device",
-				"definition": "The device used to generate the observation data.",
-				"comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.device",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/DeviceMetric"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 49062001 |Device|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-17 / PRT -10"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=DEV]"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "424226004 |Using device|"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange",
-				"path": "Observation.referenceRange",
-				"short": "Provides guide for interpretation",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "obs-3",
-						"severity": "error",
-						"human": "Must have at least a low or a high or text",
-						"expression": "low.exists() or high.exists() or text.exists()",
-						"xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.id",
-				"path": "Observation.referenceRange.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.extension",
-				"path": "Observation.referenceRange.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.modifierExtension",
-				"path": "Observation.referenceRange.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.low",
-				"path": "Observation.referenceRange.low",
-				"short": "Low Range, if relevant",
-				"definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.low",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.low"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.high",
-				"path": "Observation.referenceRange.high",
-				"short": "High Range, if relevant",
-				"definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.high",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.high"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.type",
-				"path": "Observation.referenceRange.type",
-				"short": "Reference range qualifier",
-				"definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
-				"requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeMeaning"
-						}
-					],
-					"strength": "preferred",
-					"description": "Code for the meaning of a reference range.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.appliesTo",
-				"path": "Observation.referenceRange.appliesTo",
-				"short": "Reference range population",
-				"definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
-				"requirements": "Need to be able to identify the target population for proper interpretation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange.appliesTo",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeType"
-						}
-					],
-					"strength": "example",
-					"description": "Codes identifying the population the reference range applies to.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.age",
-				"path": "Observation.referenceRange.age",
-				"short": "Applicable age range, if relevant",
-				"definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
-				"requirements": "Some analytes vary greatly over age.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.age",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Range"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.text",
-				"path": "Observation.referenceRange.text",
-				"short": "Text based reference range in an observation",
-				"definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:ST"
-					}
-				]
-			},
-			{
-				"id": "Observation.hasMember",
-				"path": "Observation.hasMember",
-				"short": "Related resource that belongs to the Observation group",
-				"definition": "This observation is a group observation (e.g. a battery, a panel of tests, a set of vital sign measurements) that includes the target as a member of the group.",
-				"comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/R4/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/R4/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.hasMember",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Observation",
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship"
-					}
-				]
-			},
-			{
-				"id": "Observation.derivedFrom",
-				"path": "Observation.derivedFrom",
-				"short": "Related measurements the observation is made from",
-				"definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
-				"comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/R4/observation.html#obsgrouping) below.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.derivedFrom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/DocumentReference",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy",
-							"http://hl7.org/fhir/StructureDefinition/Media",
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/Observation",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": ".targetObservation"
-					}
-				]
-			},
-			{
-				"id": "Observation.component",
-				"path": "Observation.component",
-				"short": "Component results",
-				"definition": "Some observations have multiple component observations.  These component observations are expressed as separate code value pairs that share the same attributes.  Examples include systolic and diastolic component observations for blood pressure measurement and multiple component observations for genetics observations.",
-				"comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/R4/observation.html#notes) below.",
-				"requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "containment by OBX-4?"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=COMP]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.id",
-				"path": "Observation.component.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.extension",
-				"path": "Observation.component.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.modifierExtension",
-				"path": "Observation.component.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.code",
-				"path": "Observation.component.code",
-				"short": "Type of component observation (code / type)",
-				"definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
-				"comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCode"
-						}
-					],
-					"strength": "example",
-					"description": "Codes identifying names of simple observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-codes"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.value[x]",
-				"path": "Observation.component.value[x]",
-				"short": "Actual component result",
-				"definition": "The information determined as a result of making the observation, if the information has a simple value.",
-				"comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/R4/observation.html#notes) below.",
-				"requirements": "An observation exists to have a value, though it might not if it is in error, or if it represents a group of observations.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.dataAbsentReason",
-				"path": "Observation.component.dataAbsentReason",
-				"short": "Why the component result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
-				"comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.interpretation",
-				"path": "Observation.component.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.referenceRange",
-				"path": "Observation.component.referenceRange",
-				"short": "Provides guide for interpretation of component result",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"contentReference": "#Observation.referenceRange",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"definition": "The US Core Smoking Status Observation Profile is based upon the core FHIR Observation Resource and created to meet the USCDI Data Set 'Smoking status' requirements.",
-				"alias": [
-					"Obs"
-				],
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation"
-					}
-				]
-			},
-			{
-				"id": "Observation.status",
-				"path": "Observation.status",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smoking-status-status|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.status"
-					}
-				]
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Smoking Status",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-smoking-status-observation-codes|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.subject",
-				"path": "Observation.subject",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
-						]
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.issued",
-				"path": "Observation.issued",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.issued"
-					}
-				]
-			},
-			{
-				"id": "Observation.valueCodeableConcept",
-				"path": "Observation.valueCodeableConcept",
-				"short": "Coded Responses from Smoking Status Value Set",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smokingstatus-max|3.1.1"
-						}
-					],
-					"strength": "preferred",
-					"description": "This value set enumerates codes SNOMED CT codes historically used for the current smoking status of a patient with a maximum required binding to Snomed CT codes.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smokingstatus|3.1.1"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.valueCodeableConcept"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-smokingstatus",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus",
+    "version": "3.1.1",
+    "name": "USCoreSmokingStatusProfile",
+    "title": "US Core Smoking Status Observation Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2019-05-21T00:00:00+00:00",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.healthit.gov"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the Observation  resource for the minimal set of data to query and retrieve patient's Smoking Status information.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "sct-concept",
+            "uri": "http://snomed.info/conceptdomain",
+            "name": "SNOMED CT Concept Domain Binding"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "sct-attr",
+            "uri": "http://snomed.org/attributebinding",
+            "name": "SNOMED CT Attribute Binding"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Observation",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Observation",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "Measurements and simple assertions",
+                "definition": "The US Core Smoking Status Observation Profile is based upon the core FHIR Observation Resource and created to meet the USCDI Data Set 'Smoking status' requirements.",
+                "comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
+                "alias": [
+                    "Vital Signs",
+                    "Measurement",
+                    "Results",
+                    "Tests",
+                    "Obs"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "obs-6",
+                        "severity": "error",
+                        "human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
+                        "expression": "dataAbsentReason.empty() or value.empty()",
+                        "xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "obs-7",
+                        "severity": "error",
+                        "human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
+                        "expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
+                        "xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation[classCode=OBS, moodCode=EVN]"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.id",
+                "path": "Observation.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.meta",
+                "path": "Observation.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.implicitRules",
+                "path": "Observation.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Observation.language",
+                "path": "Observation.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Observation.text",
+                "path": "Observation.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.contained",
+                "path": "Observation.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.extension",
+                "path": "Observation.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.modifierExtension",
+                "path": "Observation.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.identifier",
+                "path": "Observation.identifier",
+                "short": "Business Identifier for observation",
+                "definition": "A unique identifier assigned to this observation.",
+                "requirements": "Allows observations to be distinguished and referenced.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "id"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.basedOn",
+                "path": "Observation.basedOn",
+                "short": "Fulfills plan, proposal or order",
+                "definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
+                "requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
+                "alias": [
+                    "Fulfills"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceRequest",
+                            "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+                            "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.basedOn"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.partOf",
+                "path": "Observation.partOf",
+                "short": "Part of referenced event",
+                "definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
+                "comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/R4/observation.html#obsgrouping) below for guidance on referencing another Observation.",
+                "alias": [
+                    "Container"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.partOf",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationDispense",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationStatement",
+                            "http://hl7.org/fhir/StructureDefinition/Procedure",
+                            "http://hl7.org/fhir/StructureDefinition/Immunization",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.partOf"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "Varies by domain"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=FLFS].target"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.status",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
+                        "valueString": "default: final"
+                    }
+                ],
+                "path": "Observation.status",
+                "short": "registered | preliminary | final | amended +",
+                "definition": "The status of the result value.",
+                "comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
+                "requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smoking-status-status|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 445584004 |Report by finality status|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-11"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.status"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category",
+                "path": "Observation.category",
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Smoking Status",
+                "definition": "Describes what was observed. Sometimes this is called the observation \"name\".",
+                "comment": "*All* code-value and, if present, component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+                "alias": [
+                    "Name"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-smoking-status-observation-codes|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "116680003 |Is a|"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.subject",
+                "path": "Observation.subject",
+                "short": "Who and/or what the observation is about",
+                "definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
+                "comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
+                "requirements": "Observations have no value if you don't know who or what they're about.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=RTGT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.focus",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+                        "valueCode": "trial-use"
+                    }
+                ],
+                "path": "Observation.focus",
+                "short": "What the observation is about, when it is not about the subject of record",
+                "definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
+                "comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/R4/extension-observation-focuscode.html).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.focus",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SBJ]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.encounter",
+                "path": "Observation.encounter",
+                "short": "Healthcare event during which this observation is made",
+                "definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
+                "comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
+                "requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
+                "alias": [
+                    "Context"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.effective[x]",
+                "path": "Observation.effective[x]",
+                "short": "Clinically relevant time/time-period for observation",
+                "definition": "The time or time-period the observed value is asserted as being true. For biological subjects - e.g. human patients - this is usually called the \"physiologically relevant time\". This is usually either the time of the procedure or of specimen collection, but very often the source of the date/time is not known, only the date/time itself.",
+                "comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/R4/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
+                "requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
+                "alias": [
+                    "Occurrence"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.effective[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    },
+                    {
+                        "code": "Timing"
+                    },
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.issued",
+                "path": "Observation.issued",
+                "short": "Date/Time this version was made available",
+                "definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
+                "comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/R4/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.issued",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=AUT].time"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.issued"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.performer",
+                "path": "Observation.performer",
+                "short": "Who is responsible for the observation",
+                "definition": "Who was responsible for asserting the observed value as \"true\".",
+                "requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.performer",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=PRF]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]",
+                "path": "Observation.value[x]",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "type",
+                            "path": "$this"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "closed"
+                },
+                "short": "Actual result",
+                "definition": "The information determined as a result of making the observation, if the information has a simple value.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/R4/observation.html#notes) below.",
+                "requirements": "An observation exists to have a value, though it might not if it is in error, or if it represents a group of observations.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-7"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueCodeableConcept",
+                "path": "Observation.value[x]",
+                "sliceName": "valueCodeableConcept",
+                "short": "Coded Responses from Smoking Status Value Set",
+                "definition": "The information determined as a result of making the observation, if the information has a simple value.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/R4/observation.html#notes) below.",
+                "requirements": "An observation exists to have a value, though it might not if it is in error, or if it represents a group of observations.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-7"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smokingstatus-max|3.1.1"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "This value set enumerates codes SNOMED CT codes historically used for the current smoking status of a patient with a maximum required binding to Snomed CT codes.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smokingstatus|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.valueCodeableConcept"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.dataAbsentReason",
+                "path": "Observation.dataAbsentReason",
+                "short": "Why the result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
+                "comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.interpretation",
+                "path": "Observation.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.note",
+                "path": "Observation.note",
+                "short": "Comments about the observation",
+                "definition": "Comments about the observation or the results.",
+                "comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
+                "requirements": "Need to be able to provide free text additional information.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "subjectOf.observationEvent[code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.bodySite",
+                "path": "Observation.bodySite",
+                "short": "Observed body part",
+                "definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
+                "comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/R4/extension-bodysite.html).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.bodySite",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "BodySite"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing anatomical locations. May include laterality.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/body-site"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123037004 |Body structure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-20"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "targetSiteCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "718497002 |Inherent location|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.method",
+                "path": "Observation.method",
+                "short": "How it was done",
+                "definition": "Indicates the mechanism used to perform the observation.",
+                "comment": "Only used if not implicit in code for Observation.code.",
+                "requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.method",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationMethod"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Methods for simple observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "methodCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.specimen",
+                "path": "Observation.specimen",
+                "short": "Specimen used for this observation",
+                "definition": "The specimen that was used when this observation was made.",
+                "comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.specimen",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Specimen"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123038009 |Specimen|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "SPM segment"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SPC].specimen"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "704319004 |Inherent in|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.device",
+                "path": "Observation.device",
+                "short": "(Measurement) Device",
+                "definition": "The device used to generate the observation data.",
+                "comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.device",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceMetric"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 49062001 |Device|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17 / PRT -10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=DEV]"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "424226004 |Using device|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange",
+                "path": "Observation.referenceRange",
+                "short": "Provides guide for interpretation",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "obs-3",
+                        "severity": "error",
+                        "human": "Must have at least a low or a high or text",
+                        "expression": "low.exists() or high.exists() or text.exists()",
+                        "xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.id",
+                "path": "Observation.referenceRange.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.extension",
+                "path": "Observation.referenceRange.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.modifierExtension",
+                "path": "Observation.referenceRange.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.low",
+                "path": "Observation.referenceRange.low",
+                "short": "Low Range, if relevant",
+                "definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.low",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.low"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.high",
+                "path": "Observation.referenceRange.high",
+                "short": "High Range, if relevant",
+                "definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.high",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.high"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.type",
+                "path": "Observation.referenceRange.type",
+                "short": "Reference range qualifier",
+                "definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
+                "requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeMeaning"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Code for the meaning of a reference range.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.appliesTo",
+                "path": "Observation.referenceRange.appliesTo",
+                "short": "Reference range population",
+                "definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
+                "requirements": "Need to be able to identify the target population for proper interpretation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange.appliesTo",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes identifying the population the reference range applies to.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.age",
+                "path": "Observation.referenceRange.age",
+                "short": "Applicable age range, if relevant",
+                "definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
+                "requirements": "Some analytes vary greatly over age.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.age",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Range"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.text",
+                "path": "Observation.referenceRange.text",
+                "short": "Text based reference range in an observation",
+                "definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:ST"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.hasMember",
+                "path": "Observation.hasMember",
+                "short": "Related resource that belongs to the Observation group",
+                "definition": "This observation is a group observation (e.g. a battery, a panel of tests, a set of vital sign measurements) that includes the target as a member of the group.",
+                "comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/R4/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/R4/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.hasMember",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Observation",
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.derivedFrom",
+                "path": "Observation.derivedFrom",
+                "short": "Related measurements the observation is made from",
+                "definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
+                "comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/R4/observation.html#obsgrouping) below.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.derivedFrom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/DocumentReference",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy",
+                            "http://hl7.org/fhir/StructureDefinition/Media",
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/Observation",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".targetObservation"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component",
+                "path": "Observation.component",
+                "short": "Component results",
+                "definition": "Some observations have multiple component observations.  These component observations are expressed as separate code value pairs that share the same attributes.  Examples include systolic and diastolic component observations for blood pressure measurement and multiple component observations for genetics observations.",
+                "comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/R4/observation.html#notes) below.",
+                "requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "containment by OBX-4?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=COMP]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.id",
+                "path": "Observation.component.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.extension",
+                "path": "Observation.component.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.modifierExtension",
+                "path": "Observation.component.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.code",
+                "path": "Observation.component.code",
+                "short": "Type of component observation (code / type)",
+                "definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
+                "comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCode"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes identifying names of simple observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-codes"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.value[x]",
+                "path": "Observation.component.value[x]",
+                "short": "Actual component result",
+                "definition": "The information determined as a result of making the observation, if the information has a simple value.",
+                "comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/R4/observation.html#notes) below.",
+                "requirements": "An observation exists to have a value, though it might not if it is in error, or if it represents a group of observations.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.dataAbsentReason",
+                "path": "Observation.component.dataAbsentReason",
+                "short": "Why the component result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
+                "comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.interpretation",
+                "path": "Observation.component.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.referenceRange",
+                "path": "Observation.component.referenceRange",
+                "short": "Provides guide for interpretation of component result",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "contentReference": "#Observation.referenceRange",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "definition": "The US Core Smoking Status Observation Profile is based upon the core FHIR Observation Resource and created to meet the USCDI Data Set 'Smoking status' requirements.",
+                "alias": [
+                    "Obs"
+                ],
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.status",
+                "path": "Observation.status",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smoking-status-status|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.status"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Smoking Status",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-smoking-status-observation-codes|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.subject",
+                "path": "Observation.subject",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient|3.1.1"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.issued",
+                "path": "Observation.issued",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.issued"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.valueCodeableConcept",
+                "path": "Observation.valueCodeableConcept",
+                "short": "Coded Responses from Smoking Status Value Set",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smokingstatus-max|3.1.1"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "This value set enumerates codes SNOMED CT codes historically used for the current smoking status of a patient with a maximum required binding to Snomed CT codes.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smokingstatus|3.1.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.valueCodeableConcept"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-birthsex.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-birthsex.json
@@ -1,69 +1,69 @@
 {
-	"resourceType": "ValueSet",
-	"id": "birthsex",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This value set includes codes based on the following rules:</p><ul><li>Include these codes as defined in <a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-v3-AdministrativeGender.html\"><code>http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td></tr><tr><td><a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-v3-AdministrativeGender.html#v3-AdministrativeGender-F\">F</a></td><td>Female</td><td>Female</td></tr><tr><td><a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-v3-AdministrativeGender.html#v3-AdministrativeGender-M\">M</a></td><td>Male</td><td>Male</td></tr></table></li><li>Include these codes as defined in <a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-v3-NullFlavor.html\"><code>http://terminology.hl7.org/CodeSystem/v3-NullFlavor</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td></tr><tr><td><a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-v3-NullFlavor.html#v3-NullFlavor-UNK\">UNK</a></td><td>Unknown</td><td>**Description:**A proper value is applicable, but not known.<br/><br/>**Usage Notes**: This means the actual value is not known. If the only thing that is unknown is how to properly express the value in the necessary constraints (value set, datatype, etc.), then the OTH or UNC flavor should be used. No properties should be included for a datatype with this property unless:<br/><br/>1.  Those properties themselves directly translate to a semantic of &quot;unknown&quot;. (E.g. a local code sent as a translation that conveys 'unknown')<br/>2.  Those properties further qualify the nature of what is unknown. (E.g. specifying a use code of &quot;H&quot; and a URL prefix of &quot;tel:&quot; to convey that it is the home phone number that is unknown.)</td></tr></table></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/birthsex",
-	"identifier": [
-		{
-			"system": "urn:ietf:rfc:3986",
-			"value": "urn:oid:2.16.840.1.113762.1.4.1021.24"
-		}
-	],
-	"version": "3.1.1",
-	"name": "BirthSex",
-	"title": "Birth Sex",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "other",
-					"value": "http://hl7.org/fhir"
-				}
-			]
-		}
-	],
-	"description": "Codes for assigning sex at birth as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc)",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"compose": {
-		"include": [
-			{
-				"system": "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender",
-				"concept": [
-					{
-						"code": "F",
-						"display": "Female"
-					},
-					{
-						"code": "M",
-						"display": "Male"
-					}
-				]
-			},
-			{
-				"system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
-				"concept": [
-					{
-						"code": "UNK",
-						"display": "Unknown"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "birthsex",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/birthsex",
+    "identifier": [
+        {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:oid:2.16.840.1.113762.1.4.1021.24"
+        }
+    ],
+    "version": "3.1.1",
+    "name": "BirthSex",
+    "title": "Birth Sex",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "other",
+                    "value": "http://hl7.org/fhir"
+                }
+            ]
+        }
+    ],
+    "description": "Codes for assigning sex at birth as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc)",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "compose": {
+        "include": [
+            {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender",
+                "concept": [
+                    {
+                        "code": "F",
+                        "display": "Female"
+                    },
+                    {
+                        "code": "M",
+                        "display": "Male"
+                    }
+                ]
+            },
+            {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                "concept": [
+                    {
+                        "code": "UNK",
+                        "display": "Unknown"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-detailed-ethnicity.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-detailed-ethnicity.json
@@ -1,54 +1,54 @@
 {
-	"resourceType": "ValueSet",
-	"id": "detailed-ethnicity",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This value set includes codes based on the following rules:</p><ul><li>Include codes from <a href=\"CodeSystem-cdcrec.html\"><code>urn:oid:2.16.840.1.113883.6.238</code></a> where concept  is-a  <a href=\"CodeSystem-cdcrec.html#cdcrec-2133-7\">2133-7</a></li></ul><p>This value set excludes codes based on the following rules:</p><ul><li>Exclude these codes as defined in <a href=\"CodeSystem-cdcrec.html\"><code>urn:oid:2.16.840.1.113883.6.238</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td></tr><tr><td><a href=\"CodeSystem-cdcrec.html#cdcrec-2135-2\">2135-2</a></td><td>Hispanic or Latino</td><td>Hispanic or Latino</td></tr><tr><td><a href=\"CodeSystem-cdcrec.html#cdcrec-2186-5\">2186-5</a></td><td>Not Hispanic or Latino</td><td>Note that this term remains in the table for completeness, even though within HL7, the notion of &quot;not otherwise coded&quot; term is deprecated.</td></tr></table></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/detailed-ethnicity",
-	"version": "3.1.1",
-	"name": "DetailedEthnicity",
-	"title": "Detailed ethnicity",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"description": "The 41 [CDC ethnicity codes](http://www.cdc.gov/phin/resources/vocabulary/index.html) that are grouped under one of the 2 OMB ethnicity category codes.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"compose": {
-		"include": [
-			{
-				"system": "urn:oid:2.16.840.1.113883.6.238",
-				"filter": [
-					{
-						"property": "concept",
-						"op": "is-a",
-						"value": "2133-7"
-					}
-				]
-			}
-		],
-		"exclude": [
-			{
-				"system": "urn:oid:2.16.840.1.113883.6.238",
-				"concept": [
-					{
-						"code": "2135-2"
-					},
-					{
-						"code": "2186-5"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "detailed-ethnicity",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/detailed-ethnicity",
+    "version": "3.1.1",
+    "name": "DetailedEthnicity",
+    "title": "Detailed ethnicity",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "description": "The 41 [CDC ethnicity codes](http://www.cdc.gov/phin/resources/vocabulary/index.html) that are grouped under one of the 2 OMB ethnicity category codes.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "compose": {
+        "include": [
+            {
+                "system": "urn:oid:2.16.840.1.113883.6.238",
+                "filter": [
+                    {
+                        "property": "concept",
+                        "op": "is-a",
+                        "value": "2133-7"
+                    }
+                ]
+            }
+        ],
+        "exclude": [
+            {
+                "system": "urn:oid:2.16.840.1.113883.6.238",
+                "concept": [
+                    {
+                        "code": "2135-2"
+                    },
+                    {
+                        "code": "2186-5"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-detailed-race.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-detailed-race.json
@@ -1,63 +1,63 @@
 {
-	"resourceType": "ValueSet",
-	"id": "detailed-race",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This value set includes codes based on the following rules:</p><ul><li>Include codes from <a href=\"CodeSystem-cdcrec.html\"><code>urn:oid:2.16.840.1.113883.6.238</code></a> where concept  is-a  <a href=\"CodeSystem-cdcrec.html#cdcrec-1000-9\">1000-9</a></li></ul><p>This value set excludes codes based on the following rules:</p><ul><li>Exclude these codes as defined in <a href=\"CodeSystem-cdcrec.html\"><code>urn:oid:2.16.840.1.113883.6.238</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td></tr><tr><td><a href=\"CodeSystem-cdcrec.html#cdcrec-1002-5\">1002-5</a></td><td>American Indian or Alaska Native</td><td>American Indian or Alaska Native</td></tr><tr><td><a href=\"CodeSystem-cdcrec.html#cdcrec-2028-9\">2028-9</a></td><td>Asian</td><td>Asian</td></tr><tr><td><a href=\"CodeSystem-cdcrec.html#cdcrec-2054-5\">2054-5</a></td><td>Black or African American</td><td>Black or African American</td></tr><tr><td><a href=\"CodeSystem-cdcrec.html#cdcrec-2076-8\">2076-8</a></td><td>Native Hawaiian or Other Pacific Islander</td><td>Native Hawaiian or Other Pacific Islander</td></tr><tr><td><a href=\"CodeSystem-cdcrec.html#cdcrec-2106-3\">2106-3</a></td><td>White</td><td>White</td></tr></table></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/detailed-race",
-	"version": "3.1.1",
-	"name": "DetailedRace",
-	"title": "Detailed Race",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"description": "The 900+ [CDC Race codes](http://www.cdc.gov/phin/resources/vocabulary/index.html) that are grouped under one of the 5 OMB race category codes.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"compose": {
-		"include": [
-			{
-				"system": "urn:oid:2.16.840.1.113883.6.238",
-				"filter": [
-					{
-						"property": "concept",
-						"op": "is-a",
-						"value": "1000-9"
-					}
-				]
-			}
-		],
-		"exclude": [
-			{
-				"system": "urn:oid:2.16.840.1.113883.6.238",
-				"concept": [
-					{
-						"code": "1002-5"
-					},
-					{
-						"code": "2028-9"
-					},
-					{
-						"code": "2054-5"
-					},
-					{
-						"code": "2076-8"
-					},
-					{
-						"code": "2106-3"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "detailed-race",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/detailed-race",
+    "version": "3.1.1",
+    "name": "DetailedRace",
+    "title": "Detailed Race",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "description": "The 900+ [CDC Race codes](http://www.cdc.gov/phin/resources/vocabulary/index.html) that are grouped under one of the 5 OMB race category codes.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "compose": {
+        "include": [
+            {
+                "system": "urn:oid:2.16.840.1.113883.6.238",
+                "filter": [
+                    {
+                        "property": "concept",
+                        "op": "is-a",
+                        "value": "1000-9"
+                    }
+                ]
+            }
+        ],
+        "exclude": [
+            {
+                "system": "urn:oid:2.16.840.1.113883.6.238",
+                "concept": [
+                    {
+                        "code": "1002-5"
+                    },
+                    {
+                        "code": "2028-9"
+                    },
+                    {
+                        "code": "2054-5"
+                    },
+                    {
+                        "code": "2076-8"
+                    },
+                    {
+                        "code": "2106-3"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-omb-ethnicity-category.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-omb-ethnicity-category.json
@@ -1,44 +1,44 @@
 {
-	"resourceType": "ValueSet",
-	"id": "omb-ethnicity-category",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include these codes as defined in <a href=\"CodeSystem-cdcrec.html\"><code>urn:oid:2.16.840.1.113883.6.238</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td></tr><tr><td><a href=\"CodeSystem-cdcrec.html#cdcrec-2135-2\">2135-2</a></td><td>Hispanic or Latino</td><td>Hispanic or Latino</td></tr><tr><td><a href=\"CodeSystem-cdcrec.html#cdcrec-2186-5\">2186-5</a></td><td>Non Hispanic or Latino</td><td>Note that this term remains in the table for completeness, even though within HL7, the notion of &quot;not otherwise coded&quot; term is deprecated.</td></tr></table></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/omb-ethnicity-category",
-	"version": "3.1.1",
-	"name": "OmbEthnicityCategories",
-	"title": "OMB Ethnicity Categories",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"description": "The codes for the ethnicity categories - 'Hispanic or Latino' and 'Non Hispanic or Latino' - as defined by the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"compose": {
-		"include": [
-			{
-				"system": "urn:oid:2.16.840.1.113883.6.238",
-				"concept": [
-					{
-						"code": "2135-2",
-						"display": "Hispanic or Latino"
-					},
-					{
-						"code": "2186-5",
-						"display": "Non Hispanic or Latino"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "omb-ethnicity-category",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/omb-ethnicity-category",
+    "version": "3.1.1",
+    "name": "OmbEthnicityCategories",
+    "title": "OMB Ethnicity Categories",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "description": "The codes for the ethnicity categories - 'Hispanic or Latino' and 'Non Hispanic or Latino' - as defined by the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "compose": {
+        "include": [
+            {
+                "system": "urn:oid:2.16.840.1.113883.6.238",
+                "concept": [
+                    {
+                        "code": "2135-2",
+                        "display": "Hispanic or Latino"
+                    },
+                    {
+                        "code": "2186-5",
+                        "display": "Non Hispanic or Latino"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-omb-race-category.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-omb-race-category.json
@@ -1,93 +1,93 @@
 {
-	"resourceType": "ValueSet",
-	"id": "omb-race-category",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This value set includes codes based on the following rules:</p><ul><li>Include these codes as defined in <a href=\"CodeSystem-cdcrec.html\"><code>urn:oid:2.16.840.1.113883.6.238</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td></tr><tr><td><a href=\"CodeSystem-cdcrec.html#cdcrec-1002-5\">1002-5</a></td><td>American Indian or Alaska Native</td><td>American Indian or Alaska Native</td></tr><tr><td><a href=\"CodeSystem-cdcrec.html#cdcrec-2028-9\">2028-9</a></td><td>Asian</td><td>Asian</td></tr><tr><td><a href=\"CodeSystem-cdcrec.html#cdcrec-2054-5\">2054-5</a></td><td>Black or African American</td><td>Black or African American</td></tr><tr><td><a href=\"CodeSystem-cdcrec.html#cdcrec-2076-8\">2076-8</a></td><td>Native Hawaiian or Other Pacific Islander</td><td>Native Hawaiian or Other Pacific Islander</td></tr><tr><td><a href=\"CodeSystem-cdcrec.html#cdcrec-2106-3\">2106-3</a></td><td>White</td><td>White</td></tr></table></li><li>Include these codes as defined in <a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-v3-NullFlavor.html\"><code>http://terminology.hl7.org/CodeSystem/v3-NullFlavor</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td></tr><tr><td><a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-v3-NullFlavor.html#v3-NullFlavor-UNK\">UNK</a></td><td>Unknown</td><td>**Description:**A proper value is applicable, but not known.<br/><br/>**Usage Notes**: This means the actual value is not known. If the only thing that is unknown is how to properly express the value in the necessary constraints (value set, datatype, etc.), then the OTH or UNC flavor should be used. No properties should be included for a datatype with this property unless:<br/><br/>1.  Those properties themselves directly translate to a semantic of &quot;unknown&quot;. (E.g. a local code sent as a translation that conveys 'unknown')<br/>2.  Those properties further qualify the nature of what is unknown. (E.g. specifying a use code of &quot;H&quot; and a URL prefix of &quot;tel:&quot; to convey that it is the home phone number that is unknown.)</td></tr><tr><td><a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-v3-NullFlavor.html#v3-NullFlavor-ASKU\">ASKU</a></td><td>Asked but no answer</td><td>Information was sought but not found (e.g., patient was asked but didn't know)</td></tr></table></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/omb-race-category",
-	"identifier": [
-		{
-			"system": "urn:ietf:rfc:3986",
-			"value": "urn:oid:2.16.840.1.113883.4.642.2.575"
-		}
-	],
-	"version": "3.1.1",
-	"name": "OmbRaceCategories",
-	"title": "OMB Race Categories",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "other",
-					"value": "http://hl7.org/fhir"
-				}
-			]
-		},
-		{
-			"telecom": [
-				{
-					"system": "other",
-					"value": "http://wiki.siframework.org/Data+Access+Framework+Homepage"
-				}
-			]
-		}
-	],
-	"description": "The codes for the concepts 'Unknown' and  'Asked but no answer' and the the codes for the five race categories - 'American Indian' or 'Alaska Native', 'Asian', 'Black or African American', 'Native Hawaiian or Other Pacific Islander', and 'White' - as defined by the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf) .",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"compose": {
-		"include": [
-			{
-				"system": "urn:oid:2.16.840.1.113883.6.238",
-				"concept": [
-					{
-						"code": "1002-5",
-						"display": "American Indian or Alaska Native"
-					},
-					{
-						"code": "2028-9",
-						"display": "Asian"
-					},
-					{
-						"code": "2054-5",
-						"display": "Black or African American"
-					},
-					{
-						"code": "2076-8",
-						"display": "Native Hawaiian or Other Pacific Islander"
-					},
-					{
-						"code": "2106-3",
-						"display": "White"
-					}
-				]
-			},
-			{
-				"system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
-				"concept": [
-					{
-						"code": "UNK",
-						"display": "Unknown"
-					},
-					{
-						"code": "ASKU",
-						"display": "Asked but no answer"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "omb-race-category",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/omb-race-category",
+    "identifier": [
+        {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:oid:2.16.840.1.113883.4.642.2.575"
+        }
+    ],
+    "version": "3.1.1",
+    "name": "OmbRaceCategories",
+    "title": "OMB Race Categories",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "other",
+                    "value": "http://hl7.org/fhir"
+                }
+            ]
+        },
+        {
+            "telecom": [
+                {
+                    "system": "other",
+                    "value": "http://wiki.siframework.org/Data+Access+Framework+Homepage"
+                }
+            ]
+        }
+    ],
+    "description": "The codes for the concepts 'Unknown' and  'Asked but no answer' and the the codes for the five race categories - 'American Indian' or 'Alaska Native', 'Asian', 'Black or African American', 'Native Hawaiian or Other Pacific Islander', and 'White' - as defined by the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf) .",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "compose": {
+        "include": [
+            {
+                "system": "urn:oid:2.16.840.1.113883.6.238",
+                "concept": [
+                    {
+                        "code": "1002-5",
+                        "display": "American Indian or Alaska Native"
+                    },
+                    {
+                        "code": "2028-9",
+                        "display": "Asian"
+                    },
+                    {
+                        "code": "2054-5",
+                        "display": "Black or African American"
+                    },
+                    {
+                        "code": "2076-8",
+                        "display": "Native Hawaiian or Other Pacific Islander"
+                    },
+                    {
+                        "code": "2106-3",
+                        "display": "White"
+                    }
+                ]
+            },
+            {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                "concept": [
+                    {
+                        "code": "UNK",
+                        "display": "Unknown"
+                    },
+                    {
+                        "code": "ASKU",
+                        "display": "Asked but no answer"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-simple-language.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-simple-language.json
@@ -1,71 +1,71 @@
 {
-	"resourceType": "ValueSet",
-	"id": "simple-language",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include codes from <a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-v3-ietf3066.html\"><code>urn:ietf:bcp:47</code></a> where ext-lang doesn't exist, script doesn't exist, variant doesn't exist, extension doesn't exist and private-use doesn't exist</li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/simple-language",
-	"version": "3.1.1",
-	"name": "LanguageCodesWithLanguageAndOptionallyARegionModifier",
-	"title": "Language codes with language and optionally a region modifier",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://hl7.org/fhir"
-				}
-			]
-		}
-	],
-	"description": "This value set includes codes from [BCP-47](http://tools.ietf.org/html/bcp47). This value set matches the ONC 2015 Edition LanguageCommunication data element value set within C-CDA to use a 2 character language code if one exists,   and a 3 character code if a 2 character code does not exist. It points back to [RFC 5646](https://tools.ietf.org/html/rfc5646), however only the language codes are required, all other elements are optional.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"compose": {
-		"include": [
-			{
-				"system": "urn:ietf:bcp:47",
-				"filter": [
-					{
-						"property": "ext-lang",
-						"op": "exists",
-						"value": "false"
-					},
-					{
-						"property": "script",
-						"op": "exists",
-						"value": "false"
-					},
-					{
-						"property": "variant",
-						"op": "exists",
-						"value": "false"
-					},
-					{
-						"property": "extension",
-						"op": "exists",
-						"value": "false"
-					},
-					{
-						"property": "private-use",
-						"op": "exists",
-						"value": "false"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "simple-language",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/simple-language",
+    "version": "3.1.1",
+    "name": "LanguageCodesWithLanguageAndOptionallyARegionModifier",
+    "title": "Language codes with language and optionally a region modifier",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://hl7.org/fhir"
+                }
+            ]
+        }
+    ],
+    "description": "This value set includes codes from [BCP-47](http://tools.ietf.org/html/bcp47). This value set matches the ONC 2015 Edition LanguageCommunication data element value set within C-CDA to use a 2 character language code if one exists,   and a 3 character code if a 2 character code does not exist. It points back to [RFC 5646](https://tools.ietf.org/html/rfc5646), however only the language codes are required, all other elements are optional.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "compose": {
+        "include": [
+            {
+                "system": "urn:ietf:bcp:47",
+                "filter": [
+                    {
+                        "property": "ext-lang",
+                        "op": "exists",
+                        "value": "false"
+                    },
+                    {
+                        "property": "script",
+                        "op": "exists",
+                        "value": "false"
+                    },
+                    {
+                        "property": "variant",
+                        "op": "exists",
+                        "value": "false"
+                    },
+                    {
+                        "property": "extension",
+                        "op": "exists",
+                        "value": "false"
+                    },
+                    {
+                        "property": "private-use",
+                        "op": "exists",
+                        "value": "false"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-allergy-substance.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-allergy-substance.json
@@ -1,3118 +1,3118 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-allergy-substance",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This value set includes codes based on the following rules:</p><ul><li>Include these codes as defined in <a href=\"http://www.nlm.nih.gov/research/umls/rxnorm\"><code>http://www.nlm.nih.gov/research/umls/rxnorm</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td></tr><tr><td>1002293</td><td>formoterol / Mometasone</td><td/></tr><tr><td>1007388</td><td>Lactase / rennet</td><td/></tr><tr><td>1008298</td><td>Acetaminophen / Caffeine / Chlorpheniramine / Hydrocodone / Phenylephrine</td><td/></tr><tr><td>1008519</td><td>guaiacolsulfonate / Hydrocodone</td><td/></tr><tr><td>1009148</td><td>Ampicillin / Sulbactam</td><td/></tr><tr><td>10109</td><td>Streptomycin</td><td/></tr><tr><td>10154</td><td>Succinylcholine</td><td/></tr><tr><td>10156</td><td>Sucralfate</td><td/></tr><tr><td>10169</td><td>Sulfacetamide</td><td/></tr><tr><td>10171</td><td>Sulfadiazine</td><td/></tr><tr><td>10180</td><td>Sulfamethoxazole</td><td/></tr><tr><td>10207</td><td>Sulfisoxazole</td><td/></tr><tr><td>10223</td><td>Sulfur</td><td/></tr><tr><td>10237</td><td>Sulindac</td><td/></tr><tr><td>10324</td><td>Tamoxifen</td><td/></tr><tr><td>10355</td><td>Temazepam</td><td/></tr><tr><td>10368</td><td>Terbutaline</td><td/></tr><tr><td>1037042</td><td>dabigatran etexilate</td><td/></tr><tr><td>10379</td><td>Testosterone</td><td/></tr><tr><td>10395</td><td>Tetracycline</td><td/></tr><tr><td>103990</td><td>Carbidopa / Levodopa</td><td/></tr><tr><td>1040028</td><td>lurasidone</td><td/></tr><tr><td>10438</td><td>Theophylline</td><td/></tr><tr><td>10472</td><td>Thimerosal</td><td/></tr><tr><td>10493</td><td>Thiopental</td><td/></tr><tr><td>10502</td><td>Thioridazine</td><td/></tr><tr><td>10510</td><td>Thiothixene</td><td/></tr><tr><td>10582</td><td>levothyroxine</td><td/></tr><tr><td>10594</td><td>Ticlopidine</td><td/></tr><tr><td>10600</td><td>Timolol</td><td/></tr><tr><td>10627</td><td>Tobramycin</td><td/></tr><tr><td>10636</td><td>Tolmetin</td><td/></tr><tr><td>10689</td><td>Tramadol</td><td/></tr><tr><td>10737</td><td>Trazodone</td><td/></tr><tr><td>10759</td><td>Triamcinolone</td><td/></tr><tr><td>107602</td><td>Epinephrine / Lidocaine</td><td/></tr><tr><td>10763</td><td>Triamterene</td><td/></tr><tr><td>10767</td><td>Triazolam</td><td/></tr><tr><td>10800</td><td>Trifluoperazine</td><td/></tr><tr><td>108118</td><td>Mometasone</td><td/></tr><tr><td>10829</td><td>Trimethoprim</td><td/></tr><tr><td>10831</td><td>Sulfamethoxazole / Trimethoprim</td><td/></tr><tr><td>11124</td><td>Vancomycin</td><td/></tr><tr><td>1114195</td><td>rivaroxaban</td><td/></tr><tr><td>1116632</td><td>Ticagrelor</td><td/></tr><tr><td>11170</td><td>Verapamil</td><td/></tr><tr><td>11248</td><td>Vitamin B 12</td><td/></tr><tr><td>11253</td><td>Vitamin D</td><td/></tr><tr><td>11256</td><td>Vitamin E</td><td/></tr><tr><td>11289</td><td>Warfarin</td><td/></tr><tr><td>113588</td><td>Erythromycin / Sulfisoxazole</td><td/></tr><tr><td>11416</td><td>Zinc</td><td/></tr><tr><td>11423</td><td>Zinc Oxide</td><td/></tr><tr><td>114477</td><td>Levetiracetam</td><td/></tr><tr><td>114970</td><td>zafirlukast</td><td/></tr><tr><td>114979</td><td>rabeprazole</td><td/></tr><tr><td>1151</td><td>Ascorbic Acid</td><td/></tr><tr><td>115264</td><td>Ibandronate</td><td/></tr><tr><td>115552</td><td>trovafloxacin</td><td/></tr><tr><td>115698</td><td>ziprasidone</td><td/></tr><tr><td>1191</td><td>Aspirin</td><td/></tr><tr><td>119565</td><td>tolterodine</td><td/></tr><tr><td>1202</td><td>Atenolol</td><td/></tr><tr><td>121191</td><td>rituximab</td><td/></tr><tr><td>1223</td><td>Atropine</td><td/></tr><tr><td>1256</td><td>Azathioprine</td><td/></tr><tr><td>1272</td><td>Aztreonam</td><td/></tr><tr><td>1291</td><td>Bacitracin</td><td/></tr><tr><td>1292</td><td>Baclofen</td><td/></tr><tr><td>1310171</td><td>Gadolinium</td><td/></tr><tr><td>1311085</td><td>xanthine</td><td/></tr><tr><td>1311524</td><td>Aspartame</td><td/></tr><tr><td>1311629</td><td>nickel</td><td/></tr><tr><td>1314891</td><td>Latex</td><td/></tr><tr><td>1331</td><td>Barium Sulfate</td><td/></tr><tr><td>134615</td><td>brimonidine</td><td/></tr><tr><td>1347</td><td>Beclomethasone</td><td/></tr><tr><td>135447</td><td>donepezil</td><td/></tr><tr><td>135775</td><td>zolmitriptan</td><td/></tr><tr><td>1359</td><td>Belladonna Alkaloids</td><td/></tr><tr><td>1362879</td><td>Sulfur Dioxide</td><td/></tr><tr><td>1363043</td><td>ethyl ether</td><td/></tr><tr><td>136411</td><td>sildenafil</td><td/></tr><tr><td>1364430</td><td>apixaban</td><td/></tr><tr><td>138099</td><td>gemifloxacin</td><td/></tr><tr><td>139462</td><td>moxifloxacin</td><td/></tr><tr><td>1399</td><td>Benzocaine</td><td/></tr><tr><td>140587</td><td>celecoxib</td><td/></tr><tr><td>1406</td><td>benzoin resin</td><td/></tr><tr><td>141626</td><td>colesevelam</td><td/></tr><tr><td>1418</td><td>Benzoyl Peroxide</td><td/></tr><tr><td>1424</td><td>Benztropine</td><td/></tr><tr><td>1514</td><td>Betamethasone</td><td/></tr><tr><td>153970</td><td>Hyoscyamine</td><td/></tr><tr><td>1596450</td><td>Gentamicin</td><td/></tr><tr><td>15996</td><td>Mirtazapine</td><td/></tr><tr><td>161</td><td>Acetaminophen</td><td/></tr><tr><td>16681</td><td>Acarbose</td><td/></tr><tr><td>167</td><td>Acetazolamide</td><td/></tr><tr><td>17128</td><td>lansoprazole</td><td/></tr><tr><td>1727875</td><td>Tetanus immune globulin</td><td/></tr><tr><td>17300</td><td>alfuzosin</td><td/></tr><tr><td>17767</td><td>Amlodipine</td><td/></tr><tr><td>1827</td><td>Buspirone</td><td/></tr><tr><td>183379</td><td>rivastigmine</td><td/></tr><tr><td>1841</td><td>Butorphanol</td><td/></tr><tr><td>18631</td><td>Azithromycin</td><td/></tr><tr><td>187832</td><td>pregabalin</td><td/></tr><tr><td>1886</td><td>Caffeine</td><td/></tr><tr><td>18867</td><td>benazepril</td><td/></tr><tr><td>1895</td><td>Calcium</td><td/></tr><tr><td>1897</td><td>Calcium Carbonate</td><td/></tr><tr><td>18993</td><td>benzonatate</td><td/></tr><tr><td>190376</td><td>linezolid</td><td/></tr><tr><td>191831</td><td>infliximab</td><td/></tr><tr><td>19478</td><td>bismuth subsalicylate</td><td/></tr><tr><td>19552</td><td>cefprozil</td><td/></tr><tr><td>19711</td><td>Amoxicillin / Clavulanate</td><td/></tr><tr><td>19831</td><td>Budesonide</td><td/></tr><tr><td>1998</td><td>Captopril</td><td/></tr><tr><td>2002</td><td>Carbamazepine</td><td/></tr><tr><td>20352</td><td>carvedilol</td><td/></tr><tr><td>20481</td><td>cefepime</td><td/></tr><tr><td>20489</td><td>cefpodoxime</td><td/></tr><tr><td>20610</td><td>Cetirizine</td><td/></tr><tr><td>2101</td><td>Carisoprodol</td><td/></tr><tr><td>21107</td><td>cilostazol</td><td/></tr><tr><td>21183</td><td>Citric Acid</td><td/></tr><tr><td>21212</td><td>Clarithromycin</td><td/></tr><tr><td>214130</td><td>Acetaminophen / butalbital / Caffeine</td><td/></tr><tr><td>214153</td><td>Acetaminophen / dichloralphenazone / isometheptene</td><td/></tr><tr><td>214159</td><td>Aspirin / butalbital / Caffeine</td><td/></tr><tr><td>214160</td><td>Aspirin / butalbital / Caffeine / Codeine</td><td/></tr><tr><td>214181</td><td>Acetaminophen / Diphenhydramine</td><td/></tr><tr><td>214182</td><td>Acetaminophen / Hydrocodone</td><td/></tr><tr><td>214183</td><td>Acetaminophen / Oxycodone</td><td/></tr><tr><td>214199</td><td>Albuterol / Ipratropium</td><td/></tr><tr><td>214223</td><td>Amlodipine / benazepril</td><td/></tr><tr><td>214250</td><td>Aspirin / Caffeine</td><td/></tr><tr><td>214256</td><td>Aspirin / Oxycodone</td><td/></tr><tr><td>214257</td><td>Aspirin / Pentazocine</td><td/></tr><tr><td>214317</td><td>Bisoprolol / Hydrochlorothiazide</td><td/></tr><tr><td>214336</td><td>Caffeine / Ergotamine</td><td/></tr><tr><td>214354</td><td>candesartan</td><td/></tr><tr><td>214364</td><td>carbinoxamine / Pseudoephedrine</td><td/></tr><tr><td>214392</td><td>Chlorpheniramine / Hydrocodone</td><td/></tr><tr><td>214442</td><td>Codeine / Guaifenesin</td><td/></tr><tr><td>214445</td><td>Codeine / Pseudoephedrine</td><td/></tr><tr><td>214488</td><td>Dextromethorphan / Guaifenesin</td><td/></tr><tr><td>214502</td><td>Diclofenac / Misoprostol</td><td/></tr><tr><td>214555</td><td>Etanercept</td><td/></tr><tr><td>214558</td><td>Ethinyl Estradiol / Levonorgestrel</td><td/></tr><tr><td>214565</td><td>fexofenadine / Pseudoephedrine</td><td/></tr><tr><td>214599</td><td>Guaifenesin / Pseudoephedrine</td><td/></tr><tr><td>214614</td><td>homatropine / Hydrocodone</td><td/></tr><tr><td>214617</td><td>Hydrochlorothiazide / irbesartan</td><td/></tr><tr><td>214618</td><td>Hydrochlorothiazide / Lisinopril</td><td/></tr><tr><td>214619</td><td>Hydrochlorothiazide / Losartan</td><td/></tr><tr><td>214626</td><td>Hydrochlorothiazide / valsartan</td><td/></tr><tr><td>214627</td><td>Hydrocodone / Ibuprofen</td><td/></tr><tr><td>214631</td><td>Hydrocodone / Pseudoephedrine</td><td/></tr><tr><td>214682</td><td>Loratadine / Pseudoephedrine</td><td/></tr><tr><td>214721</td><td>Naloxone / Pentazocine</td><td/></tr><tr><td>214807</td><td>Pseudoephedrine / Triprolidine</td><td/></tr><tr><td>2176</td><td>Cefaclor</td><td/></tr><tr><td>217627</td><td>Hydrocortisone / Neomycin / Polymyxin B</td><td/></tr><tr><td>2177</td><td>Cefadroxil</td><td/></tr><tr><td>2180</td><td>Cefazolin</td><td/></tr><tr><td>2189</td><td>Cefoxitin</td><td/></tr><tr><td>2191</td><td>Ceftazidime</td><td/></tr><tr><td>2193</td><td>Ceftriaxone</td><td/></tr><tr><td>219314</td><td>Polymyxin B / Trimethoprim</td><td/></tr><tr><td>219315</td><td>Iron polysaccharide</td><td/></tr><tr><td>2194</td><td>Cefuroxime</td><td/></tr><tr><td>21949</td><td>cyclobenzaprine</td><td/></tr><tr><td>221147</td><td>POLYETHYLENE GLYCOL 3350</td><td/></tr><tr><td>22299</td><td>Daptomycin</td><td/></tr><tr><td>2231</td><td>Cephalexin</td><td/></tr><tr><td>226716</td><td>Aspirin / Dipyridamole</td><td/></tr><tr><td>228476</td><td>gatifloxacin</td><td/></tr><tr><td>228790</td><td>Dutasteride</td><td/></tr><tr><td>232158</td><td>rofecoxib</td><td/></tr><tr><td>233698</td><td>dronedarone</td><td/></tr><tr><td>2348</td><td>Chloramphenicol</td><td/></tr><tr><td>2356</td><td>Chlordiazepoxide</td><td/></tr><tr><td>2358</td><td>Chlorhexidine</td><td/></tr><tr><td>236778</td><td>Trospium</td><td/></tr><tr><td>237159</td><td>Levalbuterol</td><td/></tr><tr><td>2393</td><td>Chloroquine</td><td/></tr><tr><td>2400</td><td>Chlorpheniramine</td><td/></tr><tr><td>2403</td><td>Chlorpromazine</td><td/></tr><tr><td>2409</td><td>Chlorthalidone</td><td/></tr><tr><td>2410</td><td>Chlorzoxazone</td><td/></tr><tr><td>2418</td><td>Cholecalciferol</td><td/></tr><tr><td>2447</td><td>Cholestyramine Resin</td><td/></tr><tr><td>24605</td><td>Etodolac</td><td/></tr><tr><td>24947</td><td>ferrous sulfate</td><td/></tr><tr><td>25025</td><td>Finasteride</td><td/></tr><tr><td>25033</td><td>Cefixime</td><td/></tr><tr><td>25037</td><td>cefdinir</td><td/></tr><tr><td>25120</td><td>flunisolide</td><td/></tr><tr><td>25255</td><td>formoterol</td><td/></tr><tr><td>253157</td><td>Bee pollen</td><td/></tr><tr><td>2541</td><td>Cimetidine</td><td/></tr><tr><td>25480</td><td>gabapentin</td><td/></tr><tr><td>2551</td><td>Ciprofloxacin</td><td/></tr><tr><td>2556</td><td>Citalopram</td><td/></tr><tr><td>25789</td><td>glimepiride</td><td/></tr><tr><td>2582</td><td>Clindamycin</td><td/></tr><tr><td>258337</td><td>Hydrochlorothiazide / Triamterene</td><td/></tr><tr><td>2598</td><td>Clonazepam</td><td/></tr><tr><td>2599</td><td>Clonidine</td><td/></tr><tr><td>260101</td><td>Oseltamivir</td><td/></tr><tr><td>26225</td><td>Ondansetron</td><td/></tr><tr><td>2623</td><td>Clotrimazole</td><td/></tr><tr><td>2670</td><td>Codeine</td><td/></tr><tr><td>2683</td><td>Colchicine</td><td/></tr><tr><td>2685</td><td>Colestipol</td><td/></tr><tr><td>27169</td><td>leflunomide</td><td/></tr><tr><td>274783</td><td>Insulin Glargine</td><td/></tr><tr><td>274786</td><td>telithromycin</td><td/></tr><tr><td>27723</td><td>iodinated glycerol</td><td/></tr><tr><td>278567</td><td>valdecoxib</td><td/></tr><tr><td>28031</td><td>Itraconazole</td><td/></tr><tr><td>281</td><td>Acyclovir</td><td/></tr><tr><td>283742</td><td>Esomeprazole</td><td/></tr><tr><td>283809</td><td>travoprost</td><td/></tr><tr><td>28439</td><td>lamotrigine</td><td/></tr><tr><td>284635</td><td>fluticasone / salmeterol</td><td/></tr><tr><td>2878</td><td>Cortisone</td><td/></tr><tr><td>28889</td><td>Loratadine</td><td/></tr><tr><td>28981</td><td>loracarbef</td><td/></tr><tr><td>29046</td><td>Lisinopril</td><td/></tr><tr><td>29542</td><td>Mercury, Ammoniated</td><td/></tr><tr><td>29561</td><td>meropenem</td><td/></tr><tr><td>296</td><td>Adenosine</td><td/></tr><tr><td>3008</td><td>Cyclosporine</td><td/></tr><tr><td>301542</td><td>rosuvastatin</td><td/></tr><tr><td>306674</td><td>vardenafil</td><td/></tr><tr><td>3108</td><td>Dapsone</td><td/></tr><tr><td>3143</td><td>prasterone</td><td/></tr><tr><td>31448</td><td>nabumetone</td><td/></tr><tr><td>31555</td><td>nebivolol</td><td/></tr><tr><td>31565</td><td>nefazodone</td><td/></tr><tr><td>31738</td><td>nickel sulfate</td><td/></tr><tr><td>318340</td><td>Aloe vera preparation</td><td/></tr><tr><td>321064</td><td>olmesartan</td><td/></tr><tr><td>321988</td><td>Escitalopram</td><td/></tr><tr><td>322167</td><td>Solifenacin</td><td/></tr><tr><td>3247</td><td>Desipramine</td><td/></tr><tr><td>325642</td><td>ertapenem</td><td/></tr><tr><td>32592</td><td>oxaliplatin</td><td/></tr><tr><td>32613</td><td>oxaprozin</td><td/></tr><tr><td>32624</td><td>oxcarbazepine</td><td/></tr><tr><td>3264</td><td>Dexamethasone</td><td/></tr><tr><td>32675</td><td>oxybutynin</td><td/></tr><tr><td>327361</td><td>adalimumab</td><td/></tr><tr><td>3289</td><td>Dextromethorphan</td><td/></tr><tr><td>32937</td><td>Paroxetine</td><td/></tr><tr><td>32968</td><td>clopidogrel</td><td/></tr><tr><td>3322</td><td>Diazepam</td><td/></tr><tr><td>33408</td><td>phenyltoloxamine</td><td/></tr><tr><td>3355</td><td>Diclofenac</td><td/></tr><tr><td>3356</td><td>Dicloxacillin</td><td/></tr><tr><td>3361</td><td>Dicyclomine</td><td/></tr><tr><td>33738</td><td>pioglitazone</td><td/></tr><tr><td>3393</td><td>Diflunisal</td><td/></tr><tr><td>3407</td><td>Digoxin</td><td/></tr><tr><td>341248</td><td>ezetimibe</td><td/></tr><tr><td>3418</td><td>Dihydroergotamine</td><td/></tr><tr><td>3423</td><td>Hydromorphone</td><td/></tr><tr><td>3443</td><td>Diltiazem</td><td/></tr><tr><td>3444</td><td>Dimenhydrinate</td><td/></tr><tr><td>3498</td><td>Diphenhydramine</td><td/></tr><tr><td>35208</td><td>quinapril</td><td/></tr><tr><td>3521</td><td>Dipyridamole</td><td/></tr><tr><td>352362</td><td>Acetaminophen / Tramadol</td><td/></tr><tr><td>35296</td><td>Ramipril</td><td/></tr><tr><td>35382</td><td>resorcinol</td><td/></tr><tr><td>35636</td><td>Risperidone</td><td/></tr><tr><td>358263</td><td>tadalafil</td><td/></tr><tr><td>35827</td><td>Ketorolac</td><td/></tr><tr><td>35829</td><td>ranolazine</td><td/></tr><tr><td>36108</td><td>Salsalate</td><td/></tr><tr><td>36117</td><td>salmeterol</td><td/></tr><tr><td>3616</td><td>Dobutamine</td><td/></tr><tr><td>3638</td><td>Doxepin</td><td/></tr><tr><td>3640</td><td>Doxycycline</td><td/></tr><tr><td>36437</td><td>Sertraline</td><td/></tr><tr><td>3648</td><td>Droperidol</td><td/></tr><tr><td>36567</td><td>Simvastatin</td><td/></tr><tr><td>37418</td><td>Sumatriptan</td><td/></tr><tr><td>37617</td><td>tazobactam</td><td/></tr><tr><td>37798</td><td>Terazosin</td><td/></tr><tr><td>37801</td><td>terbinafine</td><td/></tr><tr><td>3827</td><td>Enalapril</td><td/></tr><tr><td>3829</td><td>Enalaprilat</td><td/></tr><tr><td>38400</td><td>atomoxetine</td><td/></tr><tr><td>38404</td><td>topiramate</td><td/></tr><tr><td>38413</td><td>torsemide</td><td/></tr><tr><td>38574</td><td>trichloroacetaldehyde</td><td/></tr><tr><td>38685</td><td>trimethobenzamide</td><td/></tr><tr><td>389132</td><td>Budesonide / formoterol</td><td/></tr><tr><td>3966</td><td>Ephedrine</td><td/></tr><tr><td>39786</td><td>venlafaxine</td><td/></tr><tr><td>3992</td><td>Epinephrine</td><td/></tr><tr><td>39993</td><td>zolpidem</td><td/></tr><tr><td>39998</td><td>zonisamide</td><td/></tr><tr><td>40048</td><td>Carboplatin</td><td/></tr><tr><td>400674</td><td>dexbrompheniramine / Pseudoephedrine</td><td/></tr><tr><td>4025</td><td>Ergotamine</td><td/></tr><tr><td>40254</td><td>Valproate</td><td/></tr><tr><td>4053</td><td>Erythromycin</td><td/></tr><tr><td>40575</td><td>zileuton</td><td/></tr><tr><td>40790</td><td>pantoprazole</td><td/></tr><tr><td>4083</td><td>Estradiol</td><td/></tr><tr><td>4099</td><td>Estrogens, Conjugated (USP)</td><td/></tr><tr><td>41126</td><td>fluticasone</td><td/></tr><tr><td>41127</td><td>fluvastatin</td><td/></tr><tr><td>4124</td><td>Ethinyl Estradiol</td><td/></tr><tr><td>41397</td><td>Lactase</td><td/></tr><tr><td>41493</td><td>meloxicam</td><td/></tr><tr><td>42330</td><td>Terfenadine</td><td/></tr><tr><td>42331</td><td>Misoprostol</td><td/></tr><tr><td>42347</td><td>Bupropion</td><td/></tr><tr><td>42351</td><td>Lithium Carbonate</td><td/></tr><tr><td>42372</td><td>Mupirocin</td><td/></tr><tr><td>42463</td><td>Pravastatin</td><td/></tr><tr><td>4278</td><td>Famotidine</td><td/></tr><tr><td>4316</td><td>Felodipine</td><td/></tr><tr><td>4337</td><td>Fentanyl</td><td/></tr><tr><td>435</td><td>Albuterol</td><td/></tr><tr><td>43611</td><td>latanoprost</td><td/></tr><tr><td>4419</td><td>Fish Oils</td><td/></tr><tr><td>4441</td><td>Flecainide</td><td/></tr><tr><td>4450</td><td>Fluconazole</td><td/></tr><tr><td>448</td><td>Ethanol</td><td/></tr><tr><td>4492</td><td>Fluorouracil</td><td/></tr><tr><td>4493</td><td>Fluoxetine</td><td/></tr><tr><td>4496</td><td>Fluphenazine</td><td/></tr><tr><td>4500</td><td>Flurandrenolide</td><td/></tr><tr><td>4530</td><td>Formaldehyde</td><td/></tr><tr><td>4603</td><td>Furosemide</td><td/></tr><tr><td>46041</td><td>Alendronate</td><td/></tr><tr><td>461016</td><td>Eszopiclone</td><td/></tr><tr><td>4637</td><td>Galantamine</td><td/></tr><tr><td>465397</td><td>Ciprofloxacin / Dexamethasone</td><td/></tr><tr><td>466522</td><td>Diphenhydramine / Zinc Acetate</td><td/></tr><tr><td>466541</td><td>Neomycin / Polymyxin B</td><td/></tr><tr><td>466549</td><td>Aspirin / Caffeine / Orphenadrine</td><td/></tr><tr><td>466553</td><td>penicillin G benzathine / penicillin G procaine</td><td/></tr><tr><td>466566</td><td>Acetaminophen / Dextromethorphan / Diphenhydramine / Pseudoephedrine</td><td/></tr><tr><td>466584</td><td>Acetaminophen / Aspirin / Caffeine</td><td/></tr><tr><td>4719</td><td>Gemfibrozil</td><td/></tr><tr><td>475968</td><td>liraglutide</td><td/></tr><tr><td>4815</td><td>Glyburide</td><td/></tr><tr><td>48203</td><td>Clavulanate</td><td/></tr><tr><td>4821</td><td>Glipizide</td><td/></tr><tr><td>48274</td><td>Acetaminophen / Propoxyphene</td><td/></tr><tr><td>484139</td><td>Chlorhexidine / Isopropyl Alcohol</td><td/></tr><tr><td>484211</td><td>ezetimibe / Simvastatin</td><td/></tr><tr><td>4850</td><td>Glucose</td><td/></tr><tr><td>4917</td><td>Nitroglycerin</td><td/></tr><tr><td>49276</td><td>Doxazosin</td><td/></tr><tr><td>50166</td><td>Fosinopril</td><td/></tr><tr><td>5021</td><td>Griseofulvin</td><td/></tr><tr><td>5032</td><td>Guaifenesin</td><td/></tr><tr><td>5093</td><td>Haloperidol</td><td/></tr><tr><td>51272</td><td>quetiapine</td><td/></tr><tr><td>519</td><td>Allopurinol</td><td/></tr><tr><td>52175</td><td>Losartan</td><td/></tr><tr><td>5224</td><td>heparin</td><td/></tr><tr><td>52582</td><td>mesalamine</td><td/></tr><tr><td>5470</td><td>Hydralazine</td><td/></tr><tr><td>5487</td><td>Hydrochlorothiazide</td><td/></tr><tr><td>5489</td><td>Hydrocodone</td><td/></tr><tr><td>5492</td><td>Hydrocortisone</td><td/></tr><tr><td>5499</td><td>Hydrogen Peroxide</td><td/></tr><tr><td>5521</td><td>Hydroxychloroquine</td><td/></tr><tr><td>5553</td><td>Hydroxyzine</td><td/></tr><tr><td>5640</td><td>Ibuprofen</td><td/></tr><tr><td>5691</td><td>Imipramine</td><td/></tr><tr><td>56946</td><td>Paclitaxel</td><td/></tr><tr><td>57258</td><td>tizanidine</td><td/></tr><tr><td>5764</td><td>Indapamide</td><td/></tr><tr><td>5781</td><td>Indomethacin</td><td/></tr><tr><td>588250</td><td>milnacipran</td><td/></tr><tr><td>59078</td><td>metaxalone</td><td/></tr><tr><td>591622</td><td>varenicline</td><td/></tr><tr><td>5933</td><td>Iodine</td><td/></tr><tr><td>593411</td><td>sitagliptin</td><td/></tr><tr><td>594040</td><td>Atropine / Diphenoxylate</td><td/></tr><tr><td>5956</td><td>Iohexol</td><td/></tr><tr><td>596</td><td>Alprazolam</td><td/></tr><tr><td>596723</td><td>cerivastatin</td><td/></tr><tr><td>597142</td><td>brimonidine / Timolol</td><td/></tr><tr><td>5992</td><td>Iron-Dextran Complex</td><td/></tr><tr><td>60207</td><td>dorzolamide</td><td/></tr><tr><td>6038</td><td>isoniazid</td><td/></tr><tr><td>60548</td><td>exenatide</td><td/></tr><tr><td>6057</td><td>Isosorbide</td><td/></tr><tr><td>6058</td><td>Isosorbide Dinitrate</td><td/></tr><tr><td>611854</td><td>Chlordiazepoxide / clidinium</td><td/></tr><tr><td>6130</td><td>Ketamine</td><td/></tr><tr><td>6135</td><td>Ketoconazole</td><td/></tr><tr><td>61381</td><td>olanzapine</td><td/></tr><tr><td>6142</td><td>Ketoprofen</td><td/></tr><tr><td>6185</td><td>Labetalol</td><td/></tr><tr><td>620</td><td>Amantadine</td><td/></tr><tr><td>6218</td><td>Lactulose</td><td/></tr><tr><td>6227</td><td>Lanolin</td><td/></tr><tr><td>6387</td><td>Lidocaine</td><td/></tr><tr><td>6398</td><td>Lincomycin</td><td/></tr><tr><td>6448</td><td>Lithium</td><td/></tr><tr><td>645555</td><td>Bacitracin / Polymyxin B</td><td/></tr><tr><td>6468</td><td>Loperamide</td><td/></tr><tr><td>6470</td><td>Lorazepam</td><td/></tr><tr><td>6472</td><td>Lovastatin</td><td/></tr><tr><td>6574</td><td>Magnesium</td><td/></tr><tr><td>6585</td><td>Magnesium Sulfate</td><td/></tr><tr><td>662263</td><td>dorzolamide / Timolol</td><td/></tr><tr><td>6676</td><td>Meclizine</td><td/></tr><tr><td>6691</td><td>Medroxyprogesterone</td><td/></tr><tr><td>67108</td><td>Enoxaparin</td><td/></tr><tr><td>6711</td><td>Melatonin</td><td/></tr><tr><td>6719</td><td>Memantine</td><td/></tr><tr><td>6750</td><td>Menthol</td><td/></tr><tr><td>6754</td><td>Meperidine</td><td/></tr><tr><td>6809</td><td>Metformin</td><td/></tr><tr><td>6813</td><td>Methadone</td><td/></tr><tr><td>6835</td><td>Methimazole</td><td/></tr><tr><td>6845</td><td>Methocarbamol</td><td/></tr><tr><td>6851</td><td>Methotrexate</td><td/></tr><tr><td>6876</td><td>Methyldopa</td><td/></tr><tr><td>689</td><td>Aminophylline</td><td/></tr><tr><td>689467</td><td>Oxytetracycline / Polymyxin B</td><td/></tr><tr><td>689518</td><td>Aspirin / Caffeine / Propoxyphene</td><td/></tr><tr><td>689556</td><td>Acetaminophen / Aspirin / Phenylpropanolamine</td><td/></tr><tr><td>689558</td><td>Acetaminophen / Brompheniramine / Pseudoephedrine</td><td/></tr><tr><td>689561</td><td>Acetaminophen / butalbital / Caffeine / Codeine</td><td/></tr><tr><td>689582</td><td>Acetaminophen / Chlorpheniramine / Dextromethorphan / Pseudoephedrine</td><td/></tr><tr><td>689606</td><td>Atropine / Hyoscyamine / Phenobarbital / Scopolamine</td><td/></tr><tr><td>689623</td><td>Bacitracin / Hydrocortisone / Neomycin / Polymyxin B</td><td/></tr><tr><td>690077</td><td>Benzalkonium / Lidocaine</td><td/></tr><tr><td>6901</td><td>Methylphenidate</td><td/></tr><tr><td>6902</td><td>Methylprednisolone</td><td/></tr><tr><td>690693</td><td>Diphenhydramine / Phenylephrine</td><td/></tr><tr><td>690808</td><td>Brompheniramine / Dextromethorphan / Pseudoephedrine</td><td/></tr><tr><td>69120</td><td>tiotropium</td><td/></tr><tr><td>6915</td><td>Metoclopramide</td><td/></tr><tr><td>6916</td><td>Metolazone</td><td/></tr><tr><td>6918</td><td>Metoprolol</td><td/></tr><tr><td>6922</td><td>Metronidazole</td><td/></tr><tr><td>692572</td><td>Bacitracin / Neomycin / Polymyxin B</td><td/></tr><tr><td>692794</td><td>Gramicidin / Neomycin / Polymyxin B</td><td/></tr><tr><td>6932</td><td>Miconazole</td><td/></tr><tr><td>6960</td><td>Midazolam</td><td/></tr><tr><td>69749</td><td>valsartan</td><td/></tr><tr><td>6980</td><td>Minocycline</td><td/></tr><tr><td>6984</td><td>Minoxidil</td><td/></tr><tr><td>703</td><td>Amiodarone</td><td/></tr><tr><td>704</td><td>Amitriptyline</td><td/></tr><tr><td>7052</td><td>Morphine</td><td/></tr><tr><td>705258</td><td>Acetaminophen / Dextromethorphan / Doxylamine</td><td/></tr><tr><td>7213</td><td>Ipratropium</td><td/></tr><tr><td>72143</td><td>Raloxifene</td><td/></tr><tr><td>72236</td><td>fosphenytoin</td><td/></tr><tr><td>723</td><td>Amoxicillin</td><td/></tr><tr><td>72302</td><td>ropinirole</td><td/></tr><tr><td>7233</td><td>Nafcillin</td><td/></tr><tr><td>7238</td><td>Nalbuphine</td><td/></tr><tr><td>7243</td><td>Naltrexone</td><td/></tr><tr><td>725</td><td>Amphetamine</td><td/></tr><tr><td>7258</td><td>Naproxen</td><td/></tr><tr><td>72625</td><td>duloxetine</td><td/></tr><tr><td>7299</td><td>Neomycin</td><td/></tr><tr><td>73056</td><td>Risedronate</td><td/></tr><tr><td>733</td><td>Ampicillin</td><td/></tr><tr><td>73494</td><td>telmisartan</td><td/></tr><tr><td>73645</td><td>valacyclovir</td><td/></tr><tr><td>7393</td><td>Niacin</td><td/></tr><tr><td>7407</td><td>Nicotine</td><td/></tr><tr><td>74169</td><td>Piperacillin / tazobactam</td><td/></tr><tr><td>7417</td><td>Nifedipine</td><td/></tr><tr><td>7454</td><td>Nitrofurantoin</td><td/></tr><tr><td>746741</td><td>Pramipexole</td><td/></tr><tr><td>7486</td><td>Nitrous Oxide</td><td/></tr><tr><td>7517</td><td>Norfloxacin</td><td/></tr><tr><td>7531</td><td>Nortriptyline</td><td/></tr><tr><td>7597</td><td>Nystatin</td><td/></tr><tr><td>7623</td><td>Ofloxacin</td><td/></tr><tr><td>7646</td><td>Omeprazole</td><td/></tr><tr><td>7676</td><td>Opium</td><td/></tr><tr><td>7715</td><td>Orphenadrine</td><td/></tr><tr><td>77492</td><td>tamsulosin</td><td/></tr><tr><td>7804</td><td>Oxycodone</td><td/></tr><tr><td>7821</td><td>Oxytetracycline</td><td/></tr><tr><td>787390</td><td>tapentadol</td><td/></tr><tr><td>7975</td><td>Penicillamine</td><td/></tr><tr><td>797541</td><td>Isopropyl Alcohol</td><td/></tr><tr><td>7980</td><td>Penicillin G</td><td/></tr><tr><td>7984</td><td>Penicillin V</td><td/></tr><tr><td>7994</td><td>Pentamidine</td><td/></tr><tr><td>8001</td><td>Pentazocine</td><td/></tr><tr><td>8120</td><td>Phenazopyridine</td><td/></tr><tr><td>8134</td><td>Phenobarbital</td><td/></tr><tr><td>815166</td><td>Dextromethorphan / Doxylamine</td><td/></tr><tr><td>8163</td><td>Phenylephrine</td><td/></tr><tr><td>816346</td><td>dexlansoprazole</td><td/></tr><tr><td>8175</td><td>Phenylpropanolamine</td><td/></tr><tr><td>817579</td><td>Acetaminophen / Codeine</td><td/></tr><tr><td>817958</td><td>Aspirin / Calcium Carbonate</td><td/></tr><tr><td>8183</td><td>Phenytoin</td><td/></tr><tr><td>82122</td><td>Levofloxacin</td><td/></tr><tr><td>822929</td><td>Amphetamine aspartate / Amphetamine Sulfate / Dextroamphetamine saccharate / Dextroamphetamine Sulfate</td><td/></tr><tr><td>83367</td><td>atorvastatin</td><td/></tr><tr><td>8356</td><td>Piroxicam</td><td/></tr><tr><td>83818</td><td>irbesartan</td><td/></tr><tr><td>84108</td><td>rosiglitazone</td><td/></tr><tr><td>8536</td><td>Polymyxin B</td><td/></tr><tr><td>857974</td><td>saxagliptin</td><td/></tr><tr><td>8588</td><td>Potassium</td><td/></tr><tr><td>8591</td><td>Potassium Chloride</td><td/></tr><tr><td>8610</td><td>Povidone</td><td/></tr><tr><td>8611</td><td>Povidone-Iodine</td><td/></tr><tr><td>861634</td><td>pitavastatin</td><td/></tr><tr><td>8629</td><td>Prazosin</td><td/></tr><tr><td>8638</td><td>prednisolone</td><td/></tr><tr><td>8640</td><td>Prednisone</td><td/></tr><tr><td>8687</td><td>Primaquine</td><td/></tr><tr><td>8691</td><td>Primidone</td><td/></tr><tr><td>8698</td><td>Probenecid</td><td/></tr><tr><td>8700</td><td>Procainamide</td><td/></tr><tr><td>8701</td><td>Procaine</td><td/></tr><tr><td>8703</td><td>Fenofibrate</td><td/></tr><tr><td>8704</td><td>Prochlorperazine</td><td/></tr><tr><td>8727</td><td>Progesterone</td><td/></tr><tr><td>8745</td><td>Promethazine</td><td/></tr><tr><td>8754</td><td>Propafenone</td><td/></tr><tr><td>87636</td><td>fexofenadine</td><td/></tr><tr><td>8782</td><td>Propofol</td><td/></tr><tr><td>8785</td><td>Propoxyphene</td><td/></tr><tr><td>8787</td><td>Propranolol</td><td/></tr><tr><td>8794</td><td>Propylthiouracil</td><td/></tr><tr><td>88014</td><td>rizatriptan</td><td/></tr><tr><td>88249</td><td>montelukast</td><td/></tr><tr><td>883815</td><td>Dexamethasone / Tobramycin</td><td/></tr><tr><td>8896</td><td>Pseudoephedrine</td><td/></tr><tr><td>89013</td><td>aripiprazole</td><td/></tr><tr><td>8928</td><td>Psyllium</td><td/></tr><tr><td>8948</td><td>Purified Protein Derivative of Tuberculin</td><td/></tr><tr><td>90176</td><td>Iron</td><td/></tr><tr><td>9068</td><td>Quinidine</td><td/></tr><tr><td>9071</td><td>Quinine</td><td/></tr><tr><td>91263</td><td>Aloe Extract</td><td/></tr><tr><td>9143</td><td>Ranitidine</td><td/></tr><tr><td>9384</td><td>Rifampin</td><td/></tr><tr><td>9524</td><td>Sulfasalazine</td><td/></tr><tr><td>9601</td><td>Scopolamine</td><td/></tr><tr><td>9778</td><td>Silicones</td><td/></tr><tr><td>9793</td><td>silver sulfadiazine</td><td/></tr><tr><td>9947</td><td>Sotalol</td><td/></tr><tr><td>9997</td><td>Spironolactone</td><td/></tr></table></li><li>Include these codes as defined in <a href=\"http://www.snomed.org/\"><code>http://snomed.info/sct</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=102259006\">102259006</a></td><td>Citrus fruit (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=102261002\">102261002</a></td><td>Strawberry (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=102262009\">102262009</a></td><td>Chocolate (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=102263004\">102263004</a></td><td>Eggs (edible) (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=102264005\">102264005</a></td><td>Cheese (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=111088007\">111088007</a></td><td>Latex (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=111151007\">111151007</a></td><td>Anabolic steroid (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=11526002\">11526002</a></td><td>Aspartame (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=116274004\">116274004</a></td><td>Artificial sweetener (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=116566001\">116566001</a></td><td>Steroid (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=13577000\">13577000</a></td><td>Nut (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=14443002\">14443002</a></td><td>Substance with aminoglycoside structure and antibacterial mechanism of action (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=226723006\">226723006</a></td><td>Buckwheat - cereal (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=226734009\">226734009</a></td><td>Wheatgerm (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=226760005\">226760005</a></td><td>Dairy foods (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=226915003\">226915003</a></td><td>Red meat (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=226916002\">226916002</a></td><td>Beef (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=226934003\">226934003</a></td><td>Pork (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=226955001\">226955001</a></td><td>Chicken - meat (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=226967004\">226967004</a></td><td>Turkey - meat (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=227144008\">227144008</a></td><td>Tuna fish (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=227151004\">227151004</a></td><td>Prawns (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=227208008\">227208008</a></td><td>Abalone canned in brine (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=227219006\">227219006</a></td><td>Aubergine (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=227313005\">227313005</a></td><td>Pulse vegetables (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=227388008\">227388008</a></td><td>Cinnamon (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=227400003\">227400003</a></td><td>Ginger (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=227421003\">227421003</a></td><td>Cranberries (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=227444000\">227444000</a></td><td>Raspberries (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=227493005\">227493005</a></td><td>Cashew nut (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=227512001\">227512001</a></td><td>Pistachio nut (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=227598003\">227598003</a></td><td>Honey (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=228102000\">228102000</a></td><td>Sodium nitrate (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=255632006\">255632006</a></td><td>Anticonvulsant (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=255637000\">255637000</a></td><td>Salicylate (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=255641001\">255641001</a></td><td>Caffeine (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=256259004\">256259004</a></td><td>Pollen (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=256277009\">256277009</a></td><td>Grass pollen (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=256306003\">256306003</a></td><td>Orange - fruit (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=256307007\">256307007</a></td><td>Banana (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=256313003\">256313003</a></td><td>Pineapple (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=256315005\">256315005</a></td><td>Grapefruit (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=256317002\">256317002</a></td><td>Grapes (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=256319004\">256319004</a></td><td>Carrot (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=256326004\">256326004</a></td><td>Celery (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=256329006\">256329006</a></td><td>Spinach (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=256350002\">256350002</a></td><td>Almond (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=256351003\">256351003</a></td><td>Brazil nut (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=256352005\">256352005</a></td><td>Walnut - nut (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=256353000\">256353000</a></td><td>Hazelnut (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=256354006\">256354006</a></td><td>Bean (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=256417003\">256417003</a></td><td>Horse dander (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=256440004\">256440004</a></td><td>Wasp venom (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=259858000\">259858000</a></td><td>Varicella-zoster virus antibody (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=260152009\">260152009</a></td><td>Cat dander (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=260154005\">260154005</a></td><td>Dog dander (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=260167008\">260167008</a></td><td>Sesame seed (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=260176001\">260176001</a></td><td>Kiwi fruit (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=260177005\">260177005</a></td><td>Melon (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=260179008\">260179008</a></td><td>Mango fruit (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=260184002\">260184002</a></td><td>Peas (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=260189007\">260189007</a></td><td>Pecan nut (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=260205009\">260205009</a></td><td>Sunflower seed (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=264287008\">264287008</a></td><td>Animal dander (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=264337003\">264337003</a></td><td>Seed (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=28230009\">28230009</a></td><td>Poultry (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=288328004\">288328004</a></td><td>Bee venom (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=28942008\">28942008</a></td><td>Coconut oil (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=29263009\">29263009</a></td><td>Coffee (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=304275008\">304275008</a></td><td>Corticosteroid and corticosteroid derivative (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=33008008\">33008008</a></td><td>Dust (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=350327004\">350327004</a></td><td>Diphtheria + tetanus vaccine (product)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=35748005\">35748005</a></td><td>Wine (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=360201004\">360201004</a></td><td>Nitrofuran derivative (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=3692009\">3692009</a></td><td>Sodium sulfite (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=372480009\">372480009</a></td><td>Substance with macrolide structure and antibacterial mechanism of action (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=372664007\">372664007</a></td><td>Benzodiazepine (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=372665008\">372665008</a></td><td>Non-steroidal anti-inflammatory agent (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=372711004\">372711004</a></td><td>Sulfonylurea (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=372722000\">372722000</a></td><td>Substance with quinolone structure and antibacterial mechanism of action (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=372733002\">372733002</a></td><td>Substance with angiotensin-converting enzyme inhibitor mechanism of action (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=372747003\">372747003</a></td><td>Thiazide diuretic (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=372783007\">372783007</a></td><td>Antiparkinsonian agent (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=372798009\">372798009</a></td><td>Barbiturate (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=372806008\">372806008</a></td><td>Substance with histamine receptor antagonist mechanism of action (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=372889003\">372889003</a></td><td>First generation cephalosporin (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=372912004\">372912004</a></td><td>Substance with 3-hydroxy-3-methylglutaryl-coenzyme A reductase inhibitor mechanism of action (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=372913009\">372913009</a></td><td>Substance with angiotensin II receptor antagonist mechanism of action (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=373206009\">373206009</a></td><td>Substance with tetracycline structure and antibacterial mechanism of action (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=373253007\">373253007</a></td><td>Tricyclic antidepressant (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=373254001\">373254001</a></td><td>Substance with beta adrenergic receptor antagonist mechanism of action (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=373262009\">373262009</a></td><td>Substance with cephalosporin structure and antibacterial mechanism of action (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=373270004\">373270004</a></td><td>Substance with penicillin structure and antibacterial mechanism of action (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=373297006\">373297006</a></td><td>Substance with beta-lactam structure and antibacterial mechanism of action (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=373304005\">373304005</a></td><td>Substance with calcium channel blocker mechanism of action (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=373531009\">373531009</a></td><td>Gelatin (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=385420005\">385420005</a></td><td>Contrast media (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=386127005\">386127005</a></td><td>Formula milk (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=386962001\">386962001</a></td><td>Plasma protein fraction (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=387050005\">387050005</a></td><td>Substance with prostaglandin-endoperoxide synthase isoform 2 inhibitor mechanism of action (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=387406002\">387406002</a></td><td>Sulfonamide (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=391737006\">391737006</a></td><td>Almond oil (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=391739009\">391739009</a></td><td>Aloe (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=396345004\">396345004</a></td><td>Carbapenem (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=396420001\">396420001</a></td><td>Anthrax vaccine (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=396425006\">396425006</a></td><td>Influenza virus vaccine (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=396433007\">396433007</a></td><td>Pertussis vaccine (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=396439006\">396439006</a></td><td>Smallpox vaccine (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=396441007\">396441007</a></td><td>Typhoid vaccine (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=396442000\">396442000</a></td><td>Varicella virus vaccine (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=398730001\">398730001</a></td><td>Pneumococcal vaccine (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=400872007\">400872007</a></td><td>Hydrocolloid (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=404642006\">404642006</a></td><td>Substance with opioid receptor agonist mechanism of action (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=406748003\">406748003</a></td><td>Carbamate (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=409137002\">409137002</a></td><td>No known drug allergy (situation)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=412061001\">412061001</a></td><td>Blueberries (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=412062008\">412062008</a></td><td>Cantaloupe (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=412066006\">412066006</a></td><td>Pepper (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=412068007\">412068007</a></td><td>Rye (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=412071004\">412071004</a></td><td>Wheat (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=412138001\">412138001</a></td><td>Horse serum protein (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=412357001\">412357001</a></td><td>Corn (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=412373007\">412373007</a></td><td>Diphtheria + pertussis + tetanus + Haemophilus influenzae type b vaccine (product)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=412375000\">412375000</a></td><td>Tetanus vaccine (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=412533000\">412533000</a></td><td>Wheat bran (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=412534006\">412534006</a></td><td>Yeast (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=412583005\">412583005</a></td><td>Bee pollen (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=41598000\">41598000</a></td><td>Estrogen (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=417889008\">417889008</a></td><td>Arachis oil (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=418000008\">418000008</a></td><td>Methadone analog (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=418504009\">418504009</a></td><td>Oats (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=418920007\">418920007</a></td><td>Adhesive agent (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=419420009\">419420009</a></td><td>Watermelon (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=419933005\">419933005</a></td><td>Glucocorticoid (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=421245007\">421245007</a></td><td>Diphtheria + pertussis + tetanus vaccine (product)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=424369009\">424369009</a></td><td>Product containing beta-galactosidase (medicinal product)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=426722004\">426722004</a></td><td>Iodinated contrast media (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=428607008\">428607008</a></td><td>No known environmental allergy (situation)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=429625007\">429625007</a></td><td>No known food allergy (situation)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=43735007\">43735007</a></td><td>Sulfur (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=43921001\">43921001</a></td><td>Nickel compound (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=44027008\">44027008</a></td><td>Seafood (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=442381000124103\">442381000124103</a></td><td>Blue food coloring (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=442571000124108\">442571000124108</a></td><td>Tree nut (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=442771000124102\">442771000124102</a></td><td>Pepperoni (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=44588005\">44588005</a></td><td>Iodine (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=446273004\">446273004</a></td><td>Red food coloring (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=446274005\">446274005</a></td><td>Yellow food coloring (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=47703008\">47703008</a></td><td>Lactose (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=51386004\">51386004</a></td><td>Food preservative (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=51905005\">51905005</a></td><td>Mustard (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=53041004\">53041004</a></td><td>Alcohol (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=61789006\">61789006</a></td><td>Dye (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=63045006\">63045006</a></td><td>Berry (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=67324005\">67324005</a></td><td>Rice (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=67866001\">67866001</a></td><td>Insulin (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=70813002\">70813002</a></td><td>Milk (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=710179004\">710179004</a></td><td>Lupine seed (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=716184000\">716184000</a></td><td>No known latex allergy (situation)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=716186003\">716186003</a></td><td>No known allergy (situation)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=720687003\">720687003</a></td><td>Dust mite protein (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=72511004\">72511004</a></td><td>Fruit (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=726730005\">726730005</a></td><td>Yam (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=734881000\">734881000</a></td><td>Tomato (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=735006003\">735006003</a></td><td>Squid (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=735009005\">735009005</a></td><td>Salmon (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=735029006\">735029006</a></td><td>Shellfish (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=735030001\">735030001</a></td><td>Garlic (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=735043001\">735043001</a></td><td>Mackerel (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=735045008\">735045008</a></td><td>Mushroom (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=735047000\">735047000</a></td><td>Onion (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=735049002\">735049002</a></td><td>Peach (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=735050002\">735050002</a></td><td>Pear (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=735051003\">735051003</a></td><td>Plum (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=735053000\">735053000</a></td><td>Potato (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=735123009\">735123009</a></td><td>Broccoli (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=735124003\">735124003</a></td><td>Barley (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=735211005\">735211005</a></td><td>Coconut (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=735212003\">735212003</a></td><td>Papaya (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=735213008\">735213008</a></td><td>Cucumber (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=735214002\">735214002</a></td><td>Apricot (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=735215001\">735215001</a></td><td>Apple (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=735248001\">735248001</a></td><td>Cherry (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=735249009\">735249009</a></td><td>Avocado (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=735340006\">735340006</a></td><td>Lemon (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=735959004\">735959004</a></td><td>Marine mollusk (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=735971005\">735971005</a></td><td>Fish (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=735977009\">735977009</a></td><td>Marine crustacean (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=736027000\">736027000</a></td><td>Scallop (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=736030007\">736030007</a></td><td>Clam (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=736031006\">736031006</a></td><td>Oyster (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=736159005\">736159005</a></td><td>Crab (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=736162008\">736162008</a></td><td>Lobster (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=74801000\">74801000</a></td><td>Sugar (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=75665004\">75665004</a></td><td>Monosodium glutamate (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=762952008\">762952008</a></td><td>Peanut (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=7791007\">7791007</a></td><td>Soy protein (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=80259003\">80259003</a></td><td>Food flavoring agent (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=84489001\">84489001</a></td><td>Mold (organism)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=89119000\">89119000</a></td><td>Nitrate salt (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=89707004\">89707004</a></td><td>Sesame oil (substance)</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=89811004\">89811004</a></td><td>Gluten (substance)</td><td/></tr></table></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-allergy-substance",
-	"identifier": [
-		{
-			"system": "urn:ietf:rfc:3986",
-			"value": "urn:oid:2.16.840.1.113762.1.4.1186.8"
-		}
-	],
-	"version": "3.1.1",
-	"name": "USCoreAllergySubstance",
-	"title": "US Core Common substances for allergy and intolerance documentation including refutations",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Documentation of substances suspected of (or not suspected of) causing an allergy or intolerance reaction in an individual. **Inclusion Criteria:** specific or general substances to which a patient may be exposed and which may be suspected of causing an adverse reaction; assertions refuting these suspicions. This includes:\n\n 1. Common dietary substances for allergy and intolerance documentation (SNOMEDCT)\n 2. Common drug classes for allergy and intolerance documentation (SNOMEDCT)\n 3. Common drug substances for allergy and intolerance documentation (RXNORM)\n 4. Common environmental substances for allergy and intolerance documentation (SNOMEDCT)\n 5. Common refutations and null values for substance causes for allergy and intolerance documentation (SNOMEDCT)\n\n  **Exclusion Criteria:** actual conditions caused by exposure (reactions, allergies)\n",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"copyright": "This value set includes content from:\n  1. SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.\n  2. RxNorm: Using RxNorm codes of type SAB=RXNORM as this specification describes [does not require](https://www.nlm.nih.gov/research/umls/rxnorm/docs/prescribe.html) a UMLS license. Access to the full set of RxNorm definitions, and/or additional use of other RxNorm structures and information requires a UMLS license. The use of RxNorm in this specification is pursuant to HL7's status as a licensee of the NLM UMLS. HL7's license does not convey the right to use RxNorm to any users of this specification; implementers must acquire a license to use RxNorm in their own right.\n",
-	"compose": {
-		"include": [
-			{
-				"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
-				"concept": [
-					{
-						"code": "1002293",
-						"display": "formoterol / Mometasone"
-					},
-					{
-						"code": "1007388",
-						"display": "Lactase / rennet"
-					},
-					{
-						"code": "1008298",
-						"display": "Acetaminophen / Caffeine / Chlorpheniramine / Hydrocodone / Phenylephrine"
-					},
-					{
-						"code": "1008519",
-						"display": "guaiacolsulfonate / Hydrocodone"
-					},
-					{
-						"code": "1009148",
-						"display": "Ampicillin / Sulbactam"
-					},
-					{
-						"code": "10109",
-						"display": "Streptomycin"
-					},
-					{
-						"code": "10154",
-						"display": "Succinylcholine"
-					},
-					{
-						"code": "10156",
-						"display": "Sucralfate"
-					},
-					{
-						"code": "10169",
-						"display": "Sulfacetamide"
-					},
-					{
-						"code": "10171",
-						"display": "Sulfadiazine"
-					},
-					{
-						"code": "10180",
-						"display": "Sulfamethoxazole"
-					},
-					{
-						"code": "10207",
-						"display": "Sulfisoxazole"
-					},
-					{
-						"code": "10223",
-						"display": "Sulfur"
-					},
-					{
-						"code": "10237",
-						"display": "Sulindac"
-					},
-					{
-						"code": "10324",
-						"display": "Tamoxifen"
-					},
-					{
-						"code": "10355",
-						"display": "Temazepam"
-					},
-					{
-						"code": "10368",
-						"display": "Terbutaline"
-					},
-					{
-						"code": "1037042",
-						"display": "dabigatran etexilate"
-					},
-					{
-						"code": "10379",
-						"display": "Testosterone"
-					},
-					{
-						"code": "10395",
-						"display": "Tetracycline"
-					},
-					{
-						"code": "103990",
-						"display": "Carbidopa / Levodopa"
-					},
-					{
-						"code": "1040028",
-						"display": "lurasidone"
-					},
-					{
-						"code": "10438",
-						"display": "Theophylline"
-					},
-					{
-						"code": "10472",
-						"display": "Thimerosal"
-					},
-					{
-						"code": "10493",
-						"display": "Thiopental"
-					},
-					{
-						"code": "10502",
-						"display": "Thioridazine"
-					},
-					{
-						"code": "10510",
-						"display": "Thiothixene"
-					},
-					{
-						"code": "10582",
-						"display": "levothyroxine"
-					},
-					{
-						"code": "10594",
-						"display": "Ticlopidine"
-					},
-					{
-						"code": "10600",
-						"display": "Timolol"
-					},
-					{
-						"code": "10627",
-						"display": "Tobramycin"
-					},
-					{
-						"code": "10636",
-						"display": "Tolmetin"
-					},
-					{
-						"code": "10689",
-						"display": "Tramadol"
-					},
-					{
-						"code": "10737",
-						"display": "Trazodone"
-					},
-					{
-						"code": "10759",
-						"display": "Triamcinolone"
-					},
-					{
-						"code": "107602",
-						"display": "Epinephrine / Lidocaine"
-					},
-					{
-						"code": "10763",
-						"display": "Triamterene"
-					},
-					{
-						"code": "10767",
-						"display": "Triazolam"
-					},
-					{
-						"code": "10800",
-						"display": "Trifluoperazine"
-					},
-					{
-						"code": "108118",
-						"display": "Mometasone"
-					},
-					{
-						"code": "10829",
-						"display": "Trimethoprim"
-					},
-					{
-						"code": "10831",
-						"display": "Sulfamethoxazole / Trimethoprim"
-					},
-					{
-						"code": "11124",
-						"display": "Vancomycin"
-					},
-					{
-						"code": "1114195",
-						"display": "rivaroxaban"
-					},
-					{
-						"code": "1116632",
-						"display": "Ticagrelor"
-					},
-					{
-						"code": "11170",
-						"display": "Verapamil"
-					},
-					{
-						"code": "11248",
-						"display": "Vitamin B 12"
-					},
-					{
-						"code": "11253",
-						"display": "Vitamin D"
-					},
-					{
-						"code": "11256",
-						"display": "Vitamin E"
-					},
-					{
-						"code": "11289",
-						"display": "Warfarin"
-					},
-					{
-						"code": "113588",
-						"display": "Erythromycin / Sulfisoxazole"
-					},
-					{
-						"code": "11416",
-						"display": "Zinc"
-					},
-					{
-						"code": "11423",
-						"display": "Zinc Oxide"
-					},
-					{
-						"code": "114477",
-						"display": "Levetiracetam"
-					},
-					{
-						"code": "114970",
-						"display": "zafirlukast"
-					},
-					{
-						"code": "114979",
-						"display": "rabeprazole"
-					},
-					{
-						"code": "1151",
-						"display": "Ascorbic Acid"
-					},
-					{
-						"code": "115264",
-						"display": "Ibandronate"
-					},
-					{
-						"code": "115552",
-						"display": "trovafloxacin"
-					},
-					{
-						"code": "115698",
-						"display": "ziprasidone"
-					},
-					{
-						"code": "1191",
-						"display": "Aspirin"
-					},
-					{
-						"code": "119565",
-						"display": "tolterodine"
-					},
-					{
-						"code": "1202",
-						"display": "Atenolol"
-					},
-					{
-						"code": "121191",
-						"display": "rituximab"
-					},
-					{
-						"code": "1223",
-						"display": "Atropine"
-					},
-					{
-						"code": "1256",
-						"display": "Azathioprine"
-					},
-					{
-						"code": "1272",
-						"display": "Aztreonam"
-					},
-					{
-						"code": "1291",
-						"display": "Bacitracin"
-					},
-					{
-						"code": "1292",
-						"display": "Baclofen"
-					},
-					{
-						"code": "1310171",
-						"display": "Gadolinium"
-					},
-					{
-						"code": "1311085",
-						"display": "xanthine"
-					},
-					{
-						"code": "1311524",
-						"display": "Aspartame"
-					},
-					{
-						"code": "1311629",
-						"display": "nickel"
-					},
-					{
-						"code": "1314891",
-						"display": "Latex"
-					},
-					{
-						"code": "1331",
-						"display": "Barium Sulfate"
-					},
-					{
-						"code": "134615",
-						"display": "brimonidine"
-					},
-					{
-						"code": "1347",
-						"display": "Beclomethasone"
-					},
-					{
-						"code": "135447",
-						"display": "donepezil"
-					},
-					{
-						"code": "135775",
-						"display": "zolmitriptan"
-					},
-					{
-						"code": "1359",
-						"display": "Belladonna Alkaloids"
-					},
-					{
-						"code": "1362879",
-						"display": "Sulfur Dioxide"
-					},
-					{
-						"code": "1363043",
-						"display": "ethyl ether"
-					},
-					{
-						"code": "136411",
-						"display": "sildenafil"
-					},
-					{
-						"code": "1364430",
-						"display": "apixaban"
-					},
-					{
-						"code": "138099",
-						"display": "gemifloxacin"
-					},
-					{
-						"code": "139462",
-						"display": "moxifloxacin"
-					},
-					{
-						"code": "1399",
-						"display": "Benzocaine"
-					},
-					{
-						"code": "140587",
-						"display": "celecoxib"
-					},
-					{
-						"code": "1406",
-						"display": "benzoin resin"
-					},
-					{
-						"code": "141626",
-						"display": "colesevelam"
-					},
-					{
-						"code": "1418",
-						"display": "Benzoyl Peroxide"
-					},
-					{
-						"code": "1424",
-						"display": "Benztropine"
-					},
-					{
-						"code": "1514",
-						"display": "Betamethasone"
-					},
-					{
-						"code": "153970",
-						"display": "Hyoscyamine"
-					},
-					{
-						"code": "1596450",
-						"display": "Gentamicin"
-					},
-					{
-						"code": "15996",
-						"display": "Mirtazapine"
-					},
-					{
-						"code": "161",
-						"display": "Acetaminophen"
-					},
-					{
-						"code": "16681",
-						"display": "Acarbose"
-					},
-					{
-						"code": "167",
-						"display": "Acetazolamide"
-					},
-					{
-						"code": "17128",
-						"display": "lansoprazole"
-					},
-					{
-						"code": "1727875",
-						"display": "Tetanus immune globulin"
-					},
-					{
-						"code": "17300",
-						"display": "alfuzosin"
-					},
-					{
-						"code": "17767",
-						"display": "Amlodipine"
-					},
-					{
-						"code": "1827",
-						"display": "Buspirone"
-					},
-					{
-						"code": "183379",
-						"display": "rivastigmine"
-					},
-					{
-						"code": "1841",
-						"display": "Butorphanol"
-					},
-					{
-						"code": "18631",
-						"display": "Azithromycin"
-					},
-					{
-						"code": "187832",
-						"display": "pregabalin"
-					},
-					{
-						"code": "1886",
-						"display": "Caffeine"
-					},
-					{
-						"code": "18867",
-						"display": "benazepril"
-					},
-					{
-						"code": "1895",
-						"display": "Calcium"
-					},
-					{
-						"code": "1897",
-						"display": "Calcium Carbonate"
-					},
-					{
-						"code": "18993",
-						"display": "benzonatate"
-					},
-					{
-						"code": "190376",
-						"display": "linezolid"
-					},
-					{
-						"code": "191831",
-						"display": "infliximab"
-					},
-					{
-						"code": "19478",
-						"display": "bismuth subsalicylate"
-					},
-					{
-						"code": "19552",
-						"display": "cefprozil"
-					},
-					{
-						"code": "19711",
-						"display": "Amoxicillin / Clavulanate"
-					},
-					{
-						"code": "19831",
-						"display": "Budesonide"
-					},
-					{
-						"code": "1998",
-						"display": "Captopril"
-					},
-					{
-						"code": "2002",
-						"display": "Carbamazepine"
-					},
-					{
-						"code": "20352",
-						"display": "carvedilol"
-					},
-					{
-						"code": "20481",
-						"display": "cefepime"
-					},
-					{
-						"code": "20489",
-						"display": "cefpodoxime"
-					},
-					{
-						"code": "20610",
-						"display": "Cetirizine"
-					},
-					{
-						"code": "2101",
-						"display": "Carisoprodol"
-					},
-					{
-						"code": "21107",
-						"display": "cilostazol"
-					},
-					{
-						"code": "21183",
-						"display": "Citric Acid"
-					},
-					{
-						"code": "21212",
-						"display": "Clarithromycin"
-					},
-					{
-						"code": "214130",
-						"display": "Acetaminophen / butalbital / Caffeine"
-					},
-					{
-						"code": "214153",
-						"display": "Acetaminophen / dichloralphenazone / isometheptene"
-					},
-					{
-						"code": "214159",
-						"display": "Aspirin / butalbital / Caffeine"
-					},
-					{
-						"code": "214160",
-						"display": "Aspirin / butalbital / Caffeine / Codeine"
-					},
-					{
-						"code": "214181",
-						"display": "Acetaminophen / Diphenhydramine"
-					},
-					{
-						"code": "214182",
-						"display": "Acetaminophen / Hydrocodone"
-					},
-					{
-						"code": "214183",
-						"display": "Acetaminophen / Oxycodone"
-					},
-					{
-						"code": "214199",
-						"display": "Albuterol / Ipratropium"
-					},
-					{
-						"code": "214223",
-						"display": "Amlodipine / benazepril"
-					},
-					{
-						"code": "214250",
-						"display": "Aspirin / Caffeine"
-					},
-					{
-						"code": "214256",
-						"display": "Aspirin / Oxycodone"
-					},
-					{
-						"code": "214257",
-						"display": "Aspirin / Pentazocine"
-					},
-					{
-						"code": "214317",
-						"display": "Bisoprolol / Hydrochlorothiazide"
-					},
-					{
-						"code": "214336",
-						"display": "Caffeine / Ergotamine"
-					},
-					{
-						"code": "214354",
-						"display": "candesartan"
-					},
-					{
-						"code": "214364",
-						"display": "carbinoxamine / Pseudoephedrine"
-					},
-					{
-						"code": "214392",
-						"display": "Chlorpheniramine / Hydrocodone"
-					},
-					{
-						"code": "214442",
-						"display": "Codeine / Guaifenesin"
-					},
-					{
-						"code": "214445",
-						"display": "Codeine / Pseudoephedrine"
-					},
-					{
-						"code": "214488",
-						"display": "Dextromethorphan / Guaifenesin"
-					},
-					{
-						"code": "214502",
-						"display": "Diclofenac / Misoprostol"
-					},
-					{
-						"code": "214555",
-						"display": "Etanercept"
-					},
-					{
-						"code": "214558",
-						"display": "Ethinyl Estradiol / Levonorgestrel"
-					},
-					{
-						"code": "214565",
-						"display": "fexofenadine / Pseudoephedrine"
-					},
-					{
-						"code": "214599",
-						"display": "Guaifenesin / Pseudoephedrine"
-					},
-					{
-						"code": "214614",
-						"display": "homatropine / Hydrocodone"
-					},
-					{
-						"code": "214617",
-						"display": "Hydrochlorothiazide / irbesartan"
-					},
-					{
-						"code": "214618",
-						"display": "Hydrochlorothiazide / Lisinopril"
-					},
-					{
-						"code": "214619",
-						"display": "Hydrochlorothiazide / Losartan"
-					},
-					{
-						"code": "214626",
-						"display": "Hydrochlorothiazide / valsartan"
-					},
-					{
-						"code": "214627",
-						"display": "Hydrocodone / Ibuprofen"
-					},
-					{
-						"code": "214631",
-						"display": "Hydrocodone / Pseudoephedrine"
-					},
-					{
-						"code": "214682",
-						"display": "Loratadine / Pseudoephedrine"
-					},
-					{
-						"code": "214721",
-						"display": "Naloxone / Pentazocine"
-					},
-					{
-						"code": "214807",
-						"display": "Pseudoephedrine / Triprolidine"
-					},
-					{
-						"code": "2176",
-						"display": "Cefaclor"
-					},
-					{
-						"code": "217627",
-						"display": "Hydrocortisone / Neomycin / Polymyxin B"
-					},
-					{
-						"code": "2177",
-						"display": "Cefadroxil"
-					},
-					{
-						"code": "2180",
-						"display": "Cefazolin"
-					},
-					{
-						"code": "2189",
-						"display": "Cefoxitin"
-					},
-					{
-						"code": "2191",
-						"display": "Ceftazidime"
-					},
-					{
-						"code": "2193",
-						"display": "Ceftriaxone"
-					},
-					{
-						"code": "219314",
-						"display": "Polymyxin B / Trimethoprim"
-					},
-					{
-						"code": "219315",
-						"display": "Iron polysaccharide"
-					},
-					{
-						"code": "2194",
-						"display": "Cefuroxime"
-					},
-					{
-						"code": "21949",
-						"display": "cyclobenzaprine"
-					},
-					{
-						"code": "221147",
-						"display": "POLYETHYLENE GLYCOL 3350"
-					},
-					{
-						"code": "22299",
-						"display": "Daptomycin"
-					},
-					{
-						"code": "2231",
-						"display": "Cephalexin"
-					},
-					{
-						"code": "226716",
-						"display": "Aspirin / Dipyridamole"
-					},
-					{
-						"code": "228476",
-						"display": "gatifloxacin"
-					},
-					{
-						"code": "228790",
-						"display": "Dutasteride"
-					},
-					{
-						"code": "232158",
-						"display": "rofecoxib"
-					},
-					{
-						"code": "233698",
-						"display": "dronedarone"
-					},
-					{
-						"code": "2348",
-						"display": "Chloramphenicol"
-					},
-					{
-						"code": "2356",
-						"display": "Chlordiazepoxide"
-					},
-					{
-						"code": "2358",
-						"display": "Chlorhexidine"
-					},
-					{
-						"code": "236778",
-						"display": "Trospium"
-					},
-					{
-						"code": "237159",
-						"display": "Levalbuterol"
-					},
-					{
-						"code": "2393",
-						"display": "Chloroquine"
-					},
-					{
-						"code": "2400",
-						"display": "Chlorpheniramine"
-					},
-					{
-						"code": "2403",
-						"display": "Chlorpromazine"
-					},
-					{
-						"code": "2409",
-						"display": "Chlorthalidone"
-					},
-					{
-						"code": "2410",
-						"display": "Chlorzoxazone"
-					},
-					{
-						"code": "2418",
-						"display": "Cholecalciferol"
-					},
-					{
-						"code": "2447",
-						"display": "Cholestyramine Resin"
-					},
-					{
-						"code": "24605",
-						"display": "Etodolac"
-					},
-					{
-						"code": "24947",
-						"display": "ferrous sulfate"
-					},
-					{
-						"code": "25025",
-						"display": "Finasteride"
-					},
-					{
-						"code": "25033",
-						"display": "Cefixime"
-					},
-					{
-						"code": "25037",
-						"display": "cefdinir"
-					},
-					{
-						"code": "25120",
-						"display": "flunisolide"
-					},
-					{
-						"code": "25255",
-						"display": "formoterol"
-					},
-					{
-						"code": "253157",
-						"display": "Bee pollen"
-					},
-					{
-						"code": "2541",
-						"display": "Cimetidine"
-					},
-					{
-						"code": "25480",
-						"display": "gabapentin"
-					},
-					{
-						"code": "2551",
-						"display": "Ciprofloxacin"
-					},
-					{
-						"code": "2556",
-						"display": "Citalopram"
-					},
-					{
-						"code": "25789",
-						"display": "glimepiride"
-					},
-					{
-						"code": "2582",
-						"display": "Clindamycin"
-					},
-					{
-						"code": "258337",
-						"display": "Hydrochlorothiazide / Triamterene"
-					},
-					{
-						"code": "2598",
-						"display": "Clonazepam"
-					},
-					{
-						"code": "2599",
-						"display": "Clonidine"
-					},
-					{
-						"code": "260101",
-						"display": "Oseltamivir"
-					},
-					{
-						"code": "26225",
-						"display": "Ondansetron"
-					},
-					{
-						"code": "2623",
-						"display": "Clotrimazole"
-					},
-					{
-						"code": "2670",
-						"display": "Codeine"
-					},
-					{
-						"code": "2683",
-						"display": "Colchicine"
-					},
-					{
-						"code": "2685",
-						"display": "Colestipol"
-					},
-					{
-						"code": "27169",
-						"display": "leflunomide"
-					},
-					{
-						"code": "274783",
-						"display": "Insulin Glargine"
-					},
-					{
-						"code": "274786",
-						"display": "telithromycin"
-					},
-					{
-						"code": "27723",
-						"display": "iodinated glycerol"
-					},
-					{
-						"code": "278567",
-						"display": "valdecoxib"
-					},
-					{
-						"code": "28031",
-						"display": "Itraconazole"
-					},
-					{
-						"code": "281",
-						"display": "Acyclovir"
-					},
-					{
-						"code": "283742",
-						"display": "Esomeprazole"
-					},
-					{
-						"code": "283809",
-						"display": "travoprost"
-					},
-					{
-						"code": "28439",
-						"display": "lamotrigine"
-					},
-					{
-						"code": "284635",
-						"display": "fluticasone / salmeterol"
-					},
-					{
-						"code": "2878",
-						"display": "Cortisone"
-					},
-					{
-						"code": "28889",
-						"display": "Loratadine"
-					},
-					{
-						"code": "28981",
-						"display": "loracarbef"
-					},
-					{
-						"code": "29046",
-						"display": "Lisinopril"
-					},
-					{
-						"code": "29542",
-						"display": "Mercury, Ammoniated"
-					},
-					{
-						"code": "29561",
-						"display": "meropenem"
-					},
-					{
-						"code": "296",
-						"display": "Adenosine"
-					},
-					{
-						"code": "3008",
-						"display": "Cyclosporine"
-					},
-					{
-						"code": "301542",
-						"display": "rosuvastatin"
-					},
-					{
-						"code": "306674",
-						"display": "vardenafil"
-					},
-					{
-						"code": "3108",
-						"display": "Dapsone"
-					},
-					{
-						"code": "3143",
-						"display": "prasterone"
-					},
-					{
-						"code": "31448",
-						"display": "nabumetone"
-					},
-					{
-						"code": "31555",
-						"display": "nebivolol"
-					},
-					{
-						"code": "31565",
-						"display": "nefazodone"
-					},
-					{
-						"code": "31738",
-						"display": "nickel sulfate"
-					},
-					{
-						"code": "318340",
-						"display": "Aloe vera preparation"
-					},
-					{
-						"code": "321064",
-						"display": "olmesartan"
-					},
-					{
-						"code": "321988",
-						"display": "Escitalopram"
-					},
-					{
-						"code": "322167",
-						"display": "Solifenacin"
-					},
-					{
-						"code": "3247",
-						"display": "Desipramine"
-					},
-					{
-						"code": "325642",
-						"display": "ertapenem"
-					},
-					{
-						"code": "32592",
-						"display": "oxaliplatin"
-					},
-					{
-						"code": "32613",
-						"display": "oxaprozin"
-					},
-					{
-						"code": "32624",
-						"display": "oxcarbazepine"
-					},
-					{
-						"code": "3264",
-						"display": "Dexamethasone"
-					},
-					{
-						"code": "32675",
-						"display": "oxybutynin"
-					},
-					{
-						"code": "327361",
-						"display": "adalimumab"
-					},
-					{
-						"code": "3289",
-						"display": "Dextromethorphan"
-					},
-					{
-						"code": "32937",
-						"display": "Paroxetine"
-					},
-					{
-						"code": "32968",
-						"display": "clopidogrel"
-					},
-					{
-						"code": "3322",
-						"display": "Diazepam"
-					},
-					{
-						"code": "33408",
-						"display": "phenyltoloxamine"
-					},
-					{
-						"code": "3355",
-						"display": "Diclofenac"
-					},
-					{
-						"code": "3356",
-						"display": "Dicloxacillin"
-					},
-					{
-						"code": "3361",
-						"display": "Dicyclomine"
-					},
-					{
-						"code": "33738",
-						"display": "pioglitazone"
-					},
-					{
-						"code": "3393",
-						"display": "Diflunisal"
-					},
-					{
-						"code": "3407",
-						"display": "Digoxin"
-					},
-					{
-						"code": "341248",
-						"display": "ezetimibe"
-					},
-					{
-						"code": "3418",
-						"display": "Dihydroergotamine"
-					},
-					{
-						"code": "3423",
-						"display": "Hydromorphone"
-					},
-					{
-						"code": "3443",
-						"display": "Diltiazem"
-					},
-					{
-						"code": "3444",
-						"display": "Dimenhydrinate"
-					},
-					{
-						"code": "3498",
-						"display": "Diphenhydramine"
-					},
-					{
-						"code": "35208",
-						"display": "quinapril"
-					},
-					{
-						"code": "3521",
-						"display": "Dipyridamole"
-					},
-					{
-						"code": "352362",
-						"display": "Acetaminophen / Tramadol"
-					},
-					{
-						"code": "35296",
-						"display": "Ramipril"
-					},
-					{
-						"code": "35382",
-						"display": "resorcinol"
-					},
-					{
-						"code": "35636",
-						"display": "Risperidone"
-					},
-					{
-						"code": "358263",
-						"display": "tadalafil"
-					},
-					{
-						"code": "35827",
-						"display": "Ketorolac"
-					},
-					{
-						"code": "35829",
-						"display": "ranolazine"
-					},
-					{
-						"code": "36108",
-						"display": "Salsalate"
-					},
-					{
-						"code": "36117",
-						"display": "salmeterol"
-					},
-					{
-						"code": "3616",
-						"display": "Dobutamine"
-					},
-					{
-						"code": "3638",
-						"display": "Doxepin"
-					},
-					{
-						"code": "3640",
-						"display": "Doxycycline"
-					},
-					{
-						"code": "36437",
-						"display": "Sertraline"
-					},
-					{
-						"code": "3648",
-						"display": "Droperidol"
-					},
-					{
-						"code": "36567",
-						"display": "Simvastatin"
-					},
-					{
-						"code": "37418",
-						"display": "Sumatriptan"
-					},
-					{
-						"code": "37617",
-						"display": "tazobactam"
-					},
-					{
-						"code": "37798",
-						"display": "Terazosin"
-					},
-					{
-						"code": "37801",
-						"display": "terbinafine"
-					},
-					{
-						"code": "3827",
-						"display": "Enalapril"
-					},
-					{
-						"code": "3829",
-						"display": "Enalaprilat"
-					},
-					{
-						"code": "38400",
-						"display": "atomoxetine"
-					},
-					{
-						"code": "38404",
-						"display": "topiramate"
-					},
-					{
-						"code": "38413",
-						"display": "torsemide"
-					},
-					{
-						"code": "38574",
-						"display": "trichloroacetaldehyde"
-					},
-					{
-						"code": "38685",
-						"display": "trimethobenzamide"
-					},
-					{
-						"code": "389132",
-						"display": "Budesonide / formoterol"
-					},
-					{
-						"code": "3966",
-						"display": "Ephedrine"
-					},
-					{
-						"code": "39786",
-						"display": "venlafaxine"
-					},
-					{
-						"code": "3992",
-						"display": "Epinephrine"
-					},
-					{
-						"code": "39993",
-						"display": "zolpidem"
-					},
-					{
-						"code": "39998",
-						"display": "zonisamide"
-					},
-					{
-						"code": "40048",
-						"display": "Carboplatin"
-					},
-					{
-						"code": "400674",
-						"display": "dexbrompheniramine / Pseudoephedrine"
-					},
-					{
-						"code": "4025",
-						"display": "Ergotamine"
-					},
-					{
-						"code": "40254",
-						"display": "Valproate"
-					},
-					{
-						"code": "4053",
-						"display": "Erythromycin"
-					},
-					{
-						"code": "40575",
-						"display": "zileuton"
-					},
-					{
-						"code": "40790",
-						"display": "pantoprazole"
-					},
-					{
-						"code": "4083",
-						"display": "Estradiol"
-					},
-					{
-						"code": "4099",
-						"display": "Estrogens, Conjugated (USP)"
-					},
-					{
-						"code": "41126",
-						"display": "fluticasone"
-					},
-					{
-						"code": "41127",
-						"display": "fluvastatin"
-					},
-					{
-						"code": "4124",
-						"display": "Ethinyl Estradiol"
-					},
-					{
-						"code": "41397",
-						"display": "Lactase"
-					},
-					{
-						"code": "41493",
-						"display": "meloxicam"
-					},
-					{
-						"code": "42330",
-						"display": "Terfenadine"
-					},
-					{
-						"code": "42331",
-						"display": "Misoprostol"
-					},
-					{
-						"code": "42347",
-						"display": "Bupropion"
-					},
-					{
-						"code": "42351",
-						"display": "Lithium Carbonate"
-					},
-					{
-						"code": "42372",
-						"display": "Mupirocin"
-					},
-					{
-						"code": "42463",
-						"display": "Pravastatin"
-					},
-					{
-						"code": "4278",
-						"display": "Famotidine"
-					},
-					{
-						"code": "4316",
-						"display": "Felodipine"
-					},
-					{
-						"code": "4337",
-						"display": "Fentanyl"
-					},
-					{
-						"code": "435",
-						"display": "Albuterol"
-					},
-					{
-						"code": "43611",
-						"display": "latanoprost"
-					},
-					{
-						"code": "4419",
-						"display": "Fish Oils"
-					},
-					{
-						"code": "4441",
-						"display": "Flecainide"
-					},
-					{
-						"code": "4450",
-						"display": "Fluconazole"
-					},
-					{
-						"code": "448",
-						"display": "Ethanol"
-					},
-					{
-						"code": "4492",
-						"display": "Fluorouracil"
-					},
-					{
-						"code": "4493",
-						"display": "Fluoxetine"
-					},
-					{
-						"code": "4496",
-						"display": "Fluphenazine"
-					},
-					{
-						"code": "4500",
-						"display": "Flurandrenolide"
-					},
-					{
-						"code": "4530",
-						"display": "Formaldehyde"
-					},
-					{
-						"code": "4603",
-						"display": "Furosemide"
-					},
-					{
-						"code": "46041",
-						"display": "Alendronate"
-					},
-					{
-						"code": "461016",
-						"display": "Eszopiclone"
-					},
-					{
-						"code": "4637",
-						"display": "Galantamine"
-					},
-					{
-						"code": "465397",
-						"display": "Ciprofloxacin / Dexamethasone"
-					},
-					{
-						"code": "466522",
-						"display": "Diphenhydramine / Zinc Acetate"
-					},
-					{
-						"code": "466541",
-						"display": "Neomycin / Polymyxin B"
-					},
-					{
-						"code": "466549",
-						"display": "Aspirin / Caffeine / Orphenadrine"
-					},
-					{
-						"code": "466553",
-						"display": "penicillin G benzathine / penicillin G procaine"
-					},
-					{
-						"code": "466566",
-						"display": "Acetaminophen / Dextromethorphan / Diphenhydramine / Pseudoephedrine"
-					},
-					{
-						"code": "466584",
-						"display": "Acetaminophen / Aspirin / Caffeine"
-					},
-					{
-						"code": "4719",
-						"display": "Gemfibrozil"
-					},
-					{
-						"code": "475968",
-						"display": "liraglutide"
-					},
-					{
-						"code": "4815",
-						"display": "Glyburide"
-					},
-					{
-						"code": "48203",
-						"display": "Clavulanate"
-					},
-					{
-						"code": "4821",
-						"display": "Glipizide"
-					},
-					{
-						"code": "48274",
-						"display": "Acetaminophen / Propoxyphene"
-					},
-					{
-						"code": "484139",
-						"display": "Chlorhexidine / Isopropyl Alcohol"
-					},
-					{
-						"code": "484211",
-						"display": "ezetimibe / Simvastatin"
-					},
-					{
-						"code": "4850",
-						"display": "Glucose"
-					},
-					{
-						"code": "4917",
-						"display": "Nitroglycerin"
-					},
-					{
-						"code": "49276",
-						"display": "Doxazosin"
-					},
-					{
-						"code": "50166",
-						"display": "Fosinopril"
-					},
-					{
-						"code": "5021",
-						"display": "Griseofulvin"
-					},
-					{
-						"code": "5032",
-						"display": "Guaifenesin"
-					},
-					{
-						"code": "5093",
-						"display": "Haloperidol"
-					},
-					{
-						"code": "51272",
-						"display": "quetiapine"
-					},
-					{
-						"code": "519",
-						"display": "Allopurinol"
-					},
-					{
-						"code": "52175",
-						"display": "Losartan"
-					},
-					{
-						"code": "5224",
-						"display": "heparin"
-					},
-					{
-						"code": "52582",
-						"display": "mesalamine"
-					},
-					{
-						"code": "5470",
-						"display": "Hydralazine"
-					},
-					{
-						"code": "5487",
-						"display": "Hydrochlorothiazide"
-					},
-					{
-						"code": "5489",
-						"display": "Hydrocodone"
-					},
-					{
-						"code": "5492",
-						"display": "Hydrocortisone"
-					},
-					{
-						"code": "5499",
-						"display": "Hydrogen Peroxide"
-					},
-					{
-						"code": "5521",
-						"display": "Hydroxychloroquine"
-					},
-					{
-						"code": "5553",
-						"display": "Hydroxyzine"
-					},
-					{
-						"code": "5640",
-						"display": "Ibuprofen"
-					},
-					{
-						"code": "5691",
-						"display": "Imipramine"
-					},
-					{
-						"code": "56946",
-						"display": "Paclitaxel"
-					},
-					{
-						"code": "57258",
-						"display": "tizanidine"
-					},
-					{
-						"code": "5764",
-						"display": "Indapamide"
-					},
-					{
-						"code": "5781",
-						"display": "Indomethacin"
-					},
-					{
-						"code": "588250",
-						"display": "milnacipran"
-					},
-					{
-						"code": "59078",
-						"display": "metaxalone"
-					},
-					{
-						"code": "591622",
-						"display": "varenicline"
-					},
-					{
-						"code": "5933",
-						"display": "Iodine"
-					},
-					{
-						"code": "593411",
-						"display": "sitagliptin"
-					},
-					{
-						"code": "594040",
-						"display": "Atropine / Diphenoxylate"
-					},
-					{
-						"code": "5956",
-						"display": "Iohexol"
-					},
-					{
-						"code": "596",
-						"display": "Alprazolam"
-					},
-					{
-						"code": "596723",
-						"display": "cerivastatin"
-					},
-					{
-						"code": "597142",
-						"display": "brimonidine / Timolol"
-					},
-					{
-						"code": "5992",
-						"display": "Iron-Dextran Complex"
-					},
-					{
-						"code": "60207",
-						"display": "dorzolamide"
-					},
-					{
-						"code": "6038",
-						"display": "isoniazid"
-					},
-					{
-						"code": "60548",
-						"display": "exenatide"
-					},
-					{
-						"code": "6057",
-						"display": "Isosorbide"
-					},
-					{
-						"code": "6058",
-						"display": "Isosorbide Dinitrate"
-					},
-					{
-						"code": "611854",
-						"display": "Chlordiazepoxide / clidinium"
-					},
-					{
-						"code": "6130",
-						"display": "Ketamine"
-					},
-					{
-						"code": "6135",
-						"display": "Ketoconazole"
-					},
-					{
-						"code": "61381",
-						"display": "olanzapine"
-					},
-					{
-						"code": "6142",
-						"display": "Ketoprofen"
-					},
-					{
-						"code": "6185",
-						"display": "Labetalol"
-					},
-					{
-						"code": "620",
-						"display": "Amantadine"
-					},
-					{
-						"code": "6218",
-						"display": "Lactulose"
-					},
-					{
-						"code": "6227",
-						"display": "Lanolin"
-					},
-					{
-						"code": "6387",
-						"display": "Lidocaine"
-					},
-					{
-						"code": "6398",
-						"display": "Lincomycin"
-					},
-					{
-						"code": "6448",
-						"display": "Lithium"
-					},
-					{
-						"code": "645555",
-						"display": "Bacitracin / Polymyxin B"
-					},
-					{
-						"code": "6468",
-						"display": "Loperamide"
-					},
-					{
-						"code": "6470",
-						"display": "Lorazepam"
-					},
-					{
-						"code": "6472",
-						"display": "Lovastatin"
-					},
-					{
-						"code": "6574",
-						"display": "Magnesium"
-					},
-					{
-						"code": "6585",
-						"display": "Magnesium Sulfate"
-					},
-					{
-						"code": "662263",
-						"display": "dorzolamide / Timolol"
-					},
-					{
-						"code": "6676",
-						"display": "Meclizine"
-					},
-					{
-						"code": "6691",
-						"display": "Medroxyprogesterone"
-					},
-					{
-						"code": "67108",
-						"display": "Enoxaparin"
-					},
-					{
-						"code": "6711",
-						"display": "Melatonin"
-					},
-					{
-						"code": "6719",
-						"display": "Memantine"
-					},
-					{
-						"code": "6750",
-						"display": "Menthol"
-					},
-					{
-						"code": "6754",
-						"display": "Meperidine"
-					},
-					{
-						"code": "6809",
-						"display": "Metformin"
-					},
-					{
-						"code": "6813",
-						"display": "Methadone"
-					},
-					{
-						"code": "6835",
-						"display": "Methimazole"
-					},
-					{
-						"code": "6845",
-						"display": "Methocarbamol"
-					},
-					{
-						"code": "6851",
-						"display": "Methotrexate"
-					},
-					{
-						"code": "6876",
-						"display": "Methyldopa"
-					},
-					{
-						"code": "689",
-						"display": "Aminophylline"
-					},
-					{
-						"code": "689467",
-						"display": "Oxytetracycline / Polymyxin B"
-					},
-					{
-						"code": "689518",
-						"display": "Aspirin / Caffeine / Propoxyphene"
-					},
-					{
-						"code": "689556",
-						"display": "Acetaminophen / Aspirin / Phenylpropanolamine"
-					},
-					{
-						"code": "689558",
-						"display": "Acetaminophen / Brompheniramine / Pseudoephedrine"
-					},
-					{
-						"code": "689561",
-						"display": "Acetaminophen / butalbital / Caffeine / Codeine"
-					},
-					{
-						"code": "689582",
-						"display": "Acetaminophen / Chlorpheniramine / Dextromethorphan / Pseudoephedrine"
-					},
-					{
-						"code": "689606",
-						"display": "Atropine / Hyoscyamine / Phenobarbital / Scopolamine"
-					},
-					{
-						"code": "689623",
-						"display": "Bacitracin / Hydrocortisone / Neomycin / Polymyxin B"
-					},
-					{
-						"code": "690077",
-						"display": "Benzalkonium / Lidocaine"
-					},
-					{
-						"code": "6901",
-						"display": "Methylphenidate"
-					},
-					{
-						"code": "6902",
-						"display": "Methylprednisolone"
-					},
-					{
-						"code": "690693",
-						"display": "Diphenhydramine / Phenylephrine"
-					},
-					{
-						"code": "690808",
-						"display": "Brompheniramine / Dextromethorphan / Pseudoephedrine"
-					},
-					{
-						"code": "69120",
-						"display": "tiotropium"
-					},
-					{
-						"code": "6915",
-						"display": "Metoclopramide"
-					},
-					{
-						"code": "6916",
-						"display": "Metolazone"
-					},
-					{
-						"code": "6918",
-						"display": "Metoprolol"
-					},
-					{
-						"code": "6922",
-						"display": "Metronidazole"
-					},
-					{
-						"code": "692572",
-						"display": "Bacitracin / Neomycin / Polymyxin B"
-					},
-					{
-						"code": "692794",
-						"display": "Gramicidin / Neomycin / Polymyxin B"
-					},
-					{
-						"code": "6932",
-						"display": "Miconazole"
-					},
-					{
-						"code": "6960",
-						"display": "Midazolam"
-					},
-					{
-						"code": "69749",
-						"display": "valsartan"
-					},
-					{
-						"code": "6980",
-						"display": "Minocycline"
-					},
-					{
-						"code": "6984",
-						"display": "Minoxidil"
-					},
-					{
-						"code": "703",
-						"display": "Amiodarone"
-					},
-					{
-						"code": "704",
-						"display": "Amitriptyline"
-					},
-					{
-						"code": "7052",
-						"display": "Morphine"
-					},
-					{
-						"code": "705258",
-						"display": "Acetaminophen / Dextromethorphan / Doxylamine"
-					},
-					{
-						"code": "7213",
-						"display": "Ipratropium"
-					},
-					{
-						"code": "72143",
-						"display": "Raloxifene"
-					},
-					{
-						"code": "72236",
-						"display": "fosphenytoin"
-					},
-					{
-						"code": "723",
-						"display": "Amoxicillin"
-					},
-					{
-						"code": "72302",
-						"display": "ropinirole"
-					},
-					{
-						"code": "7233",
-						"display": "Nafcillin"
-					},
-					{
-						"code": "7238",
-						"display": "Nalbuphine"
-					},
-					{
-						"code": "7243",
-						"display": "Naltrexone"
-					},
-					{
-						"code": "725",
-						"display": "Amphetamine"
-					},
-					{
-						"code": "7258",
-						"display": "Naproxen"
-					},
-					{
-						"code": "72625",
-						"display": "duloxetine"
-					},
-					{
-						"code": "7299",
-						"display": "Neomycin"
-					},
-					{
-						"code": "73056",
-						"display": "Risedronate"
-					},
-					{
-						"code": "733",
-						"display": "Ampicillin"
-					},
-					{
-						"code": "73494",
-						"display": "telmisartan"
-					},
-					{
-						"code": "73645",
-						"display": "valacyclovir"
-					},
-					{
-						"code": "7393",
-						"display": "Niacin"
-					},
-					{
-						"code": "7407",
-						"display": "Nicotine"
-					},
-					{
-						"code": "74169",
-						"display": "Piperacillin / tazobactam"
-					},
-					{
-						"code": "7417",
-						"display": "Nifedipine"
-					},
-					{
-						"code": "7454",
-						"display": "Nitrofurantoin"
-					},
-					{
-						"code": "746741",
-						"display": "Pramipexole"
-					},
-					{
-						"code": "7486",
-						"display": "Nitrous Oxide"
-					},
-					{
-						"code": "7517",
-						"display": "Norfloxacin"
-					},
-					{
-						"code": "7531",
-						"display": "Nortriptyline"
-					},
-					{
-						"code": "7597",
-						"display": "Nystatin"
-					},
-					{
-						"code": "7623",
-						"display": "Ofloxacin"
-					},
-					{
-						"code": "7646",
-						"display": "Omeprazole"
-					},
-					{
-						"code": "7676",
-						"display": "Opium"
-					},
-					{
-						"code": "7715",
-						"display": "Orphenadrine"
-					},
-					{
-						"code": "77492",
-						"display": "tamsulosin"
-					},
-					{
-						"code": "7804",
-						"display": "Oxycodone"
-					},
-					{
-						"code": "7821",
-						"display": "Oxytetracycline"
-					},
-					{
-						"code": "787390",
-						"display": "tapentadol"
-					},
-					{
-						"code": "7975",
-						"display": "Penicillamine"
-					},
-					{
-						"code": "797541",
-						"display": "Isopropyl Alcohol"
-					},
-					{
-						"code": "7980",
-						"display": "Penicillin G"
-					},
-					{
-						"code": "7984",
-						"display": "Penicillin V"
-					},
-					{
-						"code": "7994",
-						"display": "Pentamidine"
-					},
-					{
-						"code": "8001",
-						"display": "Pentazocine"
-					},
-					{
-						"code": "8120",
-						"display": "Phenazopyridine"
-					},
-					{
-						"code": "8134",
-						"display": "Phenobarbital"
-					},
-					{
-						"code": "815166",
-						"display": "Dextromethorphan / Doxylamine"
-					},
-					{
-						"code": "8163",
-						"display": "Phenylephrine"
-					},
-					{
-						"code": "816346",
-						"display": "dexlansoprazole"
-					},
-					{
-						"code": "8175",
-						"display": "Phenylpropanolamine"
-					},
-					{
-						"code": "817579",
-						"display": "Acetaminophen / Codeine"
-					},
-					{
-						"code": "817958",
-						"display": "Aspirin / Calcium Carbonate"
-					},
-					{
-						"code": "8183",
-						"display": "Phenytoin"
-					},
-					{
-						"code": "82122",
-						"display": "Levofloxacin"
-					},
-					{
-						"code": "822929",
-						"display": "Amphetamine aspartate / Amphetamine Sulfate / Dextroamphetamine saccharate / Dextroamphetamine Sulfate"
-					},
-					{
-						"code": "83367",
-						"display": "atorvastatin"
-					},
-					{
-						"code": "8356",
-						"display": "Piroxicam"
-					},
-					{
-						"code": "83818",
-						"display": "irbesartan"
-					},
-					{
-						"code": "84108",
-						"display": "rosiglitazone"
-					},
-					{
-						"code": "8536",
-						"display": "Polymyxin B"
-					},
-					{
-						"code": "857974",
-						"display": "saxagliptin"
-					},
-					{
-						"code": "8588",
-						"display": "Potassium"
-					},
-					{
-						"code": "8591",
-						"display": "Potassium Chloride"
-					},
-					{
-						"code": "8610",
-						"display": "Povidone"
-					},
-					{
-						"code": "8611",
-						"display": "Povidone-Iodine"
-					},
-					{
-						"code": "861634",
-						"display": "pitavastatin"
-					},
-					{
-						"code": "8629",
-						"display": "Prazosin"
-					},
-					{
-						"code": "8638",
-						"display": "prednisolone"
-					},
-					{
-						"code": "8640",
-						"display": "Prednisone"
-					},
-					{
-						"code": "8687",
-						"display": "Primaquine"
-					},
-					{
-						"code": "8691",
-						"display": "Primidone"
-					},
-					{
-						"code": "8698",
-						"display": "Probenecid"
-					},
-					{
-						"code": "8700",
-						"display": "Procainamide"
-					},
-					{
-						"code": "8701",
-						"display": "Procaine"
-					},
-					{
-						"code": "8703",
-						"display": "Fenofibrate"
-					},
-					{
-						"code": "8704",
-						"display": "Prochlorperazine"
-					},
-					{
-						"code": "8727",
-						"display": "Progesterone"
-					},
-					{
-						"code": "8745",
-						"display": "Promethazine"
-					},
-					{
-						"code": "8754",
-						"display": "Propafenone"
-					},
-					{
-						"code": "87636",
-						"display": "fexofenadine"
-					},
-					{
-						"code": "8782",
-						"display": "Propofol"
-					},
-					{
-						"code": "8785",
-						"display": "Propoxyphene"
-					},
-					{
-						"code": "8787",
-						"display": "Propranolol"
-					},
-					{
-						"code": "8794",
-						"display": "Propylthiouracil"
-					},
-					{
-						"code": "88014",
-						"display": "rizatriptan"
-					},
-					{
-						"code": "88249",
-						"display": "montelukast"
-					},
-					{
-						"code": "883815",
-						"display": "Dexamethasone / Tobramycin"
-					},
-					{
-						"code": "8896",
-						"display": "Pseudoephedrine"
-					},
-					{
-						"code": "89013",
-						"display": "aripiprazole"
-					},
-					{
-						"code": "8928",
-						"display": "Psyllium"
-					},
-					{
-						"code": "8948",
-						"display": "Purified Protein Derivative of Tuberculin"
-					},
-					{
-						"code": "90176",
-						"display": "Iron"
-					},
-					{
-						"code": "9068",
-						"display": "Quinidine"
-					},
-					{
-						"code": "9071",
-						"display": "Quinine"
-					},
-					{
-						"code": "91263",
-						"display": "Aloe Extract"
-					},
-					{
-						"code": "9143",
-						"display": "Ranitidine"
-					},
-					{
-						"code": "9384",
-						"display": "Rifampin"
-					},
-					{
-						"code": "9524",
-						"display": "Sulfasalazine"
-					},
-					{
-						"code": "9601",
-						"display": "Scopolamine"
-					},
-					{
-						"code": "9778",
-						"display": "Silicones"
-					},
-					{
-						"code": "9793",
-						"display": "silver sulfadiazine"
-					},
-					{
-						"code": "9947",
-						"display": "Sotalol"
-					},
-					{
-						"code": "9997",
-						"display": "Spironolactone"
-					}
-				]
-			},
-			{
-				"system": "http://snomed.info/sct",
-				"concept": [
-					{
-						"code": "102259006",
-						"display": "Citrus fruit (substance)"
-					},
-					{
-						"code": "102261002",
-						"display": "Strawberry (substance)"
-					},
-					{
-						"code": "102262009",
-						"display": "Chocolate (substance)"
-					},
-					{
-						"code": "102263004",
-						"display": "Eggs (edible) (substance)"
-					},
-					{
-						"code": "102264005",
-						"display": "Cheese (substance)"
-					},
-					{
-						"code": "111088007",
-						"display": "Latex (substance)"
-					},
-					{
-						"code": "111151007",
-						"display": "Anabolic steroid (substance)"
-					},
-					{
-						"code": "11526002",
-						"display": "Aspartame (substance)"
-					},
-					{
-						"code": "116274004",
-						"display": "Artificial sweetener (substance)"
-					},
-					{
-						"code": "116566001",
-						"display": "Steroid (substance)"
-					},
-					{
-						"code": "13577000",
-						"display": "Nut (substance)"
-					},
-					{
-						"code": "14443002",
-						"display": "Substance with aminoglycoside structure and antibacterial mechanism of action (substance)"
-					},
-					{
-						"code": "226723006",
-						"display": "Buckwheat - cereal (substance)"
-					},
-					{
-						"code": "226734009",
-						"display": "Wheatgerm (substance)"
-					},
-					{
-						"code": "226760005",
-						"display": "Dairy foods (substance)"
-					},
-					{
-						"code": "226915003",
-						"display": "Red meat (substance)"
-					},
-					{
-						"code": "226916002",
-						"display": "Beef (substance)"
-					},
-					{
-						"code": "226934003",
-						"display": "Pork (substance)"
-					},
-					{
-						"code": "226955001",
-						"display": "Chicken - meat (substance)"
-					},
-					{
-						"code": "226967004",
-						"display": "Turkey - meat (substance)"
-					},
-					{
-						"code": "227144008",
-						"display": "Tuna fish (substance)"
-					},
-					{
-						"code": "227151004",
-						"display": "Prawns (substance)"
-					},
-					{
-						"code": "227208008",
-						"display": "Abalone canned in brine (substance)"
-					},
-					{
-						"code": "227219006",
-						"display": "Aubergine (substance)"
-					},
-					{
-						"code": "227313005",
-						"display": "Pulse vegetables (substance)"
-					},
-					{
-						"code": "227388008",
-						"display": "Cinnamon (substance)"
-					},
-					{
-						"code": "227400003",
-						"display": "Ginger (substance)"
-					},
-					{
-						"code": "227421003",
-						"display": "Cranberries (substance)"
-					},
-					{
-						"code": "227444000",
-						"display": "Raspberries (substance)"
-					},
-					{
-						"code": "227493005",
-						"display": "Cashew nut (substance)"
-					},
-					{
-						"code": "227512001",
-						"display": "Pistachio nut (substance)"
-					},
-					{
-						"code": "227598003",
-						"display": "Honey (substance)"
-					},
-					{
-						"code": "228102000",
-						"display": "Sodium nitrate (substance)"
-					},
-					{
-						"code": "255632006",
-						"display": "Anticonvulsant (substance)"
-					},
-					{
-						"code": "255637000",
-						"display": "Salicylate (substance)"
-					},
-					{
-						"code": "255641001",
-						"display": "Caffeine (substance)"
-					},
-					{
-						"code": "256259004",
-						"display": "Pollen (substance)"
-					},
-					{
-						"code": "256277009",
-						"display": "Grass pollen (substance)"
-					},
-					{
-						"code": "256306003",
-						"display": "Orange - fruit (substance)"
-					},
-					{
-						"code": "256307007",
-						"display": "Banana (substance)"
-					},
-					{
-						"code": "256313003",
-						"display": "Pineapple (substance)"
-					},
-					{
-						"code": "256315005",
-						"display": "Grapefruit (substance)"
-					},
-					{
-						"code": "256317002",
-						"display": "Grapes (substance)"
-					},
-					{
-						"code": "256319004",
-						"display": "Carrot (substance)"
-					},
-					{
-						"code": "256326004",
-						"display": "Celery (substance)"
-					},
-					{
-						"code": "256329006",
-						"display": "Spinach (substance)"
-					},
-					{
-						"code": "256350002",
-						"display": "Almond (substance)"
-					},
-					{
-						"code": "256351003",
-						"display": "Brazil nut (substance)"
-					},
-					{
-						"code": "256352005",
-						"display": "Walnut - nut (substance)"
-					},
-					{
-						"code": "256353000",
-						"display": "Hazelnut (substance)"
-					},
-					{
-						"code": "256354006",
-						"display": "Bean (substance)"
-					},
-					{
-						"code": "256417003",
-						"display": "Horse dander (substance)"
-					},
-					{
-						"code": "256440004",
-						"display": "Wasp venom (substance)"
-					},
-					{
-						"code": "259858000",
-						"display": "Varicella-zoster virus antibody (substance)"
-					},
-					{
-						"code": "260152009",
-						"display": "Cat dander (substance)"
-					},
-					{
-						"code": "260154005",
-						"display": "Dog dander (substance)"
-					},
-					{
-						"code": "260167008",
-						"display": "Sesame seed (substance)"
-					},
-					{
-						"code": "260176001",
-						"display": "Kiwi fruit (substance)"
-					},
-					{
-						"code": "260177005",
-						"display": "Melon (substance)"
-					},
-					{
-						"code": "260179008",
-						"display": "Mango fruit (substance)"
-					},
-					{
-						"code": "260184002",
-						"display": "Peas (substance)"
-					},
-					{
-						"code": "260189007",
-						"display": "Pecan nut (substance)"
-					},
-					{
-						"code": "260205009",
-						"display": "Sunflower seed (substance)"
-					},
-					{
-						"code": "264287008",
-						"display": "Animal dander (substance)"
-					},
-					{
-						"code": "264337003",
-						"display": "Seed (substance)"
-					},
-					{
-						"code": "28230009",
-						"display": "Poultry (substance)"
-					},
-					{
-						"code": "288328004",
-						"display": "Bee venom (substance)"
-					},
-					{
-						"code": "28942008",
-						"display": "Coconut oil (substance)"
-					},
-					{
-						"code": "29263009",
-						"display": "Coffee (substance)"
-					},
-					{
-						"code": "304275008",
-						"display": "Corticosteroid and corticosteroid derivative (substance)"
-					},
-					{
-						"code": "33008008",
-						"display": "Dust (substance)"
-					},
-					{
-						"code": "350327004",
-						"display": "Diphtheria + tetanus vaccine (product)"
-					},
-					{
-						"code": "35748005",
-						"display": "Wine (substance)"
-					},
-					{
-						"code": "360201004",
-						"display": "Nitrofuran derivative (substance)"
-					},
-					{
-						"code": "3692009",
-						"display": "Sodium sulfite (substance)"
-					},
-					{
-						"code": "372480009",
-						"display": "Substance with macrolide structure and antibacterial mechanism of action (substance)"
-					},
-					{
-						"code": "372664007",
-						"display": "Benzodiazepine (substance)"
-					},
-					{
-						"code": "372665008",
-						"display": "Non-steroidal anti-inflammatory agent (substance)"
-					},
-					{
-						"code": "372711004",
-						"display": "Sulfonylurea (substance)"
-					},
-					{
-						"code": "372722000",
-						"display": "Substance with quinolone structure and antibacterial mechanism of action (substance)"
-					},
-					{
-						"code": "372733002",
-						"display": "Substance with angiotensin-converting enzyme inhibitor mechanism of action (substance)"
-					},
-					{
-						"code": "372747003",
-						"display": "Thiazide diuretic (substance)"
-					},
-					{
-						"code": "372783007",
-						"display": "Antiparkinsonian agent (substance)"
-					},
-					{
-						"code": "372798009",
-						"display": "Barbiturate (substance)"
-					},
-					{
-						"code": "372806008",
-						"display": "Substance with histamine receptor antagonist mechanism of action (substance)"
-					},
-					{
-						"code": "372889003",
-						"display": "First generation cephalosporin (substance)"
-					},
-					{
-						"code": "372912004",
-						"display": "Substance with 3-hydroxy-3-methylglutaryl-coenzyme A reductase inhibitor mechanism of action (substance)"
-					},
-					{
-						"code": "372913009",
-						"display": "Substance with angiotensin II receptor antagonist mechanism of action (substance)"
-					},
-					{
-						"code": "373206009",
-						"display": "Substance with tetracycline structure and antibacterial mechanism of action (substance)"
-					},
-					{
-						"code": "373253007",
-						"display": "Tricyclic antidepressant (substance)"
-					},
-					{
-						"code": "373254001",
-						"display": "Substance with beta adrenergic receptor antagonist mechanism of action (substance)"
-					},
-					{
-						"code": "373262009",
-						"display": "Substance with cephalosporin structure and antibacterial mechanism of action (substance)"
-					},
-					{
-						"code": "373270004",
-						"display": "Substance with penicillin structure and antibacterial mechanism of action (substance)"
-					},
-					{
-						"code": "373297006",
-						"display": "Substance with beta-lactam structure and antibacterial mechanism of action (substance)"
-					},
-					{
-						"code": "373304005",
-						"display": "Substance with calcium channel blocker mechanism of action (substance)"
-					},
-					{
-						"code": "373531009",
-						"display": "Gelatin (substance)"
-					},
-					{
-						"code": "385420005",
-						"display": "Contrast media (substance)"
-					},
-					{
-						"code": "386127005",
-						"display": "Formula milk (substance)"
-					},
-					{
-						"code": "386962001",
-						"display": "Plasma protein fraction (substance)"
-					},
-					{
-						"code": "387050005",
-						"display": "Substance with prostaglandin-endoperoxide synthase isoform 2 inhibitor mechanism of action (substance)"
-					},
-					{
-						"code": "387406002",
-						"display": "Sulfonamide (substance)"
-					},
-					{
-						"code": "391737006",
-						"display": "Almond oil (substance)"
-					},
-					{
-						"code": "391739009",
-						"display": "Aloe (substance)"
-					},
-					{
-						"code": "396345004",
-						"display": "Carbapenem (substance)"
-					},
-					{
-						"code": "396420001",
-						"display": "Anthrax vaccine (substance)"
-					},
-					{
-						"code": "396425006",
-						"display": "Influenza virus vaccine (substance)"
-					},
-					{
-						"code": "396433007",
-						"display": "Pertussis vaccine (substance)"
-					},
-					{
-						"code": "396439006",
-						"display": "Smallpox vaccine (substance)"
-					},
-					{
-						"code": "396441007",
-						"display": "Typhoid vaccine (substance)"
-					},
-					{
-						"code": "396442000",
-						"display": "Varicella virus vaccine (substance)"
-					},
-					{
-						"code": "398730001",
-						"display": "Pneumococcal vaccine (substance)"
-					},
-					{
-						"code": "400872007",
-						"display": "Hydrocolloid (substance)"
-					},
-					{
-						"code": "404642006",
-						"display": "Substance with opioid receptor agonist mechanism of action (substance)"
-					},
-					{
-						"code": "406748003",
-						"display": "Carbamate (substance)"
-					},
-					{
-						"code": "409137002",
-						"display": "No known drug allergy (situation)"
-					},
-					{
-						"code": "412061001",
-						"display": "Blueberries (substance)"
-					},
-					{
-						"code": "412062008",
-						"display": "Cantaloupe (substance)"
-					},
-					{
-						"code": "412066006",
-						"display": "Pepper (substance)"
-					},
-					{
-						"code": "412068007",
-						"display": "Rye (substance)"
-					},
-					{
-						"code": "412071004",
-						"display": "Wheat (substance)"
-					},
-					{
-						"code": "412138001",
-						"display": "Horse serum protein (substance)"
-					},
-					{
-						"code": "412357001",
-						"display": "Corn (substance)"
-					},
-					{
-						"code": "412373007",
-						"display": "Diphtheria + pertussis + tetanus + Haemophilus influenzae type b vaccine (product)"
-					},
-					{
-						"code": "412375000",
-						"display": "Tetanus vaccine (substance)"
-					},
-					{
-						"code": "412533000",
-						"display": "Wheat bran (substance)"
-					},
-					{
-						"code": "412534006",
-						"display": "Yeast (substance)"
-					},
-					{
-						"code": "412583005",
-						"display": "Bee pollen (substance)"
-					},
-					{
-						"code": "41598000",
-						"display": "Estrogen (substance)"
-					},
-					{
-						"code": "417889008",
-						"display": "Arachis oil (substance)"
-					},
-					{
-						"code": "418000008",
-						"display": "Methadone analog (substance)"
-					},
-					{
-						"code": "418504009",
-						"display": "Oats (substance)"
-					},
-					{
-						"code": "418920007",
-						"display": "Adhesive agent (substance)"
-					},
-					{
-						"code": "419420009",
-						"display": "Watermelon (substance)"
-					},
-					{
-						"code": "419933005",
-						"display": "Glucocorticoid (substance)"
-					},
-					{
-						"code": "421245007",
-						"display": "Diphtheria + pertussis + tetanus vaccine (product)"
-					},
-					{
-						"code": "424369009",
-						"display": "Product containing beta-galactosidase (medicinal product)"
-					},
-					{
-						"code": "426722004",
-						"display": "Iodinated contrast media (substance)"
-					},
-					{
-						"code": "428607008",
-						"display": "No known environmental allergy (situation)"
-					},
-					{
-						"code": "429625007",
-						"display": "No known food allergy (situation)"
-					},
-					{
-						"code": "43735007",
-						"display": "Sulfur (substance)"
-					},
-					{
-						"code": "43921001",
-						"display": "Nickel compound (substance)"
-					},
-					{
-						"code": "44027008",
-						"display": "Seafood (substance)"
-					},
-					{
-						"code": "442381000124103",
-						"display": "Blue food coloring (substance)"
-					},
-					{
-						"code": "442571000124108",
-						"display": "Tree nut (substance)"
-					},
-					{
-						"code": "442771000124102",
-						"display": "Pepperoni (substance)"
-					},
-					{
-						"code": "44588005",
-						"display": "Iodine (substance)"
-					},
-					{
-						"code": "446273004",
-						"display": "Red food coloring (substance)"
-					},
-					{
-						"code": "446274005",
-						"display": "Yellow food coloring (substance)"
-					},
-					{
-						"code": "47703008",
-						"display": "Lactose (substance)"
-					},
-					{
-						"code": "51386004",
-						"display": "Food preservative (substance)"
-					},
-					{
-						"code": "51905005",
-						"display": "Mustard (substance)"
-					},
-					{
-						"code": "53041004",
-						"display": "Alcohol (substance)"
-					},
-					{
-						"code": "61789006",
-						"display": "Dye (substance)"
-					},
-					{
-						"code": "63045006",
-						"display": "Berry (substance)"
-					},
-					{
-						"code": "67324005",
-						"display": "Rice (substance)"
-					},
-					{
-						"code": "67866001",
-						"display": "Insulin (substance)"
-					},
-					{
-						"code": "70813002",
-						"display": "Milk (substance)"
-					},
-					{
-						"code": "710179004",
-						"display": "Lupine seed (substance)"
-					},
-					{
-						"code": "716184000",
-						"display": "No known latex allergy (situation)"
-					},
-					{
-						"code": "716186003",
-						"display": "No known allergy (situation)"
-					},
-					{
-						"code": "720687003",
-						"display": "Dust mite protein (substance)"
-					},
-					{
-						"code": "72511004",
-						"display": "Fruit (substance)"
-					},
-					{
-						"code": "726730005",
-						"display": "Yam (substance)"
-					},
-					{
-						"code": "734881000",
-						"display": "Tomato (substance)"
-					},
-					{
-						"code": "735006003",
-						"display": "Squid (substance)"
-					},
-					{
-						"code": "735009005",
-						"display": "Salmon (substance)"
-					},
-					{
-						"code": "735029006",
-						"display": "Shellfish (substance)"
-					},
-					{
-						"code": "735030001",
-						"display": "Garlic (substance)"
-					},
-					{
-						"code": "735043001",
-						"display": "Mackerel (substance)"
-					},
-					{
-						"code": "735045008",
-						"display": "Mushroom (substance)"
-					},
-					{
-						"code": "735047000",
-						"display": "Onion (substance)"
-					},
-					{
-						"code": "735049002",
-						"display": "Peach (substance)"
-					},
-					{
-						"code": "735050002",
-						"display": "Pear (substance)"
-					},
-					{
-						"code": "735051003",
-						"display": "Plum (substance)"
-					},
-					{
-						"code": "735053000",
-						"display": "Potato (substance)"
-					},
-					{
-						"code": "735123009",
-						"display": "Broccoli (substance)"
-					},
-					{
-						"code": "735124003",
-						"display": "Barley (substance)"
-					},
-					{
-						"code": "735211005",
-						"display": "Coconut (substance)"
-					},
-					{
-						"code": "735212003",
-						"display": "Papaya (substance)"
-					},
-					{
-						"code": "735213008",
-						"display": "Cucumber (substance)"
-					},
-					{
-						"code": "735214002",
-						"display": "Apricot (substance)"
-					},
-					{
-						"code": "735215001",
-						"display": "Apple (substance)"
-					},
-					{
-						"code": "735248001",
-						"display": "Cherry (substance)"
-					},
-					{
-						"code": "735249009",
-						"display": "Avocado (substance)"
-					},
-					{
-						"code": "735340006",
-						"display": "Lemon (substance)"
-					},
-					{
-						"code": "735959004",
-						"display": "Marine mollusk (substance)"
-					},
-					{
-						"code": "735971005",
-						"display": "Fish (substance)"
-					},
-					{
-						"code": "735977009",
-						"display": "Marine crustacean (substance)"
-					},
-					{
-						"code": "736027000",
-						"display": "Scallop (substance)"
-					},
-					{
-						"code": "736030007",
-						"display": "Clam (substance)"
-					},
-					{
-						"code": "736031006",
-						"display": "Oyster (substance)"
-					},
-					{
-						"code": "736159005",
-						"display": "Crab (substance)"
-					},
-					{
-						"code": "736162008",
-						"display": "Lobster (substance)"
-					},
-					{
-						"code": "74801000",
-						"display": "Sugar (substance)"
-					},
-					{
-						"code": "75665004",
-						"display": "Monosodium glutamate (substance)"
-					},
-					{
-						"code": "762952008",
-						"display": "Peanut (substance)"
-					},
-					{
-						"code": "7791007",
-						"display": "Soy protein (substance)"
-					},
-					{
-						"code": "80259003",
-						"display": "Food flavoring agent (substance)"
-					},
-					{
-						"code": "84489001",
-						"display": "Mold (organism)"
-					},
-					{
-						"code": "89119000",
-						"display": "Nitrate salt (substance)"
-					},
-					{
-						"code": "89707004",
-						"display": "Sesame oil (substance)"
-					},
-					{
-						"code": "89811004",
-						"display": "Gluten (substance)"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-allergy-substance",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-allergy-substance",
+    "identifier": [
+        {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:oid:2.16.840.1.113762.1.4.1186.8"
+        }
+    ],
+    "version": "3.1.1",
+    "name": "USCoreAllergySubstance",
+    "title": "US Core Common substances for allergy and intolerance documentation including refutations",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Documentation of substances suspected of (or not suspected of) causing an allergy or intolerance reaction in an individual. **Inclusion Criteria:** specific or general substances to which a patient may be exposed and which may be suspected of causing an adverse reaction; assertions refuting these suspicions. This includes:\n\n 1. Common dietary substances for allergy and intolerance documentation (SNOMEDCT)\n 2. Common drug classes for allergy and intolerance documentation (SNOMEDCT)\n 3. Common drug substances for allergy and intolerance documentation (RXNORM)\n 4. Common environmental substances for allergy and intolerance documentation (SNOMEDCT)\n 5. Common refutations and null values for substance causes for allergy and intolerance documentation (SNOMEDCT)\n\n  **Exclusion Criteria:** actual conditions caused by exposure (reactions, allergies)\n",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "copyright": "This value set includes content from:\n  1. SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.\n  2. RxNorm: Using RxNorm codes of type SAB=RXNORM as this specification describes [does not require](https://www.nlm.nih.gov/research/umls/rxnorm/docs/prescribe.html) a UMLS license. Access to the full set of RxNorm definitions, and/or additional use of other RxNorm structures and information requires a UMLS license. The use of RxNorm in this specification is pursuant to HL7's status as a licensee of the NLM UMLS. HL7's license does not convey the right to use RxNorm to any users of this specification; implementers must acquire a license to use RxNorm in their own right.\n",
+    "compose": {
+        "include": [
+            {
+                "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+                "concept": [
+                    {
+                        "code": "1002293",
+                        "display": "formoterol / Mometasone"
+                    },
+                    {
+                        "code": "1007388",
+                        "display": "Lactase / rennet"
+                    },
+                    {
+                        "code": "1008298",
+                        "display": "Acetaminophen / Caffeine / Chlorpheniramine / Hydrocodone / Phenylephrine"
+                    },
+                    {
+                        "code": "1008519",
+                        "display": "guaiacolsulfonate / Hydrocodone"
+                    },
+                    {
+                        "code": "1009148",
+                        "display": "Ampicillin / Sulbactam"
+                    },
+                    {
+                        "code": "10109",
+                        "display": "Streptomycin"
+                    },
+                    {
+                        "code": "10154",
+                        "display": "Succinylcholine"
+                    },
+                    {
+                        "code": "10156",
+                        "display": "Sucralfate"
+                    },
+                    {
+                        "code": "10169",
+                        "display": "Sulfacetamide"
+                    },
+                    {
+                        "code": "10171",
+                        "display": "Sulfadiazine"
+                    },
+                    {
+                        "code": "10180",
+                        "display": "Sulfamethoxazole"
+                    },
+                    {
+                        "code": "10207",
+                        "display": "Sulfisoxazole"
+                    },
+                    {
+                        "code": "10223",
+                        "display": "Sulfur"
+                    },
+                    {
+                        "code": "10237",
+                        "display": "Sulindac"
+                    },
+                    {
+                        "code": "10324",
+                        "display": "Tamoxifen"
+                    },
+                    {
+                        "code": "10355",
+                        "display": "Temazepam"
+                    },
+                    {
+                        "code": "10368",
+                        "display": "Terbutaline"
+                    },
+                    {
+                        "code": "1037042",
+                        "display": "dabigatran etexilate"
+                    },
+                    {
+                        "code": "10379",
+                        "display": "Testosterone"
+                    },
+                    {
+                        "code": "10395",
+                        "display": "Tetracycline"
+                    },
+                    {
+                        "code": "103990",
+                        "display": "Carbidopa / Levodopa"
+                    },
+                    {
+                        "code": "1040028",
+                        "display": "lurasidone"
+                    },
+                    {
+                        "code": "10438",
+                        "display": "Theophylline"
+                    },
+                    {
+                        "code": "10472",
+                        "display": "Thimerosal"
+                    },
+                    {
+                        "code": "10493",
+                        "display": "Thiopental"
+                    },
+                    {
+                        "code": "10502",
+                        "display": "Thioridazine"
+                    },
+                    {
+                        "code": "10510",
+                        "display": "Thiothixene"
+                    },
+                    {
+                        "code": "10582",
+                        "display": "levothyroxine"
+                    },
+                    {
+                        "code": "10594",
+                        "display": "Ticlopidine"
+                    },
+                    {
+                        "code": "10600",
+                        "display": "Timolol"
+                    },
+                    {
+                        "code": "10627",
+                        "display": "Tobramycin"
+                    },
+                    {
+                        "code": "10636",
+                        "display": "Tolmetin"
+                    },
+                    {
+                        "code": "10689",
+                        "display": "Tramadol"
+                    },
+                    {
+                        "code": "10737",
+                        "display": "Trazodone"
+                    },
+                    {
+                        "code": "10759",
+                        "display": "Triamcinolone"
+                    },
+                    {
+                        "code": "107602",
+                        "display": "Epinephrine / Lidocaine"
+                    },
+                    {
+                        "code": "10763",
+                        "display": "Triamterene"
+                    },
+                    {
+                        "code": "10767",
+                        "display": "Triazolam"
+                    },
+                    {
+                        "code": "10800",
+                        "display": "Trifluoperazine"
+                    },
+                    {
+                        "code": "108118",
+                        "display": "Mometasone"
+                    },
+                    {
+                        "code": "10829",
+                        "display": "Trimethoprim"
+                    },
+                    {
+                        "code": "10831",
+                        "display": "Sulfamethoxazole / Trimethoprim"
+                    },
+                    {
+                        "code": "11124",
+                        "display": "Vancomycin"
+                    },
+                    {
+                        "code": "1114195",
+                        "display": "rivaroxaban"
+                    },
+                    {
+                        "code": "1116632",
+                        "display": "Ticagrelor"
+                    },
+                    {
+                        "code": "11170",
+                        "display": "Verapamil"
+                    },
+                    {
+                        "code": "11248",
+                        "display": "Vitamin B 12"
+                    },
+                    {
+                        "code": "11253",
+                        "display": "Vitamin D"
+                    },
+                    {
+                        "code": "11256",
+                        "display": "Vitamin E"
+                    },
+                    {
+                        "code": "11289",
+                        "display": "Warfarin"
+                    },
+                    {
+                        "code": "113588",
+                        "display": "Erythromycin / Sulfisoxazole"
+                    },
+                    {
+                        "code": "11416",
+                        "display": "Zinc"
+                    },
+                    {
+                        "code": "11423",
+                        "display": "Zinc Oxide"
+                    },
+                    {
+                        "code": "114477",
+                        "display": "Levetiracetam"
+                    },
+                    {
+                        "code": "114970",
+                        "display": "zafirlukast"
+                    },
+                    {
+                        "code": "114979",
+                        "display": "rabeprazole"
+                    },
+                    {
+                        "code": "1151",
+                        "display": "Ascorbic Acid"
+                    },
+                    {
+                        "code": "115264",
+                        "display": "Ibandronate"
+                    },
+                    {
+                        "code": "115552",
+                        "display": "trovafloxacin"
+                    },
+                    {
+                        "code": "115698",
+                        "display": "ziprasidone"
+                    },
+                    {
+                        "code": "1191",
+                        "display": "Aspirin"
+                    },
+                    {
+                        "code": "119565",
+                        "display": "tolterodine"
+                    },
+                    {
+                        "code": "1202",
+                        "display": "Atenolol"
+                    },
+                    {
+                        "code": "121191",
+                        "display": "rituximab"
+                    },
+                    {
+                        "code": "1223",
+                        "display": "Atropine"
+                    },
+                    {
+                        "code": "1256",
+                        "display": "Azathioprine"
+                    },
+                    {
+                        "code": "1272",
+                        "display": "Aztreonam"
+                    },
+                    {
+                        "code": "1291",
+                        "display": "Bacitracin"
+                    },
+                    {
+                        "code": "1292",
+                        "display": "Baclofen"
+                    },
+                    {
+                        "code": "1310171",
+                        "display": "Gadolinium"
+                    },
+                    {
+                        "code": "1311085",
+                        "display": "xanthine"
+                    },
+                    {
+                        "code": "1311524",
+                        "display": "Aspartame"
+                    },
+                    {
+                        "code": "1311629",
+                        "display": "nickel"
+                    },
+                    {
+                        "code": "1314891",
+                        "display": "Latex"
+                    },
+                    {
+                        "code": "1331",
+                        "display": "Barium Sulfate"
+                    },
+                    {
+                        "code": "134615",
+                        "display": "brimonidine"
+                    },
+                    {
+                        "code": "1347",
+                        "display": "Beclomethasone"
+                    },
+                    {
+                        "code": "135447",
+                        "display": "donepezil"
+                    },
+                    {
+                        "code": "135775",
+                        "display": "zolmitriptan"
+                    },
+                    {
+                        "code": "1359",
+                        "display": "Belladonna Alkaloids"
+                    },
+                    {
+                        "code": "1362879",
+                        "display": "Sulfur Dioxide"
+                    },
+                    {
+                        "code": "1363043",
+                        "display": "ethyl ether"
+                    },
+                    {
+                        "code": "136411",
+                        "display": "sildenafil"
+                    },
+                    {
+                        "code": "1364430",
+                        "display": "apixaban"
+                    },
+                    {
+                        "code": "138099",
+                        "display": "gemifloxacin"
+                    },
+                    {
+                        "code": "139462",
+                        "display": "moxifloxacin"
+                    },
+                    {
+                        "code": "1399",
+                        "display": "Benzocaine"
+                    },
+                    {
+                        "code": "140587",
+                        "display": "celecoxib"
+                    },
+                    {
+                        "code": "1406",
+                        "display": "benzoin resin"
+                    },
+                    {
+                        "code": "141626",
+                        "display": "colesevelam"
+                    },
+                    {
+                        "code": "1418",
+                        "display": "Benzoyl Peroxide"
+                    },
+                    {
+                        "code": "1424",
+                        "display": "Benztropine"
+                    },
+                    {
+                        "code": "1514",
+                        "display": "Betamethasone"
+                    },
+                    {
+                        "code": "153970",
+                        "display": "Hyoscyamine"
+                    },
+                    {
+                        "code": "1596450",
+                        "display": "Gentamicin"
+                    },
+                    {
+                        "code": "15996",
+                        "display": "Mirtazapine"
+                    },
+                    {
+                        "code": "161",
+                        "display": "Acetaminophen"
+                    },
+                    {
+                        "code": "16681",
+                        "display": "Acarbose"
+                    },
+                    {
+                        "code": "167",
+                        "display": "Acetazolamide"
+                    },
+                    {
+                        "code": "17128",
+                        "display": "lansoprazole"
+                    },
+                    {
+                        "code": "1727875",
+                        "display": "Tetanus immune globulin"
+                    },
+                    {
+                        "code": "17300",
+                        "display": "alfuzosin"
+                    },
+                    {
+                        "code": "17767",
+                        "display": "Amlodipine"
+                    },
+                    {
+                        "code": "1827",
+                        "display": "Buspirone"
+                    },
+                    {
+                        "code": "183379",
+                        "display": "rivastigmine"
+                    },
+                    {
+                        "code": "1841",
+                        "display": "Butorphanol"
+                    },
+                    {
+                        "code": "18631",
+                        "display": "Azithromycin"
+                    },
+                    {
+                        "code": "187832",
+                        "display": "pregabalin"
+                    },
+                    {
+                        "code": "1886",
+                        "display": "Caffeine"
+                    },
+                    {
+                        "code": "18867",
+                        "display": "benazepril"
+                    },
+                    {
+                        "code": "1895",
+                        "display": "Calcium"
+                    },
+                    {
+                        "code": "1897",
+                        "display": "Calcium Carbonate"
+                    },
+                    {
+                        "code": "18993",
+                        "display": "benzonatate"
+                    },
+                    {
+                        "code": "190376",
+                        "display": "linezolid"
+                    },
+                    {
+                        "code": "191831",
+                        "display": "infliximab"
+                    },
+                    {
+                        "code": "19478",
+                        "display": "bismuth subsalicylate"
+                    },
+                    {
+                        "code": "19552",
+                        "display": "cefprozil"
+                    },
+                    {
+                        "code": "19711",
+                        "display": "Amoxicillin / Clavulanate"
+                    },
+                    {
+                        "code": "19831",
+                        "display": "Budesonide"
+                    },
+                    {
+                        "code": "1998",
+                        "display": "Captopril"
+                    },
+                    {
+                        "code": "2002",
+                        "display": "Carbamazepine"
+                    },
+                    {
+                        "code": "20352",
+                        "display": "carvedilol"
+                    },
+                    {
+                        "code": "20481",
+                        "display": "cefepime"
+                    },
+                    {
+                        "code": "20489",
+                        "display": "cefpodoxime"
+                    },
+                    {
+                        "code": "20610",
+                        "display": "Cetirizine"
+                    },
+                    {
+                        "code": "2101",
+                        "display": "Carisoprodol"
+                    },
+                    {
+                        "code": "21107",
+                        "display": "cilostazol"
+                    },
+                    {
+                        "code": "21183",
+                        "display": "Citric Acid"
+                    },
+                    {
+                        "code": "21212",
+                        "display": "Clarithromycin"
+                    },
+                    {
+                        "code": "214130",
+                        "display": "Acetaminophen / butalbital / Caffeine"
+                    },
+                    {
+                        "code": "214153",
+                        "display": "Acetaminophen / dichloralphenazone / isometheptene"
+                    },
+                    {
+                        "code": "214159",
+                        "display": "Aspirin / butalbital / Caffeine"
+                    },
+                    {
+                        "code": "214160",
+                        "display": "Aspirin / butalbital / Caffeine / Codeine"
+                    },
+                    {
+                        "code": "214181",
+                        "display": "Acetaminophen / Diphenhydramine"
+                    },
+                    {
+                        "code": "214182",
+                        "display": "Acetaminophen / Hydrocodone"
+                    },
+                    {
+                        "code": "214183",
+                        "display": "Acetaminophen / Oxycodone"
+                    },
+                    {
+                        "code": "214199",
+                        "display": "Albuterol / Ipratropium"
+                    },
+                    {
+                        "code": "214223",
+                        "display": "Amlodipine / benazepril"
+                    },
+                    {
+                        "code": "214250",
+                        "display": "Aspirin / Caffeine"
+                    },
+                    {
+                        "code": "214256",
+                        "display": "Aspirin / Oxycodone"
+                    },
+                    {
+                        "code": "214257",
+                        "display": "Aspirin / Pentazocine"
+                    },
+                    {
+                        "code": "214317",
+                        "display": "Bisoprolol / Hydrochlorothiazide"
+                    },
+                    {
+                        "code": "214336",
+                        "display": "Caffeine / Ergotamine"
+                    },
+                    {
+                        "code": "214354",
+                        "display": "candesartan"
+                    },
+                    {
+                        "code": "214364",
+                        "display": "carbinoxamine / Pseudoephedrine"
+                    },
+                    {
+                        "code": "214392",
+                        "display": "Chlorpheniramine / Hydrocodone"
+                    },
+                    {
+                        "code": "214442",
+                        "display": "Codeine / Guaifenesin"
+                    },
+                    {
+                        "code": "214445",
+                        "display": "Codeine / Pseudoephedrine"
+                    },
+                    {
+                        "code": "214488",
+                        "display": "Dextromethorphan / Guaifenesin"
+                    },
+                    {
+                        "code": "214502",
+                        "display": "Diclofenac / Misoprostol"
+                    },
+                    {
+                        "code": "214555",
+                        "display": "Etanercept"
+                    },
+                    {
+                        "code": "214558",
+                        "display": "Ethinyl Estradiol / Levonorgestrel"
+                    },
+                    {
+                        "code": "214565",
+                        "display": "fexofenadine / Pseudoephedrine"
+                    },
+                    {
+                        "code": "214599",
+                        "display": "Guaifenesin / Pseudoephedrine"
+                    },
+                    {
+                        "code": "214614",
+                        "display": "homatropine / Hydrocodone"
+                    },
+                    {
+                        "code": "214617",
+                        "display": "Hydrochlorothiazide / irbesartan"
+                    },
+                    {
+                        "code": "214618",
+                        "display": "Hydrochlorothiazide / Lisinopril"
+                    },
+                    {
+                        "code": "214619",
+                        "display": "Hydrochlorothiazide / Losartan"
+                    },
+                    {
+                        "code": "214626",
+                        "display": "Hydrochlorothiazide / valsartan"
+                    },
+                    {
+                        "code": "214627",
+                        "display": "Hydrocodone / Ibuprofen"
+                    },
+                    {
+                        "code": "214631",
+                        "display": "Hydrocodone / Pseudoephedrine"
+                    },
+                    {
+                        "code": "214682",
+                        "display": "Loratadine / Pseudoephedrine"
+                    },
+                    {
+                        "code": "214721",
+                        "display": "Naloxone / Pentazocine"
+                    },
+                    {
+                        "code": "214807",
+                        "display": "Pseudoephedrine / Triprolidine"
+                    },
+                    {
+                        "code": "2176",
+                        "display": "Cefaclor"
+                    },
+                    {
+                        "code": "217627",
+                        "display": "Hydrocortisone / Neomycin / Polymyxin B"
+                    },
+                    {
+                        "code": "2177",
+                        "display": "Cefadroxil"
+                    },
+                    {
+                        "code": "2180",
+                        "display": "Cefazolin"
+                    },
+                    {
+                        "code": "2189",
+                        "display": "Cefoxitin"
+                    },
+                    {
+                        "code": "2191",
+                        "display": "Ceftazidime"
+                    },
+                    {
+                        "code": "2193",
+                        "display": "Ceftriaxone"
+                    },
+                    {
+                        "code": "219314",
+                        "display": "Polymyxin B / Trimethoprim"
+                    },
+                    {
+                        "code": "219315",
+                        "display": "Iron polysaccharide"
+                    },
+                    {
+                        "code": "2194",
+                        "display": "Cefuroxime"
+                    },
+                    {
+                        "code": "21949",
+                        "display": "cyclobenzaprine"
+                    },
+                    {
+                        "code": "221147",
+                        "display": "POLYETHYLENE GLYCOL 3350"
+                    },
+                    {
+                        "code": "22299",
+                        "display": "Daptomycin"
+                    },
+                    {
+                        "code": "2231",
+                        "display": "Cephalexin"
+                    },
+                    {
+                        "code": "226716",
+                        "display": "Aspirin / Dipyridamole"
+                    },
+                    {
+                        "code": "228476",
+                        "display": "gatifloxacin"
+                    },
+                    {
+                        "code": "228790",
+                        "display": "Dutasteride"
+                    },
+                    {
+                        "code": "232158",
+                        "display": "rofecoxib"
+                    },
+                    {
+                        "code": "233698",
+                        "display": "dronedarone"
+                    },
+                    {
+                        "code": "2348",
+                        "display": "Chloramphenicol"
+                    },
+                    {
+                        "code": "2356",
+                        "display": "Chlordiazepoxide"
+                    },
+                    {
+                        "code": "2358",
+                        "display": "Chlorhexidine"
+                    },
+                    {
+                        "code": "236778",
+                        "display": "Trospium"
+                    },
+                    {
+                        "code": "237159",
+                        "display": "Levalbuterol"
+                    },
+                    {
+                        "code": "2393",
+                        "display": "Chloroquine"
+                    },
+                    {
+                        "code": "2400",
+                        "display": "Chlorpheniramine"
+                    },
+                    {
+                        "code": "2403",
+                        "display": "Chlorpromazine"
+                    },
+                    {
+                        "code": "2409",
+                        "display": "Chlorthalidone"
+                    },
+                    {
+                        "code": "2410",
+                        "display": "Chlorzoxazone"
+                    },
+                    {
+                        "code": "2418",
+                        "display": "Cholecalciferol"
+                    },
+                    {
+                        "code": "2447",
+                        "display": "Cholestyramine Resin"
+                    },
+                    {
+                        "code": "24605",
+                        "display": "Etodolac"
+                    },
+                    {
+                        "code": "24947",
+                        "display": "ferrous sulfate"
+                    },
+                    {
+                        "code": "25025",
+                        "display": "Finasteride"
+                    },
+                    {
+                        "code": "25033",
+                        "display": "Cefixime"
+                    },
+                    {
+                        "code": "25037",
+                        "display": "cefdinir"
+                    },
+                    {
+                        "code": "25120",
+                        "display": "flunisolide"
+                    },
+                    {
+                        "code": "25255",
+                        "display": "formoterol"
+                    },
+                    {
+                        "code": "253157",
+                        "display": "Bee pollen"
+                    },
+                    {
+                        "code": "2541",
+                        "display": "Cimetidine"
+                    },
+                    {
+                        "code": "25480",
+                        "display": "gabapentin"
+                    },
+                    {
+                        "code": "2551",
+                        "display": "Ciprofloxacin"
+                    },
+                    {
+                        "code": "2556",
+                        "display": "Citalopram"
+                    },
+                    {
+                        "code": "25789",
+                        "display": "glimepiride"
+                    },
+                    {
+                        "code": "2582",
+                        "display": "Clindamycin"
+                    },
+                    {
+                        "code": "258337",
+                        "display": "Hydrochlorothiazide / Triamterene"
+                    },
+                    {
+                        "code": "2598",
+                        "display": "Clonazepam"
+                    },
+                    {
+                        "code": "2599",
+                        "display": "Clonidine"
+                    },
+                    {
+                        "code": "260101",
+                        "display": "Oseltamivir"
+                    },
+                    {
+                        "code": "26225",
+                        "display": "Ondansetron"
+                    },
+                    {
+                        "code": "2623",
+                        "display": "Clotrimazole"
+                    },
+                    {
+                        "code": "2670",
+                        "display": "Codeine"
+                    },
+                    {
+                        "code": "2683",
+                        "display": "Colchicine"
+                    },
+                    {
+                        "code": "2685",
+                        "display": "Colestipol"
+                    },
+                    {
+                        "code": "27169",
+                        "display": "leflunomide"
+                    },
+                    {
+                        "code": "274783",
+                        "display": "Insulin Glargine"
+                    },
+                    {
+                        "code": "274786",
+                        "display": "telithromycin"
+                    },
+                    {
+                        "code": "27723",
+                        "display": "iodinated glycerol"
+                    },
+                    {
+                        "code": "278567",
+                        "display": "valdecoxib"
+                    },
+                    {
+                        "code": "28031",
+                        "display": "Itraconazole"
+                    },
+                    {
+                        "code": "281",
+                        "display": "Acyclovir"
+                    },
+                    {
+                        "code": "283742",
+                        "display": "Esomeprazole"
+                    },
+                    {
+                        "code": "283809",
+                        "display": "travoprost"
+                    },
+                    {
+                        "code": "28439",
+                        "display": "lamotrigine"
+                    },
+                    {
+                        "code": "284635",
+                        "display": "fluticasone / salmeterol"
+                    },
+                    {
+                        "code": "2878",
+                        "display": "Cortisone"
+                    },
+                    {
+                        "code": "28889",
+                        "display": "Loratadine"
+                    },
+                    {
+                        "code": "28981",
+                        "display": "loracarbef"
+                    },
+                    {
+                        "code": "29046",
+                        "display": "Lisinopril"
+                    },
+                    {
+                        "code": "29542",
+                        "display": "Mercury, Ammoniated"
+                    },
+                    {
+                        "code": "29561",
+                        "display": "meropenem"
+                    },
+                    {
+                        "code": "296",
+                        "display": "Adenosine"
+                    },
+                    {
+                        "code": "3008",
+                        "display": "Cyclosporine"
+                    },
+                    {
+                        "code": "301542",
+                        "display": "rosuvastatin"
+                    },
+                    {
+                        "code": "306674",
+                        "display": "vardenafil"
+                    },
+                    {
+                        "code": "3108",
+                        "display": "Dapsone"
+                    },
+                    {
+                        "code": "3143",
+                        "display": "prasterone"
+                    },
+                    {
+                        "code": "31448",
+                        "display": "nabumetone"
+                    },
+                    {
+                        "code": "31555",
+                        "display": "nebivolol"
+                    },
+                    {
+                        "code": "31565",
+                        "display": "nefazodone"
+                    },
+                    {
+                        "code": "31738",
+                        "display": "nickel sulfate"
+                    },
+                    {
+                        "code": "318340",
+                        "display": "Aloe vera preparation"
+                    },
+                    {
+                        "code": "321064",
+                        "display": "olmesartan"
+                    },
+                    {
+                        "code": "321988",
+                        "display": "Escitalopram"
+                    },
+                    {
+                        "code": "322167",
+                        "display": "Solifenacin"
+                    },
+                    {
+                        "code": "3247",
+                        "display": "Desipramine"
+                    },
+                    {
+                        "code": "325642",
+                        "display": "ertapenem"
+                    },
+                    {
+                        "code": "32592",
+                        "display": "oxaliplatin"
+                    },
+                    {
+                        "code": "32613",
+                        "display": "oxaprozin"
+                    },
+                    {
+                        "code": "32624",
+                        "display": "oxcarbazepine"
+                    },
+                    {
+                        "code": "3264",
+                        "display": "Dexamethasone"
+                    },
+                    {
+                        "code": "32675",
+                        "display": "oxybutynin"
+                    },
+                    {
+                        "code": "327361",
+                        "display": "adalimumab"
+                    },
+                    {
+                        "code": "3289",
+                        "display": "Dextromethorphan"
+                    },
+                    {
+                        "code": "32937",
+                        "display": "Paroxetine"
+                    },
+                    {
+                        "code": "32968",
+                        "display": "clopidogrel"
+                    },
+                    {
+                        "code": "3322",
+                        "display": "Diazepam"
+                    },
+                    {
+                        "code": "33408",
+                        "display": "phenyltoloxamine"
+                    },
+                    {
+                        "code": "3355",
+                        "display": "Diclofenac"
+                    },
+                    {
+                        "code": "3356",
+                        "display": "Dicloxacillin"
+                    },
+                    {
+                        "code": "3361",
+                        "display": "Dicyclomine"
+                    },
+                    {
+                        "code": "33738",
+                        "display": "pioglitazone"
+                    },
+                    {
+                        "code": "3393",
+                        "display": "Diflunisal"
+                    },
+                    {
+                        "code": "3407",
+                        "display": "Digoxin"
+                    },
+                    {
+                        "code": "341248",
+                        "display": "ezetimibe"
+                    },
+                    {
+                        "code": "3418",
+                        "display": "Dihydroergotamine"
+                    },
+                    {
+                        "code": "3423",
+                        "display": "Hydromorphone"
+                    },
+                    {
+                        "code": "3443",
+                        "display": "Diltiazem"
+                    },
+                    {
+                        "code": "3444",
+                        "display": "Dimenhydrinate"
+                    },
+                    {
+                        "code": "3498",
+                        "display": "Diphenhydramine"
+                    },
+                    {
+                        "code": "35208",
+                        "display": "quinapril"
+                    },
+                    {
+                        "code": "3521",
+                        "display": "Dipyridamole"
+                    },
+                    {
+                        "code": "352362",
+                        "display": "Acetaminophen / Tramadol"
+                    },
+                    {
+                        "code": "35296",
+                        "display": "Ramipril"
+                    },
+                    {
+                        "code": "35382",
+                        "display": "resorcinol"
+                    },
+                    {
+                        "code": "35636",
+                        "display": "Risperidone"
+                    },
+                    {
+                        "code": "358263",
+                        "display": "tadalafil"
+                    },
+                    {
+                        "code": "35827",
+                        "display": "Ketorolac"
+                    },
+                    {
+                        "code": "35829",
+                        "display": "ranolazine"
+                    },
+                    {
+                        "code": "36108",
+                        "display": "Salsalate"
+                    },
+                    {
+                        "code": "36117",
+                        "display": "salmeterol"
+                    },
+                    {
+                        "code": "3616",
+                        "display": "Dobutamine"
+                    },
+                    {
+                        "code": "3638",
+                        "display": "Doxepin"
+                    },
+                    {
+                        "code": "3640",
+                        "display": "Doxycycline"
+                    },
+                    {
+                        "code": "36437",
+                        "display": "Sertraline"
+                    },
+                    {
+                        "code": "3648",
+                        "display": "Droperidol"
+                    },
+                    {
+                        "code": "36567",
+                        "display": "Simvastatin"
+                    },
+                    {
+                        "code": "37418",
+                        "display": "Sumatriptan"
+                    },
+                    {
+                        "code": "37617",
+                        "display": "tazobactam"
+                    },
+                    {
+                        "code": "37798",
+                        "display": "Terazosin"
+                    },
+                    {
+                        "code": "37801",
+                        "display": "terbinafine"
+                    },
+                    {
+                        "code": "3827",
+                        "display": "Enalapril"
+                    },
+                    {
+                        "code": "3829",
+                        "display": "Enalaprilat"
+                    },
+                    {
+                        "code": "38400",
+                        "display": "atomoxetine"
+                    },
+                    {
+                        "code": "38404",
+                        "display": "topiramate"
+                    },
+                    {
+                        "code": "38413",
+                        "display": "torsemide"
+                    },
+                    {
+                        "code": "38574",
+                        "display": "trichloroacetaldehyde"
+                    },
+                    {
+                        "code": "38685",
+                        "display": "trimethobenzamide"
+                    },
+                    {
+                        "code": "389132",
+                        "display": "Budesonide / formoterol"
+                    },
+                    {
+                        "code": "3966",
+                        "display": "Ephedrine"
+                    },
+                    {
+                        "code": "39786",
+                        "display": "venlafaxine"
+                    },
+                    {
+                        "code": "3992",
+                        "display": "Epinephrine"
+                    },
+                    {
+                        "code": "39993",
+                        "display": "zolpidem"
+                    },
+                    {
+                        "code": "39998",
+                        "display": "zonisamide"
+                    },
+                    {
+                        "code": "40048",
+                        "display": "Carboplatin"
+                    },
+                    {
+                        "code": "400674",
+                        "display": "dexbrompheniramine / Pseudoephedrine"
+                    },
+                    {
+                        "code": "4025",
+                        "display": "Ergotamine"
+                    },
+                    {
+                        "code": "40254",
+                        "display": "Valproate"
+                    },
+                    {
+                        "code": "4053",
+                        "display": "Erythromycin"
+                    },
+                    {
+                        "code": "40575",
+                        "display": "zileuton"
+                    },
+                    {
+                        "code": "40790",
+                        "display": "pantoprazole"
+                    },
+                    {
+                        "code": "4083",
+                        "display": "Estradiol"
+                    },
+                    {
+                        "code": "4099",
+                        "display": "Estrogens, Conjugated (USP)"
+                    },
+                    {
+                        "code": "41126",
+                        "display": "fluticasone"
+                    },
+                    {
+                        "code": "41127",
+                        "display": "fluvastatin"
+                    },
+                    {
+                        "code": "4124",
+                        "display": "Ethinyl Estradiol"
+                    },
+                    {
+                        "code": "41397",
+                        "display": "Lactase"
+                    },
+                    {
+                        "code": "41493",
+                        "display": "meloxicam"
+                    },
+                    {
+                        "code": "42330",
+                        "display": "Terfenadine"
+                    },
+                    {
+                        "code": "42331",
+                        "display": "Misoprostol"
+                    },
+                    {
+                        "code": "42347",
+                        "display": "Bupropion"
+                    },
+                    {
+                        "code": "42351",
+                        "display": "Lithium Carbonate"
+                    },
+                    {
+                        "code": "42372",
+                        "display": "Mupirocin"
+                    },
+                    {
+                        "code": "42463",
+                        "display": "Pravastatin"
+                    },
+                    {
+                        "code": "4278",
+                        "display": "Famotidine"
+                    },
+                    {
+                        "code": "4316",
+                        "display": "Felodipine"
+                    },
+                    {
+                        "code": "4337",
+                        "display": "Fentanyl"
+                    },
+                    {
+                        "code": "435",
+                        "display": "Albuterol"
+                    },
+                    {
+                        "code": "43611",
+                        "display": "latanoprost"
+                    },
+                    {
+                        "code": "4419",
+                        "display": "Fish Oils"
+                    },
+                    {
+                        "code": "4441",
+                        "display": "Flecainide"
+                    },
+                    {
+                        "code": "4450",
+                        "display": "Fluconazole"
+                    },
+                    {
+                        "code": "448",
+                        "display": "Ethanol"
+                    },
+                    {
+                        "code": "4492",
+                        "display": "Fluorouracil"
+                    },
+                    {
+                        "code": "4493",
+                        "display": "Fluoxetine"
+                    },
+                    {
+                        "code": "4496",
+                        "display": "Fluphenazine"
+                    },
+                    {
+                        "code": "4500",
+                        "display": "Flurandrenolide"
+                    },
+                    {
+                        "code": "4530",
+                        "display": "Formaldehyde"
+                    },
+                    {
+                        "code": "4603",
+                        "display": "Furosemide"
+                    },
+                    {
+                        "code": "46041",
+                        "display": "Alendronate"
+                    },
+                    {
+                        "code": "461016",
+                        "display": "Eszopiclone"
+                    },
+                    {
+                        "code": "4637",
+                        "display": "Galantamine"
+                    },
+                    {
+                        "code": "465397",
+                        "display": "Ciprofloxacin / Dexamethasone"
+                    },
+                    {
+                        "code": "466522",
+                        "display": "Diphenhydramine / Zinc Acetate"
+                    },
+                    {
+                        "code": "466541",
+                        "display": "Neomycin / Polymyxin B"
+                    },
+                    {
+                        "code": "466549",
+                        "display": "Aspirin / Caffeine / Orphenadrine"
+                    },
+                    {
+                        "code": "466553",
+                        "display": "penicillin G benzathine / penicillin G procaine"
+                    },
+                    {
+                        "code": "466566",
+                        "display": "Acetaminophen / Dextromethorphan / Diphenhydramine / Pseudoephedrine"
+                    },
+                    {
+                        "code": "466584",
+                        "display": "Acetaminophen / Aspirin / Caffeine"
+                    },
+                    {
+                        "code": "4719",
+                        "display": "Gemfibrozil"
+                    },
+                    {
+                        "code": "475968",
+                        "display": "liraglutide"
+                    },
+                    {
+                        "code": "4815",
+                        "display": "Glyburide"
+                    },
+                    {
+                        "code": "48203",
+                        "display": "Clavulanate"
+                    },
+                    {
+                        "code": "4821",
+                        "display": "Glipizide"
+                    },
+                    {
+                        "code": "48274",
+                        "display": "Acetaminophen / Propoxyphene"
+                    },
+                    {
+                        "code": "484139",
+                        "display": "Chlorhexidine / Isopropyl Alcohol"
+                    },
+                    {
+                        "code": "484211",
+                        "display": "ezetimibe / Simvastatin"
+                    },
+                    {
+                        "code": "4850",
+                        "display": "Glucose"
+                    },
+                    {
+                        "code": "4917",
+                        "display": "Nitroglycerin"
+                    },
+                    {
+                        "code": "49276",
+                        "display": "Doxazosin"
+                    },
+                    {
+                        "code": "50166",
+                        "display": "Fosinopril"
+                    },
+                    {
+                        "code": "5021",
+                        "display": "Griseofulvin"
+                    },
+                    {
+                        "code": "5032",
+                        "display": "Guaifenesin"
+                    },
+                    {
+                        "code": "5093",
+                        "display": "Haloperidol"
+                    },
+                    {
+                        "code": "51272",
+                        "display": "quetiapine"
+                    },
+                    {
+                        "code": "519",
+                        "display": "Allopurinol"
+                    },
+                    {
+                        "code": "52175",
+                        "display": "Losartan"
+                    },
+                    {
+                        "code": "5224",
+                        "display": "heparin"
+                    },
+                    {
+                        "code": "52582",
+                        "display": "mesalamine"
+                    },
+                    {
+                        "code": "5470",
+                        "display": "Hydralazine"
+                    },
+                    {
+                        "code": "5487",
+                        "display": "Hydrochlorothiazide"
+                    },
+                    {
+                        "code": "5489",
+                        "display": "Hydrocodone"
+                    },
+                    {
+                        "code": "5492",
+                        "display": "Hydrocortisone"
+                    },
+                    {
+                        "code": "5499",
+                        "display": "Hydrogen Peroxide"
+                    },
+                    {
+                        "code": "5521",
+                        "display": "Hydroxychloroquine"
+                    },
+                    {
+                        "code": "5553",
+                        "display": "Hydroxyzine"
+                    },
+                    {
+                        "code": "5640",
+                        "display": "Ibuprofen"
+                    },
+                    {
+                        "code": "5691",
+                        "display": "Imipramine"
+                    },
+                    {
+                        "code": "56946",
+                        "display": "Paclitaxel"
+                    },
+                    {
+                        "code": "57258",
+                        "display": "tizanidine"
+                    },
+                    {
+                        "code": "5764",
+                        "display": "Indapamide"
+                    },
+                    {
+                        "code": "5781",
+                        "display": "Indomethacin"
+                    },
+                    {
+                        "code": "588250",
+                        "display": "milnacipran"
+                    },
+                    {
+                        "code": "59078",
+                        "display": "metaxalone"
+                    },
+                    {
+                        "code": "591622",
+                        "display": "varenicline"
+                    },
+                    {
+                        "code": "5933",
+                        "display": "Iodine"
+                    },
+                    {
+                        "code": "593411",
+                        "display": "sitagliptin"
+                    },
+                    {
+                        "code": "594040",
+                        "display": "Atropine / Diphenoxylate"
+                    },
+                    {
+                        "code": "5956",
+                        "display": "Iohexol"
+                    },
+                    {
+                        "code": "596",
+                        "display": "Alprazolam"
+                    },
+                    {
+                        "code": "596723",
+                        "display": "cerivastatin"
+                    },
+                    {
+                        "code": "597142",
+                        "display": "brimonidine / Timolol"
+                    },
+                    {
+                        "code": "5992",
+                        "display": "Iron-Dextran Complex"
+                    },
+                    {
+                        "code": "60207",
+                        "display": "dorzolamide"
+                    },
+                    {
+                        "code": "6038",
+                        "display": "isoniazid"
+                    },
+                    {
+                        "code": "60548",
+                        "display": "exenatide"
+                    },
+                    {
+                        "code": "6057",
+                        "display": "Isosorbide"
+                    },
+                    {
+                        "code": "6058",
+                        "display": "Isosorbide Dinitrate"
+                    },
+                    {
+                        "code": "611854",
+                        "display": "Chlordiazepoxide / clidinium"
+                    },
+                    {
+                        "code": "6130",
+                        "display": "Ketamine"
+                    },
+                    {
+                        "code": "6135",
+                        "display": "Ketoconazole"
+                    },
+                    {
+                        "code": "61381",
+                        "display": "olanzapine"
+                    },
+                    {
+                        "code": "6142",
+                        "display": "Ketoprofen"
+                    },
+                    {
+                        "code": "6185",
+                        "display": "Labetalol"
+                    },
+                    {
+                        "code": "620",
+                        "display": "Amantadine"
+                    },
+                    {
+                        "code": "6218",
+                        "display": "Lactulose"
+                    },
+                    {
+                        "code": "6227",
+                        "display": "Lanolin"
+                    },
+                    {
+                        "code": "6387",
+                        "display": "Lidocaine"
+                    },
+                    {
+                        "code": "6398",
+                        "display": "Lincomycin"
+                    },
+                    {
+                        "code": "6448",
+                        "display": "Lithium"
+                    },
+                    {
+                        "code": "645555",
+                        "display": "Bacitracin / Polymyxin B"
+                    },
+                    {
+                        "code": "6468",
+                        "display": "Loperamide"
+                    },
+                    {
+                        "code": "6470",
+                        "display": "Lorazepam"
+                    },
+                    {
+                        "code": "6472",
+                        "display": "Lovastatin"
+                    },
+                    {
+                        "code": "6574",
+                        "display": "Magnesium"
+                    },
+                    {
+                        "code": "6585",
+                        "display": "Magnesium Sulfate"
+                    },
+                    {
+                        "code": "662263",
+                        "display": "dorzolamide / Timolol"
+                    },
+                    {
+                        "code": "6676",
+                        "display": "Meclizine"
+                    },
+                    {
+                        "code": "6691",
+                        "display": "Medroxyprogesterone"
+                    },
+                    {
+                        "code": "67108",
+                        "display": "Enoxaparin"
+                    },
+                    {
+                        "code": "6711",
+                        "display": "Melatonin"
+                    },
+                    {
+                        "code": "6719",
+                        "display": "Memantine"
+                    },
+                    {
+                        "code": "6750",
+                        "display": "Menthol"
+                    },
+                    {
+                        "code": "6754",
+                        "display": "Meperidine"
+                    },
+                    {
+                        "code": "6809",
+                        "display": "Metformin"
+                    },
+                    {
+                        "code": "6813",
+                        "display": "Methadone"
+                    },
+                    {
+                        "code": "6835",
+                        "display": "Methimazole"
+                    },
+                    {
+                        "code": "6845",
+                        "display": "Methocarbamol"
+                    },
+                    {
+                        "code": "6851",
+                        "display": "Methotrexate"
+                    },
+                    {
+                        "code": "6876",
+                        "display": "Methyldopa"
+                    },
+                    {
+                        "code": "689",
+                        "display": "Aminophylline"
+                    },
+                    {
+                        "code": "689467",
+                        "display": "Oxytetracycline / Polymyxin B"
+                    },
+                    {
+                        "code": "689518",
+                        "display": "Aspirin / Caffeine / Propoxyphene"
+                    },
+                    {
+                        "code": "689556",
+                        "display": "Acetaminophen / Aspirin / Phenylpropanolamine"
+                    },
+                    {
+                        "code": "689558",
+                        "display": "Acetaminophen / Brompheniramine / Pseudoephedrine"
+                    },
+                    {
+                        "code": "689561",
+                        "display": "Acetaminophen / butalbital / Caffeine / Codeine"
+                    },
+                    {
+                        "code": "689582",
+                        "display": "Acetaminophen / Chlorpheniramine / Dextromethorphan / Pseudoephedrine"
+                    },
+                    {
+                        "code": "689606",
+                        "display": "Atropine / Hyoscyamine / Phenobarbital / Scopolamine"
+                    },
+                    {
+                        "code": "689623",
+                        "display": "Bacitracin / Hydrocortisone / Neomycin / Polymyxin B"
+                    },
+                    {
+                        "code": "690077",
+                        "display": "Benzalkonium / Lidocaine"
+                    },
+                    {
+                        "code": "6901",
+                        "display": "Methylphenidate"
+                    },
+                    {
+                        "code": "6902",
+                        "display": "Methylprednisolone"
+                    },
+                    {
+                        "code": "690693",
+                        "display": "Diphenhydramine / Phenylephrine"
+                    },
+                    {
+                        "code": "690808",
+                        "display": "Brompheniramine / Dextromethorphan / Pseudoephedrine"
+                    },
+                    {
+                        "code": "69120",
+                        "display": "tiotropium"
+                    },
+                    {
+                        "code": "6915",
+                        "display": "Metoclopramide"
+                    },
+                    {
+                        "code": "6916",
+                        "display": "Metolazone"
+                    },
+                    {
+                        "code": "6918",
+                        "display": "Metoprolol"
+                    },
+                    {
+                        "code": "6922",
+                        "display": "Metronidazole"
+                    },
+                    {
+                        "code": "692572",
+                        "display": "Bacitracin / Neomycin / Polymyxin B"
+                    },
+                    {
+                        "code": "692794",
+                        "display": "Gramicidin / Neomycin / Polymyxin B"
+                    },
+                    {
+                        "code": "6932",
+                        "display": "Miconazole"
+                    },
+                    {
+                        "code": "6960",
+                        "display": "Midazolam"
+                    },
+                    {
+                        "code": "69749",
+                        "display": "valsartan"
+                    },
+                    {
+                        "code": "6980",
+                        "display": "Minocycline"
+                    },
+                    {
+                        "code": "6984",
+                        "display": "Minoxidil"
+                    },
+                    {
+                        "code": "703",
+                        "display": "Amiodarone"
+                    },
+                    {
+                        "code": "704",
+                        "display": "Amitriptyline"
+                    },
+                    {
+                        "code": "7052",
+                        "display": "Morphine"
+                    },
+                    {
+                        "code": "705258",
+                        "display": "Acetaminophen / Dextromethorphan / Doxylamine"
+                    },
+                    {
+                        "code": "7213",
+                        "display": "Ipratropium"
+                    },
+                    {
+                        "code": "72143",
+                        "display": "Raloxifene"
+                    },
+                    {
+                        "code": "72236",
+                        "display": "fosphenytoin"
+                    },
+                    {
+                        "code": "723",
+                        "display": "Amoxicillin"
+                    },
+                    {
+                        "code": "72302",
+                        "display": "ropinirole"
+                    },
+                    {
+                        "code": "7233",
+                        "display": "Nafcillin"
+                    },
+                    {
+                        "code": "7238",
+                        "display": "Nalbuphine"
+                    },
+                    {
+                        "code": "7243",
+                        "display": "Naltrexone"
+                    },
+                    {
+                        "code": "725",
+                        "display": "Amphetamine"
+                    },
+                    {
+                        "code": "7258",
+                        "display": "Naproxen"
+                    },
+                    {
+                        "code": "72625",
+                        "display": "duloxetine"
+                    },
+                    {
+                        "code": "7299",
+                        "display": "Neomycin"
+                    },
+                    {
+                        "code": "73056",
+                        "display": "Risedronate"
+                    },
+                    {
+                        "code": "733",
+                        "display": "Ampicillin"
+                    },
+                    {
+                        "code": "73494",
+                        "display": "telmisartan"
+                    },
+                    {
+                        "code": "73645",
+                        "display": "valacyclovir"
+                    },
+                    {
+                        "code": "7393",
+                        "display": "Niacin"
+                    },
+                    {
+                        "code": "7407",
+                        "display": "Nicotine"
+                    },
+                    {
+                        "code": "74169",
+                        "display": "Piperacillin / tazobactam"
+                    },
+                    {
+                        "code": "7417",
+                        "display": "Nifedipine"
+                    },
+                    {
+                        "code": "7454",
+                        "display": "Nitrofurantoin"
+                    },
+                    {
+                        "code": "746741",
+                        "display": "Pramipexole"
+                    },
+                    {
+                        "code": "7486",
+                        "display": "Nitrous Oxide"
+                    },
+                    {
+                        "code": "7517",
+                        "display": "Norfloxacin"
+                    },
+                    {
+                        "code": "7531",
+                        "display": "Nortriptyline"
+                    },
+                    {
+                        "code": "7597",
+                        "display": "Nystatin"
+                    },
+                    {
+                        "code": "7623",
+                        "display": "Ofloxacin"
+                    },
+                    {
+                        "code": "7646",
+                        "display": "Omeprazole"
+                    },
+                    {
+                        "code": "7676",
+                        "display": "Opium"
+                    },
+                    {
+                        "code": "7715",
+                        "display": "Orphenadrine"
+                    },
+                    {
+                        "code": "77492",
+                        "display": "tamsulosin"
+                    },
+                    {
+                        "code": "7804",
+                        "display": "Oxycodone"
+                    },
+                    {
+                        "code": "7821",
+                        "display": "Oxytetracycline"
+                    },
+                    {
+                        "code": "787390",
+                        "display": "tapentadol"
+                    },
+                    {
+                        "code": "7975",
+                        "display": "Penicillamine"
+                    },
+                    {
+                        "code": "797541",
+                        "display": "Isopropyl Alcohol"
+                    },
+                    {
+                        "code": "7980",
+                        "display": "Penicillin G"
+                    },
+                    {
+                        "code": "7984",
+                        "display": "Penicillin V"
+                    },
+                    {
+                        "code": "7994",
+                        "display": "Pentamidine"
+                    },
+                    {
+                        "code": "8001",
+                        "display": "Pentazocine"
+                    },
+                    {
+                        "code": "8120",
+                        "display": "Phenazopyridine"
+                    },
+                    {
+                        "code": "8134",
+                        "display": "Phenobarbital"
+                    },
+                    {
+                        "code": "815166",
+                        "display": "Dextromethorphan / Doxylamine"
+                    },
+                    {
+                        "code": "8163",
+                        "display": "Phenylephrine"
+                    },
+                    {
+                        "code": "816346",
+                        "display": "dexlansoprazole"
+                    },
+                    {
+                        "code": "8175",
+                        "display": "Phenylpropanolamine"
+                    },
+                    {
+                        "code": "817579",
+                        "display": "Acetaminophen / Codeine"
+                    },
+                    {
+                        "code": "817958",
+                        "display": "Aspirin / Calcium Carbonate"
+                    },
+                    {
+                        "code": "8183",
+                        "display": "Phenytoin"
+                    },
+                    {
+                        "code": "82122",
+                        "display": "Levofloxacin"
+                    },
+                    {
+                        "code": "822929",
+                        "display": "Amphetamine aspartate / Amphetamine Sulfate / Dextroamphetamine saccharate / Dextroamphetamine Sulfate"
+                    },
+                    {
+                        "code": "83367",
+                        "display": "atorvastatin"
+                    },
+                    {
+                        "code": "8356",
+                        "display": "Piroxicam"
+                    },
+                    {
+                        "code": "83818",
+                        "display": "irbesartan"
+                    },
+                    {
+                        "code": "84108",
+                        "display": "rosiglitazone"
+                    },
+                    {
+                        "code": "8536",
+                        "display": "Polymyxin B"
+                    },
+                    {
+                        "code": "857974",
+                        "display": "saxagliptin"
+                    },
+                    {
+                        "code": "8588",
+                        "display": "Potassium"
+                    },
+                    {
+                        "code": "8591",
+                        "display": "Potassium Chloride"
+                    },
+                    {
+                        "code": "8610",
+                        "display": "Povidone"
+                    },
+                    {
+                        "code": "8611",
+                        "display": "Povidone-Iodine"
+                    },
+                    {
+                        "code": "861634",
+                        "display": "pitavastatin"
+                    },
+                    {
+                        "code": "8629",
+                        "display": "Prazosin"
+                    },
+                    {
+                        "code": "8638",
+                        "display": "prednisolone"
+                    },
+                    {
+                        "code": "8640",
+                        "display": "Prednisone"
+                    },
+                    {
+                        "code": "8687",
+                        "display": "Primaquine"
+                    },
+                    {
+                        "code": "8691",
+                        "display": "Primidone"
+                    },
+                    {
+                        "code": "8698",
+                        "display": "Probenecid"
+                    },
+                    {
+                        "code": "8700",
+                        "display": "Procainamide"
+                    },
+                    {
+                        "code": "8701",
+                        "display": "Procaine"
+                    },
+                    {
+                        "code": "8703",
+                        "display": "Fenofibrate"
+                    },
+                    {
+                        "code": "8704",
+                        "display": "Prochlorperazine"
+                    },
+                    {
+                        "code": "8727",
+                        "display": "Progesterone"
+                    },
+                    {
+                        "code": "8745",
+                        "display": "Promethazine"
+                    },
+                    {
+                        "code": "8754",
+                        "display": "Propafenone"
+                    },
+                    {
+                        "code": "87636",
+                        "display": "fexofenadine"
+                    },
+                    {
+                        "code": "8782",
+                        "display": "Propofol"
+                    },
+                    {
+                        "code": "8785",
+                        "display": "Propoxyphene"
+                    },
+                    {
+                        "code": "8787",
+                        "display": "Propranolol"
+                    },
+                    {
+                        "code": "8794",
+                        "display": "Propylthiouracil"
+                    },
+                    {
+                        "code": "88014",
+                        "display": "rizatriptan"
+                    },
+                    {
+                        "code": "88249",
+                        "display": "montelukast"
+                    },
+                    {
+                        "code": "883815",
+                        "display": "Dexamethasone / Tobramycin"
+                    },
+                    {
+                        "code": "8896",
+                        "display": "Pseudoephedrine"
+                    },
+                    {
+                        "code": "89013",
+                        "display": "aripiprazole"
+                    },
+                    {
+                        "code": "8928",
+                        "display": "Psyllium"
+                    },
+                    {
+                        "code": "8948",
+                        "display": "Purified Protein Derivative of Tuberculin"
+                    },
+                    {
+                        "code": "90176",
+                        "display": "Iron"
+                    },
+                    {
+                        "code": "9068",
+                        "display": "Quinidine"
+                    },
+                    {
+                        "code": "9071",
+                        "display": "Quinine"
+                    },
+                    {
+                        "code": "91263",
+                        "display": "Aloe Extract"
+                    },
+                    {
+                        "code": "9143",
+                        "display": "Ranitidine"
+                    },
+                    {
+                        "code": "9384",
+                        "display": "Rifampin"
+                    },
+                    {
+                        "code": "9524",
+                        "display": "Sulfasalazine"
+                    },
+                    {
+                        "code": "9601",
+                        "display": "Scopolamine"
+                    },
+                    {
+                        "code": "9778",
+                        "display": "Silicones"
+                    },
+                    {
+                        "code": "9793",
+                        "display": "silver sulfadiazine"
+                    },
+                    {
+                        "code": "9947",
+                        "display": "Sotalol"
+                    },
+                    {
+                        "code": "9997",
+                        "display": "Spironolactone"
+                    }
+                ]
+            },
+            {
+                "system": "http://snomed.info/sct",
+                "concept": [
+                    {
+                        "code": "102259006",
+                        "display": "Citrus fruit (substance)"
+                    },
+                    {
+                        "code": "102261002",
+                        "display": "Strawberry (substance)"
+                    },
+                    {
+                        "code": "102262009",
+                        "display": "Chocolate (substance)"
+                    },
+                    {
+                        "code": "102263004",
+                        "display": "Eggs (edible) (substance)"
+                    },
+                    {
+                        "code": "102264005",
+                        "display": "Cheese (substance)"
+                    },
+                    {
+                        "code": "111088007",
+                        "display": "Latex (substance)"
+                    },
+                    {
+                        "code": "111151007",
+                        "display": "Anabolic steroid (substance)"
+                    },
+                    {
+                        "code": "11526002",
+                        "display": "Aspartame (substance)"
+                    },
+                    {
+                        "code": "116274004",
+                        "display": "Artificial sweetener (substance)"
+                    },
+                    {
+                        "code": "116566001",
+                        "display": "Steroid (substance)"
+                    },
+                    {
+                        "code": "13577000",
+                        "display": "Nut (substance)"
+                    },
+                    {
+                        "code": "14443002",
+                        "display": "Substance with aminoglycoside structure and antibacterial mechanism of action (substance)"
+                    },
+                    {
+                        "code": "226723006",
+                        "display": "Buckwheat - cereal (substance)"
+                    },
+                    {
+                        "code": "226734009",
+                        "display": "Wheatgerm (substance)"
+                    },
+                    {
+                        "code": "226760005",
+                        "display": "Dairy foods (substance)"
+                    },
+                    {
+                        "code": "226915003",
+                        "display": "Red meat (substance)"
+                    },
+                    {
+                        "code": "226916002",
+                        "display": "Beef (substance)"
+                    },
+                    {
+                        "code": "226934003",
+                        "display": "Pork (substance)"
+                    },
+                    {
+                        "code": "226955001",
+                        "display": "Chicken - meat (substance)"
+                    },
+                    {
+                        "code": "226967004",
+                        "display": "Turkey - meat (substance)"
+                    },
+                    {
+                        "code": "227144008",
+                        "display": "Tuna fish (substance)"
+                    },
+                    {
+                        "code": "227151004",
+                        "display": "Prawns (substance)"
+                    },
+                    {
+                        "code": "227208008",
+                        "display": "Abalone canned in brine (substance)"
+                    },
+                    {
+                        "code": "227219006",
+                        "display": "Aubergine (substance)"
+                    },
+                    {
+                        "code": "227313005",
+                        "display": "Pulse vegetables (substance)"
+                    },
+                    {
+                        "code": "227388008",
+                        "display": "Cinnamon (substance)"
+                    },
+                    {
+                        "code": "227400003",
+                        "display": "Ginger (substance)"
+                    },
+                    {
+                        "code": "227421003",
+                        "display": "Cranberries (substance)"
+                    },
+                    {
+                        "code": "227444000",
+                        "display": "Raspberries (substance)"
+                    },
+                    {
+                        "code": "227493005",
+                        "display": "Cashew nut (substance)"
+                    },
+                    {
+                        "code": "227512001",
+                        "display": "Pistachio nut (substance)"
+                    },
+                    {
+                        "code": "227598003",
+                        "display": "Honey (substance)"
+                    },
+                    {
+                        "code": "228102000",
+                        "display": "Sodium nitrate (substance)"
+                    },
+                    {
+                        "code": "255632006",
+                        "display": "Anticonvulsant (substance)"
+                    },
+                    {
+                        "code": "255637000",
+                        "display": "Salicylate (substance)"
+                    },
+                    {
+                        "code": "255641001",
+                        "display": "Caffeine (substance)"
+                    },
+                    {
+                        "code": "256259004",
+                        "display": "Pollen (substance)"
+                    },
+                    {
+                        "code": "256277009",
+                        "display": "Grass pollen (substance)"
+                    },
+                    {
+                        "code": "256306003",
+                        "display": "Orange - fruit (substance)"
+                    },
+                    {
+                        "code": "256307007",
+                        "display": "Banana (substance)"
+                    },
+                    {
+                        "code": "256313003",
+                        "display": "Pineapple (substance)"
+                    },
+                    {
+                        "code": "256315005",
+                        "display": "Grapefruit (substance)"
+                    },
+                    {
+                        "code": "256317002",
+                        "display": "Grapes (substance)"
+                    },
+                    {
+                        "code": "256319004",
+                        "display": "Carrot (substance)"
+                    },
+                    {
+                        "code": "256326004",
+                        "display": "Celery (substance)"
+                    },
+                    {
+                        "code": "256329006",
+                        "display": "Spinach (substance)"
+                    },
+                    {
+                        "code": "256350002",
+                        "display": "Almond (substance)"
+                    },
+                    {
+                        "code": "256351003",
+                        "display": "Brazil nut (substance)"
+                    },
+                    {
+                        "code": "256352005",
+                        "display": "Walnut - nut (substance)"
+                    },
+                    {
+                        "code": "256353000",
+                        "display": "Hazelnut (substance)"
+                    },
+                    {
+                        "code": "256354006",
+                        "display": "Bean (substance)"
+                    },
+                    {
+                        "code": "256417003",
+                        "display": "Horse dander (substance)"
+                    },
+                    {
+                        "code": "256440004",
+                        "display": "Wasp venom (substance)"
+                    },
+                    {
+                        "code": "259858000",
+                        "display": "Varicella-zoster virus antibody (substance)"
+                    },
+                    {
+                        "code": "260152009",
+                        "display": "Cat dander (substance)"
+                    },
+                    {
+                        "code": "260154005",
+                        "display": "Dog dander (substance)"
+                    },
+                    {
+                        "code": "260167008",
+                        "display": "Sesame seed (substance)"
+                    },
+                    {
+                        "code": "260176001",
+                        "display": "Kiwi fruit (substance)"
+                    },
+                    {
+                        "code": "260177005",
+                        "display": "Melon (substance)"
+                    },
+                    {
+                        "code": "260179008",
+                        "display": "Mango fruit (substance)"
+                    },
+                    {
+                        "code": "260184002",
+                        "display": "Peas (substance)"
+                    },
+                    {
+                        "code": "260189007",
+                        "display": "Pecan nut (substance)"
+                    },
+                    {
+                        "code": "260205009",
+                        "display": "Sunflower seed (substance)"
+                    },
+                    {
+                        "code": "264287008",
+                        "display": "Animal dander (substance)"
+                    },
+                    {
+                        "code": "264337003",
+                        "display": "Seed (substance)"
+                    },
+                    {
+                        "code": "28230009",
+                        "display": "Poultry (substance)"
+                    },
+                    {
+                        "code": "288328004",
+                        "display": "Bee venom (substance)"
+                    },
+                    {
+                        "code": "28942008",
+                        "display": "Coconut oil (substance)"
+                    },
+                    {
+                        "code": "29263009",
+                        "display": "Coffee (substance)"
+                    },
+                    {
+                        "code": "304275008",
+                        "display": "Corticosteroid and corticosteroid derivative (substance)"
+                    },
+                    {
+                        "code": "33008008",
+                        "display": "Dust (substance)"
+                    },
+                    {
+                        "code": "350327004",
+                        "display": "Diphtheria + tetanus vaccine (product)"
+                    },
+                    {
+                        "code": "35748005",
+                        "display": "Wine (substance)"
+                    },
+                    {
+                        "code": "360201004",
+                        "display": "Nitrofuran derivative (substance)"
+                    },
+                    {
+                        "code": "3692009",
+                        "display": "Sodium sulfite (substance)"
+                    },
+                    {
+                        "code": "372480009",
+                        "display": "Substance with macrolide structure and antibacterial mechanism of action (substance)"
+                    },
+                    {
+                        "code": "372664007",
+                        "display": "Benzodiazepine (substance)"
+                    },
+                    {
+                        "code": "372665008",
+                        "display": "Non-steroidal anti-inflammatory agent (substance)"
+                    },
+                    {
+                        "code": "372711004",
+                        "display": "Sulfonylurea (substance)"
+                    },
+                    {
+                        "code": "372722000",
+                        "display": "Substance with quinolone structure and antibacterial mechanism of action (substance)"
+                    },
+                    {
+                        "code": "372733002",
+                        "display": "Substance with angiotensin-converting enzyme inhibitor mechanism of action (substance)"
+                    },
+                    {
+                        "code": "372747003",
+                        "display": "Thiazide diuretic (substance)"
+                    },
+                    {
+                        "code": "372783007",
+                        "display": "Antiparkinsonian agent (substance)"
+                    },
+                    {
+                        "code": "372798009",
+                        "display": "Barbiturate (substance)"
+                    },
+                    {
+                        "code": "372806008",
+                        "display": "Substance with histamine receptor antagonist mechanism of action (substance)"
+                    },
+                    {
+                        "code": "372889003",
+                        "display": "First generation cephalosporin (substance)"
+                    },
+                    {
+                        "code": "372912004",
+                        "display": "Substance with 3-hydroxy-3-methylglutaryl-coenzyme A reductase inhibitor mechanism of action (substance)"
+                    },
+                    {
+                        "code": "372913009",
+                        "display": "Substance with angiotensin II receptor antagonist mechanism of action (substance)"
+                    },
+                    {
+                        "code": "373206009",
+                        "display": "Substance with tetracycline structure and antibacterial mechanism of action (substance)"
+                    },
+                    {
+                        "code": "373253007",
+                        "display": "Tricyclic antidepressant (substance)"
+                    },
+                    {
+                        "code": "373254001",
+                        "display": "Substance with beta adrenergic receptor antagonist mechanism of action (substance)"
+                    },
+                    {
+                        "code": "373262009",
+                        "display": "Substance with cephalosporin structure and antibacterial mechanism of action (substance)"
+                    },
+                    {
+                        "code": "373270004",
+                        "display": "Substance with penicillin structure and antibacterial mechanism of action (substance)"
+                    },
+                    {
+                        "code": "373297006",
+                        "display": "Substance with beta-lactam structure and antibacterial mechanism of action (substance)"
+                    },
+                    {
+                        "code": "373304005",
+                        "display": "Substance with calcium channel blocker mechanism of action (substance)"
+                    },
+                    {
+                        "code": "373531009",
+                        "display": "Gelatin (substance)"
+                    },
+                    {
+                        "code": "385420005",
+                        "display": "Contrast media (substance)"
+                    },
+                    {
+                        "code": "386127005",
+                        "display": "Formula milk (substance)"
+                    },
+                    {
+                        "code": "386962001",
+                        "display": "Plasma protein fraction (substance)"
+                    },
+                    {
+                        "code": "387050005",
+                        "display": "Substance with prostaglandin-endoperoxide synthase isoform 2 inhibitor mechanism of action (substance)"
+                    },
+                    {
+                        "code": "387406002",
+                        "display": "Sulfonamide (substance)"
+                    },
+                    {
+                        "code": "391737006",
+                        "display": "Almond oil (substance)"
+                    },
+                    {
+                        "code": "391739009",
+                        "display": "Aloe (substance)"
+                    },
+                    {
+                        "code": "396345004",
+                        "display": "Carbapenem (substance)"
+                    },
+                    {
+                        "code": "396420001",
+                        "display": "Anthrax vaccine (substance)"
+                    },
+                    {
+                        "code": "396425006",
+                        "display": "Influenza virus vaccine (substance)"
+                    },
+                    {
+                        "code": "396433007",
+                        "display": "Pertussis vaccine (substance)"
+                    },
+                    {
+                        "code": "396439006",
+                        "display": "Smallpox vaccine (substance)"
+                    },
+                    {
+                        "code": "396441007",
+                        "display": "Typhoid vaccine (substance)"
+                    },
+                    {
+                        "code": "396442000",
+                        "display": "Varicella virus vaccine (substance)"
+                    },
+                    {
+                        "code": "398730001",
+                        "display": "Pneumococcal vaccine (substance)"
+                    },
+                    {
+                        "code": "400872007",
+                        "display": "Hydrocolloid (substance)"
+                    },
+                    {
+                        "code": "404642006",
+                        "display": "Substance with opioid receptor agonist mechanism of action (substance)"
+                    },
+                    {
+                        "code": "406748003",
+                        "display": "Carbamate (substance)"
+                    },
+                    {
+                        "code": "409137002",
+                        "display": "No known drug allergy (situation)"
+                    },
+                    {
+                        "code": "412061001",
+                        "display": "Blueberries (substance)"
+                    },
+                    {
+                        "code": "412062008",
+                        "display": "Cantaloupe (substance)"
+                    },
+                    {
+                        "code": "412066006",
+                        "display": "Pepper (substance)"
+                    },
+                    {
+                        "code": "412068007",
+                        "display": "Rye (substance)"
+                    },
+                    {
+                        "code": "412071004",
+                        "display": "Wheat (substance)"
+                    },
+                    {
+                        "code": "412138001",
+                        "display": "Horse serum protein (substance)"
+                    },
+                    {
+                        "code": "412357001",
+                        "display": "Corn (substance)"
+                    },
+                    {
+                        "code": "412373007",
+                        "display": "Diphtheria + pertussis + tetanus + Haemophilus influenzae type b vaccine (product)"
+                    },
+                    {
+                        "code": "412375000",
+                        "display": "Tetanus vaccine (substance)"
+                    },
+                    {
+                        "code": "412533000",
+                        "display": "Wheat bran (substance)"
+                    },
+                    {
+                        "code": "412534006",
+                        "display": "Yeast (substance)"
+                    },
+                    {
+                        "code": "412583005",
+                        "display": "Bee pollen (substance)"
+                    },
+                    {
+                        "code": "41598000",
+                        "display": "Estrogen (substance)"
+                    },
+                    {
+                        "code": "417889008",
+                        "display": "Arachis oil (substance)"
+                    },
+                    {
+                        "code": "418000008",
+                        "display": "Methadone analog (substance)"
+                    },
+                    {
+                        "code": "418504009",
+                        "display": "Oats (substance)"
+                    },
+                    {
+                        "code": "418920007",
+                        "display": "Adhesive agent (substance)"
+                    },
+                    {
+                        "code": "419420009",
+                        "display": "Watermelon (substance)"
+                    },
+                    {
+                        "code": "419933005",
+                        "display": "Glucocorticoid (substance)"
+                    },
+                    {
+                        "code": "421245007",
+                        "display": "Diphtheria + pertussis + tetanus vaccine (product)"
+                    },
+                    {
+                        "code": "424369009",
+                        "display": "Product containing beta-galactosidase (medicinal product)"
+                    },
+                    {
+                        "code": "426722004",
+                        "display": "Iodinated contrast media (substance)"
+                    },
+                    {
+                        "code": "428607008",
+                        "display": "No known environmental allergy (situation)"
+                    },
+                    {
+                        "code": "429625007",
+                        "display": "No known food allergy (situation)"
+                    },
+                    {
+                        "code": "43735007",
+                        "display": "Sulfur (substance)"
+                    },
+                    {
+                        "code": "43921001",
+                        "display": "Nickel compound (substance)"
+                    },
+                    {
+                        "code": "44027008",
+                        "display": "Seafood (substance)"
+                    },
+                    {
+                        "code": "442381000124103",
+                        "display": "Blue food coloring (substance)"
+                    },
+                    {
+                        "code": "442571000124108",
+                        "display": "Tree nut (substance)"
+                    },
+                    {
+                        "code": "442771000124102",
+                        "display": "Pepperoni (substance)"
+                    },
+                    {
+                        "code": "44588005",
+                        "display": "Iodine (substance)"
+                    },
+                    {
+                        "code": "446273004",
+                        "display": "Red food coloring (substance)"
+                    },
+                    {
+                        "code": "446274005",
+                        "display": "Yellow food coloring (substance)"
+                    },
+                    {
+                        "code": "47703008",
+                        "display": "Lactose (substance)"
+                    },
+                    {
+                        "code": "51386004",
+                        "display": "Food preservative (substance)"
+                    },
+                    {
+                        "code": "51905005",
+                        "display": "Mustard (substance)"
+                    },
+                    {
+                        "code": "53041004",
+                        "display": "Alcohol (substance)"
+                    },
+                    {
+                        "code": "61789006",
+                        "display": "Dye (substance)"
+                    },
+                    {
+                        "code": "63045006",
+                        "display": "Berry (substance)"
+                    },
+                    {
+                        "code": "67324005",
+                        "display": "Rice (substance)"
+                    },
+                    {
+                        "code": "67866001",
+                        "display": "Insulin (substance)"
+                    },
+                    {
+                        "code": "70813002",
+                        "display": "Milk (substance)"
+                    },
+                    {
+                        "code": "710179004",
+                        "display": "Lupine seed (substance)"
+                    },
+                    {
+                        "code": "716184000",
+                        "display": "No known latex allergy (situation)"
+                    },
+                    {
+                        "code": "716186003",
+                        "display": "No known allergy (situation)"
+                    },
+                    {
+                        "code": "720687003",
+                        "display": "Dust mite protein (substance)"
+                    },
+                    {
+                        "code": "72511004",
+                        "display": "Fruit (substance)"
+                    },
+                    {
+                        "code": "726730005",
+                        "display": "Yam (substance)"
+                    },
+                    {
+                        "code": "734881000",
+                        "display": "Tomato (substance)"
+                    },
+                    {
+                        "code": "735006003",
+                        "display": "Squid (substance)"
+                    },
+                    {
+                        "code": "735009005",
+                        "display": "Salmon (substance)"
+                    },
+                    {
+                        "code": "735029006",
+                        "display": "Shellfish (substance)"
+                    },
+                    {
+                        "code": "735030001",
+                        "display": "Garlic (substance)"
+                    },
+                    {
+                        "code": "735043001",
+                        "display": "Mackerel (substance)"
+                    },
+                    {
+                        "code": "735045008",
+                        "display": "Mushroom (substance)"
+                    },
+                    {
+                        "code": "735047000",
+                        "display": "Onion (substance)"
+                    },
+                    {
+                        "code": "735049002",
+                        "display": "Peach (substance)"
+                    },
+                    {
+                        "code": "735050002",
+                        "display": "Pear (substance)"
+                    },
+                    {
+                        "code": "735051003",
+                        "display": "Plum (substance)"
+                    },
+                    {
+                        "code": "735053000",
+                        "display": "Potato (substance)"
+                    },
+                    {
+                        "code": "735123009",
+                        "display": "Broccoli (substance)"
+                    },
+                    {
+                        "code": "735124003",
+                        "display": "Barley (substance)"
+                    },
+                    {
+                        "code": "735211005",
+                        "display": "Coconut (substance)"
+                    },
+                    {
+                        "code": "735212003",
+                        "display": "Papaya (substance)"
+                    },
+                    {
+                        "code": "735213008",
+                        "display": "Cucumber (substance)"
+                    },
+                    {
+                        "code": "735214002",
+                        "display": "Apricot (substance)"
+                    },
+                    {
+                        "code": "735215001",
+                        "display": "Apple (substance)"
+                    },
+                    {
+                        "code": "735248001",
+                        "display": "Cherry (substance)"
+                    },
+                    {
+                        "code": "735249009",
+                        "display": "Avocado (substance)"
+                    },
+                    {
+                        "code": "735340006",
+                        "display": "Lemon (substance)"
+                    },
+                    {
+                        "code": "735959004",
+                        "display": "Marine mollusk (substance)"
+                    },
+                    {
+                        "code": "735971005",
+                        "display": "Fish (substance)"
+                    },
+                    {
+                        "code": "735977009",
+                        "display": "Marine crustacean (substance)"
+                    },
+                    {
+                        "code": "736027000",
+                        "display": "Scallop (substance)"
+                    },
+                    {
+                        "code": "736030007",
+                        "display": "Clam (substance)"
+                    },
+                    {
+                        "code": "736031006",
+                        "display": "Oyster (substance)"
+                    },
+                    {
+                        "code": "736159005",
+                        "display": "Crab (substance)"
+                    },
+                    {
+                        "code": "736162008",
+                        "display": "Lobster (substance)"
+                    },
+                    {
+                        "code": "74801000",
+                        "display": "Sugar (substance)"
+                    },
+                    {
+                        "code": "75665004",
+                        "display": "Monosodium glutamate (substance)"
+                    },
+                    {
+                        "code": "762952008",
+                        "display": "Peanut (substance)"
+                    },
+                    {
+                        "code": "7791007",
+                        "display": "Soy protein (substance)"
+                    },
+                    {
+                        "code": "80259003",
+                        "display": "Food flavoring agent (substance)"
+                    },
+                    {
+                        "code": "84489001",
+                        "display": "Mold (organism)"
+                    },
+                    {
+                        "code": "89119000",
+                        "display": "Nitrate salt (substance)"
+                    },
+                    {
+                        "code": "89707004",
+                        "display": "Sesame oil (substance)"
+                    },
+                    {
+                        "code": "89811004",
+                        "display": "Gluten (substance)"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-careteam-provider-roles.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-careteam-provider-roles.json
@@ -1,66 +1,66 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-careteam-provider-roles",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This value set includes codes based on the following rules:</p><ul><li>Include all codes defined in <code>http://nucc.org/provider-taxonomy</code></li><li>Include codes from <a href=\"http://www.snomed.org/\"><code>http://snomed.info/sct</code></a> where concept  is-a  223366009 (Healthcare professional)</li><li>Include codes from <a href=\"http://www.snomed.org/\"><code>http://snomed.info/sct</code></a> where concept  is-a  224930009 (Services)</li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-careteam-provider-roles",
-	"version": "3.1.1",
-	"name": "USCoreCareTeamProviderRoles",
-	"title": "US Core CareTeam Provider Roles",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "other",
-					"value": "http://hl7.org/fhir"
-				}
-			]
-		}
-	],
-	"description": "Provider roles codes consist of NUCC Health Care Provider Taxonomy Code Set for providers and SNOMED-CT for - non clinical and organization roles including codes from the SCTID 223366009 Healthcare professional (occupation) heirarchy and the SCTID 224930009 Services (qualifier value) heirarchy.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"purpose": "Codes that may be used for implementation of the Argonaut Procedures IG and MU2015 certification.",
-	"copyright": "This value set includes content from:\n 1. SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.\n 2. NUCC Health Care Provider Taxonomy Code Set for providers which is copyright © 2016+ American Medical Association.  For commercial use, including sales or licensing, a license must be obtained.",
-	"compose": {
-		"include": [
-			{
-				"system": "http://nucc.org/provider-taxonomy"
-			},
-			{
-				"system": "http://snomed.info/sct",
-				"filter": [
-					{
-						"property": "concept",
-						"op": "is-a",
-						"value": "223366009"
-					}
-				]
-			},
-			{
-				"system": "http://snomed.info/sct",
-				"filter": [
-					{
-						"property": "concept",
-						"op": "is-a",
-						"value": "224930009"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-careteam-provider-roles",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-careteam-provider-roles",
+    "version": "3.1.1",
+    "name": "USCoreCareTeamProviderRoles",
+    "title": "US Core CareTeam Provider Roles",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "other",
+                    "value": "http://hl7.org/fhir"
+                }
+            ]
+        }
+    ],
+    "description": "Provider roles codes consist of NUCC Health Care Provider Taxonomy Code Set for providers and SNOMED-CT for - non clinical and organization roles including codes from the SCTID 223366009 Healthcare professional (occupation) heirarchy and the SCTID 224930009 Services (qualifier value) heirarchy.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "purpose": "Codes that may be used for implementation of the Argonaut Procedures IG and MU2015 certification.",
+    "copyright": "This value set includes content from:\n 1. SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.\n 2. NUCC Health Care Provider Taxonomy Code Set for providers which is copyright © 2016+ American Medical Association.  For commercial use, including sales or licensing, a license must be obtained.",
+    "compose": {
+        "include": [
+            {
+                "system": "http://nucc.org/provider-taxonomy"
+            },
+            {
+                "system": "http://snomed.info/sct",
+                "filter": [
+                    {
+                        "property": "concept",
+                        "op": "is-a",
+                        "value": "223366009"
+                    }
+                ]
+            },
+            {
+                "system": "http://snomed.info/sct",
+                "filter": [
+                    {
+                        "property": "concept",
+                        "op": "is-a",
+                        "value": "224930009"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-clinical-note-type.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-clinical-note-type.json
@@ -1,62 +1,62 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-clinical-note-type",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include these codes as defined in <a href=\"http://loinc.org\"><code>http://loinc.org</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/18842-5.html\">18842-5</a></td><td>Discharge summary</td><td/></tr><tr><td><a href=\"http://details.loinc.org/LOINC/11488-4.html\">11488-4</a></td><td>Consult note</td><td/></tr><tr><td><a href=\"http://details.loinc.org/LOINC/34117-2.html\">34117-2</a></td><td>History and physical note</td><td/></tr><tr><td><a href=\"http://details.loinc.org/LOINC/11506-3.html\">11506-3</a></td><td>Progress note</td><td/></tr><tr><td><a href=\"http://details.loinc.org/LOINC/28570-0.html\">28570-0</a></td><td>Procedure note</td><td/></tr></table></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-clinical-note-type",
-	"version": "3.1.1",
-	"name": "USCoreClinicalNoteType",
-	"title": "US Core Clinical Note Type",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "other",
-					"value": "http://hl7.org/fhir"
-				}
-			]
-		}
-	],
-	"description": "The US Core Clinical Note Type Value Set is a 'starter set' of types supported for fetching and storing clinical notes.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"copyright": "This material contains content from [LOINC](http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc",
-	"compose": {
-		"include": [
-			{
-				"system": "http://loinc.org",
-				"concept": [
-					{
-						"code": "18842-5"
-					},
-					{
-						"code": "11488-4"
-					},
-					{
-						"code": "34117-2"
-					},
-					{
-						"code": "11506-3"
-					},
-					{
-						"code": "28570-0"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-clinical-note-type",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-clinical-note-type",
+    "version": "3.1.1",
+    "name": "USCoreClinicalNoteType",
+    "title": "US Core Clinical Note Type",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "other",
+                    "value": "http://hl7.org/fhir"
+                }
+            ]
+        }
+    ],
+    "description": "The US Core Clinical Note Type Value Set is a 'starter set' of types supported for fetching and storing clinical notes.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "copyright": "This material contains content from [LOINC](http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc",
+    "compose": {
+        "include": [
+            {
+                "system": "http://loinc.org",
+                "concept": [
+                    {
+                        "code": "18842-5"
+                    },
+                    {
+                        "code": "11488-4"
+                    },
+                    {
+                        "code": "34117-2"
+                    },
+                    {
+                        "code": "11506-3"
+                    },
+                    {
+                        "code": "28570-0"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-condition-category.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-condition-category.json
@@ -1,44 +1,44 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-condition-category",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This value set includes codes based on the following rules:</p><ul><li>Include all codes defined in <a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-condition-category.html\"><code>http://terminology.hl7.org/CodeSystem/condition-category</code></a></li><li>Include these codes as defined in <a href=\"CodeSystem-condition-category.html\"><code>http://hl7.org/fhir/us/core/CodeSystem/condition-category</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td></tr><tr><td><a href=\"CodeSystem-condition-category.html#condition-category-health-concern\">health-concern</a></td><td>Health Concern</td><td>Additional health concerns from other stakeholders which are outside the provider’s problem list.</td></tr></table></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category",
-	"version": "3.1.1",
-	"name": "USCoreConditionCategoryCodes",
-	"title": "US Core Condition Category Codes",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"description": "The US Core Condition Category Codes support the separate concepts of problems and health concerns in Condition.category in order for API consumers to be able to separate health concerns and problems. However this is not mandatory for 2015 certification",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"purpose": "So API consumers can separate health concerns and problems.",
-	"compose": {
-		"include": [
-			{
-				"system": "http://terminology.hl7.org/CodeSystem/condition-category"
-			},
-			{
-				"system": "http://hl7.org/fhir/us/core/CodeSystem/condition-category|3.1.1",
-				"concept": [
-					{
-						"code": "health-concern",
-						"display": "Health Concern"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-condition-category",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category",
+    "version": "3.1.1",
+    "name": "USCoreConditionCategoryCodes",
+    "title": "US Core Condition Category Codes",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "description": "The US Core Condition Category Codes support the separate concepts of problems and health concerns in Condition.category in order for API consumers to be able to separate health concerns and problems. However this is not mandatory for 2015 certification",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "purpose": "So API consumers can separate health concerns and problems.",
+    "compose": {
+        "include": [
+            {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category"
+            },
+            {
+                "system": "http://hl7.org/fhir/us/core/CodeSystem/condition-category|3.1.1",
+                "concept": [
+                    {
+                        "code": "health-concern",
+                        "display": "Health Concern"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-condition-code.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-condition-code.json
@@ -1,76 +1,76 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-condition-code",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This value set includes codes based on the following rules:</p><ul><li>Include these codes as defined in <a href=\"http://www.snomed.org/\"><code>http://snomed.info/sct</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=160245001\">160245001</a></td><td>No current problems or disability</td><td/></tr></table></li><li>Include codes from <a href=\"http://www.snomed.org/\"><code>http://snomed.info/sct</code></a> where concept  is-a  404684003 (Clinical finding (finding))</li><li>Include codes from <a href=\"http://www.snomed.org/\"><code>http://snomed.info/sct</code></a> where concept  is-a  243796009 (Context-dependent categories)</li><li>Include all codes defined in <a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-icd10CM.html\"><code>http://hl7.org/fhir/sid/icd-10-cm</code></a></li><li>Include all codes defined in <code>http://hl7.org/fhir/sid/icd-9-cm</code></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-code",
-	"version": "3.1.1",
-	"name": "USCoreConditionCode",
-	"title": "US Core Condition Code",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "other",
-					"value": "http://hl7.org/fhir"
-				}
-			]
-		}
-	],
-	"description": "This describes the problem. Diagnosis/Problem List is broadly defined as a series of brief statements that catalog a patient's medical, nursing, dental, social, preventative and psychiatric events and issues that are relevant to that patient's healthcare (e.g., signs, symptoms, and defined conditions).   ICD-10 is appropriate for Diagnosis information, and ICD-9 for historical information.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"copyright": "This value set includes content from:\n  1. SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.\n  2. ICD-9 and ICD-10 are copyrighted by the World Health Organization (WHO) which owns and publishes the classification. See https://www.who.int/classifications/icd/en. WHO has authorized the development of an adaptation of ICD-9 and ICD-10 to ICD-9-CM to ICD-10-CM for use in the United States for U.S. government purposes.\n",
-	"compose": {
-		"include": [
-			{
-				"system": "http://snomed.info/sct",
-				"concept": [
-					{
-						"code": "160245001"
-					}
-				]
-			},
-			{
-				"system": "http://snomed.info/sct",
-				"filter": [
-					{
-						"property": "concept",
-						"op": "is-a",
-						"value": "404684003"
-					}
-				]
-			},
-			{
-				"system": "http://snomed.info/sct",
-				"filter": [
-					{
-						"property": "concept",
-						"op": "is-a",
-						"value": "243796009"
-					}
-				]
-			},
-			{
-				"system": "http://hl7.org/fhir/sid/icd-10-cm"
-			},
-			{
-				"system": "http://hl7.org/fhir/sid/icd-9-cm"
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-condition-code",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-code",
+    "version": "3.1.1",
+    "name": "USCoreConditionCode",
+    "title": "US Core Condition Code",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "other",
+                    "value": "http://hl7.org/fhir"
+                }
+            ]
+        }
+    ],
+    "description": "This describes the problem. Diagnosis/Problem List is broadly defined as a series of brief statements that catalog a patient's medical, nursing, dental, social, preventative and psychiatric events and issues that are relevant to that patient's healthcare (e.g., signs, symptoms, and defined conditions).   ICD-10 is appropriate for Diagnosis information, and ICD-9 for historical information.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "copyright": "This value set includes content from:\n  1. SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.\n  2. ICD-9 and ICD-10 are copyrighted by the World Health Organization (WHO) which owns and publishes the classification. See https://www.who.int/classifications/icd/en. WHO has authorized the development of an adaptation of ICD-9 and ICD-10 to ICD-9-CM to ICD-10-CM for use in the United States for U.S. government purposes.\n",
+    "compose": {
+        "include": [
+            {
+                "system": "http://snomed.info/sct",
+                "concept": [
+                    {
+                        "code": "160245001"
+                    }
+                ]
+            },
+            {
+                "system": "http://snomed.info/sct",
+                "filter": [
+                    {
+                        "property": "concept",
+                        "op": "is-a",
+                        "value": "404684003"
+                    }
+                ]
+            },
+            {
+                "system": "http://snomed.info/sct",
+                "filter": [
+                    {
+                        "property": "concept",
+                        "op": "is-a",
+                        "value": "243796009"
+                    }
+                ]
+            },
+            {
+                "system": "http://hl7.org/fhir/sid/icd-10-cm"
+            },
+            {
+                "system": "http://hl7.org/fhir/sid/icd-9-cm"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-diagnosticreport-category.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-diagnosticreport-category.json
@@ -1,48 +1,48 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-diagnosticreport-category",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include these codes as defined in <a href=\"http://loinc.org\"><code>http://loinc.org</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/LP29684-5.html\">LP29684-5</a></td><td>Radiology</td><td/></tr><tr><td><a href=\"http://details.loinc.org/LOINC/LP29708-2.html\">LP29708-2</a></td><td>Cardiology</td><td/></tr><tr><td><a href=\"http://details.loinc.org/LOINC/LP7839-6.html\">LP7839-6</a></td><td>Pathology</td><td/></tr></table></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-category",
-	"version": "3.1.1",
-	"name": "USCoreDiagnosticReportCategory",
-	"title": "US Core DiagnosticReport Category",
-	"status": "active",
-	"date": "2019-05-21",
-	"description": "The US Core Diagnostic Report Category Value Set is a 'starter set' of categories supported for fetching and Diagnostic Reports and notes.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"copyright": "This material contains content from [LOINC](http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc",
-	"compose": {
-		"include": [
-			{
-				"system": "http://loinc.org",
-				"concept": [
-					{
-						"code": "LP29684-5",
-						"display": "Radiology"
-					},
-					{
-						"code": "LP29708-2",
-						"display": "Cardiology"
-					},
-					{
-						"code": "LP7839-6",
-						"display": "Pathology"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-diagnosticreport-category",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-category",
+    "version": "3.1.1",
+    "name": "USCoreDiagnosticReportCategory",
+    "title": "US Core DiagnosticReport Category",
+    "status": "active",
+    "date": "2019-05-21",
+    "description": "The US Core Diagnostic Report Category Value Set is a 'starter set' of categories supported for fetching and Diagnostic Reports and notes.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "copyright": "This material contains content from [LOINC](http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc",
+    "compose": {
+        "include": [
+            {
+                "system": "http://loinc.org",
+                "concept": [
+                    {
+                        "code": "LP29684-5",
+                        "display": "Radiology"
+                    },
+                    {
+                        "code": "LP29708-2",
+                        "display": "Cardiology"
+                    },
+                    {
+                        "code": "LP7839-6",
+                        "display": "Pathology"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-diagnosticreport-lab-codes.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-diagnosticreport-lab-codes.json
@@ -1,52 +1,52 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-diagnosticreport-lab-codes",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include codes from <a href=\"http://loinc.org\"><code>http://loinc.org</code></a> where CLASSTYPE  =  1</li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-lab-codes",
-	"version": "3.1.1",
-	"name": "USCoreDiagnosticReportLabCodes",
-	"title": "US Core Diagnostic Report Laboratory Codes",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "other",
-					"value": "http://hl7.org/fhir"
-				}
-			]
-		}
-	],
-	"description": "The Document Type value set includes all LOINC  values whose CLASSTYPE is LABORATORY in the LOINC database",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"copyright": "This material contains content from [LOINC](http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc",
-	"compose": {
-		"include": [
-			{
-				"system": "http://loinc.org",
-				"filter": [
-					{
-						"property": "CLASSTYPE",
-						"op": "=",
-						"value": "1"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-diagnosticreport-lab-codes",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-lab-codes",
+    "version": "3.1.1",
+    "name": "USCoreDiagnosticReportLabCodes",
+    "title": "US Core Diagnostic Report Laboratory Codes",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "other",
+                    "value": "http://hl7.org/fhir"
+                }
+            ]
+        }
+    ],
+    "description": "The Document Type value set includes all LOINC  values whose CLASSTYPE is LABORATORY in the LOINC database",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "copyright": "This material contains content from [LOINC](http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc",
+    "compose": {
+        "include": [
+            {
+                "system": "http://loinc.org",
+                "filter": [
+                    {
+                        "property": "CLASSTYPE",
+                        "op": "=",
+                        "value": "1"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-diagnosticreport-report-and-note-codes.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-diagnosticreport-report-and-note-codes.json
@@ -1,46 +1,46 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-diagnosticreport-report-and-note-codes",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include all codes defined in <a href=\"http://loinc.org\"><code>http://loinc.org</code></a></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-report-and-note-codes",
-	"version": "3.1.1",
-	"name": "USCoreDiagnosticreportReportAndNoteCodes",
-	"title": "US Core Diagnosticreport Report And Note Codes",
-	"status": "active",
-	"experimental": false,
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "other",
-					"value": "http://hl7.org/fhir"
-				}
-			]
-		}
-	],
-	"description": "This value set currently contains all of LOINC. The codes selected should represent discrete and narrative diagnostic observations and reports",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"copyright": "This material contains content from [LOINC](http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc",
-	"compose": {
-		"include": [
-			{
-				"system": "http://loinc.org"
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-diagnosticreport-report-and-note-codes",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-report-and-note-codes",
+    "version": "3.1.1",
+    "name": "USCoreDiagnosticreportReportAndNoteCodes",
+    "title": "US Core Diagnosticreport Report And Note Codes",
+    "status": "active",
+    "experimental": false,
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "other",
+                    "value": "http://hl7.org/fhir"
+                }
+            ]
+        }
+    ],
+    "description": "This value set currently contains all of LOINC. The codes selected should represent discrete and narrative diagnostic observations and reports",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "copyright": "This material contains content from [LOINC](http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc",
+    "compose": {
+        "include": [
+            {
+                "system": "http://loinc.org"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-documentreference-category.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-documentreference-category.json
@@ -1,44 +1,44 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-documentreference-category",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include all codes defined in <a href=\"CodeSystem-us-core-documentreference-category.html\"><code>http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category</code></a></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-category",
-	"version": "3.1.1",
-	"name": "USCoreDocumentReferenceCategory",
-	"title": "US Core DocumentReference Category",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "other",
-					"value": "http://hl7.org/fhir"
-				}
-			]
-		}
-	],
-	"description": "The US Core DocumentReferences Category Value Set is a 'starter set' of categories supported for fetching and storing clinical notes.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"compose": {
-		"include": [
-			{
-				"system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category|3.1.1"
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-documentreference-category",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-category",
+    "version": "3.1.1",
+    "name": "USCoreDocumentReferenceCategory",
+    "title": "US Core DocumentReference Category",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "other",
+                    "value": "http://hl7.org/fhir"
+                }
+            ]
+        }
+    ],
+    "description": "The US Core DocumentReferences Category Value Set is a 'starter set' of categories supported for fetching and storing clinical notes.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "compose": {
+        "include": [
+            {
+                "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category|3.1.1"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-documentreference-type.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-documentreference-type.json
@@ -1,61 +1,61 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-documentreference-type",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This value set includes codes based on the following rules:</p><ul><li>Include these codes as defined in <a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-v3-NullFlavor.html\"><code>http://terminology.hl7.org/CodeSystem/v3-NullFlavor</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td></tr><tr><td><a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-v3-NullFlavor.html#v3-NullFlavor-UNK\">UNK</a></td><td>unknown</td><td>**Description:**A proper value is applicable, but not known.<br/><br/>**Usage Notes**: This means the actual value is not known. If the only thing that is unknown is how to properly express the value in the necessary constraints (value set, datatype, etc.), then the OTH or UNC flavor should be used. No properties should be included for a datatype with this property unless:<br/><br/>1.  Those properties themselves directly translate to a semantic of &quot;unknown&quot;. (E.g. a local code sent as a translation that conveys 'unknown')<br/>2.  Those properties further qualify the nature of what is unknown. (E.g. specifying a use code of &quot;H&quot; and a URL prefix of &quot;tel:&quot; to convey that it is the home phone number that is unknown.)</td></tr></table></li><li>Include codes from <a href=\"http://loinc.org\"><code>http://loinc.org</code></a> where SCALE_TYP  =  DOC</li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-type",
-	"version": "3.1.1",
-	"name": "USCoreDocumentReferenceType",
-	"title": "US Core DocumentReference Type",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "other",
-					"value": "http://hl7.org/fhir"
-				}
-			]
-		}
-	],
-	"description": "The US Core DocumentReference Type Value Set includes all LOINC  values whose SCALE is DOC in the LOINC database and the HL7 v3 Code System NullFlavor concept 'unknown'",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"copyright": "This material contains content from [LOINC](http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc",
-	"compose": {
-		"include": [
-			{
-				"system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
-				"concept": [
-					{
-						"code": "UNK",
-						"display": "unknown"
-					}
-				]
-			},
-			{
-				"system": "http://loinc.org",
-				"filter": [
-					{
-						"property": "SCALE_TYP",
-						"op": "=",
-						"value": "DOC"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-documentreference-type",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-type",
+    "version": "3.1.1",
+    "name": "USCoreDocumentReferenceType",
+    "title": "US Core DocumentReference Type",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "other",
+                    "value": "http://hl7.org/fhir"
+                }
+            ]
+        }
+    ],
+    "description": "The US Core DocumentReference Type Value Set includes all LOINC  values whose SCALE is DOC in the LOINC database and the HL7 v3 Code System NullFlavor concept 'unknown'",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "copyright": "This material contains content from [LOINC](http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc",
+    "compose": {
+        "include": [
+            {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                "concept": [
+                    {
+                        "code": "UNK",
+                        "display": "unknown"
+                    }
+                ]
+            },
+            {
+                "system": "http://loinc.org",
+                "filter": [
+                    {
+                        "property": "SCALE_TYP",
+                        "op": "=",
+                        "value": "DOC"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-encounter-type.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-encounter-type.json
@@ -1,61 +1,61 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-encounter-type",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This value set includes codes based on the following rules:</p><ul><li>Include codes from <a href=\"http://www.snomed.org/\"><code>http://snomed.info/sct</code></a> where concept  is-a  308335008 (Patient encounter procedure)</li><li>Include all codes defined in <a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-v3-cpt-4.html\"><code>http://www.ama-assn.org/go/cpt</code></a></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-encounter-type",
-	"identifier": [
-		{
-			"system": "urn:ietf:rfc:3986",
-			"value": "urn:oid:2.16.840.1.113883.3.88.12.80.32"
-		}
-	],
-	"version": "3.1.1",
-	"name": "USCoreEncounterType",
-	"title": "US Core Encounter Type",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "other",
-					"value": "http://hl7.org/fhir"
-				}
-			]
-		}
-	],
-	"description": "The type of encounter: a specific code indicating type of service provided. This value set includes codes from SNOMED CT decending from the concept 308335008 (Patient encounter procedure (procedure)) and from the Current Procedure and Terminology(CPT) designated for Evaluation and Management (99200 – 99607) (subscription to AMA Required)",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"copyright": "This value set includes content from:\n 1. SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.\n  2. CPT copyright 2014 American Medical Association. All rights reserved.",
-	"compose": {
-		"include": [
-			{
-				"system": "http://snomed.info/sct",
-				"filter": [
-					{
-						"property": "concept",
-						"op": "is-a",
-						"value": "308335008"
-					}
-				]
-			},
-			{
-				"system": "http://www.ama-assn.org/go/cpt"
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-encounter-type",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-encounter-type",
+    "identifier": [
+        {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:oid:2.16.840.1.113883.3.88.12.80.32"
+        }
+    ],
+    "version": "3.1.1",
+    "name": "USCoreEncounterType",
+    "title": "US Core Encounter Type",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "other",
+                    "value": "http://hl7.org/fhir"
+                }
+            ]
+        }
+    ],
+    "description": "The type of encounter: a specific code indicating type of service provided. This value set includes codes from SNOMED CT decending from the concept 308335008 (Patient encounter procedure (procedure)) and from the Current Procedure and Terminology(CPT) designated for Evaluation and Management (99200 – 99607) (subscription to AMA Required)",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "copyright": "This value set includes content from:\n 1. SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.\n  2. CPT copyright 2014 American Medical Association. All rights reserved.",
+    "compose": {
+        "include": [
+            {
+                "system": "http://snomed.info/sct",
+                "filter": [
+                    {
+                        "property": "concept",
+                        "op": "is-a",
+                        "value": "308335008"
+                    }
+                ]
+            },
+            {
+                "system": "http://www.ama-assn.org/go/cpt"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-medication-codes.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-medication-codes.json
@@ -1,58 +1,58 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-medication-codes",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n\t\t\t<h2>Medication Clinical Drug (RxNorm)</h2>\n\t\t\t<p>All prescribable medication formulations represented using  either a 'generic' or 'brand-specific' concept. This includes RxNorm codes whose Term Type is SCD (semantic clinical drug), SBD (semantic brand drug), GPCK (generic pack), BPCK (brand pack), SCDG (semantic clinical drug group), SBDG (semantic brand drug group), SCDF (semantic clinical drug form), or SBDF (semantic brand drug form)</p>\n\t\t\t<p>This value set includes codes from the following code systems:</p>\n\t\t\t<ul>\n\t\t\t\t<li>Include codes from http://www.nlm.nih.gov/research/umls/rxnorm where TTY  in  SCD,SBD,GPCK,BPCK,SCDG,SBDG,SCDF,SBDF</li>\n\t\t\t</ul>\n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-medication-codes",
-	"identifier": [
-		{
-			"system": "urn:ietf:rfc:3986",
-			"value": "urn:oid:2.16.840.1.113762.1.4.1010.4"
-		}
-	],
-	"version": "3.1.1",
-	"name": "USCoreMedicationCodes",
-	"title": "US Core Medication Codes (RxNorm)",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "other",
-					"value": "http://hl7.org/fhir"
-				}
-			]
-		}
-	],
-	"description": "All prescribable medication formulations represented using  either a 'generic' or 'brand-specific' concept. This includes RxNorm codes whose Term Type is SCD (semantic clinical drug), SBD (semantic brand drug), GPCK (generic pack), BPCK (brand pack), SCDG (semantic clinical drug group), SBDG (semantic brand drug group), SCDF (semantic clinical drug form), or SBDF (semantic brand drug form)",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"copyright": "Using RxNorm codes of type SAB=RXNORM as this specification describes [does not require](https://www.nlm.nih.gov/research/umls/rxnorm/docs/prescribe.html)  a UMLS license. Access to the full set of RxNorm definitions, and/or additional use of other RxNorm structures and information requires a UMLS license. The use of RxNorm in this specification is pursuant to HL7's status as a licensee of the NLM UMLS. HL7's license does not convey the right to use RxNorm to any users of this specification; implementers must acquire a license to use RxNorm in their own right",
-	"compose": {
-		"include": [
-			{
-				"system": "http://www.nlm.nih.gov/research/umls/rxnorm",
-				"filter": [
-					{
-						"property": "TTY",
-						"op": "in",
-						"value": "SCD,SBD,GPCK,BPCK,SCDG,SBDG,SCDF,SBDF"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-medication-codes",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-medication-codes",
+    "identifier": [
+        {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:oid:2.16.840.1.113762.1.4.1010.4"
+        }
+    ],
+    "version": "3.1.1",
+    "name": "USCoreMedicationCodes",
+    "title": "US Core Medication Codes (RxNorm)",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "other",
+                    "value": "http://hl7.org/fhir"
+                }
+            ]
+        }
+    ],
+    "description": "All prescribable medication formulations represented using  either a 'generic' or 'brand-specific' concept. This includes RxNorm codes whose Term Type is SCD (semantic clinical drug), SBD (semantic brand drug), GPCK (generic pack), BPCK (brand pack), SCDG (semantic clinical drug group), SBDG (semantic brand drug group), SCDF (semantic clinical drug form), or SBDF (semantic brand drug form)",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "copyright": "Using RxNorm codes of type SAB=RXNORM as this specification describes [does not require](https://www.nlm.nih.gov/research/umls/rxnorm/docs/prescribe.html)  a UMLS license. Access to the full set of RxNorm definitions, and/or additional use of other RxNorm structures and information requires a UMLS license. The use of RxNorm in this specification is pursuant to HL7's status as a licensee of the NLM UMLS. HL7's license does not convey the right to use RxNorm to any users of this specification; implementers must acquire a license to use RxNorm in their own right",
+    "compose": {
+        "include": [
+            {
+                "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+                "filter": [
+                    {
+                        "property": "TTY",
+                        "op": "in",
+                        "value": "SCD,SBD,GPCK,BPCK,SCDG,SBDG,SCDF,SBDF"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-narrative-status.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-narrative-status.json
@@ -1,55 +1,55 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-narrative-status",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include these codes as defined in <a href=\"http://hl7.org/fhir/R4/codesystem-narrative-status.html\"><code>http://hl7.org/fhir/narrative-status</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td></tr><tr><td><a href=\"http://hl7.org/fhir/R4/codesystem-narrative-status.html#narrative-status-additional\">additional</a></td><td>additional</td><td>The contents of the narrative may contain additional information not found in the structured data. Note that there is no computable way to determine what the extra information is, other than by human inspection.</td></tr><tr><td><a href=\"http://hl7.org/fhir/R4/codesystem-narrative-status.html#narrative-status-generated\">generated</a></td><td>generated</td><td>The contents of the narrative are entirely generated from the core elements in the content.</td></tr></table></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-narrative-status",
-	"version": "3.1.1",
-	"name": "NarrativeStatus",
-	"title": "US Core Narrative Status",
-	"status": "active",
-	"date": "2020-08-28T10:54:27+10:00",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "other",
-					"value": "http://hl7.org/fhir"
-				}
-			]
-		}
-	],
-	"description": "The US Core Narrative Status Value Set limits the text status for the resource narrative.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"copyright": "HL7",
-	"compose": {
-		"include": [
-			{
-				"system": "http://hl7.org/fhir/narrative-status",
-				"concept": [
-					{
-						"code": "additional",
-						"display": "additional"
-					},
-					{
-						"code": "generated",
-						"display": "generated"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-narrative-status",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-narrative-status",
+    "version": "3.1.1",
+    "name": "NarrativeStatus",
+    "title": "US Core Narrative Status",
+    "status": "active",
+    "date": "2020-08-28T10:54:27+10:00",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "other",
+                    "value": "http://hl7.org/fhir"
+                }
+            ]
+        }
+    ],
+    "description": "The US Core Narrative Status Value Set limits the text status for the resource narrative.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "copyright": "HL7",
+    "compose": {
+        "include": [
+            {
+                "system": "http://hl7.org/fhir/narrative-status",
+                "concept": [
+                    {
+                        "code": "additional",
+                        "display": "additional"
+                    },
+                    {
+                        "code": "generated",
+                        "display": "generated"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-ndc-vaccine-codes.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-ndc-vaccine-codes.json
@@ -1,1297 +1,1297 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-ndc-vaccine-codes",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include these codes as defined in <a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-v3-ndc.html\"><code>http://hl7.org/fhir/sid/ndc</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td></tr><tr><td>49281-0703-55</td><td>FLUZONE INTRADERMAL</td><td/></tr><tr><td>49281-0790-20</td><td>Typhim Vi</td><td/></tr><tr><td>33332-0316-01</td><td>AFLURIA QUADRIVALENT</td><td/></tr><tr><td>49281-0712-40</td><td>FLUZONE INTRADERMAL QUADRIVALENT</td><td/></tr><tr><td>66521-0112-02</td><td>Fluvirin</td><td/></tr><tr><td>58160-0816-05</td><td>Hiberix</td><td/></tr><tr><td>00006-4837-02</td><td>PNEUMOVAX 23</td><td/></tr><tr><td>58160-0808-15</td><td>Influenza A (H5N1) Monovalent Vaccine, Adjuvanted</td><td/></tr><tr><td>58160-0842-51</td><td>BOOSTRIX</td><td/></tr><tr><td>49281-0418-50</td><td>FLUZONE QUADRIVALENT</td><td/></tr><tr><td>00006-4943-00</td><td>PNEUMOVAX 23</td><td/></tr><tr><td>49281-0708-40</td><td>FLUZONE INTRADERMAL QUADRIVALENT</td><td/></tr><tr><td>54868-0734-00</td><td>ENGERIX-B</td><td/></tr><tr><td>58160-0819-12</td><td>Shingrix</td><td/></tr><tr><td>49281-0517-25</td><td>FLUZONE QUADRIVALENT</td><td/></tr><tr><td>00006-4133-41</td><td>Tetanus and Diphtheria Toxoids Adsorbed</td><td/></tr><tr><td>50090-3096-00</td><td>RabAvert</td><td/></tr><tr><td>33332-0118-10</td><td>AFLURIA</td><td/></tr><tr><td>19515-0909-52</td><td>Flulaval Quadrivalent</td><td/></tr><tr><td>49281-0650-10</td><td>INFLUENZA A (H1N1) 2009 MONOVALENT VACCINE</td><td/></tr><tr><td>58160-0820-11</td><td>ENGERIX-B</td><td/></tr><tr><td>42515-0001-01</td><td>IXIARO</td><td/></tr><tr><td>49281-0625-15</td><td>FLUZONE QUADRIVALENT</td><td/></tr><tr><td>49281-0516-25</td><td>FLUZONE QUADRIVALENT</td><td/></tr><tr><td>66521-0114-02</td><td>FLUVIRIN</td><td/></tr><tr><td>19515-0896-11</td><td>Flulaval Quadrivalent</td><td/></tr><tr><td>33332-0117-10</td><td>AFLURIA</td><td/></tr><tr><td>33332-0416-10</td><td>AFLURIA QUADRIVALENT</td><td/></tr><tr><td>66521-0118-02</td><td>Fluvirin</td><td/></tr><tr><td>58160-0821-11</td><td>ENGERIX-B</td><td/></tr><tr><td>00005-1971-05</td><td>PREVNAR 13</td><td/></tr><tr><td>66019-0109-10</td><td>FLUMIST</td><td/></tr><tr><td>49281-0278-10</td><td>DIPHTHERIA AND TETANUS TOXOIDS ADSORBED</td><td/></tr><tr><td>49281-0011-10</td><td>FLUZONE</td><td/></tr><tr><td>54868-2219-00</td><td>RECOMBIVAX HB</td><td/></tr><tr><td>49281-0415-10</td><td>FLUZONE QUADRIVALENT</td><td/></tr><tr><td>33332-0016-01</td><td>AFLURIA</td><td/></tr><tr><td>49281-0705-55</td><td>FLUZONE</td><td/></tr><tr><td>49281-0621-15</td><td>FLUZONE QUADRIVALENT</td><td/></tr><tr><td>58160-0842-34</td><td>BOOSTRIX</td><td/></tr><tr><td>49281-0010-10</td><td>FLUZONE</td><td/></tr><tr><td>66521-0113-02</td><td>FLUVIRIN</td><td/></tr><tr><td>49281-0514-25</td><td>FLUZONE QUADRIVALENT</td><td/></tr><tr><td>58160-0842-52</td><td>BOOSTRIX</td><td/></tr><tr><td>19515-0901-52</td><td>Flulaval Quadrivalent</td><td/></tr><tr><td>62577-0613-01</td><td>Flucelvax</td><td/></tr><tr><td>66019-0303-10</td><td>FluMist Quadrivalent</td><td/></tr><tr><td>49281-0388-15</td><td>FLUZONE</td><td/></tr><tr><td>00006-4841-41</td><td>VAQTA</td><td/></tr><tr><td>58160-0900-52</td><td>FLUARIX QUADRIVALENT</td><td/></tr><tr><td>70461-0200-01</td><td>FLUCELVAX QUADRIVALENT</td><td/></tr><tr><td>49281-0915-05</td><td>YF-VAX</td><td/></tr><tr><td>49281-0650-50</td><td>INFLUENZA A (H1N1) 2009 MONOVALENT VACCINE</td><td/></tr><tr><td>33332-0116-10</td><td>AFLURIA</td><td/></tr><tr><td>54868-3339-01</td><td>PNEUMOVAX 23</td><td/></tr><tr><td>49281-0418-10</td><td>FLUZONE QUADRIVALENT</td><td/></tr><tr><td>58160-0812-52</td><td>KINRIX</td><td/></tr><tr><td>49281-0286-05</td><td>DAPTACEL</td><td/></tr><tr><td>63851-0612-01</td><td>Flucelvax</td><td/></tr><tr><td>19515-0908-52</td><td>Flulaval Quadrivalent</td><td/></tr><tr><td>54868-0980-00</td><td>M-M-R II</td><td/></tr><tr><td>58160-0830-52</td><td>CERVARIX</td><td/></tr><tr><td>49281-0113-25</td><td>FLUZONE</td><td/></tr><tr><td>49281-0650-70</td><td>INFLUENZA A (H1N1) 2009 MONOVALENT VACCINE</td><td/></tr><tr><td>66521-0115-10</td><td>FLUVIRIN</td><td/></tr><tr><td>49281-0417-50</td><td>FLUZONE QUADRIVALENT</td><td/></tr><tr><td>33332-0113-10</td><td>AFLURIA</td><td/></tr><tr><td>49281-0629-15</td><td>FLUZONE QUADRIVALENT</td><td/></tr><tr><td>58160-0823-11</td><td>Shingrix</td><td/></tr><tr><td>00006-4897-00</td><td>PedvaxHIB</td><td/></tr><tr><td>58160-0821-34</td><td>ENGERIX-B</td><td/></tr><tr><td>66521-0115-02</td><td>FLUVIRIN</td><td/></tr><tr><td>33332-0014-01</td><td>AFLURIA</td><td/></tr><tr><td>49281-0562-10</td><td>QUADRACEL</td><td/></tr><tr><td>42874-0014-10</td><td>Flublok</td><td/></tr><tr><td>42874-0013-10</td><td>Flublok</td><td/></tr><tr><td>33332-0115-10</td><td>AFLURIA</td><td/></tr><tr><td>00006-4963-00</td><td>ZOSTAVAX</td><td/></tr><tr><td>49281-0010-25</td><td>FLUZONE</td><td/></tr><tr><td>33332-0519-01</td><td>Influenza A</td><td/></tr><tr><td>58160-0898-52</td><td>FLUARIX QUADRIVALENT</td><td/></tr><tr><td>49281-0112-25</td><td>FLUZONE</td><td/></tr><tr><td>19515-0898-11</td><td>Flulaval Quadrivalent</td><td/></tr><tr><td>00006-4109-09</td><td>GARDASIL</td><td/></tr><tr><td>49281-0414-50</td><td>FLUZONE QUADRIVALENT</td><td/></tr><tr><td>00006-4095-09</td><td>VAQTA</td><td/></tr><tr><td>00006-4045-00</td><td>GARDASIL</td><td/></tr><tr><td>19515-0912-52</td><td>Flulaval Quadrivalent</td><td/></tr><tr><td>58160-0801-11</td><td>Menhibrix</td><td/></tr><tr><td>49281-0489-01</td><td>MENOMUNE - A/C/Y/W-135 COMBINED</td><td/></tr><tr><td>42874-0017-10</td><td>Flublok</td><td/></tr><tr><td>66521-0116-02</td><td>Fluvirin</td><td/></tr><tr><td>46028-0208-01</td><td>Menveo</td><td/></tr><tr><td>49281-0627-15</td><td>FLUZONE QUADRIVALENT</td><td/></tr><tr><td>00005-0100-02</td><td>Trumenba</td><td/></tr><tr><td>69401-0000-01</td><td>Vivotif</td><td/></tr><tr><td>21695-0413-01</td><td>Tetanus and Diphtheria Toxoids Adsorbed</td><td/></tr><tr><td>49281-0416-10</td><td>FLUZONE QUADRIVALENT</td><td/></tr><tr><td>49281-0650-25</td><td>INFLUENZA A (H1N1) 2009 MONOVALENT VACCINE</td><td/></tr><tr><td>49281-0800-83</td><td>TETANUS TOXOID ADSORBED</td><td/></tr><tr><td>49281-0291-83</td><td>DECAVAC</td><td/></tr><tr><td>00006-4095-02</td><td>VAQTA</td><td/></tr><tr><td>58160-0854-52</td><td>ROTARIX</td><td/></tr><tr><td>19515-0889-07</td><td>FLULAVAL</td><td/></tr><tr><td>49281-0392-15</td><td>FLUZONE</td><td/></tr><tr><td>19515-0891-11</td><td>Flulaval Quadrivalent</td><td/></tr><tr><td>49281-0400-05</td><td>Adacel</td><td/></tr><tr><td>49281-0913-01</td><td>STAMARIL</td><td/></tr><tr><td>49281-0640-15</td><td>INFLUENZA A (H1N1) 2009 MONOVALENT VACCINE</td><td/></tr><tr><td>49281-0513-25</td><td>FLUZONE QUADRIVALENT</td><td/></tr><tr><td>00006-4171-00</td><td>ProQuad</td><td/></tr><tr><td>00006-4096-09</td><td>VAQTA</td><td/></tr><tr><td>58160-0830-34</td><td>CERVARIX</td><td/></tr><tr><td>00006-4980-00</td><td>RECOMBIVAX HB</td><td/></tr><tr><td>17478-0131-01</td><td>Tetanus and Diphtheria Toxoids Adsorbed</td><td/></tr><tr><td>49281-0414-10</td><td>FLUZONE QUADRIVALENT</td><td/></tr><tr><td>43528-0002-05</td><td>HEPLISAV-B</td><td/></tr><tr><td>66521-0200-02</td><td>Influenza A (H1N1) 2009 Monovalent Vaccine</td><td/></tr><tr><td>49281-0011-50</td><td>FLUZONE</td><td/></tr><tr><td>70461-0120-10</td><td>Fluvirin</td><td/></tr><tr><td>66019-0304-10</td><td>FluMist Quadrivalent</td><td/></tr><tr><td>58160-0976-20</td><td>Bexsero</td><td/></tr><tr><td>00006-4826-00</td><td>VARIVAX</td><td/></tr><tr><td>66521-0116-10</td><td>Fluvirin</td><td/></tr><tr><td>00006-4963-41</td><td>ZOSTAVAX</td><td/></tr><tr><td>49281-0510-05</td><td>PENTACEL</td><td/></tr><tr><td>42874-0012-10</td><td>Flublok</td><td/></tr><tr><td>58160-0955-09</td><td>Menveo</td><td/></tr><tr><td>00005-0100-05</td><td>Trumenba</td><td/></tr><tr><td>49281-0707-55</td><td>FLUZONE</td><td/></tr><tr><td>14362-0111-04</td><td>Tetanus and Diphtheria Toxoids Adsorbed</td><td/></tr><tr><td>66521-0112-10</td><td>Fluvirin</td><td/></tr><tr><td>66521-0117-10</td><td>Fluvirin</td><td/></tr><tr><td>00006-4045-41</td><td>GARDASIL</td><td/></tr><tr><td>49281-0389-65</td><td>FLUZONE HIGH DOSE</td><td/></tr><tr><td>69401-0000-02</td><td>Vivotif</td><td/></tr><tr><td>49281-0915-01</td><td>YF-VAX</td><td/></tr><tr><td>00006-4093-02</td><td>RECOMBIVAX HB</td><td/></tr><tr><td>58160-0815-48</td><td>TWINRIX</td><td/></tr><tr><td>70460-0001-01</td><td>Vaxchora</td><td/></tr><tr><td>58160-0826-11</td><td>HAVRIX</td><td/></tr><tr><td>00006-4992-00</td><td>RECOMBIVAX HB</td><td/></tr><tr><td>49281-0111-25</td><td>FLUZONE</td><td/></tr><tr><td>00006-4093-09</td><td>RECOMBIVAX HB</td><td/></tr><tr><td>50090-3469-00</td><td>HEPLISAV-B</td><td/></tr><tr><td>49281-0403-65</td><td>FLUZONE High-Dose</td><td/></tr><tr><td>70461-0119-10</td><td>Fluvirin</td><td/></tr><tr><td>00006-4995-00</td><td>RECOMBIVAX HB</td><td/></tr><tr><td>58160-0815-34</td><td>TWINRIX</td><td/></tr><tr><td>49281-0393-65</td><td>FLUZONE High-Dose</td><td/></tr><tr><td>00005-1970-50</td><td>Prevnar</td><td/></tr><tr><td>33332-0017-01</td><td>AFLURIA</td><td/></tr><tr><td>63851-0501-01</td><td>RabAvert</td><td/></tr><tr><td>58160-0881-52</td><td>FLUARIX</td><td/></tr><tr><td>64678-0211-01</td><td>BioThrax</td><td/></tr><tr><td>49281-0394-15</td><td>FLUZONE</td><td/></tr><tr><td>00006-4827-00</td><td>VARIVAX</td><td/></tr><tr><td>58160-0806-05</td><td>HIBERIX</td><td/></tr><tr><td>49281-0518-25</td><td>FLUZONE QUADRIVALENT</td><td/></tr><tr><td>62195-0051-10</td><td>Ixiaro</td><td/></tr><tr><td>63361-0245-10</td><td>VAXELIS</td><td/></tr><tr><td>49281-0709-55</td><td>FLUZONE Intradermal</td><td/></tr><tr><td>66019-0300-10</td><td>FluMist Quadrivalent</td><td/></tr><tr><td>49281-0215-15</td><td>TENIVAC</td><td/></tr><tr><td>58160-0825-52</td><td>HAVRIX</td><td/></tr><tr><td>00005-0100-10</td><td>Trumenba</td><td/></tr><tr><td>66521-0117-02</td><td>Fluvirin</td><td/></tr><tr><td>49281-0650-90</td><td>INFLUENZA A (H1N1) 2009 MONOVALENT VACCINE</td><td/></tr><tr><td>42874-0015-10</td><td>Flublok</td><td/></tr><tr><td>33332-0018-01</td><td>AFLURIA</td><td/></tr><tr><td>00006-4999-00</td><td>ProQuad</td><td/></tr><tr><td>00005-1971-04</td><td>PREVNAR 13</td><td/></tr><tr><td>19515-0850-52</td><td>FLULAVAL</td><td/></tr><tr><td>00005-1971-02</td><td>PREVNAR 13</td><td/></tr><tr><td>00006-4094-02</td><td>RECOMBIVAX HB</td><td/></tr><tr><td>00006-4096-02</td><td>VAQTA</td><td/></tr><tr><td>58160-0825-11</td><td>HAVRIX</td><td/></tr><tr><td>58160-0811-52</td><td>PEDIARIX</td><td/></tr><tr><td>42515-0002-01</td><td>IXIARO</td><td/></tr><tr><td>49281-0013-50</td><td>FLUZONE</td><td/></tr><tr><td>76420-0483-01</td><td>Medical Provider Single Use EZ Flu Shot 2013-2014</td><td/></tr><tr><td>66521-0118-10</td><td>Fluvirin</td><td/></tr><tr><td>49281-0399-65</td><td>FLUZONE High-Dose</td><td/></tr><tr><td>49281-0396-15</td><td>FLUZONE</td><td/></tr><tr><td>66019-0107-01</td><td>FLUMIST</td><td/></tr><tr><td>19515-0890-07</td><td>FLULAVAL</td><td/></tr><tr><td>76420-0482-01</td><td>Medical Provider Single Use EZ Flu Shot 2013-2014</td><td/></tr><tr><td>33332-0015-01</td><td>AFLURIA</td><td/></tr><tr><td>66019-0302-10</td><td>FluMist Quadrivalent</td><td/></tr><tr><td>49281-0012-10</td><td>FLUZONE</td><td/></tr><tr><td>49281-0710-40</td><td>FLUZONE INTRADERMAL QUADRIVALENT</td><td/></tr><tr><td>63851-0501-02</td><td>RabAvert</td><td/></tr><tr><td>58160-0879-52</td><td>FLUARIX</td><td/></tr><tr><td>49281-0397-65</td><td>FLUZONE High-Dose</td><td/></tr><tr><td>00006-4831-41</td><td>VAQTA</td><td/></tr><tr><td>58160-0815-46</td><td>TWINRIX</td><td/></tr><tr><td>33332-0110-10</td><td>AFLURIA</td><td/></tr><tr><td>54868-4320-00</td><td>PNEUMOVAX 23</td><td/></tr><tr><td>42874-0016-10</td><td>Flublok</td><td/></tr><tr><td>49281-0012-50</td><td>FLUZONE</td><td/></tr><tr><td>58160-0818-11</td><td>Hiberix</td><td/></tr><tr><td>49281-0386-15</td><td>FLUZONE</td><td/></tr><tr><td>46028-0114-01</td><td>Bexsero</td><td/></tr><tr><td>00006-4898-00</td><td>COMVAX</td><td/></tr><tr><td>58160-0826-52</td><td>HAVRIX</td><td/></tr><tr><td>49281-0545-05</td><td>ActHIB</td><td/></tr><tr><td>66019-0108-10</td><td>FLUMIST</td><td/></tr><tr><td>70461-0418-10</td><td>FLUCELVAX QUADRIVALENT (MULTI-DOSE VIAL)</td><td/></tr><tr><td>00006-4094-09</td><td>RECOMBIVAX HB</td><td/></tr><tr><td>49281-0298-10</td><td>TRIPEDIA</td><td/></tr><tr><td>33332-0629-10</td><td>Influenza A</td><td/></tr><tr><td>58160-0880-52</td><td>FLUARIX</td><td/></tr><tr><td>00006-4047-20</td><td>RotaTeq</td><td/></tr><tr><td>00006-4119-02</td><td>GARDASIL 9</td><td/></tr><tr><td>58160-0842-11</td><td>BOOSTRIX</td><td/></tr><tr><td>19515-0903-11</td><td>Flulaval Quadrivalent</td><td/></tr><tr><td>00006-4981-00</td><td>RECOMBIVAX HB</td><td/></tr><tr><td>58160-0905-52</td><td>FLUARIX QUADRIVALENT</td><td/></tr><tr><td>49281-0401-65</td><td>FLUZONE High-Dose</td><td/></tr><tr><td>33332-0114-10</td><td>AFLURIA</td><td/></tr><tr><td>49281-0860-10</td><td>IPOL</td><td/></tr><tr><td>70461-0318-03</td><td>FLUCELVAX QUADRIVALENT (PREFILLED SYRINGE)</td><td/></tr><tr><td>54868-2219-01</td><td>RECOMBIVAX HB</td><td/></tr><tr><td>49281-0718-10</td><td>Flublok Quadrivalent</td><td/></tr><tr><td>49281-0400-15</td><td>Adacel</td><td/></tr><tr><td>70461-0120-02</td><td>Fluvirin</td><td/></tr><tr><td>49281-0416-50</td><td>FLUZONE QUADRIVALENT</td><td/></tr><tr><td>49281-0413-50</td><td>FLUZONE QUADRIVALENT</td><td/></tr><tr><td>58160-0883-52</td><td>FLUARIX</td><td/></tr><tr><td>49281-0790-51</td><td>Typhim Vi</td><td/></tr><tr><td>49281-0286-10</td><td>DAPTACEL</td><td/></tr><tr><td>66019-0110-10</td><td>FluMist</td><td/></tr><tr><td>46028-0114-02</td><td>Bexsero</td><td/></tr><tr><td>58160-0821-52</td><td>ENGERIX-B</td><td/></tr><tr><td>49281-0013-10</td><td>FLUZONE</td><td/></tr><tr><td>19515-0894-52</td><td>Flulaval Quadrivalent</td><td/></tr><tr><td>66019-0305-10</td><td>FluMist Quadrivalent</td><td/></tr><tr><td>49281-0400-10</td><td>Adacel</td><td/></tr><tr><td>49281-0390-15</td><td>FLUZONE</td><td/></tr><tr><td>00052-0603-02</td><td>BCG VACCINE</td><td/></tr><tr><td>51285-0138-50</td><td>Adenovirus Type 4 and Type 7 Vaccine, Live</td><td/></tr><tr><td>33332-0417-10</td><td>AFLURIA QUADRIVALENT</td><td/></tr><tr><td>49281-0395-65</td><td>FLUZONE High-Dose</td><td/></tr><tr><td>66019-0301-10</td><td>FluMist Quadrivalent</td><td/></tr><tr><td>49281-0215-10</td><td>TENIVAC</td><td/></tr><tr><td>19515-0895-11</td><td>Flulaval Quadrivalent</td><td/></tr><tr><td>70461-0201-01</td><td>FLUCELVAX QUADRIVALENT (PREFILLED SYRINGE)</td><td/></tr><tr><td>58160-0907-52</td><td>FLUARIX QUADRIVALENT</td><td/></tr><tr><td>55045-3841-01</td><td>HAVRIX</td><td/></tr><tr><td>50090-2883-00</td><td>INFANRIX</td><td/></tr><tr><td>49281-0820-10</td><td>TETANUS TOXOID ADSORBED</td><td/></tr><tr><td>49281-0417-10</td><td>FLUZONE QUADRIVALENT</td><td/></tr><tr><td>33332-0010-01</td><td>AFLURIA</td><td/></tr><tr><td>33332-0013-01</td><td>AFLURIA</td><td/></tr><tr><td>66521-0200-10</td><td>Influenza A (H1N1) 2009 Monovalent Vaccine</td><td/></tr><tr><td>58160-0976-06</td><td>Bexsero</td><td/></tr><tr><td>58160-0809-05</td><td>MENHIBRIX</td><td/></tr><tr><td>00006-4739-00</td><td>PNEUMOVAX 23</td><td/></tr><tr><td>70461-0018-03</td><td>FLUAD</td><td/></tr><tr><td>49281-0413-10</td><td>FLUZONE QUADRIVALENT</td><td/></tr><tr><td>13533-0131-01</td><td>Tetanus and Diphtheria Toxoids Adsorbed</td><td/></tr><tr><td>58160-0812-11</td><td>KINRIX</td><td/></tr><tr><td>49281-0391-65</td><td>FLUZONE High-Dose</td><td/></tr><tr><td>19515-0845-11</td><td>FLULAVAL</td><td/></tr><tr><td>58160-0811-51</td><td>PEDIARIX</td><td/></tr><tr><td>58160-0815-52</td><td>TWINRIX</td><td/></tr><tr><td>70461-0119-02</td><td>Fluvirin</td><td/></tr><tr><td>58160-0810-52</td><td>INFANRIX</td><td/></tr><tr><td>62577-0614-01</td><td>Flucelvax</td><td/></tr><tr><td>42874-0117-10</td><td>Flublok Quadrivalent</td><td/></tr><tr><td>49281-0489-91</td><td>MENOMUNE - A/C/Y/W-135 COMBINED</td><td/></tr><tr><td>58160-0964-12</td><td>RabAvert</td><td/></tr><tr><td>49281-0014-50</td><td>FLUZONE</td><td/></tr><tr><td>00006-4109-02</td><td>GARDASIL</td><td/></tr><tr><td>70461-0002-01</td><td>FLUAD</td><td/></tr><tr><td>49281-0286-01</td><td>DAPTACEL</td><td/></tr><tr><td>58160-0810-11</td><td>INFANRIX</td><td/></tr><tr><td>19515-0900-11</td><td>Flulaval Quadrivalent</td><td/></tr><tr><td>00006-4837-03</td><td>PNEUMOVAX 23</td><td/></tr><tr><td>66521-0113-10</td><td>FLUVIRIN</td><td/></tr><tr><td>58160-0826-34</td><td>HAVRIX</td><td/></tr><tr><td>58160-0903-52</td><td>FLUARIX QUADRIVALENT</td><td/></tr><tr><td>00006-4841-00</td><td>VAQTA</td><td/></tr><tr><td>54868-6180-00</td><td>FLUZONE</td><td/></tr><tr><td>00006-4681-00</td><td>M-M-R II</td><td/></tr><tr><td>33332-0317-01</td><td>AFLURIA QUADRIVALENT</td><td/></tr><tr><td>70461-0001-01</td><td>FLUAD</td><td/></tr><tr><td>49281-0589-05</td><td>Menactra</td><td/></tr><tr><td>49281-0387-65</td><td>FLUZONE</td><td/></tr><tr><td>49281-0860-55</td><td>IPOL</td><td/></tr><tr><td>19515-0893-07</td><td>FLULAVAL</td><td/></tr><tr><td>33332-0519-25</td><td>Influenza A</td><td/></tr><tr><td>70461-0301-10</td><td>FLUCELVAX QUADRIVALENT (MULTI-DOSE VIAL)</td><td/></tr><tr><td>66019-0200-10</td><td>Influenza A H1N1 Intranasal</td><td/></tr><tr><td>43528-0003-05</td><td>HEPLISAV-B</td><td/></tr><tr><td>58160-0820-52</td><td>ENGERIX-B</td><td/></tr><tr><td>66521-0000-01</td><td>FLUAD</td><td/></tr><tr><td>49281-0250-51</td><td>IMOVAX RABIES</td><td/></tr><tr><td>49281-0291-10</td><td>DECAVAC</td><td/></tr><tr><td>33332-0418-10</td><td>AFLURIA QUADRIVALENT</td><td/></tr><tr><td>00006-4121-02</td><td>GARDASIL 9</td><td/></tr><tr><td>63851-0613-01</td><td>FLUCELVAX</td><td/></tr><tr><td>66521-0114-10</td><td>FLUVIRIN</td><td/></tr><tr><td>00006-4047-41</td><td>RotaTeq</td><td/></tr><tr><td>58160-0901-52</td><td>FLUARIX QUADRIVALENT</td><td/></tr><tr><td>33332-0318-01</td><td>AFLURIA QUADRIVALENT</td><td/></tr><tr><td>00006-4119-03</td><td>GARDASIL 9</td><td/></tr><tr><td>49281-0225-10</td><td>DIPHTHERIA AND TETANUS TOXOIDS ADSORBED</td><td/></tr><tr><td>58160-0815-11</td><td>TWINRIX</td><td/></tr><tr><td>54868-6177-00</td><td>FLUZONE</td><td/></tr><tr><td>49281-0010-50</td><td>FLUZONE</td><td/></tr><tr><td>49281-0400-20</td><td>Adacel</td><td/></tr><tr><td>49281-0545-03</td><td>ActHIB</td><td/></tr><tr><td>50090-1693-09</td><td>IPOL</td><td/></tr><tr><td>00006-4995-41</td><td>RECOMBIVAX HB</td><td/></tr></table></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-ndc-vaccine-codes",
-	"version": "3.1.1",
-	"name": "USCoreVaccineNationalDrugCode",
-	"title": "US Core Vaccine National Drug Codes (NDC)",
-	"status": "active",
-	"date": "2019-05-20T17:00:00-07:00",
-	"publisher": "HL7 US Realm Steering Committee",
-	"description": "This value set includes all the Vaccine National Drug Codes (NDC).  This source of this data is provided by the [CDC](https://www2a.cdc.gov/vaccines/iis/iisstandards/ndc_crosswalk.asp)",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"purpose": "Codes that are used as translations for CVS code for implementation of the Argonaut Immunization IG and MU2015 certification.",
-	"compose": {
-		"include": [
-			{
-				"system": "http://hl7.org/fhir/sid/ndc",
-				"concept": [
-					{
-						"code": "49281-0703-55",
-						"display": "FLUZONE INTRADERMAL"
-					},
-					{
-						"code": "49281-0790-20",
-						"display": "Typhim Vi"
-					},
-					{
-						"code": "33332-0316-01",
-						"display": "AFLURIA QUADRIVALENT"
-					},
-					{
-						"code": "49281-0712-40",
-						"display": "FLUZONE INTRADERMAL QUADRIVALENT"
-					},
-					{
-						"code": "66521-0112-02",
-						"display": "Fluvirin"
-					},
-					{
-						"code": "58160-0816-05",
-						"display": "Hiberix"
-					},
-					{
-						"code": "00006-4837-02",
-						"display": "PNEUMOVAX 23"
-					},
-					{
-						"code": "58160-0808-15",
-						"display": "Influenza A (H5N1) Monovalent Vaccine, Adjuvanted"
-					},
-					{
-						"code": "58160-0842-51",
-						"display": "BOOSTRIX"
-					},
-					{
-						"code": "49281-0418-50",
-						"display": "FLUZONE QUADRIVALENT"
-					},
-					{
-						"code": "00006-4943-00",
-						"display": "PNEUMOVAX 23"
-					},
-					{
-						"code": "49281-0708-40",
-						"display": "FLUZONE INTRADERMAL QUADRIVALENT"
-					},
-					{
-						"code": "54868-0734-00",
-						"display": "ENGERIX-B"
-					},
-					{
-						"code": "58160-0819-12",
-						"display": "Shingrix"
-					},
-					{
-						"code": "49281-0517-25",
-						"display": "FLUZONE QUADRIVALENT"
-					},
-					{
-						"code": "00006-4133-41",
-						"display": "Tetanus and Diphtheria Toxoids Adsorbed"
-					},
-					{
-						"code": "50090-3096-00",
-						"display": "RabAvert"
-					},
-					{
-						"code": "33332-0118-10",
-						"display": "AFLURIA"
-					},
-					{
-						"code": "19515-0909-52",
-						"display": "Flulaval Quadrivalent"
-					},
-					{
-						"code": "49281-0650-10",
-						"display": "INFLUENZA A (H1N1) 2009 MONOVALENT VACCINE"
-					},
-					{
-						"code": "58160-0820-11",
-						"display": "ENGERIX-B"
-					},
-					{
-						"code": "42515-0001-01",
-						"display": "IXIARO"
-					},
-					{
-						"code": "49281-0625-15",
-						"display": "FLUZONE QUADRIVALENT"
-					},
-					{
-						"code": "49281-0516-25",
-						"display": "FLUZONE QUADRIVALENT"
-					},
-					{
-						"code": "66521-0114-02",
-						"display": "FLUVIRIN"
-					},
-					{
-						"code": "19515-0896-11",
-						"display": "Flulaval Quadrivalent"
-					},
-					{
-						"code": "33332-0117-10",
-						"display": "AFLURIA"
-					},
-					{
-						"code": "33332-0416-10",
-						"display": "AFLURIA QUADRIVALENT"
-					},
-					{
-						"code": "66521-0118-02",
-						"display": "Fluvirin"
-					},
-					{
-						"code": "58160-0821-11",
-						"display": "ENGERIX-B"
-					},
-					{
-						"code": "00005-1971-05",
-						"display": "PREVNAR 13"
-					},
-					{
-						"code": "66019-0109-10",
-						"display": "FLUMIST"
-					},
-					{
-						"code": "49281-0278-10",
-						"display": "DIPHTHERIA AND TETANUS TOXOIDS ADSORBED"
-					},
-					{
-						"code": "49281-0011-10",
-						"display": "FLUZONE"
-					},
-					{
-						"code": "54868-2219-00",
-						"display": "RECOMBIVAX HB"
-					},
-					{
-						"code": "49281-0415-10",
-						"display": "FLUZONE QUADRIVALENT"
-					},
-					{
-						"code": "33332-0016-01",
-						"display": "AFLURIA"
-					},
-					{
-						"code": "49281-0705-55",
-						"display": "FLUZONE"
-					},
-					{
-						"code": "49281-0621-15",
-						"display": "FLUZONE QUADRIVALENT"
-					},
-					{
-						"code": "58160-0842-34",
-						"display": "BOOSTRIX"
-					},
-					{
-						"code": "49281-0010-10",
-						"display": "FLUZONE"
-					},
-					{
-						"code": "66521-0113-02",
-						"display": "FLUVIRIN"
-					},
-					{
-						"code": "49281-0514-25",
-						"display": "FLUZONE QUADRIVALENT"
-					},
-					{
-						"code": "58160-0842-52",
-						"display": "BOOSTRIX"
-					},
-					{
-						"code": "19515-0901-52",
-						"display": "Flulaval Quadrivalent"
-					},
-					{
-						"code": "62577-0613-01",
-						"display": "Flucelvax"
-					},
-					{
-						"code": "66019-0303-10",
-						"display": "FluMist Quadrivalent"
-					},
-					{
-						"code": "49281-0388-15",
-						"display": "FLUZONE"
-					},
-					{
-						"code": "00006-4841-41",
-						"display": "VAQTA"
-					},
-					{
-						"code": "58160-0900-52",
-						"display": "FLUARIX QUADRIVALENT"
-					},
-					{
-						"code": "70461-0200-01",
-						"display": "FLUCELVAX QUADRIVALENT"
-					},
-					{
-						"code": "49281-0915-05",
-						"display": "YF-VAX"
-					},
-					{
-						"code": "49281-0650-50",
-						"display": "INFLUENZA A (H1N1) 2009 MONOVALENT VACCINE"
-					},
-					{
-						"code": "33332-0116-10",
-						"display": "AFLURIA"
-					},
-					{
-						"code": "54868-3339-01",
-						"display": "PNEUMOVAX 23"
-					},
-					{
-						"code": "49281-0418-10",
-						"display": "FLUZONE QUADRIVALENT"
-					},
-					{
-						"code": "58160-0812-52",
-						"display": "KINRIX"
-					},
-					{
-						"code": "49281-0286-05",
-						"display": "DAPTACEL"
-					},
-					{
-						"code": "63851-0612-01",
-						"display": "Flucelvax"
-					},
-					{
-						"code": "19515-0908-52",
-						"display": "Flulaval Quadrivalent"
-					},
-					{
-						"code": "54868-0980-00",
-						"display": "M-M-R II"
-					},
-					{
-						"code": "58160-0830-52",
-						"display": "CERVARIX"
-					},
-					{
-						"code": "49281-0113-25",
-						"display": "FLUZONE"
-					},
-					{
-						"code": "49281-0650-70",
-						"display": "INFLUENZA A (H1N1) 2009 MONOVALENT VACCINE"
-					},
-					{
-						"code": "66521-0115-10",
-						"display": "FLUVIRIN"
-					},
-					{
-						"code": "49281-0417-50",
-						"display": "FLUZONE QUADRIVALENT"
-					},
-					{
-						"code": "33332-0113-10",
-						"display": "AFLURIA"
-					},
-					{
-						"code": "49281-0629-15",
-						"display": "FLUZONE QUADRIVALENT"
-					},
-					{
-						"code": "58160-0823-11",
-						"display": "Shingrix"
-					},
-					{
-						"code": "00006-4897-00",
-						"display": "PedvaxHIB"
-					},
-					{
-						"code": "58160-0821-34",
-						"display": "ENGERIX-B"
-					},
-					{
-						"code": "66521-0115-02",
-						"display": "FLUVIRIN"
-					},
-					{
-						"code": "33332-0014-01",
-						"display": "AFLURIA"
-					},
-					{
-						"code": "49281-0562-10",
-						"display": "QUADRACEL"
-					},
-					{
-						"code": "42874-0014-10",
-						"display": "Flublok"
-					},
-					{
-						"code": "42874-0013-10",
-						"display": "Flublok"
-					},
-					{
-						"code": "33332-0115-10",
-						"display": "AFLURIA"
-					},
-					{
-						"code": "00006-4963-00",
-						"display": "ZOSTAVAX"
-					},
-					{
-						"code": "49281-0010-25",
-						"display": "FLUZONE"
-					},
-					{
-						"code": "33332-0519-01",
-						"display": "Influenza A"
-					},
-					{
-						"code": "58160-0898-52",
-						"display": "FLUARIX QUADRIVALENT"
-					},
-					{
-						"code": "49281-0112-25",
-						"display": "FLUZONE"
-					},
-					{
-						"code": "19515-0898-11",
-						"display": "Flulaval Quadrivalent"
-					},
-					{
-						"code": "00006-4109-09",
-						"display": "GARDASIL"
-					},
-					{
-						"code": "49281-0414-50",
-						"display": "FLUZONE QUADRIVALENT"
-					},
-					{
-						"code": "00006-4095-09",
-						"display": "VAQTA"
-					},
-					{
-						"code": "00006-4045-00",
-						"display": "GARDASIL"
-					},
-					{
-						"code": "19515-0912-52",
-						"display": "Flulaval Quadrivalent"
-					},
-					{
-						"code": "58160-0801-11",
-						"display": "Menhibrix"
-					},
-					{
-						"code": "49281-0489-01",
-						"display": "MENOMUNE - A/C/Y/W-135 COMBINED"
-					},
-					{
-						"code": "42874-0017-10",
-						"display": "Flublok"
-					},
-					{
-						"code": "66521-0116-02",
-						"display": "Fluvirin"
-					},
-					{
-						"code": "46028-0208-01",
-						"display": "Menveo"
-					},
-					{
-						"code": "49281-0627-15",
-						"display": "FLUZONE QUADRIVALENT"
-					},
-					{
-						"code": "00005-0100-02",
-						"display": "Trumenba"
-					},
-					{
-						"code": "69401-0000-01",
-						"display": "Vivotif"
-					},
-					{
-						"code": "21695-0413-01",
-						"display": "Tetanus and Diphtheria Toxoids Adsorbed"
-					},
-					{
-						"code": "49281-0416-10",
-						"display": "FLUZONE QUADRIVALENT"
-					},
-					{
-						"code": "49281-0650-25",
-						"display": "INFLUENZA A (H1N1) 2009 MONOVALENT VACCINE"
-					},
-					{
-						"code": "49281-0800-83",
-						"display": "TETANUS TOXOID ADSORBED"
-					},
-					{
-						"code": "49281-0291-83",
-						"display": "DECAVAC"
-					},
-					{
-						"code": "00006-4095-02",
-						"display": "VAQTA"
-					},
-					{
-						"code": "58160-0854-52",
-						"display": "ROTARIX"
-					},
-					{
-						"code": "19515-0889-07",
-						"display": "FLULAVAL"
-					},
-					{
-						"code": "49281-0392-15",
-						"display": "FLUZONE"
-					},
-					{
-						"code": "19515-0891-11",
-						"display": "Flulaval Quadrivalent"
-					},
-					{
-						"code": "49281-0400-05",
-						"display": "Adacel"
-					},
-					{
-						"code": "49281-0913-01",
-						"display": "STAMARIL"
-					},
-					{
-						"code": "49281-0640-15",
-						"display": "INFLUENZA A (H1N1) 2009 MONOVALENT VACCINE"
-					},
-					{
-						"code": "49281-0513-25",
-						"display": "FLUZONE QUADRIVALENT"
-					},
-					{
-						"code": "00006-4171-00",
-						"display": "ProQuad"
-					},
-					{
-						"code": "00006-4096-09",
-						"display": "VAQTA"
-					},
-					{
-						"code": "58160-0830-34",
-						"display": "CERVARIX"
-					},
-					{
-						"code": "00006-4980-00",
-						"display": "RECOMBIVAX HB"
-					},
-					{
-						"code": "17478-0131-01",
-						"display": "Tetanus and Diphtheria Toxoids Adsorbed"
-					},
-					{
-						"code": "49281-0414-10",
-						"display": "FLUZONE QUADRIVALENT"
-					},
-					{
-						"code": "43528-0002-05",
-						"display": "HEPLISAV-B"
-					},
-					{
-						"code": "66521-0200-02",
-						"display": "Influenza A (H1N1) 2009 Monovalent Vaccine"
-					},
-					{
-						"code": "49281-0011-50",
-						"display": "FLUZONE"
-					},
-					{
-						"code": "70461-0120-10",
-						"display": "Fluvirin"
-					},
-					{
-						"code": "66019-0304-10",
-						"display": "FluMist Quadrivalent"
-					},
-					{
-						"code": "58160-0976-20",
-						"display": "Bexsero"
-					},
-					{
-						"code": "00006-4826-00",
-						"display": "VARIVAX"
-					},
-					{
-						"code": "66521-0116-10",
-						"display": "Fluvirin"
-					},
-					{
-						"code": "00006-4963-41",
-						"display": "ZOSTAVAX"
-					},
-					{
-						"code": "49281-0510-05",
-						"display": "PENTACEL"
-					},
-					{
-						"code": "42874-0012-10",
-						"display": "Flublok"
-					},
-					{
-						"code": "58160-0955-09",
-						"display": "Menveo"
-					},
-					{
-						"code": "00005-0100-05",
-						"display": "Trumenba"
-					},
-					{
-						"code": "49281-0707-55",
-						"display": "FLUZONE"
-					},
-					{
-						"code": "14362-0111-04",
-						"display": "Tetanus and Diphtheria Toxoids Adsorbed"
-					},
-					{
-						"code": "66521-0112-10",
-						"display": "Fluvirin"
-					},
-					{
-						"code": "66521-0117-10",
-						"display": "Fluvirin"
-					},
-					{
-						"code": "00006-4045-41",
-						"display": "GARDASIL"
-					},
-					{
-						"code": "49281-0389-65",
-						"display": "FLUZONE HIGH DOSE"
-					},
-					{
-						"code": "69401-0000-02",
-						"display": "Vivotif"
-					},
-					{
-						"code": "49281-0915-01",
-						"display": "YF-VAX"
-					},
-					{
-						"code": "00006-4093-02",
-						"display": "RECOMBIVAX HB"
-					},
-					{
-						"code": "58160-0815-48",
-						"display": "TWINRIX"
-					},
-					{
-						"code": "70460-0001-01",
-						"display": "Vaxchora"
-					},
-					{
-						"code": "58160-0826-11",
-						"display": "HAVRIX"
-					},
-					{
-						"code": "00006-4992-00",
-						"display": "RECOMBIVAX HB"
-					},
-					{
-						"code": "49281-0111-25",
-						"display": "FLUZONE"
-					},
-					{
-						"code": "00006-4093-09",
-						"display": "RECOMBIVAX HB"
-					},
-					{
-						"code": "50090-3469-00",
-						"display": "HEPLISAV-B"
-					},
-					{
-						"code": "49281-0403-65",
-						"display": "FLUZONE High-Dose"
-					},
-					{
-						"code": "70461-0119-10",
-						"display": "Fluvirin"
-					},
-					{
-						"code": "00006-4995-00",
-						"display": "RECOMBIVAX HB"
-					},
-					{
-						"code": "58160-0815-34",
-						"display": "TWINRIX"
-					},
-					{
-						"code": "49281-0393-65",
-						"display": "FLUZONE High-Dose"
-					},
-					{
-						"code": "00005-1970-50",
-						"display": "Prevnar"
-					},
-					{
-						"code": "33332-0017-01",
-						"display": "AFLURIA"
-					},
-					{
-						"code": "63851-0501-01",
-						"display": "RabAvert"
-					},
-					{
-						"code": "58160-0881-52",
-						"display": "FLUARIX"
-					},
-					{
-						"code": "64678-0211-01",
-						"display": "BioThrax"
-					},
-					{
-						"code": "49281-0394-15",
-						"display": "FLUZONE"
-					},
-					{
-						"code": "00006-4827-00",
-						"display": "VARIVAX"
-					},
-					{
-						"code": "58160-0806-05",
-						"display": "HIBERIX"
-					},
-					{
-						"code": "49281-0518-25",
-						"display": "FLUZONE QUADRIVALENT"
-					},
-					{
-						"code": "62195-0051-10",
-						"display": "Ixiaro"
-					},
-					{
-						"code": "63361-0245-10",
-						"display": "VAXELIS"
-					},
-					{
-						"code": "49281-0709-55",
-						"display": "FLUZONE Intradermal"
-					},
-					{
-						"code": "66019-0300-10",
-						"display": "FluMist Quadrivalent"
-					},
-					{
-						"code": "49281-0215-15",
-						"display": "TENIVAC"
-					},
-					{
-						"code": "58160-0825-52",
-						"display": "HAVRIX"
-					},
-					{
-						"code": "00005-0100-10",
-						"display": "Trumenba"
-					},
-					{
-						"code": "66521-0117-02",
-						"display": "Fluvirin"
-					},
-					{
-						"code": "49281-0650-90",
-						"display": "INFLUENZA A (H1N1) 2009 MONOVALENT VACCINE"
-					},
-					{
-						"code": "42874-0015-10",
-						"display": "Flublok"
-					},
-					{
-						"code": "33332-0018-01",
-						"display": "AFLURIA"
-					},
-					{
-						"code": "00006-4999-00",
-						"display": "ProQuad"
-					},
-					{
-						"code": "00005-1971-04",
-						"display": "PREVNAR 13"
-					},
-					{
-						"code": "19515-0850-52",
-						"display": "FLULAVAL"
-					},
-					{
-						"code": "00005-1971-02",
-						"display": "PREVNAR 13"
-					},
-					{
-						"code": "00006-4094-02",
-						"display": "RECOMBIVAX HB"
-					},
-					{
-						"code": "00006-4096-02",
-						"display": "VAQTA"
-					},
-					{
-						"code": "58160-0825-11",
-						"display": "HAVRIX"
-					},
-					{
-						"code": "58160-0811-52",
-						"display": "PEDIARIX"
-					},
-					{
-						"code": "42515-0002-01",
-						"display": "IXIARO"
-					},
-					{
-						"code": "49281-0013-50",
-						"display": "FLUZONE"
-					},
-					{
-						"code": "76420-0483-01",
-						"display": "Medical Provider Single Use EZ Flu Shot 2013-2014"
-					},
-					{
-						"code": "66521-0118-10",
-						"display": "Fluvirin"
-					},
-					{
-						"code": "49281-0399-65",
-						"display": "FLUZONE High-Dose"
-					},
-					{
-						"code": "49281-0396-15",
-						"display": "FLUZONE"
-					},
-					{
-						"code": "66019-0107-01",
-						"display": "FLUMIST"
-					},
-					{
-						"code": "19515-0890-07",
-						"display": "FLULAVAL"
-					},
-					{
-						"code": "76420-0482-01",
-						"display": "Medical Provider Single Use EZ Flu Shot 2013-2014"
-					},
-					{
-						"code": "33332-0015-01",
-						"display": "AFLURIA"
-					},
-					{
-						"code": "66019-0302-10",
-						"display": "FluMist Quadrivalent"
-					},
-					{
-						"code": "49281-0012-10",
-						"display": "FLUZONE"
-					},
-					{
-						"code": "49281-0710-40",
-						"display": "FLUZONE INTRADERMAL QUADRIVALENT"
-					},
-					{
-						"code": "63851-0501-02",
-						"display": "RabAvert"
-					},
-					{
-						"code": "58160-0879-52",
-						"display": "FLUARIX"
-					},
-					{
-						"code": "49281-0397-65",
-						"display": "FLUZONE High-Dose"
-					},
-					{
-						"code": "00006-4831-41",
-						"display": "VAQTA"
-					},
-					{
-						"code": "58160-0815-46",
-						"display": "TWINRIX"
-					},
-					{
-						"code": "33332-0110-10",
-						"display": "AFLURIA"
-					},
-					{
-						"code": "54868-4320-00",
-						"display": "PNEUMOVAX 23"
-					},
-					{
-						"code": "42874-0016-10",
-						"display": "Flublok"
-					},
-					{
-						"code": "49281-0012-50",
-						"display": "FLUZONE"
-					},
-					{
-						"code": "58160-0818-11",
-						"display": "Hiberix"
-					},
-					{
-						"code": "49281-0386-15",
-						"display": "FLUZONE"
-					},
-					{
-						"code": "46028-0114-01",
-						"display": "Bexsero"
-					},
-					{
-						"code": "00006-4898-00",
-						"display": "COMVAX"
-					},
-					{
-						"code": "58160-0826-52",
-						"display": "HAVRIX"
-					},
-					{
-						"code": "49281-0545-05",
-						"display": "ActHIB"
-					},
-					{
-						"code": "66019-0108-10",
-						"display": "FLUMIST"
-					},
-					{
-						"code": "70461-0418-10",
-						"display": "FLUCELVAX QUADRIVALENT (MULTI-DOSE VIAL)"
-					},
-					{
-						"code": "00006-4094-09",
-						"display": "RECOMBIVAX HB"
-					},
-					{
-						"code": "49281-0298-10",
-						"display": "TRIPEDIA"
-					},
-					{
-						"code": "33332-0629-10",
-						"display": "Influenza A"
-					},
-					{
-						"code": "58160-0880-52",
-						"display": "FLUARIX"
-					},
-					{
-						"code": "00006-4047-20",
-						"display": "RotaTeq"
-					},
-					{
-						"code": "00006-4119-02",
-						"display": "GARDASIL 9"
-					},
-					{
-						"code": "58160-0842-11",
-						"display": "BOOSTRIX"
-					},
-					{
-						"code": "19515-0903-11",
-						"display": "Flulaval Quadrivalent"
-					},
-					{
-						"code": "00006-4981-00",
-						"display": "RECOMBIVAX HB"
-					},
-					{
-						"code": "58160-0905-52",
-						"display": "FLUARIX QUADRIVALENT"
-					},
-					{
-						"code": "49281-0401-65",
-						"display": "FLUZONE High-Dose"
-					},
-					{
-						"code": "33332-0114-10",
-						"display": "AFLURIA"
-					},
-					{
-						"code": "49281-0860-10",
-						"display": "IPOL"
-					},
-					{
-						"code": "70461-0318-03",
-						"display": "FLUCELVAX QUADRIVALENT (PREFILLED SYRINGE)"
-					},
-					{
-						"code": "54868-2219-01",
-						"display": "RECOMBIVAX HB"
-					},
-					{
-						"code": "49281-0718-10",
-						"display": "Flublok Quadrivalent"
-					},
-					{
-						"code": "49281-0400-15",
-						"display": "Adacel"
-					},
-					{
-						"code": "70461-0120-02",
-						"display": "Fluvirin"
-					},
-					{
-						"code": "49281-0416-50",
-						"display": "FLUZONE QUADRIVALENT"
-					},
-					{
-						"code": "49281-0413-50",
-						"display": "FLUZONE QUADRIVALENT"
-					},
-					{
-						"code": "58160-0883-52",
-						"display": "FLUARIX"
-					},
-					{
-						"code": "49281-0790-51",
-						"display": "Typhim Vi"
-					},
-					{
-						"code": "49281-0286-10",
-						"display": "DAPTACEL"
-					},
-					{
-						"code": "66019-0110-10",
-						"display": "FluMist"
-					},
-					{
-						"code": "46028-0114-02",
-						"display": "Bexsero"
-					},
-					{
-						"code": "58160-0821-52",
-						"display": "ENGERIX-B"
-					},
-					{
-						"code": "49281-0013-10",
-						"display": "FLUZONE"
-					},
-					{
-						"code": "19515-0894-52",
-						"display": "Flulaval Quadrivalent"
-					},
-					{
-						"code": "66019-0305-10",
-						"display": "FluMist Quadrivalent"
-					},
-					{
-						"code": "49281-0400-10",
-						"display": "Adacel"
-					},
-					{
-						"code": "49281-0390-15",
-						"display": "FLUZONE"
-					},
-					{
-						"code": "00052-0603-02",
-						"display": "BCG VACCINE"
-					},
-					{
-						"code": "51285-0138-50",
-						"display": "Adenovirus Type 4 and Type 7 Vaccine, Live"
-					},
-					{
-						"code": "33332-0417-10",
-						"display": "AFLURIA QUADRIVALENT"
-					},
-					{
-						"code": "49281-0395-65",
-						"display": "FLUZONE High-Dose"
-					},
-					{
-						"code": "66019-0301-10",
-						"display": "FluMist Quadrivalent"
-					},
-					{
-						"code": "49281-0215-10",
-						"display": "TENIVAC"
-					},
-					{
-						"code": "19515-0895-11",
-						"display": "Flulaval Quadrivalent"
-					},
-					{
-						"code": "70461-0201-01",
-						"display": "FLUCELVAX QUADRIVALENT (PREFILLED SYRINGE)"
-					},
-					{
-						"code": "58160-0907-52",
-						"display": "FLUARIX QUADRIVALENT"
-					},
-					{
-						"code": "55045-3841-01",
-						"display": "HAVRIX"
-					},
-					{
-						"code": "50090-2883-00",
-						"display": "INFANRIX"
-					},
-					{
-						"code": "49281-0820-10",
-						"display": "TETANUS TOXOID ADSORBED"
-					},
-					{
-						"code": "49281-0417-10",
-						"display": "FLUZONE QUADRIVALENT"
-					},
-					{
-						"code": "33332-0010-01",
-						"display": "AFLURIA"
-					},
-					{
-						"code": "33332-0013-01",
-						"display": "AFLURIA"
-					},
-					{
-						"code": "66521-0200-10",
-						"display": "Influenza A (H1N1) 2009 Monovalent Vaccine"
-					},
-					{
-						"code": "58160-0976-06",
-						"display": "Bexsero"
-					},
-					{
-						"code": "58160-0809-05",
-						"display": "MENHIBRIX"
-					},
-					{
-						"code": "00006-4739-00",
-						"display": "PNEUMOVAX 23"
-					},
-					{
-						"code": "70461-0018-03",
-						"display": "FLUAD"
-					},
-					{
-						"code": "49281-0413-10",
-						"display": "FLUZONE QUADRIVALENT"
-					},
-					{
-						"code": "13533-0131-01",
-						"display": "Tetanus and Diphtheria Toxoids Adsorbed"
-					},
-					{
-						"code": "58160-0812-11",
-						"display": "KINRIX"
-					},
-					{
-						"code": "49281-0391-65",
-						"display": "FLUZONE High-Dose"
-					},
-					{
-						"code": "19515-0845-11",
-						"display": "FLULAVAL"
-					},
-					{
-						"code": "58160-0811-51",
-						"display": "PEDIARIX"
-					},
-					{
-						"code": "58160-0815-52",
-						"display": "TWINRIX"
-					},
-					{
-						"code": "70461-0119-02",
-						"display": "Fluvirin"
-					},
-					{
-						"code": "58160-0810-52",
-						"display": "INFANRIX"
-					},
-					{
-						"code": "62577-0614-01",
-						"display": "Flucelvax"
-					},
-					{
-						"code": "42874-0117-10",
-						"display": "Flublok Quadrivalent"
-					},
-					{
-						"code": "49281-0489-91",
-						"display": "MENOMUNE - A/C/Y/W-135 COMBINED"
-					},
-					{
-						"code": "58160-0964-12",
-						"display": "RabAvert"
-					},
-					{
-						"code": "49281-0014-50",
-						"display": "FLUZONE"
-					},
-					{
-						"code": "00006-4109-02",
-						"display": "GARDASIL"
-					},
-					{
-						"code": "70461-0002-01",
-						"display": "FLUAD"
-					},
-					{
-						"code": "49281-0286-01",
-						"display": "DAPTACEL"
-					},
-					{
-						"code": "58160-0810-11",
-						"display": "INFANRIX"
-					},
-					{
-						"code": "19515-0900-11",
-						"display": "Flulaval Quadrivalent"
-					},
-					{
-						"code": "00006-4837-03",
-						"display": "PNEUMOVAX 23"
-					},
-					{
-						"code": "66521-0113-10",
-						"display": "FLUVIRIN"
-					},
-					{
-						"code": "58160-0826-34",
-						"display": "HAVRIX"
-					},
-					{
-						"code": "58160-0903-52",
-						"display": "FLUARIX QUADRIVALENT"
-					},
-					{
-						"code": "00006-4841-00",
-						"display": "VAQTA"
-					},
-					{
-						"code": "54868-6180-00",
-						"display": "FLUZONE"
-					},
-					{
-						"code": "00006-4681-00",
-						"display": "M-M-R II"
-					},
-					{
-						"code": "33332-0317-01",
-						"display": "AFLURIA QUADRIVALENT"
-					},
-					{
-						"code": "70461-0001-01",
-						"display": "FLUAD"
-					},
-					{
-						"code": "49281-0589-05",
-						"display": "Menactra"
-					},
-					{
-						"code": "49281-0387-65",
-						"display": "FLUZONE"
-					},
-					{
-						"code": "49281-0860-55",
-						"display": "IPOL"
-					},
-					{
-						"code": "19515-0893-07",
-						"display": "FLULAVAL"
-					},
-					{
-						"code": "33332-0519-25",
-						"display": "Influenza A"
-					},
-					{
-						"code": "70461-0301-10",
-						"display": "FLUCELVAX QUADRIVALENT (MULTI-DOSE VIAL)"
-					},
-					{
-						"code": "66019-0200-10",
-						"display": "Influenza A H1N1 Intranasal"
-					},
-					{
-						"code": "43528-0003-05",
-						"display": "HEPLISAV-B"
-					},
-					{
-						"code": "58160-0820-52",
-						"display": "ENGERIX-B"
-					},
-					{
-						"code": "66521-0000-01",
-						"display": "FLUAD"
-					},
-					{
-						"code": "49281-0250-51",
-						"display": "IMOVAX RABIES"
-					},
-					{
-						"code": "49281-0291-10",
-						"display": "DECAVAC"
-					},
-					{
-						"code": "33332-0418-10",
-						"display": "AFLURIA QUADRIVALENT"
-					},
-					{
-						"code": "00006-4121-02",
-						"display": "GARDASIL 9"
-					},
-					{
-						"code": "63851-0613-01",
-						"display": "FLUCELVAX"
-					},
-					{
-						"code": "66521-0114-10",
-						"display": "FLUVIRIN"
-					},
-					{
-						"code": "00006-4047-41",
-						"display": "RotaTeq"
-					},
-					{
-						"code": "58160-0901-52",
-						"display": "FLUARIX QUADRIVALENT"
-					},
-					{
-						"code": "33332-0318-01",
-						"display": "AFLURIA QUADRIVALENT"
-					},
-					{
-						"code": "00006-4119-03",
-						"display": "GARDASIL 9"
-					},
-					{
-						"code": "49281-0225-10",
-						"display": "DIPHTHERIA AND TETANUS TOXOIDS ADSORBED"
-					},
-					{
-						"code": "58160-0815-11",
-						"display": "TWINRIX"
-					},
-					{
-						"code": "54868-6177-00",
-						"display": "FLUZONE"
-					},
-					{
-						"code": "49281-0010-50",
-						"display": "FLUZONE"
-					},
-					{
-						"code": "49281-0400-20",
-						"display": "Adacel"
-					},
-					{
-						"code": "49281-0545-03",
-						"display": "ActHIB"
-					},
-					{
-						"code": "50090-1693-09",
-						"display": "IPOL"
-					},
-					{
-						"code": "00006-4995-41",
-						"display": "RECOMBIVAX HB"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-ndc-vaccine-codes",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-ndc-vaccine-codes",
+    "version": "3.1.1",
+    "name": "USCoreVaccineNationalDrugCode",
+    "title": "US Core Vaccine National Drug Codes (NDC)",
+    "status": "active",
+    "date": "2019-05-20T17:00:00-07:00",
+    "publisher": "HL7 US Realm Steering Committee",
+    "description": "This value set includes all the Vaccine National Drug Codes (NDC).  This source of this data is provided by the [CDC](https://www2a.cdc.gov/vaccines/iis/iisstandards/ndc_crosswalk.asp)",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "purpose": "Codes that are used as translations for CVS code for implementation of the Argonaut Immunization IG and MU2015 certification.",
+    "compose": {
+        "include": [
+            {
+                "system": "http://hl7.org/fhir/sid/ndc",
+                "concept": [
+                    {
+                        "code": "49281-0703-55",
+                        "display": "FLUZONE INTRADERMAL"
+                    },
+                    {
+                        "code": "49281-0790-20",
+                        "display": "Typhim Vi"
+                    },
+                    {
+                        "code": "33332-0316-01",
+                        "display": "AFLURIA QUADRIVALENT"
+                    },
+                    {
+                        "code": "49281-0712-40",
+                        "display": "FLUZONE INTRADERMAL QUADRIVALENT"
+                    },
+                    {
+                        "code": "66521-0112-02",
+                        "display": "Fluvirin"
+                    },
+                    {
+                        "code": "58160-0816-05",
+                        "display": "Hiberix"
+                    },
+                    {
+                        "code": "00006-4837-02",
+                        "display": "PNEUMOVAX 23"
+                    },
+                    {
+                        "code": "58160-0808-15",
+                        "display": "Influenza A (H5N1) Monovalent Vaccine, Adjuvanted"
+                    },
+                    {
+                        "code": "58160-0842-51",
+                        "display": "BOOSTRIX"
+                    },
+                    {
+                        "code": "49281-0418-50",
+                        "display": "FLUZONE QUADRIVALENT"
+                    },
+                    {
+                        "code": "00006-4943-00",
+                        "display": "PNEUMOVAX 23"
+                    },
+                    {
+                        "code": "49281-0708-40",
+                        "display": "FLUZONE INTRADERMAL QUADRIVALENT"
+                    },
+                    {
+                        "code": "54868-0734-00",
+                        "display": "ENGERIX-B"
+                    },
+                    {
+                        "code": "58160-0819-12",
+                        "display": "Shingrix"
+                    },
+                    {
+                        "code": "49281-0517-25",
+                        "display": "FLUZONE QUADRIVALENT"
+                    },
+                    {
+                        "code": "00006-4133-41",
+                        "display": "Tetanus and Diphtheria Toxoids Adsorbed"
+                    },
+                    {
+                        "code": "50090-3096-00",
+                        "display": "RabAvert"
+                    },
+                    {
+                        "code": "33332-0118-10",
+                        "display": "AFLURIA"
+                    },
+                    {
+                        "code": "19515-0909-52",
+                        "display": "Flulaval Quadrivalent"
+                    },
+                    {
+                        "code": "49281-0650-10",
+                        "display": "INFLUENZA A (H1N1) 2009 MONOVALENT VACCINE"
+                    },
+                    {
+                        "code": "58160-0820-11",
+                        "display": "ENGERIX-B"
+                    },
+                    {
+                        "code": "42515-0001-01",
+                        "display": "IXIARO"
+                    },
+                    {
+                        "code": "49281-0625-15",
+                        "display": "FLUZONE QUADRIVALENT"
+                    },
+                    {
+                        "code": "49281-0516-25",
+                        "display": "FLUZONE QUADRIVALENT"
+                    },
+                    {
+                        "code": "66521-0114-02",
+                        "display": "FLUVIRIN"
+                    },
+                    {
+                        "code": "19515-0896-11",
+                        "display": "Flulaval Quadrivalent"
+                    },
+                    {
+                        "code": "33332-0117-10",
+                        "display": "AFLURIA"
+                    },
+                    {
+                        "code": "33332-0416-10",
+                        "display": "AFLURIA QUADRIVALENT"
+                    },
+                    {
+                        "code": "66521-0118-02",
+                        "display": "Fluvirin"
+                    },
+                    {
+                        "code": "58160-0821-11",
+                        "display": "ENGERIX-B"
+                    },
+                    {
+                        "code": "00005-1971-05",
+                        "display": "PREVNAR 13"
+                    },
+                    {
+                        "code": "66019-0109-10",
+                        "display": "FLUMIST"
+                    },
+                    {
+                        "code": "49281-0278-10",
+                        "display": "DIPHTHERIA AND TETANUS TOXOIDS ADSORBED"
+                    },
+                    {
+                        "code": "49281-0011-10",
+                        "display": "FLUZONE"
+                    },
+                    {
+                        "code": "54868-2219-00",
+                        "display": "RECOMBIVAX HB"
+                    },
+                    {
+                        "code": "49281-0415-10",
+                        "display": "FLUZONE QUADRIVALENT"
+                    },
+                    {
+                        "code": "33332-0016-01",
+                        "display": "AFLURIA"
+                    },
+                    {
+                        "code": "49281-0705-55",
+                        "display": "FLUZONE"
+                    },
+                    {
+                        "code": "49281-0621-15",
+                        "display": "FLUZONE QUADRIVALENT"
+                    },
+                    {
+                        "code": "58160-0842-34",
+                        "display": "BOOSTRIX"
+                    },
+                    {
+                        "code": "49281-0010-10",
+                        "display": "FLUZONE"
+                    },
+                    {
+                        "code": "66521-0113-02",
+                        "display": "FLUVIRIN"
+                    },
+                    {
+                        "code": "49281-0514-25",
+                        "display": "FLUZONE QUADRIVALENT"
+                    },
+                    {
+                        "code": "58160-0842-52",
+                        "display": "BOOSTRIX"
+                    },
+                    {
+                        "code": "19515-0901-52",
+                        "display": "Flulaval Quadrivalent"
+                    },
+                    {
+                        "code": "62577-0613-01",
+                        "display": "Flucelvax"
+                    },
+                    {
+                        "code": "66019-0303-10",
+                        "display": "FluMist Quadrivalent"
+                    },
+                    {
+                        "code": "49281-0388-15",
+                        "display": "FLUZONE"
+                    },
+                    {
+                        "code": "00006-4841-41",
+                        "display": "VAQTA"
+                    },
+                    {
+                        "code": "58160-0900-52",
+                        "display": "FLUARIX QUADRIVALENT"
+                    },
+                    {
+                        "code": "70461-0200-01",
+                        "display": "FLUCELVAX QUADRIVALENT"
+                    },
+                    {
+                        "code": "49281-0915-05",
+                        "display": "YF-VAX"
+                    },
+                    {
+                        "code": "49281-0650-50",
+                        "display": "INFLUENZA A (H1N1) 2009 MONOVALENT VACCINE"
+                    },
+                    {
+                        "code": "33332-0116-10",
+                        "display": "AFLURIA"
+                    },
+                    {
+                        "code": "54868-3339-01",
+                        "display": "PNEUMOVAX 23"
+                    },
+                    {
+                        "code": "49281-0418-10",
+                        "display": "FLUZONE QUADRIVALENT"
+                    },
+                    {
+                        "code": "58160-0812-52",
+                        "display": "KINRIX"
+                    },
+                    {
+                        "code": "49281-0286-05",
+                        "display": "DAPTACEL"
+                    },
+                    {
+                        "code": "63851-0612-01",
+                        "display": "Flucelvax"
+                    },
+                    {
+                        "code": "19515-0908-52",
+                        "display": "Flulaval Quadrivalent"
+                    },
+                    {
+                        "code": "54868-0980-00",
+                        "display": "M-M-R II"
+                    },
+                    {
+                        "code": "58160-0830-52",
+                        "display": "CERVARIX"
+                    },
+                    {
+                        "code": "49281-0113-25",
+                        "display": "FLUZONE"
+                    },
+                    {
+                        "code": "49281-0650-70",
+                        "display": "INFLUENZA A (H1N1) 2009 MONOVALENT VACCINE"
+                    },
+                    {
+                        "code": "66521-0115-10",
+                        "display": "FLUVIRIN"
+                    },
+                    {
+                        "code": "49281-0417-50",
+                        "display": "FLUZONE QUADRIVALENT"
+                    },
+                    {
+                        "code": "33332-0113-10",
+                        "display": "AFLURIA"
+                    },
+                    {
+                        "code": "49281-0629-15",
+                        "display": "FLUZONE QUADRIVALENT"
+                    },
+                    {
+                        "code": "58160-0823-11",
+                        "display": "Shingrix"
+                    },
+                    {
+                        "code": "00006-4897-00",
+                        "display": "PedvaxHIB"
+                    },
+                    {
+                        "code": "58160-0821-34",
+                        "display": "ENGERIX-B"
+                    },
+                    {
+                        "code": "66521-0115-02",
+                        "display": "FLUVIRIN"
+                    },
+                    {
+                        "code": "33332-0014-01",
+                        "display": "AFLURIA"
+                    },
+                    {
+                        "code": "49281-0562-10",
+                        "display": "QUADRACEL"
+                    },
+                    {
+                        "code": "42874-0014-10",
+                        "display": "Flublok"
+                    },
+                    {
+                        "code": "42874-0013-10",
+                        "display": "Flublok"
+                    },
+                    {
+                        "code": "33332-0115-10",
+                        "display": "AFLURIA"
+                    },
+                    {
+                        "code": "00006-4963-00",
+                        "display": "ZOSTAVAX"
+                    },
+                    {
+                        "code": "49281-0010-25",
+                        "display": "FLUZONE"
+                    },
+                    {
+                        "code": "33332-0519-01",
+                        "display": "Influenza A"
+                    },
+                    {
+                        "code": "58160-0898-52",
+                        "display": "FLUARIX QUADRIVALENT"
+                    },
+                    {
+                        "code": "49281-0112-25",
+                        "display": "FLUZONE"
+                    },
+                    {
+                        "code": "19515-0898-11",
+                        "display": "Flulaval Quadrivalent"
+                    },
+                    {
+                        "code": "00006-4109-09",
+                        "display": "GARDASIL"
+                    },
+                    {
+                        "code": "49281-0414-50",
+                        "display": "FLUZONE QUADRIVALENT"
+                    },
+                    {
+                        "code": "00006-4095-09",
+                        "display": "VAQTA"
+                    },
+                    {
+                        "code": "00006-4045-00",
+                        "display": "GARDASIL"
+                    },
+                    {
+                        "code": "19515-0912-52",
+                        "display": "Flulaval Quadrivalent"
+                    },
+                    {
+                        "code": "58160-0801-11",
+                        "display": "Menhibrix"
+                    },
+                    {
+                        "code": "49281-0489-01",
+                        "display": "MENOMUNE - A/C/Y/W-135 COMBINED"
+                    },
+                    {
+                        "code": "42874-0017-10",
+                        "display": "Flublok"
+                    },
+                    {
+                        "code": "66521-0116-02",
+                        "display": "Fluvirin"
+                    },
+                    {
+                        "code": "46028-0208-01",
+                        "display": "Menveo"
+                    },
+                    {
+                        "code": "49281-0627-15",
+                        "display": "FLUZONE QUADRIVALENT"
+                    },
+                    {
+                        "code": "00005-0100-02",
+                        "display": "Trumenba"
+                    },
+                    {
+                        "code": "69401-0000-01",
+                        "display": "Vivotif"
+                    },
+                    {
+                        "code": "21695-0413-01",
+                        "display": "Tetanus and Diphtheria Toxoids Adsorbed"
+                    },
+                    {
+                        "code": "49281-0416-10",
+                        "display": "FLUZONE QUADRIVALENT"
+                    },
+                    {
+                        "code": "49281-0650-25",
+                        "display": "INFLUENZA A (H1N1) 2009 MONOVALENT VACCINE"
+                    },
+                    {
+                        "code": "49281-0800-83",
+                        "display": "TETANUS TOXOID ADSORBED"
+                    },
+                    {
+                        "code": "49281-0291-83",
+                        "display": "DECAVAC"
+                    },
+                    {
+                        "code": "00006-4095-02",
+                        "display": "VAQTA"
+                    },
+                    {
+                        "code": "58160-0854-52",
+                        "display": "ROTARIX"
+                    },
+                    {
+                        "code": "19515-0889-07",
+                        "display": "FLULAVAL"
+                    },
+                    {
+                        "code": "49281-0392-15",
+                        "display": "FLUZONE"
+                    },
+                    {
+                        "code": "19515-0891-11",
+                        "display": "Flulaval Quadrivalent"
+                    },
+                    {
+                        "code": "49281-0400-05",
+                        "display": "Adacel"
+                    },
+                    {
+                        "code": "49281-0913-01",
+                        "display": "STAMARIL"
+                    },
+                    {
+                        "code": "49281-0640-15",
+                        "display": "INFLUENZA A (H1N1) 2009 MONOVALENT VACCINE"
+                    },
+                    {
+                        "code": "49281-0513-25",
+                        "display": "FLUZONE QUADRIVALENT"
+                    },
+                    {
+                        "code": "00006-4171-00",
+                        "display": "ProQuad"
+                    },
+                    {
+                        "code": "00006-4096-09",
+                        "display": "VAQTA"
+                    },
+                    {
+                        "code": "58160-0830-34",
+                        "display": "CERVARIX"
+                    },
+                    {
+                        "code": "00006-4980-00",
+                        "display": "RECOMBIVAX HB"
+                    },
+                    {
+                        "code": "17478-0131-01",
+                        "display": "Tetanus and Diphtheria Toxoids Adsorbed"
+                    },
+                    {
+                        "code": "49281-0414-10",
+                        "display": "FLUZONE QUADRIVALENT"
+                    },
+                    {
+                        "code": "43528-0002-05",
+                        "display": "HEPLISAV-B"
+                    },
+                    {
+                        "code": "66521-0200-02",
+                        "display": "Influenza A (H1N1) 2009 Monovalent Vaccine"
+                    },
+                    {
+                        "code": "49281-0011-50",
+                        "display": "FLUZONE"
+                    },
+                    {
+                        "code": "70461-0120-10",
+                        "display": "Fluvirin"
+                    },
+                    {
+                        "code": "66019-0304-10",
+                        "display": "FluMist Quadrivalent"
+                    },
+                    {
+                        "code": "58160-0976-20",
+                        "display": "Bexsero"
+                    },
+                    {
+                        "code": "00006-4826-00",
+                        "display": "VARIVAX"
+                    },
+                    {
+                        "code": "66521-0116-10",
+                        "display": "Fluvirin"
+                    },
+                    {
+                        "code": "00006-4963-41",
+                        "display": "ZOSTAVAX"
+                    },
+                    {
+                        "code": "49281-0510-05",
+                        "display": "PENTACEL"
+                    },
+                    {
+                        "code": "42874-0012-10",
+                        "display": "Flublok"
+                    },
+                    {
+                        "code": "58160-0955-09",
+                        "display": "Menveo"
+                    },
+                    {
+                        "code": "00005-0100-05",
+                        "display": "Trumenba"
+                    },
+                    {
+                        "code": "49281-0707-55",
+                        "display": "FLUZONE"
+                    },
+                    {
+                        "code": "14362-0111-04",
+                        "display": "Tetanus and Diphtheria Toxoids Adsorbed"
+                    },
+                    {
+                        "code": "66521-0112-10",
+                        "display": "Fluvirin"
+                    },
+                    {
+                        "code": "66521-0117-10",
+                        "display": "Fluvirin"
+                    },
+                    {
+                        "code": "00006-4045-41",
+                        "display": "GARDASIL"
+                    },
+                    {
+                        "code": "49281-0389-65",
+                        "display": "FLUZONE HIGH DOSE"
+                    },
+                    {
+                        "code": "69401-0000-02",
+                        "display": "Vivotif"
+                    },
+                    {
+                        "code": "49281-0915-01",
+                        "display": "YF-VAX"
+                    },
+                    {
+                        "code": "00006-4093-02",
+                        "display": "RECOMBIVAX HB"
+                    },
+                    {
+                        "code": "58160-0815-48",
+                        "display": "TWINRIX"
+                    },
+                    {
+                        "code": "70460-0001-01",
+                        "display": "Vaxchora"
+                    },
+                    {
+                        "code": "58160-0826-11",
+                        "display": "HAVRIX"
+                    },
+                    {
+                        "code": "00006-4992-00",
+                        "display": "RECOMBIVAX HB"
+                    },
+                    {
+                        "code": "49281-0111-25",
+                        "display": "FLUZONE"
+                    },
+                    {
+                        "code": "00006-4093-09",
+                        "display": "RECOMBIVAX HB"
+                    },
+                    {
+                        "code": "50090-3469-00",
+                        "display": "HEPLISAV-B"
+                    },
+                    {
+                        "code": "49281-0403-65",
+                        "display": "FLUZONE High-Dose"
+                    },
+                    {
+                        "code": "70461-0119-10",
+                        "display": "Fluvirin"
+                    },
+                    {
+                        "code": "00006-4995-00",
+                        "display": "RECOMBIVAX HB"
+                    },
+                    {
+                        "code": "58160-0815-34",
+                        "display": "TWINRIX"
+                    },
+                    {
+                        "code": "49281-0393-65",
+                        "display": "FLUZONE High-Dose"
+                    },
+                    {
+                        "code": "00005-1970-50",
+                        "display": "Prevnar"
+                    },
+                    {
+                        "code": "33332-0017-01",
+                        "display": "AFLURIA"
+                    },
+                    {
+                        "code": "63851-0501-01",
+                        "display": "RabAvert"
+                    },
+                    {
+                        "code": "58160-0881-52",
+                        "display": "FLUARIX"
+                    },
+                    {
+                        "code": "64678-0211-01",
+                        "display": "BioThrax"
+                    },
+                    {
+                        "code": "49281-0394-15",
+                        "display": "FLUZONE"
+                    },
+                    {
+                        "code": "00006-4827-00",
+                        "display": "VARIVAX"
+                    },
+                    {
+                        "code": "58160-0806-05",
+                        "display": "HIBERIX"
+                    },
+                    {
+                        "code": "49281-0518-25",
+                        "display": "FLUZONE QUADRIVALENT"
+                    },
+                    {
+                        "code": "62195-0051-10",
+                        "display": "Ixiaro"
+                    },
+                    {
+                        "code": "63361-0245-10",
+                        "display": "VAXELIS"
+                    },
+                    {
+                        "code": "49281-0709-55",
+                        "display": "FLUZONE Intradermal"
+                    },
+                    {
+                        "code": "66019-0300-10",
+                        "display": "FluMist Quadrivalent"
+                    },
+                    {
+                        "code": "49281-0215-15",
+                        "display": "TENIVAC"
+                    },
+                    {
+                        "code": "58160-0825-52",
+                        "display": "HAVRIX"
+                    },
+                    {
+                        "code": "00005-0100-10",
+                        "display": "Trumenba"
+                    },
+                    {
+                        "code": "66521-0117-02",
+                        "display": "Fluvirin"
+                    },
+                    {
+                        "code": "49281-0650-90",
+                        "display": "INFLUENZA A (H1N1) 2009 MONOVALENT VACCINE"
+                    },
+                    {
+                        "code": "42874-0015-10",
+                        "display": "Flublok"
+                    },
+                    {
+                        "code": "33332-0018-01",
+                        "display": "AFLURIA"
+                    },
+                    {
+                        "code": "00006-4999-00",
+                        "display": "ProQuad"
+                    },
+                    {
+                        "code": "00005-1971-04",
+                        "display": "PREVNAR 13"
+                    },
+                    {
+                        "code": "19515-0850-52",
+                        "display": "FLULAVAL"
+                    },
+                    {
+                        "code": "00005-1971-02",
+                        "display": "PREVNAR 13"
+                    },
+                    {
+                        "code": "00006-4094-02",
+                        "display": "RECOMBIVAX HB"
+                    },
+                    {
+                        "code": "00006-4096-02",
+                        "display": "VAQTA"
+                    },
+                    {
+                        "code": "58160-0825-11",
+                        "display": "HAVRIX"
+                    },
+                    {
+                        "code": "58160-0811-52",
+                        "display": "PEDIARIX"
+                    },
+                    {
+                        "code": "42515-0002-01",
+                        "display": "IXIARO"
+                    },
+                    {
+                        "code": "49281-0013-50",
+                        "display": "FLUZONE"
+                    },
+                    {
+                        "code": "76420-0483-01",
+                        "display": "Medical Provider Single Use EZ Flu Shot 2013-2014"
+                    },
+                    {
+                        "code": "66521-0118-10",
+                        "display": "Fluvirin"
+                    },
+                    {
+                        "code": "49281-0399-65",
+                        "display": "FLUZONE High-Dose"
+                    },
+                    {
+                        "code": "49281-0396-15",
+                        "display": "FLUZONE"
+                    },
+                    {
+                        "code": "66019-0107-01",
+                        "display": "FLUMIST"
+                    },
+                    {
+                        "code": "19515-0890-07",
+                        "display": "FLULAVAL"
+                    },
+                    {
+                        "code": "76420-0482-01",
+                        "display": "Medical Provider Single Use EZ Flu Shot 2013-2014"
+                    },
+                    {
+                        "code": "33332-0015-01",
+                        "display": "AFLURIA"
+                    },
+                    {
+                        "code": "66019-0302-10",
+                        "display": "FluMist Quadrivalent"
+                    },
+                    {
+                        "code": "49281-0012-10",
+                        "display": "FLUZONE"
+                    },
+                    {
+                        "code": "49281-0710-40",
+                        "display": "FLUZONE INTRADERMAL QUADRIVALENT"
+                    },
+                    {
+                        "code": "63851-0501-02",
+                        "display": "RabAvert"
+                    },
+                    {
+                        "code": "58160-0879-52",
+                        "display": "FLUARIX"
+                    },
+                    {
+                        "code": "49281-0397-65",
+                        "display": "FLUZONE High-Dose"
+                    },
+                    {
+                        "code": "00006-4831-41",
+                        "display": "VAQTA"
+                    },
+                    {
+                        "code": "58160-0815-46",
+                        "display": "TWINRIX"
+                    },
+                    {
+                        "code": "33332-0110-10",
+                        "display": "AFLURIA"
+                    },
+                    {
+                        "code": "54868-4320-00",
+                        "display": "PNEUMOVAX 23"
+                    },
+                    {
+                        "code": "42874-0016-10",
+                        "display": "Flublok"
+                    },
+                    {
+                        "code": "49281-0012-50",
+                        "display": "FLUZONE"
+                    },
+                    {
+                        "code": "58160-0818-11",
+                        "display": "Hiberix"
+                    },
+                    {
+                        "code": "49281-0386-15",
+                        "display": "FLUZONE"
+                    },
+                    {
+                        "code": "46028-0114-01",
+                        "display": "Bexsero"
+                    },
+                    {
+                        "code": "00006-4898-00",
+                        "display": "COMVAX"
+                    },
+                    {
+                        "code": "58160-0826-52",
+                        "display": "HAVRIX"
+                    },
+                    {
+                        "code": "49281-0545-05",
+                        "display": "ActHIB"
+                    },
+                    {
+                        "code": "66019-0108-10",
+                        "display": "FLUMIST"
+                    },
+                    {
+                        "code": "70461-0418-10",
+                        "display": "FLUCELVAX QUADRIVALENT (MULTI-DOSE VIAL)"
+                    },
+                    {
+                        "code": "00006-4094-09",
+                        "display": "RECOMBIVAX HB"
+                    },
+                    {
+                        "code": "49281-0298-10",
+                        "display": "TRIPEDIA"
+                    },
+                    {
+                        "code": "33332-0629-10",
+                        "display": "Influenza A"
+                    },
+                    {
+                        "code": "58160-0880-52",
+                        "display": "FLUARIX"
+                    },
+                    {
+                        "code": "00006-4047-20",
+                        "display": "RotaTeq"
+                    },
+                    {
+                        "code": "00006-4119-02",
+                        "display": "GARDASIL 9"
+                    },
+                    {
+                        "code": "58160-0842-11",
+                        "display": "BOOSTRIX"
+                    },
+                    {
+                        "code": "19515-0903-11",
+                        "display": "Flulaval Quadrivalent"
+                    },
+                    {
+                        "code": "00006-4981-00",
+                        "display": "RECOMBIVAX HB"
+                    },
+                    {
+                        "code": "58160-0905-52",
+                        "display": "FLUARIX QUADRIVALENT"
+                    },
+                    {
+                        "code": "49281-0401-65",
+                        "display": "FLUZONE High-Dose"
+                    },
+                    {
+                        "code": "33332-0114-10",
+                        "display": "AFLURIA"
+                    },
+                    {
+                        "code": "49281-0860-10",
+                        "display": "IPOL"
+                    },
+                    {
+                        "code": "70461-0318-03",
+                        "display": "FLUCELVAX QUADRIVALENT (PREFILLED SYRINGE)"
+                    },
+                    {
+                        "code": "54868-2219-01",
+                        "display": "RECOMBIVAX HB"
+                    },
+                    {
+                        "code": "49281-0718-10",
+                        "display": "Flublok Quadrivalent"
+                    },
+                    {
+                        "code": "49281-0400-15",
+                        "display": "Adacel"
+                    },
+                    {
+                        "code": "70461-0120-02",
+                        "display": "Fluvirin"
+                    },
+                    {
+                        "code": "49281-0416-50",
+                        "display": "FLUZONE QUADRIVALENT"
+                    },
+                    {
+                        "code": "49281-0413-50",
+                        "display": "FLUZONE QUADRIVALENT"
+                    },
+                    {
+                        "code": "58160-0883-52",
+                        "display": "FLUARIX"
+                    },
+                    {
+                        "code": "49281-0790-51",
+                        "display": "Typhim Vi"
+                    },
+                    {
+                        "code": "49281-0286-10",
+                        "display": "DAPTACEL"
+                    },
+                    {
+                        "code": "66019-0110-10",
+                        "display": "FluMist"
+                    },
+                    {
+                        "code": "46028-0114-02",
+                        "display": "Bexsero"
+                    },
+                    {
+                        "code": "58160-0821-52",
+                        "display": "ENGERIX-B"
+                    },
+                    {
+                        "code": "49281-0013-10",
+                        "display": "FLUZONE"
+                    },
+                    {
+                        "code": "19515-0894-52",
+                        "display": "Flulaval Quadrivalent"
+                    },
+                    {
+                        "code": "66019-0305-10",
+                        "display": "FluMist Quadrivalent"
+                    },
+                    {
+                        "code": "49281-0400-10",
+                        "display": "Adacel"
+                    },
+                    {
+                        "code": "49281-0390-15",
+                        "display": "FLUZONE"
+                    },
+                    {
+                        "code": "00052-0603-02",
+                        "display": "BCG VACCINE"
+                    },
+                    {
+                        "code": "51285-0138-50",
+                        "display": "Adenovirus Type 4 and Type 7 Vaccine, Live"
+                    },
+                    {
+                        "code": "33332-0417-10",
+                        "display": "AFLURIA QUADRIVALENT"
+                    },
+                    {
+                        "code": "49281-0395-65",
+                        "display": "FLUZONE High-Dose"
+                    },
+                    {
+                        "code": "66019-0301-10",
+                        "display": "FluMist Quadrivalent"
+                    },
+                    {
+                        "code": "49281-0215-10",
+                        "display": "TENIVAC"
+                    },
+                    {
+                        "code": "19515-0895-11",
+                        "display": "Flulaval Quadrivalent"
+                    },
+                    {
+                        "code": "70461-0201-01",
+                        "display": "FLUCELVAX QUADRIVALENT (PREFILLED SYRINGE)"
+                    },
+                    {
+                        "code": "58160-0907-52",
+                        "display": "FLUARIX QUADRIVALENT"
+                    },
+                    {
+                        "code": "55045-3841-01",
+                        "display": "HAVRIX"
+                    },
+                    {
+                        "code": "50090-2883-00",
+                        "display": "INFANRIX"
+                    },
+                    {
+                        "code": "49281-0820-10",
+                        "display": "TETANUS TOXOID ADSORBED"
+                    },
+                    {
+                        "code": "49281-0417-10",
+                        "display": "FLUZONE QUADRIVALENT"
+                    },
+                    {
+                        "code": "33332-0010-01",
+                        "display": "AFLURIA"
+                    },
+                    {
+                        "code": "33332-0013-01",
+                        "display": "AFLURIA"
+                    },
+                    {
+                        "code": "66521-0200-10",
+                        "display": "Influenza A (H1N1) 2009 Monovalent Vaccine"
+                    },
+                    {
+                        "code": "58160-0976-06",
+                        "display": "Bexsero"
+                    },
+                    {
+                        "code": "58160-0809-05",
+                        "display": "MENHIBRIX"
+                    },
+                    {
+                        "code": "00006-4739-00",
+                        "display": "PNEUMOVAX 23"
+                    },
+                    {
+                        "code": "70461-0018-03",
+                        "display": "FLUAD"
+                    },
+                    {
+                        "code": "49281-0413-10",
+                        "display": "FLUZONE QUADRIVALENT"
+                    },
+                    {
+                        "code": "13533-0131-01",
+                        "display": "Tetanus and Diphtheria Toxoids Adsorbed"
+                    },
+                    {
+                        "code": "58160-0812-11",
+                        "display": "KINRIX"
+                    },
+                    {
+                        "code": "49281-0391-65",
+                        "display": "FLUZONE High-Dose"
+                    },
+                    {
+                        "code": "19515-0845-11",
+                        "display": "FLULAVAL"
+                    },
+                    {
+                        "code": "58160-0811-51",
+                        "display": "PEDIARIX"
+                    },
+                    {
+                        "code": "58160-0815-52",
+                        "display": "TWINRIX"
+                    },
+                    {
+                        "code": "70461-0119-02",
+                        "display": "Fluvirin"
+                    },
+                    {
+                        "code": "58160-0810-52",
+                        "display": "INFANRIX"
+                    },
+                    {
+                        "code": "62577-0614-01",
+                        "display": "Flucelvax"
+                    },
+                    {
+                        "code": "42874-0117-10",
+                        "display": "Flublok Quadrivalent"
+                    },
+                    {
+                        "code": "49281-0489-91",
+                        "display": "MENOMUNE - A/C/Y/W-135 COMBINED"
+                    },
+                    {
+                        "code": "58160-0964-12",
+                        "display": "RabAvert"
+                    },
+                    {
+                        "code": "49281-0014-50",
+                        "display": "FLUZONE"
+                    },
+                    {
+                        "code": "00006-4109-02",
+                        "display": "GARDASIL"
+                    },
+                    {
+                        "code": "70461-0002-01",
+                        "display": "FLUAD"
+                    },
+                    {
+                        "code": "49281-0286-01",
+                        "display": "DAPTACEL"
+                    },
+                    {
+                        "code": "58160-0810-11",
+                        "display": "INFANRIX"
+                    },
+                    {
+                        "code": "19515-0900-11",
+                        "display": "Flulaval Quadrivalent"
+                    },
+                    {
+                        "code": "00006-4837-03",
+                        "display": "PNEUMOVAX 23"
+                    },
+                    {
+                        "code": "66521-0113-10",
+                        "display": "FLUVIRIN"
+                    },
+                    {
+                        "code": "58160-0826-34",
+                        "display": "HAVRIX"
+                    },
+                    {
+                        "code": "58160-0903-52",
+                        "display": "FLUARIX QUADRIVALENT"
+                    },
+                    {
+                        "code": "00006-4841-00",
+                        "display": "VAQTA"
+                    },
+                    {
+                        "code": "54868-6180-00",
+                        "display": "FLUZONE"
+                    },
+                    {
+                        "code": "00006-4681-00",
+                        "display": "M-M-R II"
+                    },
+                    {
+                        "code": "33332-0317-01",
+                        "display": "AFLURIA QUADRIVALENT"
+                    },
+                    {
+                        "code": "70461-0001-01",
+                        "display": "FLUAD"
+                    },
+                    {
+                        "code": "49281-0589-05",
+                        "display": "Menactra"
+                    },
+                    {
+                        "code": "49281-0387-65",
+                        "display": "FLUZONE"
+                    },
+                    {
+                        "code": "49281-0860-55",
+                        "display": "IPOL"
+                    },
+                    {
+                        "code": "19515-0893-07",
+                        "display": "FLULAVAL"
+                    },
+                    {
+                        "code": "33332-0519-25",
+                        "display": "Influenza A"
+                    },
+                    {
+                        "code": "70461-0301-10",
+                        "display": "FLUCELVAX QUADRIVALENT (MULTI-DOSE VIAL)"
+                    },
+                    {
+                        "code": "66019-0200-10",
+                        "display": "Influenza A H1N1 Intranasal"
+                    },
+                    {
+                        "code": "43528-0003-05",
+                        "display": "HEPLISAV-B"
+                    },
+                    {
+                        "code": "58160-0820-52",
+                        "display": "ENGERIX-B"
+                    },
+                    {
+                        "code": "66521-0000-01",
+                        "display": "FLUAD"
+                    },
+                    {
+                        "code": "49281-0250-51",
+                        "display": "IMOVAX RABIES"
+                    },
+                    {
+                        "code": "49281-0291-10",
+                        "display": "DECAVAC"
+                    },
+                    {
+                        "code": "33332-0418-10",
+                        "display": "AFLURIA QUADRIVALENT"
+                    },
+                    {
+                        "code": "00006-4121-02",
+                        "display": "GARDASIL 9"
+                    },
+                    {
+                        "code": "63851-0613-01",
+                        "display": "FLUCELVAX"
+                    },
+                    {
+                        "code": "66521-0114-10",
+                        "display": "FLUVIRIN"
+                    },
+                    {
+                        "code": "00006-4047-41",
+                        "display": "RotaTeq"
+                    },
+                    {
+                        "code": "58160-0901-52",
+                        "display": "FLUARIX QUADRIVALENT"
+                    },
+                    {
+                        "code": "33332-0318-01",
+                        "display": "AFLURIA QUADRIVALENT"
+                    },
+                    {
+                        "code": "00006-4119-03",
+                        "display": "GARDASIL 9"
+                    },
+                    {
+                        "code": "49281-0225-10",
+                        "display": "DIPHTHERIA AND TETANUS TOXOIDS ADSORBED"
+                    },
+                    {
+                        "code": "58160-0815-11",
+                        "display": "TWINRIX"
+                    },
+                    {
+                        "code": "54868-6177-00",
+                        "display": "FLUZONE"
+                    },
+                    {
+                        "code": "49281-0010-50",
+                        "display": "FLUZONE"
+                    },
+                    {
+                        "code": "49281-0400-20",
+                        "display": "Adacel"
+                    },
+                    {
+                        "code": "49281-0545-03",
+                        "display": "ActHIB"
+                    },
+                    {
+                        "code": "50090-1693-09",
+                        "display": "IPOL"
+                    },
+                    {
+                        "code": "00006-4995-41",
+                        "display": "RECOMBIVAX HB"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-observation-smoking-status-status.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-observation-smoking-status-status.json
@@ -1,52 +1,52 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-observation-smoking-status-status",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include these codes as defined in <a href=\"http://hl7.org/fhir/R4/codesystem-observation-status.html\"><code>http://hl7.org/fhir/observation-status</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td></tr><tr><td><a href=\"http://hl7.org/fhir/R4/codesystem-observation-status.html#observation-status-final\">final</a></td><td>Final</td><td>The observation is complete and there are no further actions needed. Additional information such &quot;released&quot;, &quot;signed&quot;, etc would be represented using [Provenance](provenance.html) which provides not only the act but also the actors and dates and other related data. These act states would be associated with an observation status of `preliminary` until they are all completed and then a status of `final` would be applied.</td></tr><tr><td><a href=\"http://hl7.org/fhir/R4/codesystem-observation-status.html#observation-status-entered-in-error\">entered-in-error</a></td><td>Entered in Error</td><td>The observation has been withdrawn following previous final release.  This electronic record should never have existed, though it is possible that real-world decisions were based on it. (If real-world activity has occurred, the status should be &quot;cancelled&quot; rather than &quot;entered-in-error&quot;.).</td></tr></table></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smoking-status-status",
-	"version": "3.1.1",
-	"name": "USCoreObservationSmokingStatusStatus",
-	"title": "US Core Status for Smoking Status Observation",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "other",
-					"value": "http://hl7.org/fhir"
-				}
-			]
-		}
-	],
-	"description": "Codes providing the status of an observation for smoking status. Constrained to `final`and `entered-in-error`.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"compose": {
-		"include": [
-			{
-				"system": "http://hl7.org/fhir/observation-status",
-				"concept": [
-					{
-						"code": "final"
-					},
-					{
-						"code": "entered-in-error"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-observation-smoking-status-status",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smoking-status-status",
+    "version": "3.1.1",
+    "name": "USCoreObservationSmokingStatusStatus",
+    "title": "US Core Status for Smoking Status Observation",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "other",
+                    "value": "http://hl7.org/fhir"
+                }
+            ]
+        }
+    ],
+    "description": "Codes providing the status of an observation for smoking status. Constrained to `final`and `entered-in-error`.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "compose": {
+        "include": [
+            {
+                "system": "http://hl7.org/fhir/observation-status",
+                "concept": [
+                    {
+                        "code": "final"
+                    },
+                    {
+                        "code": "entered-in-error"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-observation-smokingstatus-max.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-observation-smokingstatus-max.json
@@ -1,45 +1,45 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-observation-smokingstatus-max",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include all codes defined in <a href=\"http://www.snomed.org/\"><code>http://snomed.info/sct</code></a></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smokingstatus-max",
-	"version": "3.1.1",
-	"name": "USCoreSmokingStatusmaxValueSet",
-	"title": "US Core Smoking Status Max-Binding",
-	"status": "active",
-	"date": "2020-06-29",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "other",
-					"value": "http://hl7.org/fhir"
-				}
-			]
-		}
-	],
-	"description": "Representing a patient’s smoking behavior using concepts from SNOMED CT.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"copyright": "This value set includes content from SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement",
-	"compose": {
-		"include": [
-			{
-				"system": "http://snomed.info/sct"
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-observation-smokingstatus-max",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smokingstatus-max",
+    "version": "3.1.1",
+    "name": "USCoreSmokingStatusmaxValueSet",
+    "title": "US Core Smoking Status Max-Binding",
+    "status": "active",
+    "date": "2020-06-29",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "other",
+                    "value": "http://hl7.org/fhir"
+                }
+            ]
+        }
+    ],
+    "description": "Representing a patient’s smoking behavior using concepts from SNOMED CT.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "copyright": "This value set includes content from SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement",
+    "compose": {
+        "include": [
+            {
+                "system": "http://snomed.info/sct"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-observation-smokingstatus.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-observation-smokingstatus.json
@@ -1,85 +1,85 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-observation-smokingstatus",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include these codes as defined in <a href=\"http://www.snomed.org/\"><code>http://snomed.info/sct</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=449868002\">449868002</a></td><td>Current every day smoker</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=428041000124106\">428041000124106</a></td><td>Current some day smoker</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=8517006\">8517006</a></td><td>Former smoker</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=266919005\">266919005</a></td><td>Never smoker</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=77176002\">77176002</a></td><td>Smoker, current status unknown</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=266927001\">266927001</a></td><td>Unknown if ever smoked</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=428071000124103\">428071000124103</a></td><td>Current Heavy tobacco smoker</td><td/></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=428061000124105\">428061000124105</a></td><td>Current Light tobacco smoker</td><td/></tr></table></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smokingstatus",
-	"identifier": [
-		{
-			"system": "urn:ietf:rfc:3986",
-			"value": "urn:oid:2.16.840.1.113883.4.642.2.602"
-		}
-	],
-	"version": "3.1.1",
-	"name": "UsCoreSmokingStatusPreferred",
-	"title": "US Core Smoking Status Preferred",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "other",
-					"value": "http://hl7.org/fhir"
-				}
-			]
-		}
-	],
-	"description": "This value set enumerates a preferred set of SNOMED CT codes historically used for the current smoking status of a patient.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"copyright": "This value set includes content from SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement",
-	"compose": {
-		"include": [
-			{
-				"system": "http://snomed.info/sct",
-				"concept": [
-					{
-						"code": "449868002",
-						"display": "Current every day smoker"
-					},
-					{
-						"code": "428041000124106",
-						"display": "Current some day smoker"
-					},
-					{
-						"code": "8517006",
-						"display": "Former smoker"
-					},
-					{
-						"code": "266919005",
-						"display": "Never smoker"
-					},
-					{
-						"code": "77176002",
-						"display": "Smoker, current status unknown"
-					},
-					{
-						"code": "266927001",
-						"display": "Unknown if ever smoked"
-					},
-					{
-						"code": "428071000124103",
-						"display": "Current Heavy tobacco smoker"
-					},
-					{
-						"code": "428061000124105",
-						"display": "Current Light tobacco smoker"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-observation-smokingstatus",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smokingstatus",
+    "identifier": [
+        {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:oid:2.16.840.1.113883.4.642.2.602"
+        }
+    ],
+    "version": "3.1.1",
+    "name": "UsCoreSmokingStatusPreferred",
+    "title": "US Core Smoking Status Preferred",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "other",
+                    "value": "http://hl7.org/fhir"
+                }
+            ]
+        }
+    ],
+    "description": "This value set enumerates a preferred set of SNOMED CT codes historically used for the current smoking status of a patient.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "copyright": "This value set includes content from SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement",
+    "compose": {
+        "include": [
+            {
+                "system": "http://snomed.info/sct",
+                "concept": [
+                    {
+                        "code": "449868002",
+                        "display": "Current every day smoker"
+                    },
+                    {
+                        "code": "428041000124106",
+                        "display": "Current some day smoker"
+                    },
+                    {
+                        "code": "8517006",
+                        "display": "Former smoker"
+                    },
+                    {
+                        "code": "266919005",
+                        "display": "Never smoker"
+                    },
+                    {
+                        "code": "77176002",
+                        "display": "Smoker, current status unknown"
+                    },
+                    {
+                        "code": "266927001",
+                        "display": "Unknown if ever smoked"
+                    },
+                    {
+                        "code": "428071000124103",
+                        "display": "Current Heavy tobacco smoker"
+                    },
+                    {
+                        "code": "428061000124105",
+                        "display": "Current Light tobacco smoker"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-observation-value-codes.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-observation-value-codes.json
@@ -1,49 +1,49 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-observation-value-codes",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include all codes defined in <a href=\"http://www.snomed.org/\"><code>http://snomed.info/sct</code></a></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-value-codes",
-	"version": "3.1.1",
-	"name": "USCoreObservationValueCodes",
-	"title": "US Core Observation Value Codes (SNOMED-CT)",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "other",
-					"value": "http://hl7.org/fhir"
-				},
-				{
-					"system": "email",
-					"value": "fhir@lists.hl7.org"
-				}
-			]
-		}
-	],
-	"description": "[Snomed-CT](http://www.ihtsdo.org/) concept codes for coded results",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"copyright": "This value set includes content from SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement",
-	"compose": {
-		"include": [
-			{
-				"system": "http://snomed.info/sct"
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-observation-value-codes",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-value-codes",
+    "version": "3.1.1",
+    "name": "USCoreObservationValueCodes",
+    "title": "US Core Observation Value Codes (SNOMED-CT)",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "other",
+                    "value": "http://hl7.org/fhir"
+                },
+                {
+                    "system": "email",
+                    "value": "fhir@lists.hl7.org"
+                }
+            ]
+        }
+    ],
+    "description": "[Snomed-CT](http://www.ihtsdo.org/) concept codes for coded results",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "copyright": "This value set includes content from SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement",
+    "compose": {
+        "include": [
+            {
+                "system": "http://snomed.info/sct"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-procedure-code.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-procedure-code.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-procedure-code",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This value set includes codes based on the following rules:</p><ul><li>Include all codes defined in <a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-v3-cpt-4.html\"><code>http://www.ama-assn.org/go/cpt</code></a></li><li>Include codes from <a href=\"http://www.snomed.org/\"><code>http://snomed.info/sct</code></a> where concept  is-a  71388002 (Procedure)</li><li>Include all codes defined in <code>urn:oid:2.16.840.1.113883.6.285</code></li><li>Include all codes defined in <a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-icd10PCS.html\"><code>http://www.cms.gov/Medicare/Coding/ICD10</code></a></li><li>Include all codes defined in <code>urn:oid:2.16.840.1.113883.6.13</code></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-code",
-	"version": "3.1.1",
-	"name": "USCoreProcedureCodes",
-	"title": "US Core Procedure Codes",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "other",
-					"value": "http://hl7.org/fhir"
-				}
-			]
-		}
-	],
-	"description": "Concepts from CPT, SNOMED CT, HCPCS Level II Alphanumeric Codes, ICD-10-PCS and CDT code systems that can be used to indicate the type of procedure performed.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"copyright": "This value set includes content from:\n  1. CPT copyright 2014 American Medical Association. All rights reserved.\n  2.  SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.\n  3. HCPCS Level II Alphanumeric Codes codes are maintained by the US Centers for Medicare and Medicaid Services (CMS) available for public use.\n  4. The International Classification of Diseases, Tenth Revision, Procedure Coding System (ICD-10-PCS) was developed for the Centers for Medicare and Medicaid Services (CMS) available for public use.  CMS is the U.S. governmental agency responsible for overseeing all changes and modifications to the ICD-10-PCS.\n  5. The ADA is the exclusive copyright owner of CDT, the Code on Dental Procedures and Nomenclature (the Code), and the ADA Dental Claim Form. Except as permitted by law, all use, copying or distribution of CDT, or any portion thereof (including the Code on Dental Procedures and Nomenclature) in any product or services (including works prepared for clients by consultants and other professionals), whether in printed, electronic or other format, requires a valid commercial user license from the ADA. CDT® is a registered trademark of the American Dental Association. All Rights Reserved.",
-	"compose": {
-		"include": [
-			{
-				"system": "http://www.ama-assn.org/go/cpt"
-			},
-			{
-				"system": "http://snomed.info/sct",
-				"filter": [
-					{
-						"property": "concept",
-						"op": "is-a",
-						"value": "71388002"
-					}
-				]
-			},
-			{
-				"system": "urn:oid:2.16.840.1.113883.6.285"
-			},
-			{
-				"system": "http://www.cms.gov/Medicare/Coding/ICD10"
-			},
-			{
-				"system": "urn:oid:2.16.840.1.113883.6.13"
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-procedure-code",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-code",
+    "version": "3.1.1",
+    "name": "USCoreProcedureCodes",
+    "title": "US Core Procedure Codes",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "other",
+                    "value": "http://hl7.org/fhir"
+                }
+            ]
+        }
+    ],
+    "description": "Concepts from CPT, SNOMED CT, HCPCS Level II Alphanumeric Codes, ICD-10-PCS and CDT code systems that can be used to indicate the type of procedure performed.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "copyright": "This value set includes content from:\n  1. CPT copyright 2014 American Medical Association. All rights reserved.\n  2.  SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.\n  3. HCPCS Level II Alphanumeric Codes codes are maintained by the US Centers for Medicare and Medicaid Services (CMS) available for public use.\n  4. The International Classification of Diseases, Tenth Revision, Procedure Coding System (ICD-10-PCS) was developed for the Centers for Medicare and Medicaid Services (CMS) available for public use.  CMS is the U.S. governmental agency responsible for overseeing all changes and modifications to the ICD-10-PCS.\n  5. The ADA is the exclusive copyright owner of CDT, the Code on Dental Procedures and Nomenclature (the Code), and the ADA Dental Claim Form. Except as permitted by law, all use, copying or distribution of CDT, or any portion thereof (including the Code on Dental Procedures and Nomenclature) in any product or services (including works prepared for clients by consultants and other professionals), whether in printed, electronic or other format, requires a valid commercial user license from the ADA. CDT® is a registered trademark of the American Dental Association. All Rights Reserved.",
+    "compose": {
+        "include": [
+            {
+                "system": "http://www.ama-assn.org/go/cpt"
+            },
+            {
+                "system": "http://snomed.info/sct",
+                "filter": [
+                    {
+                        "property": "concept",
+                        "op": "is-a",
+                        "value": "71388002"
+                    }
+                ]
+            },
+            {
+                "system": "urn:oid:2.16.840.1.113883.6.285"
+            },
+            {
+                "system": "http://www.cms.gov/Medicare/Coding/ICD10"
+            },
+            {
+                "system": "urn:oid:2.16.840.1.113883.6.13"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-procedure-icd10pcs.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-procedure-icd10pcs.json
@@ -1,45 +1,45 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-procedure-icd10pcs",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include all codes defined in <a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-icd10PCS.html\"><code>http://www.cms.gov/Medicare/Coding/ICD10</code></a></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-icd10pcs",
-	"version": "3.1.1",
-	"name": "USCoreIcd_10PcsProcedureCodes",
-	"title": "US Core ICD-10-PCS Procedure Codes",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "other",
-					"value": "http://hl7.org/fhir"
-				}
-			]
-		}
-	],
-	"description": "This value set defines the set of codes from ICD10-PCS",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"copyright": "The International Classification of Diseases, Tenth Revision, Procedure Coding System (ICD-10-PCS) was developed for the Centers for Medicare and Medicaid Services (CMS).  CMS is the U.S. governmental agency responsible for overseeing all changes and modifications to the ICD-10-PCS.",
-	"compose": {
-		"include": [
-			{
-				"system": "http://www.cms.gov/Medicare/Coding/ICD10"
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-procedure-icd10pcs",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-icd10pcs",
+    "version": "3.1.1",
+    "name": "USCoreIcd_10PcsProcedureCodes",
+    "title": "US Core ICD-10-PCS Procedure Codes",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "other",
+                    "value": "http://hl7.org/fhir"
+                }
+            ]
+        }
+    ],
+    "description": "This value set defines the set of codes from ICD10-PCS",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "copyright": "The International Classification of Diseases, Tenth Revision, Procedure Coding System (ICD-10-PCS) was developed for the Centers for Medicare and Medicaid Services (CMS).  CMS is the U.S. governmental agency responsible for overseeing all changes and modifications to the ICD-10-PCS.",
+    "compose": {
+        "include": [
+            {
+                "system": "http://www.cms.gov/Medicare/Coding/ICD10"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-provenance-participant-type.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-provenance-participant-type.json
@@ -1,38 +1,38 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-provenance-participant-type",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This value set includes codes based on the following rules:</p><ul><li>Include all codes defined in <a href=\"CodeSystem-us-core-provenance-participant-type.html\"><code>http://hl7.org/fhir/us/core/CodeSystem/us-core-provenance-participant-type</code></a></li><li>Include all codes defined in <a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-provenance-participant-type.html\"><code>http://terminology.hl7.org/CodeSystem/provenance-participant-type</code></a></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-provenance-participant-type",
-	"version": "3.1.1",
-	"name": "USCoreProvenancePaticipantTypeCodes",
-	"title": "US Core Provenance Participant Type Codes",
-	"status": "active",
-	"date": "2019-08-28",
-	"publisher": "HL7 US Realm Steering Committee",
-	"description": "The type of participation a provenance agent played for a given target.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"purpose": "So API consumers can identify the provenance participant type.",
-	"compose": {
-		"include": [
-			{
-				"system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-provenance-participant-type|3.1.1"
-			},
-			{
-				"system": "http://terminology.hl7.org/CodeSystem/provenance-participant-type|3.1.1"
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-provenance-participant-type",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-provenance-participant-type",
+    "version": "3.1.1",
+    "name": "USCoreProvenancePaticipantTypeCodes",
+    "title": "US Core Provenance Participant Type Codes",
+    "status": "active",
+    "date": "2019-08-28",
+    "publisher": "HL7 US Realm Steering Committee",
+    "description": "The type of participation a provenance agent played for a given target.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "purpose": "So API consumers can identify the provenance participant type.",
+    "compose": {
+        "include": [
+            {
+                "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-provenance-participant-type|3.1.1"
+            },
+            {
+                "system": "http://terminology.hl7.org/CodeSystem/provenance-participant-type|3.1.1"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-provider-role.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-provider-role.json
@@ -1,995 +1,995 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-provider-role",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include these codes as defined in <code>http://nucc.org/provider-taxonomy</code><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td></tr><tr><td>101Y00000X</td><td>Counselor</td><td/></tr><tr><td>102L00000X</td><td>Psychoanalyst</td><td/></tr><tr><td>102X00000X</td><td>Poetry Therapist</td><td/></tr><tr><td>103G00000X</td><td>Clinical Neuropsychologist</td><td/></tr><tr><td>103K00000X</td><td>Behavior Analyst</td><td/></tr><tr><td>103T00000X</td><td>Psychologist</td><td/></tr><tr><td>104100000X</td><td>Social Worker</td><td/></tr><tr><td>106E00000X</td><td>Assistant Behavior Analyst</td><td/></tr><tr><td>106H00000X</td><td>Marriage &amp; Family Therapist</td><td/></tr><tr><td>106S00000X</td><td>Behavior Technician</td><td/></tr><tr><td>111N00000X</td><td>Chiropractor</td><td/></tr><tr><td>122300000X</td><td>Dentist</td><td/></tr><tr><td>122400000X</td><td>Denturist</td><td/></tr><tr><td>124Q00000X</td><td>Dental Hygienist</td><td/></tr><tr><td>125J00000X</td><td>Dental Therapist</td><td/></tr><tr><td>125K00000X</td><td>Advanced Practice Dental Therapist</td><td/></tr><tr><td>125Q00000X</td><td>Oral Medicinist</td><td/></tr><tr><td>126800000X</td><td>Dental Assistant</td><td/></tr><tr><td>126900000X</td><td>Dental Laboratory Technician</td><td/></tr><tr><td>132700000X</td><td>Dietary Manager</td><td/></tr><tr><td>133N00000X</td><td>Nutritionist</td><td/></tr><tr><td>133V00000X</td><td>Dietitian, Registered</td><td/></tr><tr><td>136A00000X</td><td>Dietetic Technician, Registered</td><td/></tr><tr><td>146D00000X</td><td>Personal Emergency Response Attendant</td><td/></tr><tr><td>146L00000X</td><td>Emergency Medical Technician, Paramedic</td><td/></tr><tr><td>146M00000X</td><td>Emergency Medical Technician, Intermediate</td><td/></tr><tr><td>146N00000X</td><td>Emergency Medical Technician, Basic</td><td/></tr><tr><td>152W00000X</td><td>Optometrist</td><td/></tr><tr><td>156F00000X</td><td>Technician/Technologist</td><td/></tr><tr><td>163W00000X</td><td>Registered Nurse</td><td/></tr><tr><td>164W00000X</td><td>Licensed Practical Nurse</td><td/></tr><tr><td>164X00000X</td><td>Licensed Vocational Nurse</td><td/></tr><tr><td>167G00000X</td><td>Licensed Psychiatric Technician</td><td/></tr><tr><td>170100000X</td><td>Medical Genetics, Ph.D. Medical Genetics</td><td/></tr><tr><td>170300000X</td><td>Genetic Counselor, MS</td><td/></tr><tr><td>171000000X</td><td>Military Health Care Provider</td><td/></tr><tr><td>171100000X</td><td>Acupuncturist</td><td/></tr><tr><td>171M00000X</td><td>Case Manager/Care Coordinator</td><td/></tr><tr><td>171R00000X</td><td>Interpreter</td><td/></tr><tr><td>171W00000X</td><td>Contractor</td><td/></tr><tr><td>172A00000X</td><td>Driver</td><td/></tr><tr><td>172M00000X</td><td>Mechanotherapist</td><td/></tr><tr><td>172P00000X</td><td>Naprapath</td><td/></tr><tr><td>172V00000X</td><td>Community Health Worker</td><td/></tr><tr><td>173000000X</td><td>Legal Medicine</td><td/></tr><tr><td>173C00000X</td><td>Reflexologist</td><td/></tr><tr><td>173F00000X</td><td>Sleep Specialist, PhD</td><td/></tr><tr><td>174200000X</td><td>Meals</td><td/></tr><tr><td>174400000X</td><td>Specialist</td><td/></tr><tr><td>174H00000X</td><td>Health Educator</td><td/></tr><tr><td>174M00000X</td><td>Veterinarian</td><td/></tr><tr><td>174N00000X</td><td>Lactation Consultant, Non-RN</td><td/></tr><tr><td>174V00000X</td><td>Clinical Ethicist</td><td/></tr><tr><td>175F00000X</td><td>Naturopath</td><td/></tr><tr><td>175L00000X</td><td>Homeopath</td><td/></tr><tr><td>175M00000X</td><td>Midwife, Lay</td><td/></tr><tr><td>175T00000X</td><td>Peer Specialist</td><td/></tr><tr><td>176B00000X</td><td>Midwife</td><td/></tr><tr><td>176P00000X</td><td>Funeral Director</td><td/></tr><tr><td>177F00000X</td><td>Lodging</td><td/></tr><tr><td>183500000X</td><td>Pharmacist</td><td/></tr><tr><td>183700000X</td><td>Pharmacy Technician</td><td/></tr><tr><td>193200000X</td><td>Multi-Specialty</td><td/></tr><tr><td>193400000X</td><td>Single Specialty</td><td/></tr><tr><td>202C00000X</td><td>Independent Medical Examiner</td><td/></tr><tr><td>202K00000X</td><td>Phlebology</td><td/></tr><tr><td>204C00000X</td><td>Neuromusculoskeletal Medicine, Sports Medicine</td><td/></tr><tr><td>204D00000X</td><td>Neuromusculoskeletal Medicine &amp; OMM</td><td/></tr><tr><td>204E00000X</td><td>Oral &amp; Maxillofacial Surgery</td><td/></tr><tr><td>204F00000X</td><td>Transplant Surgery</td><td/></tr><tr><td>204R00000X</td><td>Electrodiagnostic Medicine</td><td/></tr><tr><td>207K00000X</td><td>Allergy &amp; Immunology</td><td/></tr><tr><td>207L00000X</td><td>Anesthesiology</td><td/></tr><tr><td>207N00000X</td><td>Dermatology</td><td/></tr><tr><td>207P00000X</td><td>Emergency Medicine</td><td/></tr><tr><td>207Q00000X</td><td>Family Medicine</td><td/></tr><tr><td>207R00000X</td><td>Internal Medicine</td><td/></tr><tr><td>207T00000X</td><td>Neurological Surgery</td><td/></tr><tr><td>207U00000X</td><td>Nuclear Medicine</td><td/></tr><tr><td>207V00000X</td><td>Obstetrics &amp; Gynecology</td><td/></tr><tr><td>207W00000X</td><td>Ophthalmology</td><td/></tr><tr><td>207X00000X</td><td>Orthopaedic Surgery</td><td/></tr><tr><td>207Y00000X</td><td>Otolaryngology</td><td/></tr><tr><td>208000000X</td><td>Pediatrics</td><td/></tr><tr><td>208100000X</td><td>Physical Medicine &amp; Rehabilitation</td><td/></tr><tr><td>208200000X</td><td>Plastic Surgery</td><td/></tr><tr><td>208600000X</td><td>Surgery</td><td/></tr><tr><td>208800000X</td><td>Urology</td><td/></tr><tr><td>208C00000X</td><td>Colon &amp; Rectal Surgery</td><td/></tr><tr><td>208D00000X</td><td>General Practice</td><td/></tr><tr><td>208G00000X</td><td>Thoracic Surgery (Cardiothoracic Vascular Surgery)</td><td/></tr><tr><td>208M00000X</td><td>Hospitalist</td><td/></tr><tr><td>208U00000X</td><td>Clinical Pharmacology</td><td/></tr><tr><td>209800000X</td><td>Legal Medicine</td><td/></tr><tr><td>211D00000X</td><td>Assistant, Podiatric</td><td/></tr><tr><td>213E00000X</td><td>Podiatrist</td><td/></tr><tr><td>221700000X</td><td>Art Therapist</td><td/></tr><tr><td>222Q00000X</td><td>Developmental Therapist</td><td/></tr><tr><td>222Z00000X</td><td>Orthotist</td><td/></tr><tr><td>224900000X</td><td>Mastectomy Fitter</td><td/></tr><tr><td>224L00000X</td><td>Pedorthist</td><td/></tr><tr><td>224P00000X</td><td>Prosthetist</td><td/></tr><tr><td>224Y00000X</td><td>Clinical Exercise Physiologist</td><td/></tr><tr><td>224Z00000X</td><td>Occupational Therapy Assistant</td><td/></tr><tr><td>225000000X</td><td>Orthotic Fitter</td><td/></tr><tr><td>225100000X</td><td>Physical Therapist</td><td/></tr><tr><td>225200000X</td><td>Physical Therapy Assistant</td><td/></tr><tr><td>225400000X</td><td>Rehabilitation Practitioner</td><td/></tr><tr><td>225500000X</td><td>Specialist/Technologist</td><td/></tr><tr><td>225600000X</td><td>Dance Therapist</td><td/></tr><tr><td>225700000X</td><td>Massage Therapist</td><td/></tr><tr><td>225800000X</td><td>Recreation Therapist</td><td/></tr><tr><td>225A00000X</td><td>Music Therapist</td><td/></tr><tr><td>225B00000X</td><td>Pulmonary Function Technologist</td><td/></tr><tr><td>225C00000X</td><td>Rehabilitation Counselor</td><td/></tr><tr><td>225X00000X</td><td>Occupational Therapist</td><td/></tr><tr><td>226000000X</td><td>Recreational Therapist Assistant</td><td/></tr><tr><td>226300000X</td><td>Kinesiotherapist</td><td/></tr><tr><td>227800000X</td><td>Respiratory Therapist, Certified</td><td/></tr><tr><td>227900000X</td><td>Respiratory Therapist, Registered</td><td/></tr><tr><td>229N00000X</td><td>Anaplastologist</td><td/></tr><tr><td>231H00000X</td><td>Audiologist</td><td/></tr><tr><td>235500000X</td><td>Specialist/Technologist</td><td/></tr><tr><td>235Z00000X</td><td>Speech-Language Pathologist</td><td/></tr><tr><td>237600000X</td><td>Audiologist-Hearing Aid Fitter</td><td/></tr><tr><td>237700000X</td><td>Hearing Instrument Specialist</td><td/></tr><tr><td>242T00000X</td><td>Perfusionist</td><td/></tr><tr><td>243U00000X</td><td>Radiology Practitioner Assistant</td><td/></tr><tr><td>246Q00000X</td><td>Specialist/Technologist, Pathology</td><td/></tr><tr><td>246R00000X</td><td>Technician, Pathology</td><td/></tr><tr><td>246W00000X</td><td>Technician, Cardiology</td><td/></tr><tr><td>246X00000X</td><td>Specialist/Technologist Cardiovascular</td><td/></tr><tr><td>246Y00000X</td><td>Specialist/Technologist, Health Information</td><td/></tr><tr><td>246Z00000X</td><td>Specialist/Technologist, Other</td><td/></tr><tr><td>247000000X</td><td>Technician, Health Information</td><td/></tr><tr><td>247100000X</td><td>Radiologic Technologist</td><td/></tr><tr><td>247200000X</td><td>Technician, Other</td><td/></tr><tr><td>251300000X</td><td>Local Education Agency (LEA)</td><td/></tr><tr><td>251B00000X</td><td>Case Management</td><td/></tr><tr><td>251C00000X</td><td>Day Training, Developmentally Disabled Services</td><td/></tr><tr><td>251E00000X</td><td>Home Health</td><td/></tr><tr><td>251F00000X</td><td>Home Infusion</td><td/></tr><tr><td>251G00000X</td><td>Hospice Care, Community Based</td><td/></tr><tr><td>251J00000X</td><td>Nursing Care</td><td/></tr><tr><td>251K00000X</td><td>Public Health or Welfare</td><td/></tr><tr><td>251S00000X</td><td>Community/Behavioral Health</td><td/></tr><tr><td>251T00000X</td><td>Program of All-Inclusive Care for the Elderly (PACE) Provider Organization</td><td/></tr><tr><td>251V00000X</td><td>Voluntary or Charitable</td><td/></tr><tr><td>251X00000X</td><td>Supports Brokerage</td><td/></tr><tr><td>252Y00000X</td><td>Early Intervention Provider Agency</td><td/></tr><tr><td>253J00000X</td><td>Foster Care Agency</td><td/></tr><tr><td>253Z00000X</td><td>In Home Supportive Care</td><td/></tr><tr><td>261Q00000X</td><td>Clinic/Center</td><td/></tr><tr><td>273100000X</td><td>Epilepsy Unit</td><td/></tr><tr><td>273R00000X</td><td>Psychiatric Unit</td><td/></tr><tr><td>273Y00000X</td><td>Rehabilitation Unit</td><td/></tr><tr><td>275N00000X</td><td>Medicare Defined Swing Bed Unit</td><td/></tr><tr><td>276400000X</td><td>Rehabilitation, Substance Use Disorder Unit</td><td/></tr><tr><td>281P00000X</td><td>Chronic Disease Hospital</td><td/></tr><tr><td>282E00000X</td><td>Long Term Care Hospital</td><td/></tr><tr><td>282J00000X</td><td>Religious Nonmedical Health Care Institution</td><td/></tr><tr><td>282N00000X</td><td>General Acute Care Hospital</td><td/></tr><tr><td>283Q00000X</td><td>Psychiatric Hospital</td><td/></tr><tr><td>283X00000X</td><td>Rehabilitation Hospital</td><td/></tr><tr><td>284300000X</td><td>Special Hospital</td><td/></tr><tr><td>286500000X</td><td>Military Hospital</td><td/></tr><tr><td>287300000X</td><td>Christian Science Sanitorium</td><td/></tr><tr><td>291900000X</td><td>Military Clinical Medical Laboratory</td><td/></tr><tr><td>291U00000X</td><td>Clinical Medical Laboratory</td><td/></tr><tr><td>292200000X</td><td>Dental Laboratory</td><td/></tr><tr><td>293D00000X</td><td>Physiological Laboratory</td><td/></tr><tr><td>302F00000X</td><td>Exclusive Provider Organization</td><td/></tr><tr><td>302R00000X</td><td>Health Maintenance Organization</td><td/></tr><tr><td>305R00000X</td><td>Preferred Provider Organization</td><td/></tr><tr><td>305S00000X</td><td>Point of Service</td><td/></tr><tr><td>310400000X</td><td>Assisted Living Facility</td><td/></tr><tr><td>310500000X</td><td>Intermediate Care Facility, Mental Illness</td><td/></tr><tr><td>311500000X</td><td>Alzheimer Center (Dementia Center)</td><td/></tr><tr><td>311Z00000X</td><td>Custodial Care Facility</td><td/></tr><tr><td>313M00000X</td><td>Nursing Facility/Intermediate Care Facility</td><td/></tr><tr><td>314000000X</td><td>Skilled Nursing Facility</td><td/></tr><tr><td>315D00000X</td><td>Hospice, Inpatient</td><td/></tr><tr><td>315P00000X</td><td>Intermediate Care Facility, Mentally Retarded</td><td/></tr><tr><td>317400000X</td><td>Christian Science Facility</td><td/></tr><tr><td>320600000X</td><td>Residential Treatment Facility, Mental Retardation and/or Developmental Disabilities</td><td/></tr><tr><td>320700000X</td><td>Residential Treatment Facility, Physical Disabilities</td><td/></tr><tr><td>320800000X</td><td>Community Based Residential Treatment Facility, Mental Illness</td><td/></tr><tr><td>320900000X</td><td>Community Based Residential Treatment Facility, Mental Retardation and/or Developmental Disabilities</td><td/></tr><tr><td>322D00000X</td><td>Residential Treatment Facility, Emotionally Disturbed Children</td><td/></tr><tr><td>323P00000X</td><td>Psychiatric Residential Treatment Facility</td><td/></tr><tr><td>324500000X</td><td>Substance Abuse Rehabilitation Facility</td><td/></tr><tr><td>331L00000X</td><td>Blood Bank</td><td/></tr><tr><td>332000000X</td><td>Military/U.S. Coast Guard Pharmacy</td><td/></tr><tr><td>332100000X</td><td>Department of Veterans Affairs (VA) Pharmacy</td><td/></tr><tr><td>332800000X</td><td>Indian Health Service/Tribal/Urban Indian Health (I/T/U) Pharmacy</td><td/></tr><tr><td>332900000X</td><td>Non-Pharmacy Dispensing Site</td><td/></tr><tr><td>332B00000X</td><td>Durable Medical Equipment &amp; Medical Supplies</td><td/></tr><tr><td>332G00000X</td><td>Eye Bank</td><td/></tr><tr><td>332H00000X</td><td>Eyewear Supplier</td><td/></tr><tr><td>332S00000X</td><td>Hearing Aid Equipment</td><td/></tr><tr><td>332U00000X</td><td>Home Delivered Meals</td><td/></tr><tr><td>333300000X</td><td>Emergency Response System Companies</td><td/></tr><tr><td>333600000X</td><td>Pharmacy</td><td/></tr><tr><td>335E00000X</td><td>Prosthetic/Orthotic Supplier</td><td/></tr><tr><td>335G00000X</td><td>Medical Foods Supplier</td><td/></tr><tr><td>335U00000X</td><td>Organ Procurement Organization</td><td/></tr><tr><td>335V00000X</td><td>Portable X-ray and/or Other Portable Diagnostic Imaging Supplier</td><td/></tr><tr><td>341600000X</td><td>Ambulance</td><td/></tr><tr><td>341800000X</td><td>Military/U.S. Coast Guard Transport</td><td/></tr><tr><td>343800000X</td><td>Secured Medical Transport (VAN)</td><td/></tr><tr><td>343900000X</td><td>Non-emergency Medical Transport (VAN)</td><td/></tr><tr><td>344600000X</td><td>Taxi</td><td/></tr><tr><td>344800000X</td><td>Air Carrier</td><td/></tr><tr><td>347B00000X</td><td>Bus</td><td/></tr><tr><td>347C00000X</td><td>Private Vehicle</td><td/></tr><tr><td>347D00000X</td><td>Train</td><td/></tr><tr><td>347E00000X</td><td>Transportation Broker</td><td/></tr><tr><td>363A00000X</td><td>Physician Assistant</td><td/></tr><tr><td>363L00000X</td><td>Nurse Practitioner</td><td/></tr><tr><td>364S00000X</td><td>Clinical Nurse Specialist</td><td/></tr><tr><td>367500000X</td><td>Nurse Anesthetist, Certified Registered</td><td/></tr><tr><td>367A00000X</td><td>Advanced Practice Midwife</td><td/></tr><tr><td>367H00000X</td><td>Anesthesiologist Assistant</td><td/></tr><tr><td>372500000X</td><td>Chore Provider</td><td/></tr><tr><td>372600000X</td><td>Adult Companion</td><td/></tr><tr><td>373H00000X</td><td>Day Training/Habilitation Specialist</td><td/></tr><tr><td>374700000X</td><td>Technician</td><td/></tr><tr><td>374J00000X</td><td>Doula</td><td/></tr><tr><td>374K00000X</td><td>Religious Nonmedical Practitioner</td><td/></tr><tr><td>374T00000X</td><td>Religious Nonmedical Nursing Personnel</td><td/></tr><tr><td>374U00000X</td><td>Home Health Aide</td><td/></tr><tr><td>376G00000X</td><td>Nursing Home Administrator</td><td/></tr><tr><td>376J00000X</td><td>Homemaker</td><td/></tr><tr><td>376K00000X</td><td>Nurse's Aide</td><td/></tr><tr><td>385H00000X</td><td>Respite Care</td><td/></tr><tr><td>390200000X</td><td>Student in an Organized Health Care Education/Training Program</td><td/></tr><tr><td>405300000X</td><td>Prevention Professional</td><td/></tr></table></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-provider-role",
-	"version": "3.1.1",
-	"name": "USCoreProviderRoleNucc",
-	"title": "US Core Provider Role (NUCC)",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "other",
-					"value": "http://hl7.org/fhir"
-				}
-			]
-		}
-	],
-	"description": "Provider roles codes which are composed of the NUCC Health Care Provider Taxonomy Code Set classification codes for providers. Only concepts with a classification and no specialization are included. ",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"copyright": "This value set includes content from NUCC Health Care Provider Taxonomy Code Set for providers which is copyright © 2016+ American Medical Association.  For commercial use, including sales or licensing, a license must be obtained.",
-	"compose": {
-		"include": [
-			{
-				"system": "http://nucc.org/provider-taxonomy",
-				"concept": [
-					{
-						"code": "101Y00000X",
-						"display": "Counselor"
-					},
-					{
-						"code": "102L00000X",
-						"display": "Psychoanalyst"
-					},
-					{
-						"code": "102X00000X",
-						"display": "Poetry Therapist"
-					},
-					{
-						"code": "103G00000X",
-						"display": "Clinical Neuropsychologist"
-					},
-					{
-						"code": "103K00000X",
-						"display": "Behavior Analyst"
-					},
-					{
-						"code": "103T00000X",
-						"display": "Psychologist"
-					},
-					{
-						"code": "104100000X",
-						"display": "Social Worker"
-					},
-					{
-						"code": "106E00000X",
-						"display": "Assistant Behavior Analyst"
-					},
-					{
-						"code": "106H00000X",
-						"display": "Marriage & Family Therapist"
-					},
-					{
-						"code": "106S00000X",
-						"display": "Behavior Technician"
-					},
-					{
-						"code": "111N00000X",
-						"display": "Chiropractor"
-					},
-					{
-						"code": "122300000X",
-						"display": "Dentist"
-					},
-					{
-						"code": "122400000X",
-						"display": "Denturist"
-					},
-					{
-						"code": "124Q00000X",
-						"display": "Dental Hygienist"
-					},
-					{
-						"code": "125J00000X",
-						"display": "Dental Therapist"
-					},
-					{
-						"code": "125K00000X",
-						"display": "Advanced Practice Dental Therapist"
-					},
-					{
-						"code": "125Q00000X",
-						"display": "Oral Medicinist"
-					},
-					{
-						"code": "126800000X",
-						"display": "Dental Assistant"
-					},
-					{
-						"code": "126900000X",
-						"display": "Dental Laboratory Technician"
-					},
-					{
-						"code": "132700000X",
-						"display": "Dietary Manager"
-					},
-					{
-						"code": "133N00000X",
-						"display": "Nutritionist"
-					},
-					{
-						"code": "133V00000X",
-						"display": "Dietitian, Registered"
-					},
-					{
-						"code": "136A00000X",
-						"display": "Dietetic Technician, Registered"
-					},
-					{
-						"code": "146D00000X",
-						"display": "Personal Emergency Response Attendant"
-					},
-					{
-						"code": "146L00000X",
-						"display": "Emergency Medical Technician, Paramedic"
-					},
-					{
-						"code": "146M00000X",
-						"display": "Emergency Medical Technician, Intermediate"
-					},
-					{
-						"code": "146N00000X",
-						"display": "Emergency Medical Technician, Basic"
-					},
-					{
-						"code": "152W00000X",
-						"display": "Optometrist"
-					},
-					{
-						"code": "156F00000X",
-						"display": "Technician/Technologist"
-					},
-					{
-						"code": "163W00000X",
-						"display": "Registered Nurse"
-					},
-					{
-						"code": "164W00000X",
-						"display": "Licensed Practical Nurse"
-					},
-					{
-						"code": "164X00000X",
-						"display": "Licensed Vocational Nurse"
-					},
-					{
-						"code": "167G00000X",
-						"display": "Licensed Psychiatric Technician"
-					},
-					{
-						"code": "170100000X",
-						"display": "Medical Genetics, Ph.D. Medical Genetics"
-					},
-					{
-						"code": "170300000X",
-						"display": "Genetic Counselor, MS"
-					},
-					{
-						"code": "171000000X",
-						"display": "Military Health Care Provider"
-					},
-					{
-						"code": "171100000X",
-						"display": "Acupuncturist"
-					},
-					{
-						"code": "171M00000X",
-						"display": "Case Manager/Care Coordinator"
-					},
-					{
-						"code": "171R00000X",
-						"display": "Interpreter"
-					},
-					{
-						"code": "171W00000X",
-						"display": "Contractor"
-					},
-					{
-						"code": "172A00000X",
-						"display": "Driver"
-					},
-					{
-						"code": "172M00000X",
-						"display": "Mechanotherapist"
-					},
-					{
-						"code": "172P00000X",
-						"display": "Naprapath"
-					},
-					{
-						"code": "172V00000X",
-						"display": "Community Health Worker"
-					},
-					{
-						"code": "173000000X",
-						"display": "Legal Medicine"
-					},
-					{
-						"code": "173C00000X",
-						"display": "Reflexologist"
-					},
-					{
-						"code": "173F00000X",
-						"display": "Sleep Specialist, PhD"
-					},
-					{
-						"code": "174200000X",
-						"display": "Meals"
-					},
-					{
-						"code": "174400000X",
-						"display": "Specialist"
-					},
-					{
-						"code": "174H00000X",
-						"display": "Health Educator"
-					},
-					{
-						"code": "174M00000X",
-						"display": "Veterinarian"
-					},
-					{
-						"code": "174N00000X",
-						"display": "Lactation Consultant, Non-RN"
-					},
-					{
-						"code": "174V00000X",
-						"display": "Clinical Ethicist"
-					},
-					{
-						"code": "175F00000X",
-						"display": "Naturopath"
-					},
-					{
-						"code": "175L00000X",
-						"display": "Homeopath"
-					},
-					{
-						"code": "175M00000X",
-						"display": "Midwife, Lay"
-					},
-					{
-						"code": "175T00000X",
-						"display": "Peer Specialist"
-					},
-					{
-						"code": "176B00000X",
-						"display": "Midwife"
-					},
-					{
-						"code": "176P00000X",
-						"display": "Funeral Director"
-					},
-					{
-						"code": "177F00000X",
-						"display": "Lodging"
-					},
-					{
-						"code": "183500000X",
-						"display": "Pharmacist"
-					},
-					{
-						"code": "183700000X",
-						"display": "Pharmacy Technician"
-					},
-					{
-						"code": "193200000X",
-						"display": "Multi-Specialty"
-					},
-					{
-						"code": "193400000X",
-						"display": "Single Specialty"
-					},
-					{
-						"code": "202C00000X",
-						"display": "Independent Medical Examiner"
-					},
-					{
-						"code": "202K00000X",
-						"display": "Phlebology"
-					},
-					{
-						"code": "204C00000X",
-						"display": "Neuromusculoskeletal Medicine, Sports Medicine"
-					},
-					{
-						"code": "204D00000X",
-						"display": "Neuromusculoskeletal Medicine & OMM"
-					},
-					{
-						"code": "204E00000X",
-						"display": "Oral & Maxillofacial Surgery"
-					},
-					{
-						"code": "204F00000X",
-						"display": "Transplant Surgery"
-					},
-					{
-						"code": "204R00000X",
-						"display": "Electrodiagnostic Medicine"
-					},
-					{
-						"code": "207K00000X",
-						"display": "Allergy & Immunology"
-					},
-					{
-						"code": "207L00000X",
-						"display": "Anesthesiology"
-					},
-					{
-						"code": "207N00000X",
-						"display": "Dermatology"
-					},
-					{
-						"code": "207P00000X",
-						"display": "Emergency Medicine"
-					},
-					{
-						"code": "207Q00000X",
-						"display": "Family Medicine"
-					},
-					{
-						"code": "207R00000X",
-						"display": "Internal Medicine"
-					},
-					{
-						"code": "207T00000X",
-						"display": "Neurological Surgery"
-					},
-					{
-						"code": "207U00000X",
-						"display": "Nuclear Medicine"
-					},
-					{
-						"code": "207V00000X",
-						"display": "Obstetrics & Gynecology"
-					},
-					{
-						"code": "207W00000X",
-						"display": "Ophthalmology"
-					},
-					{
-						"code": "207X00000X",
-						"display": "Orthopaedic Surgery"
-					},
-					{
-						"code": "207Y00000X",
-						"display": "Otolaryngology"
-					},
-					{
-						"code": "208000000X",
-						"display": "Pediatrics"
-					},
-					{
-						"code": "208100000X",
-						"display": "Physical Medicine & Rehabilitation"
-					},
-					{
-						"code": "208200000X",
-						"display": "Plastic Surgery"
-					},
-					{
-						"code": "208600000X",
-						"display": "Surgery"
-					},
-					{
-						"code": "208800000X",
-						"display": "Urology"
-					},
-					{
-						"code": "208C00000X",
-						"display": "Colon & Rectal Surgery"
-					},
-					{
-						"code": "208D00000X",
-						"display": "General Practice"
-					},
-					{
-						"code": "208G00000X",
-						"display": "Thoracic Surgery (Cardiothoracic Vascular Surgery)"
-					},
-					{
-						"code": "208M00000X",
-						"display": "Hospitalist"
-					},
-					{
-						"code": "208U00000X",
-						"display": "Clinical Pharmacology"
-					},
-					{
-						"code": "209800000X",
-						"display": "Legal Medicine"
-					},
-					{
-						"code": "211D00000X",
-						"display": "Assistant, Podiatric"
-					},
-					{
-						"code": "213E00000X",
-						"display": "Podiatrist"
-					},
-					{
-						"code": "221700000X",
-						"display": "Art Therapist"
-					},
-					{
-						"code": "222Q00000X",
-						"display": "Developmental Therapist"
-					},
-					{
-						"code": "222Z00000X",
-						"display": "Orthotist"
-					},
-					{
-						"code": "224900000X",
-						"display": "Mastectomy Fitter"
-					},
-					{
-						"code": "224L00000X",
-						"display": "Pedorthist"
-					},
-					{
-						"code": "224P00000X",
-						"display": "Prosthetist"
-					},
-					{
-						"code": "224Y00000X",
-						"display": "Clinical Exercise Physiologist"
-					},
-					{
-						"code": "224Z00000X",
-						"display": "Occupational Therapy Assistant"
-					},
-					{
-						"code": "225000000X",
-						"display": "Orthotic Fitter"
-					},
-					{
-						"code": "225100000X",
-						"display": "Physical Therapist"
-					},
-					{
-						"code": "225200000X",
-						"display": "Physical Therapy Assistant"
-					},
-					{
-						"code": "225400000X",
-						"display": "Rehabilitation Practitioner"
-					},
-					{
-						"code": "225500000X",
-						"display": "Specialist/Technologist"
-					},
-					{
-						"code": "225600000X",
-						"display": "Dance Therapist"
-					},
-					{
-						"code": "225700000X",
-						"display": "Massage Therapist"
-					},
-					{
-						"code": "225800000X",
-						"display": "Recreation Therapist"
-					},
-					{
-						"code": "225A00000X",
-						"display": "Music Therapist"
-					},
-					{
-						"code": "225B00000X",
-						"display": "Pulmonary Function Technologist"
-					},
-					{
-						"code": "225C00000X",
-						"display": "Rehabilitation Counselor"
-					},
-					{
-						"code": "225X00000X",
-						"display": "Occupational Therapist"
-					},
-					{
-						"code": "226000000X",
-						"display": "Recreational Therapist Assistant"
-					},
-					{
-						"code": "226300000X",
-						"display": "Kinesiotherapist"
-					},
-					{
-						"code": "227800000X",
-						"display": "Respiratory Therapist, Certified"
-					},
-					{
-						"code": "227900000X",
-						"display": "Respiratory Therapist, Registered"
-					},
-					{
-						"code": "229N00000X",
-						"display": "Anaplastologist"
-					},
-					{
-						"code": "231H00000X",
-						"display": "Audiologist"
-					},
-					{
-						"code": "235500000X",
-						"display": "Specialist/Technologist"
-					},
-					{
-						"code": "235Z00000X",
-						"display": "Speech-Language Pathologist"
-					},
-					{
-						"code": "237600000X",
-						"display": "Audiologist-Hearing Aid Fitter"
-					},
-					{
-						"code": "237700000X",
-						"display": "Hearing Instrument Specialist"
-					},
-					{
-						"code": "242T00000X",
-						"display": "Perfusionist"
-					},
-					{
-						"code": "243U00000X",
-						"display": "Radiology Practitioner Assistant"
-					},
-					{
-						"code": "246Q00000X",
-						"display": "Specialist/Technologist, Pathology"
-					},
-					{
-						"code": "246R00000X",
-						"display": "Technician, Pathology"
-					},
-					{
-						"code": "246W00000X",
-						"display": "Technician, Cardiology"
-					},
-					{
-						"code": "246X00000X",
-						"display": "Specialist/Technologist Cardiovascular"
-					},
-					{
-						"code": "246Y00000X",
-						"display": "Specialist/Technologist, Health Information"
-					},
-					{
-						"code": "246Z00000X",
-						"display": "Specialist/Technologist, Other"
-					},
-					{
-						"code": "247000000X",
-						"display": "Technician, Health Information"
-					},
-					{
-						"code": "247100000X",
-						"display": "Radiologic Technologist"
-					},
-					{
-						"code": "247200000X",
-						"display": "Technician, Other"
-					},
-					{
-						"code": "251300000X",
-						"display": "Local Education Agency (LEA)"
-					},
-					{
-						"code": "251B00000X",
-						"display": "Case Management"
-					},
-					{
-						"code": "251C00000X",
-						"display": "Day Training, Developmentally Disabled Services"
-					},
-					{
-						"code": "251E00000X",
-						"display": "Home Health"
-					},
-					{
-						"code": "251F00000X",
-						"display": "Home Infusion"
-					},
-					{
-						"code": "251G00000X",
-						"display": "Hospice Care, Community Based"
-					},
-					{
-						"code": "251J00000X",
-						"display": "Nursing Care"
-					},
-					{
-						"code": "251K00000X",
-						"display": "Public Health or Welfare"
-					},
-					{
-						"code": "251S00000X",
-						"display": "Community/Behavioral Health"
-					},
-					{
-						"code": "251T00000X",
-						"display": "Program of All-Inclusive Care for the Elderly (PACE) Provider Organization"
-					},
-					{
-						"code": "251V00000X",
-						"display": "Voluntary or Charitable"
-					},
-					{
-						"code": "251X00000X",
-						"display": "Supports Brokerage"
-					},
-					{
-						"code": "252Y00000X",
-						"display": "Early Intervention Provider Agency"
-					},
-					{
-						"code": "253J00000X",
-						"display": "Foster Care Agency"
-					},
-					{
-						"code": "253Z00000X",
-						"display": "In Home Supportive Care"
-					},
-					{
-						"code": "261Q00000X",
-						"display": "Clinic/Center"
-					},
-					{
-						"code": "273100000X",
-						"display": "Epilepsy Unit"
-					},
-					{
-						"code": "273R00000X",
-						"display": "Psychiatric Unit"
-					},
-					{
-						"code": "273Y00000X",
-						"display": "Rehabilitation Unit"
-					},
-					{
-						"code": "275N00000X",
-						"display": "Medicare Defined Swing Bed Unit"
-					},
-					{
-						"code": "276400000X",
-						"display": "Rehabilitation, Substance Use Disorder Unit"
-					},
-					{
-						"code": "281P00000X",
-						"display": "Chronic Disease Hospital"
-					},
-					{
-						"code": "282E00000X",
-						"display": "Long Term Care Hospital"
-					},
-					{
-						"code": "282J00000X",
-						"display": "Religious Nonmedical Health Care Institution"
-					},
-					{
-						"code": "282N00000X",
-						"display": "General Acute Care Hospital"
-					},
-					{
-						"code": "283Q00000X",
-						"display": "Psychiatric Hospital"
-					},
-					{
-						"code": "283X00000X",
-						"display": "Rehabilitation Hospital"
-					},
-					{
-						"code": "284300000X",
-						"display": "Special Hospital"
-					},
-					{
-						"code": "286500000X",
-						"display": "Military Hospital"
-					},
-					{
-						"code": "287300000X",
-						"display": "Christian Science Sanitorium"
-					},
-					{
-						"code": "291900000X",
-						"display": "Military Clinical Medical Laboratory"
-					},
-					{
-						"code": "291U00000X",
-						"display": "Clinical Medical Laboratory"
-					},
-					{
-						"code": "292200000X",
-						"display": "Dental Laboratory"
-					},
-					{
-						"code": "293D00000X",
-						"display": "Physiological Laboratory"
-					},
-					{
-						"code": "302F00000X",
-						"display": "Exclusive Provider Organization"
-					},
-					{
-						"code": "302R00000X",
-						"display": "Health Maintenance Organization"
-					},
-					{
-						"code": "305R00000X",
-						"display": "Preferred Provider Organization"
-					},
-					{
-						"code": "305S00000X",
-						"display": "Point of Service"
-					},
-					{
-						"code": "310400000X",
-						"display": "Assisted Living Facility"
-					},
-					{
-						"code": "310500000X",
-						"display": "Intermediate Care Facility, Mental Illness"
-					},
-					{
-						"code": "311500000X",
-						"display": "Alzheimer Center (Dementia Center)"
-					},
-					{
-						"code": "311Z00000X",
-						"display": "Custodial Care Facility"
-					},
-					{
-						"code": "313M00000X",
-						"display": "Nursing Facility/Intermediate Care Facility"
-					},
-					{
-						"code": "314000000X",
-						"display": "Skilled Nursing Facility"
-					},
-					{
-						"code": "315D00000X",
-						"display": "Hospice, Inpatient"
-					},
-					{
-						"code": "315P00000X",
-						"display": "Intermediate Care Facility, Mentally Retarded"
-					},
-					{
-						"code": "317400000X",
-						"display": "Christian Science Facility"
-					},
-					{
-						"code": "320600000X",
-						"display": "Residential Treatment Facility, Mental Retardation and/or Developmental Disabilities"
-					},
-					{
-						"code": "320700000X",
-						"display": "Residential Treatment Facility, Physical Disabilities"
-					},
-					{
-						"code": "320800000X",
-						"display": "Community Based Residential Treatment Facility, Mental Illness"
-					},
-					{
-						"code": "320900000X",
-						"display": "Community Based Residential Treatment Facility, Mental Retardation and/or Developmental Disabilities"
-					},
-					{
-						"code": "322D00000X",
-						"display": "Residential Treatment Facility, Emotionally Disturbed Children"
-					},
-					{
-						"code": "323P00000X",
-						"display": "Psychiatric Residential Treatment Facility"
-					},
-					{
-						"code": "324500000X",
-						"display": "Substance Abuse Rehabilitation Facility"
-					},
-					{
-						"code": "331L00000X",
-						"display": "Blood Bank"
-					},
-					{
-						"code": "332000000X",
-						"display": "Military/U.S. Coast Guard Pharmacy"
-					},
-					{
-						"code": "332100000X",
-						"display": "Department of Veterans Affairs (VA) Pharmacy"
-					},
-					{
-						"code": "332800000X",
-						"display": "Indian Health Service/Tribal/Urban Indian Health (I/T/U) Pharmacy"
-					},
-					{
-						"code": "332900000X",
-						"display": "Non-Pharmacy Dispensing Site"
-					},
-					{
-						"code": "332B00000X",
-						"display": "Durable Medical Equipment & Medical Supplies"
-					},
-					{
-						"code": "332G00000X",
-						"display": "Eye Bank"
-					},
-					{
-						"code": "332H00000X",
-						"display": "Eyewear Supplier"
-					},
-					{
-						"code": "332S00000X",
-						"display": "Hearing Aid Equipment"
-					},
-					{
-						"code": "332U00000X",
-						"display": "Home Delivered Meals"
-					},
-					{
-						"code": "333300000X",
-						"display": "Emergency Response System Companies"
-					},
-					{
-						"code": "333600000X",
-						"display": "Pharmacy"
-					},
-					{
-						"code": "335E00000X",
-						"display": "Prosthetic/Orthotic Supplier"
-					},
-					{
-						"code": "335G00000X",
-						"display": "Medical Foods Supplier"
-					},
-					{
-						"code": "335U00000X",
-						"display": "Organ Procurement Organization"
-					},
-					{
-						"code": "335V00000X",
-						"display": "Portable X-ray and/or Other Portable Diagnostic Imaging Supplier"
-					},
-					{
-						"code": "341600000X",
-						"display": "Ambulance"
-					},
-					{
-						"code": "341800000X",
-						"display": "Military/U.S. Coast Guard Transport"
-					},
-					{
-						"code": "343800000X",
-						"display": "Secured Medical Transport (VAN)"
-					},
-					{
-						"code": "343900000X",
-						"display": "Non-emergency Medical Transport (VAN)"
-					},
-					{
-						"code": "344600000X",
-						"display": "Taxi"
-					},
-					{
-						"code": "344800000X",
-						"display": "Air Carrier"
-					},
-					{
-						"code": "347B00000X",
-						"display": "Bus"
-					},
-					{
-						"code": "347C00000X",
-						"display": "Private Vehicle"
-					},
-					{
-						"code": "347D00000X",
-						"display": "Train"
-					},
-					{
-						"code": "347E00000X",
-						"display": "Transportation Broker"
-					},
-					{
-						"code": "363A00000X",
-						"display": "Physician Assistant"
-					},
-					{
-						"code": "363L00000X",
-						"display": "Nurse Practitioner"
-					},
-					{
-						"code": "364S00000X",
-						"display": "Clinical Nurse Specialist"
-					},
-					{
-						"code": "367500000X",
-						"display": "Nurse Anesthetist, Certified Registered"
-					},
-					{
-						"code": "367A00000X",
-						"display": "Advanced Practice Midwife"
-					},
-					{
-						"code": "367H00000X",
-						"display": "Anesthesiologist Assistant"
-					},
-					{
-						"code": "372500000X",
-						"display": "Chore Provider"
-					},
-					{
-						"code": "372600000X",
-						"display": "Adult Companion"
-					},
-					{
-						"code": "373H00000X",
-						"display": "Day Training/Habilitation Specialist"
-					},
-					{
-						"code": "374700000X",
-						"display": "Technician"
-					},
-					{
-						"code": "374J00000X",
-						"display": "Doula"
-					},
-					{
-						"code": "374K00000X",
-						"display": "Religious Nonmedical Practitioner"
-					},
-					{
-						"code": "374T00000X",
-						"display": "Religious Nonmedical Nursing Personnel"
-					},
-					{
-						"code": "374U00000X",
-						"display": "Home Health Aide"
-					},
-					{
-						"code": "376G00000X",
-						"display": "Nursing Home Administrator"
-					},
-					{
-						"code": "376J00000X",
-						"display": "Homemaker"
-					},
-					{
-						"code": "376K00000X",
-						"display": "Nurse's Aide"
-					},
-					{
-						"code": "385H00000X",
-						"display": "Respite Care"
-					},
-					{
-						"code": "390200000X",
-						"display": "Student in an Organized Health Care Education/Training Program"
-					},
-					{
-						"code": "405300000X",
-						"display": "Prevention Professional"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-provider-role",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-provider-role",
+    "version": "3.1.1",
+    "name": "USCoreProviderRoleNucc",
+    "title": "US Core Provider Role (NUCC)",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "other",
+                    "value": "http://hl7.org/fhir"
+                }
+            ]
+        }
+    ],
+    "description": "Provider roles codes which are composed of the NUCC Health Care Provider Taxonomy Code Set classification codes for providers. Only concepts with a classification and no specialization are included. ",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "copyright": "This value set includes content from NUCC Health Care Provider Taxonomy Code Set for providers which is copyright © 2016+ American Medical Association.  For commercial use, including sales or licensing, a license must be obtained.",
+    "compose": {
+        "include": [
+            {
+                "system": "http://nucc.org/provider-taxonomy",
+                "concept": [
+                    {
+                        "code": "101Y00000X",
+                        "display": "Counselor"
+                    },
+                    {
+                        "code": "102L00000X",
+                        "display": "Psychoanalyst"
+                    },
+                    {
+                        "code": "102X00000X",
+                        "display": "Poetry Therapist"
+                    },
+                    {
+                        "code": "103G00000X",
+                        "display": "Clinical Neuropsychologist"
+                    },
+                    {
+                        "code": "103K00000X",
+                        "display": "Behavior Analyst"
+                    },
+                    {
+                        "code": "103T00000X",
+                        "display": "Psychologist"
+                    },
+                    {
+                        "code": "104100000X",
+                        "display": "Social Worker"
+                    },
+                    {
+                        "code": "106E00000X",
+                        "display": "Assistant Behavior Analyst"
+                    },
+                    {
+                        "code": "106H00000X",
+                        "display": "Marriage & Family Therapist"
+                    },
+                    {
+                        "code": "106S00000X",
+                        "display": "Behavior Technician"
+                    },
+                    {
+                        "code": "111N00000X",
+                        "display": "Chiropractor"
+                    },
+                    {
+                        "code": "122300000X",
+                        "display": "Dentist"
+                    },
+                    {
+                        "code": "122400000X",
+                        "display": "Denturist"
+                    },
+                    {
+                        "code": "124Q00000X",
+                        "display": "Dental Hygienist"
+                    },
+                    {
+                        "code": "125J00000X",
+                        "display": "Dental Therapist"
+                    },
+                    {
+                        "code": "125K00000X",
+                        "display": "Advanced Practice Dental Therapist"
+                    },
+                    {
+                        "code": "125Q00000X",
+                        "display": "Oral Medicinist"
+                    },
+                    {
+                        "code": "126800000X",
+                        "display": "Dental Assistant"
+                    },
+                    {
+                        "code": "126900000X",
+                        "display": "Dental Laboratory Technician"
+                    },
+                    {
+                        "code": "132700000X",
+                        "display": "Dietary Manager"
+                    },
+                    {
+                        "code": "133N00000X",
+                        "display": "Nutritionist"
+                    },
+                    {
+                        "code": "133V00000X",
+                        "display": "Dietitian, Registered"
+                    },
+                    {
+                        "code": "136A00000X",
+                        "display": "Dietetic Technician, Registered"
+                    },
+                    {
+                        "code": "146D00000X",
+                        "display": "Personal Emergency Response Attendant"
+                    },
+                    {
+                        "code": "146L00000X",
+                        "display": "Emergency Medical Technician, Paramedic"
+                    },
+                    {
+                        "code": "146M00000X",
+                        "display": "Emergency Medical Technician, Intermediate"
+                    },
+                    {
+                        "code": "146N00000X",
+                        "display": "Emergency Medical Technician, Basic"
+                    },
+                    {
+                        "code": "152W00000X",
+                        "display": "Optometrist"
+                    },
+                    {
+                        "code": "156F00000X",
+                        "display": "Technician/Technologist"
+                    },
+                    {
+                        "code": "163W00000X",
+                        "display": "Registered Nurse"
+                    },
+                    {
+                        "code": "164W00000X",
+                        "display": "Licensed Practical Nurse"
+                    },
+                    {
+                        "code": "164X00000X",
+                        "display": "Licensed Vocational Nurse"
+                    },
+                    {
+                        "code": "167G00000X",
+                        "display": "Licensed Psychiatric Technician"
+                    },
+                    {
+                        "code": "170100000X",
+                        "display": "Medical Genetics, Ph.D. Medical Genetics"
+                    },
+                    {
+                        "code": "170300000X",
+                        "display": "Genetic Counselor, MS"
+                    },
+                    {
+                        "code": "171000000X",
+                        "display": "Military Health Care Provider"
+                    },
+                    {
+                        "code": "171100000X",
+                        "display": "Acupuncturist"
+                    },
+                    {
+                        "code": "171M00000X",
+                        "display": "Case Manager/Care Coordinator"
+                    },
+                    {
+                        "code": "171R00000X",
+                        "display": "Interpreter"
+                    },
+                    {
+                        "code": "171W00000X",
+                        "display": "Contractor"
+                    },
+                    {
+                        "code": "172A00000X",
+                        "display": "Driver"
+                    },
+                    {
+                        "code": "172M00000X",
+                        "display": "Mechanotherapist"
+                    },
+                    {
+                        "code": "172P00000X",
+                        "display": "Naprapath"
+                    },
+                    {
+                        "code": "172V00000X",
+                        "display": "Community Health Worker"
+                    },
+                    {
+                        "code": "173000000X",
+                        "display": "Legal Medicine"
+                    },
+                    {
+                        "code": "173C00000X",
+                        "display": "Reflexologist"
+                    },
+                    {
+                        "code": "173F00000X",
+                        "display": "Sleep Specialist, PhD"
+                    },
+                    {
+                        "code": "174200000X",
+                        "display": "Meals"
+                    },
+                    {
+                        "code": "174400000X",
+                        "display": "Specialist"
+                    },
+                    {
+                        "code": "174H00000X",
+                        "display": "Health Educator"
+                    },
+                    {
+                        "code": "174M00000X",
+                        "display": "Veterinarian"
+                    },
+                    {
+                        "code": "174N00000X",
+                        "display": "Lactation Consultant, Non-RN"
+                    },
+                    {
+                        "code": "174V00000X",
+                        "display": "Clinical Ethicist"
+                    },
+                    {
+                        "code": "175F00000X",
+                        "display": "Naturopath"
+                    },
+                    {
+                        "code": "175L00000X",
+                        "display": "Homeopath"
+                    },
+                    {
+                        "code": "175M00000X",
+                        "display": "Midwife, Lay"
+                    },
+                    {
+                        "code": "175T00000X",
+                        "display": "Peer Specialist"
+                    },
+                    {
+                        "code": "176B00000X",
+                        "display": "Midwife"
+                    },
+                    {
+                        "code": "176P00000X",
+                        "display": "Funeral Director"
+                    },
+                    {
+                        "code": "177F00000X",
+                        "display": "Lodging"
+                    },
+                    {
+                        "code": "183500000X",
+                        "display": "Pharmacist"
+                    },
+                    {
+                        "code": "183700000X",
+                        "display": "Pharmacy Technician"
+                    },
+                    {
+                        "code": "193200000X",
+                        "display": "Multi-Specialty"
+                    },
+                    {
+                        "code": "193400000X",
+                        "display": "Single Specialty"
+                    },
+                    {
+                        "code": "202C00000X",
+                        "display": "Independent Medical Examiner"
+                    },
+                    {
+                        "code": "202K00000X",
+                        "display": "Phlebology"
+                    },
+                    {
+                        "code": "204C00000X",
+                        "display": "Neuromusculoskeletal Medicine, Sports Medicine"
+                    },
+                    {
+                        "code": "204D00000X",
+                        "display": "Neuromusculoskeletal Medicine & OMM"
+                    },
+                    {
+                        "code": "204E00000X",
+                        "display": "Oral & Maxillofacial Surgery"
+                    },
+                    {
+                        "code": "204F00000X",
+                        "display": "Transplant Surgery"
+                    },
+                    {
+                        "code": "204R00000X",
+                        "display": "Electrodiagnostic Medicine"
+                    },
+                    {
+                        "code": "207K00000X",
+                        "display": "Allergy & Immunology"
+                    },
+                    {
+                        "code": "207L00000X",
+                        "display": "Anesthesiology"
+                    },
+                    {
+                        "code": "207N00000X",
+                        "display": "Dermatology"
+                    },
+                    {
+                        "code": "207P00000X",
+                        "display": "Emergency Medicine"
+                    },
+                    {
+                        "code": "207Q00000X",
+                        "display": "Family Medicine"
+                    },
+                    {
+                        "code": "207R00000X",
+                        "display": "Internal Medicine"
+                    },
+                    {
+                        "code": "207T00000X",
+                        "display": "Neurological Surgery"
+                    },
+                    {
+                        "code": "207U00000X",
+                        "display": "Nuclear Medicine"
+                    },
+                    {
+                        "code": "207V00000X",
+                        "display": "Obstetrics & Gynecology"
+                    },
+                    {
+                        "code": "207W00000X",
+                        "display": "Ophthalmology"
+                    },
+                    {
+                        "code": "207X00000X",
+                        "display": "Orthopaedic Surgery"
+                    },
+                    {
+                        "code": "207Y00000X",
+                        "display": "Otolaryngology"
+                    },
+                    {
+                        "code": "208000000X",
+                        "display": "Pediatrics"
+                    },
+                    {
+                        "code": "208100000X",
+                        "display": "Physical Medicine & Rehabilitation"
+                    },
+                    {
+                        "code": "208200000X",
+                        "display": "Plastic Surgery"
+                    },
+                    {
+                        "code": "208600000X",
+                        "display": "Surgery"
+                    },
+                    {
+                        "code": "208800000X",
+                        "display": "Urology"
+                    },
+                    {
+                        "code": "208C00000X",
+                        "display": "Colon & Rectal Surgery"
+                    },
+                    {
+                        "code": "208D00000X",
+                        "display": "General Practice"
+                    },
+                    {
+                        "code": "208G00000X",
+                        "display": "Thoracic Surgery (Cardiothoracic Vascular Surgery)"
+                    },
+                    {
+                        "code": "208M00000X",
+                        "display": "Hospitalist"
+                    },
+                    {
+                        "code": "208U00000X",
+                        "display": "Clinical Pharmacology"
+                    },
+                    {
+                        "code": "209800000X",
+                        "display": "Legal Medicine"
+                    },
+                    {
+                        "code": "211D00000X",
+                        "display": "Assistant, Podiatric"
+                    },
+                    {
+                        "code": "213E00000X",
+                        "display": "Podiatrist"
+                    },
+                    {
+                        "code": "221700000X",
+                        "display": "Art Therapist"
+                    },
+                    {
+                        "code": "222Q00000X",
+                        "display": "Developmental Therapist"
+                    },
+                    {
+                        "code": "222Z00000X",
+                        "display": "Orthotist"
+                    },
+                    {
+                        "code": "224900000X",
+                        "display": "Mastectomy Fitter"
+                    },
+                    {
+                        "code": "224L00000X",
+                        "display": "Pedorthist"
+                    },
+                    {
+                        "code": "224P00000X",
+                        "display": "Prosthetist"
+                    },
+                    {
+                        "code": "224Y00000X",
+                        "display": "Clinical Exercise Physiologist"
+                    },
+                    {
+                        "code": "224Z00000X",
+                        "display": "Occupational Therapy Assistant"
+                    },
+                    {
+                        "code": "225000000X",
+                        "display": "Orthotic Fitter"
+                    },
+                    {
+                        "code": "225100000X",
+                        "display": "Physical Therapist"
+                    },
+                    {
+                        "code": "225200000X",
+                        "display": "Physical Therapy Assistant"
+                    },
+                    {
+                        "code": "225400000X",
+                        "display": "Rehabilitation Practitioner"
+                    },
+                    {
+                        "code": "225500000X",
+                        "display": "Specialist/Technologist"
+                    },
+                    {
+                        "code": "225600000X",
+                        "display": "Dance Therapist"
+                    },
+                    {
+                        "code": "225700000X",
+                        "display": "Massage Therapist"
+                    },
+                    {
+                        "code": "225800000X",
+                        "display": "Recreation Therapist"
+                    },
+                    {
+                        "code": "225A00000X",
+                        "display": "Music Therapist"
+                    },
+                    {
+                        "code": "225B00000X",
+                        "display": "Pulmonary Function Technologist"
+                    },
+                    {
+                        "code": "225C00000X",
+                        "display": "Rehabilitation Counselor"
+                    },
+                    {
+                        "code": "225X00000X",
+                        "display": "Occupational Therapist"
+                    },
+                    {
+                        "code": "226000000X",
+                        "display": "Recreational Therapist Assistant"
+                    },
+                    {
+                        "code": "226300000X",
+                        "display": "Kinesiotherapist"
+                    },
+                    {
+                        "code": "227800000X",
+                        "display": "Respiratory Therapist, Certified"
+                    },
+                    {
+                        "code": "227900000X",
+                        "display": "Respiratory Therapist, Registered"
+                    },
+                    {
+                        "code": "229N00000X",
+                        "display": "Anaplastologist"
+                    },
+                    {
+                        "code": "231H00000X",
+                        "display": "Audiologist"
+                    },
+                    {
+                        "code": "235500000X",
+                        "display": "Specialist/Technologist"
+                    },
+                    {
+                        "code": "235Z00000X",
+                        "display": "Speech-Language Pathologist"
+                    },
+                    {
+                        "code": "237600000X",
+                        "display": "Audiologist-Hearing Aid Fitter"
+                    },
+                    {
+                        "code": "237700000X",
+                        "display": "Hearing Instrument Specialist"
+                    },
+                    {
+                        "code": "242T00000X",
+                        "display": "Perfusionist"
+                    },
+                    {
+                        "code": "243U00000X",
+                        "display": "Radiology Practitioner Assistant"
+                    },
+                    {
+                        "code": "246Q00000X",
+                        "display": "Specialist/Technologist, Pathology"
+                    },
+                    {
+                        "code": "246R00000X",
+                        "display": "Technician, Pathology"
+                    },
+                    {
+                        "code": "246W00000X",
+                        "display": "Technician, Cardiology"
+                    },
+                    {
+                        "code": "246X00000X",
+                        "display": "Specialist/Technologist Cardiovascular"
+                    },
+                    {
+                        "code": "246Y00000X",
+                        "display": "Specialist/Technologist, Health Information"
+                    },
+                    {
+                        "code": "246Z00000X",
+                        "display": "Specialist/Technologist, Other"
+                    },
+                    {
+                        "code": "247000000X",
+                        "display": "Technician, Health Information"
+                    },
+                    {
+                        "code": "247100000X",
+                        "display": "Radiologic Technologist"
+                    },
+                    {
+                        "code": "247200000X",
+                        "display": "Technician, Other"
+                    },
+                    {
+                        "code": "251300000X",
+                        "display": "Local Education Agency (LEA)"
+                    },
+                    {
+                        "code": "251B00000X",
+                        "display": "Case Management"
+                    },
+                    {
+                        "code": "251C00000X",
+                        "display": "Day Training, Developmentally Disabled Services"
+                    },
+                    {
+                        "code": "251E00000X",
+                        "display": "Home Health"
+                    },
+                    {
+                        "code": "251F00000X",
+                        "display": "Home Infusion"
+                    },
+                    {
+                        "code": "251G00000X",
+                        "display": "Hospice Care, Community Based"
+                    },
+                    {
+                        "code": "251J00000X",
+                        "display": "Nursing Care"
+                    },
+                    {
+                        "code": "251K00000X",
+                        "display": "Public Health or Welfare"
+                    },
+                    {
+                        "code": "251S00000X",
+                        "display": "Community/Behavioral Health"
+                    },
+                    {
+                        "code": "251T00000X",
+                        "display": "Program of All-Inclusive Care for the Elderly (PACE) Provider Organization"
+                    },
+                    {
+                        "code": "251V00000X",
+                        "display": "Voluntary or Charitable"
+                    },
+                    {
+                        "code": "251X00000X",
+                        "display": "Supports Brokerage"
+                    },
+                    {
+                        "code": "252Y00000X",
+                        "display": "Early Intervention Provider Agency"
+                    },
+                    {
+                        "code": "253J00000X",
+                        "display": "Foster Care Agency"
+                    },
+                    {
+                        "code": "253Z00000X",
+                        "display": "In Home Supportive Care"
+                    },
+                    {
+                        "code": "261Q00000X",
+                        "display": "Clinic/Center"
+                    },
+                    {
+                        "code": "273100000X",
+                        "display": "Epilepsy Unit"
+                    },
+                    {
+                        "code": "273R00000X",
+                        "display": "Psychiatric Unit"
+                    },
+                    {
+                        "code": "273Y00000X",
+                        "display": "Rehabilitation Unit"
+                    },
+                    {
+                        "code": "275N00000X",
+                        "display": "Medicare Defined Swing Bed Unit"
+                    },
+                    {
+                        "code": "276400000X",
+                        "display": "Rehabilitation, Substance Use Disorder Unit"
+                    },
+                    {
+                        "code": "281P00000X",
+                        "display": "Chronic Disease Hospital"
+                    },
+                    {
+                        "code": "282E00000X",
+                        "display": "Long Term Care Hospital"
+                    },
+                    {
+                        "code": "282J00000X",
+                        "display": "Religious Nonmedical Health Care Institution"
+                    },
+                    {
+                        "code": "282N00000X",
+                        "display": "General Acute Care Hospital"
+                    },
+                    {
+                        "code": "283Q00000X",
+                        "display": "Psychiatric Hospital"
+                    },
+                    {
+                        "code": "283X00000X",
+                        "display": "Rehabilitation Hospital"
+                    },
+                    {
+                        "code": "284300000X",
+                        "display": "Special Hospital"
+                    },
+                    {
+                        "code": "286500000X",
+                        "display": "Military Hospital"
+                    },
+                    {
+                        "code": "287300000X",
+                        "display": "Christian Science Sanitorium"
+                    },
+                    {
+                        "code": "291900000X",
+                        "display": "Military Clinical Medical Laboratory"
+                    },
+                    {
+                        "code": "291U00000X",
+                        "display": "Clinical Medical Laboratory"
+                    },
+                    {
+                        "code": "292200000X",
+                        "display": "Dental Laboratory"
+                    },
+                    {
+                        "code": "293D00000X",
+                        "display": "Physiological Laboratory"
+                    },
+                    {
+                        "code": "302F00000X",
+                        "display": "Exclusive Provider Organization"
+                    },
+                    {
+                        "code": "302R00000X",
+                        "display": "Health Maintenance Organization"
+                    },
+                    {
+                        "code": "305R00000X",
+                        "display": "Preferred Provider Organization"
+                    },
+                    {
+                        "code": "305S00000X",
+                        "display": "Point of Service"
+                    },
+                    {
+                        "code": "310400000X",
+                        "display": "Assisted Living Facility"
+                    },
+                    {
+                        "code": "310500000X",
+                        "display": "Intermediate Care Facility, Mental Illness"
+                    },
+                    {
+                        "code": "311500000X",
+                        "display": "Alzheimer Center (Dementia Center)"
+                    },
+                    {
+                        "code": "311Z00000X",
+                        "display": "Custodial Care Facility"
+                    },
+                    {
+                        "code": "313M00000X",
+                        "display": "Nursing Facility/Intermediate Care Facility"
+                    },
+                    {
+                        "code": "314000000X",
+                        "display": "Skilled Nursing Facility"
+                    },
+                    {
+                        "code": "315D00000X",
+                        "display": "Hospice, Inpatient"
+                    },
+                    {
+                        "code": "315P00000X",
+                        "display": "Intermediate Care Facility, Mentally Retarded"
+                    },
+                    {
+                        "code": "317400000X",
+                        "display": "Christian Science Facility"
+                    },
+                    {
+                        "code": "320600000X",
+                        "display": "Residential Treatment Facility, Mental Retardation and/or Developmental Disabilities"
+                    },
+                    {
+                        "code": "320700000X",
+                        "display": "Residential Treatment Facility, Physical Disabilities"
+                    },
+                    {
+                        "code": "320800000X",
+                        "display": "Community Based Residential Treatment Facility, Mental Illness"
+                    },
+                    {
+                        "code": "320900000X",
+                        "display": "Community Based Residential Treatment Facility, Mental Retardation and/or Developmental Disabilities"
+                    },
+                    {
+                        "code": "322D00000X",
+                        "display": "Residential Treatment Facility, Emotionally Disturbed Children"
+                    },
+                    {
+                        "code": "323P00000X",
+                        "display": "Psychiatric Residential Treatment Facility"
+                    },
+                    {
+                        "code": "324500000X",
+                        "display": "Substance Abuse Rehabilitation Facility"
+                    },
+                    {
+                        "code": "331L00000X",
+                        "display": "Blood Bank"
+                    },
+                    {
+                        "code": "332000000X",
+                        "display": "Military/U.S. Coast Guard Pharmacy"
+                    },
+                    {
+                        "code": "332100000X",
+                        "display": "Department of Veterans Affairs (VA) Pharmacy"
+                    },
+                    {
+                        "code": "332800000X",
+                        "display": "Indian Health Service/Tribal/Urban Indian Health (I/T/U) Pharmacy"
+                    },
+                    {
+                        "code": "332900000X",
+                        "display": "Non-Pharmacy Dispensing Site"
+                    },
+                    {
+                        "code": "332B00000X",
+                        "display": "Durable Medical Equipment & Medical Supplies"
+                    },
+                    {
+                        "code": "332G00000X",
+                        "display": "Eye Bank"
+                    },
+                    {
+                        "code": "332H00000X",
+                        "display": "Eyewear Supplier"
+                    },
+                    {
+                        "code": "332S00000X",
+                        "display": "Hearing Aid Equipment"
+                    },
+                    {
+                        "code": "332U00000X",
+                        "display": "Home Delivered Meals"
+                    },
+                    {
+                        "code": "333300000X",
+                        "display": "Emergency Response System Companies"
+                    },
+                    {
+                        "code": "333600000X",
+                        "display": "Pharmacy"
+                    },
+                    {
+                        "code": "335E00000X",
+                        "display": "Prosthetic/Orthotic Supplier"
+                    },
+                    {
+                        "code": "335G00000X",
+                        "display": "Medical Foods Supplier"
+                    },
+                    {
+                        "code": "335U00000X",
+                        "display": "Organ Procurement Organization"
+                    },
+                    {
+                        "code": "335V00000X",
+                        "display": "Portable X-ray and/or Other Portable Diagnostic Imaging Supplier"
+                    },
+                    {
+                        "code": "341600000X",
+                        "display": "Ambulance"
+                    },
+                    {
+                        "code": "341800000X",
+                        "display": "Military/U.S. Coast Guard Transport"
+                    },
+                    {
+                        "code": "343800000X",
+                        "display": "Secured Medical Transport (VAN)"
+                    },
+                    {
+                        "code": "343900000X",
+                        "display": "Non-emergency Medical Transport (VAN)"
+                    },
+                    {
+                        "code": "344600000X",
+                        "display": "Taxi"
+                    },
+                    {
+                        "code": "344800000X",
+                        "display": "Air Carrier"
+                    },
+                    {
+                        "code": "347B00000X",
+                        "display": "Bus"
+                    },
+                    {
+                        "code": "347C00000X",
+                        "display": "Private Vehicle"
+                    },
+                    {
+                        "code": "347D00000X",
+                        "display": "Train"
+                    },
+                    {
+                        "code": "347E00000X",
+                        "display": "Transportation Broker"
+                    },
+                    {
+                        "code": "363A00000X",
+                        "display": "Physician Assistant"
+                    },
+                    {
+                        "code": "363L00000X",
+                        "display": "Nurse Practitioner"
+                    },
+                    {
+                        "code": "364S00000X",
+                        "display": "Clinical Nurse Specialist"
+                    },
+                    {
+                        "code": "367500000X",
+                        "display": "Nurse Anesthetist, Certified Registered"
+                    },
+                    {
+                        "code": "367A00000X",
+                        "display": "Advanced Practice Midwife"
+                    },
+                    {
+                        "code": "367H00000X",
+                        "display": "Anesthesiologist Assistant"
+                    },
+                    {
+                        "code": "372500000X",
+                        "display": "Chore Provider"
+                    },
+                    {
+                        "code": "372600000X",
+                        "display": "Adult Companion"
+                    },
+                    {
+                        "code": "373H00000X",
+                        "display": "Day Training/Habilitation Specialist"
+                    },
+                    {
+                        "code": "374700000X",
+                        "display": "Technician"
+                    },
+                    {
+                        "code": "374J00000X",
+                        "display": "Doula"
+                    },
+                    {
+                        "code": "374K00000X",
+                        "display": "Religious Nonmedical Practitioner"
+                    },
+                    {
+                        "code": "374T00000X",
+                        "display": "Religious Nonmedical Nursing Personnel"
+                    },
+                    {
+                        "code": "374U00000X",
+                        "display": "Home Health Aide"
+                    },
+                    {
+                        "code": "376G00000X",
+                        "display": "Nursing Home Administrator"
+                    },
+                    {
+                        "code": "376J00000X",
+                        "display": "Homemaker"
+                    },
+                    {
+                        "code": "376K00000X",
+                        "display": "Nurse's Aide"
+                    },
+                    {
+                        "code": "385H00000X",
+                        "display": "Respite Care"
+                    },
+                    {
+                        "code": "390200000X",
+                        "display": "Student in an Organized Health Care Education/Training Program"
+                    },
+                    {
+                        "code": "405300000X",
+                        "display": "Prevention Professional"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-provider-specialty.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-provider-specialty.json
@@ -1,52 +1,52 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-provider-specialty",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include codes from <code>http://nucc.org/provider-taxonomy</code> where abstract  =  false</li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-provider-specialty",
-	"version": "3.1.1",
-	"name": "USCoreProviderSpecialityNucc",
-	"title": "US Core Provider Speciality (NUCC)",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "other",
-					"value": "http://hl7.org/fhir"
-				}
-			]
-		}
-	],
-	"description": "Provider speciality roles codes which are composed of the NUCC Health Care Provider Taxonomy Code Set for providers",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"copyright": "This value set includes content from NUCC Health Care Provider Taxonomy Code Set for providers which is copyright © 2016+ American Medical Association.  For commercial use, including sales or licensing, a license must be obtained.",
-	"compose": {
-		"include": [
-			{
-				"system": "http://nucc.org/provider-taxonomy",
-				"filter": [
-					{
-						"property": "abstract",
-						"op": "=",
-						"value": "false"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-provider-specialty",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-provider-specialty",
+    "version": "3.1.1",
+    "name": "USCoreProviderSpecialityNucc",
+    "title": "US Core Provider Speciality (NUCC)",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "other",
+                    "value": "http://hl7.org/fhir"
+                }
+            ]
+        }
+    ],
+    "description": "Provider speciality roles codes which are composed of the NUCC Health Care Provider Taxonomy Code Set for providers",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "copyright": "This value set includes content from NUCC Health Care Provider Taxonomy Code Set for providers which is copyright © 2016+ American Medical Association.  For commercial use, including sales or licensing, a license must be obtained.",
+    "compose": {
+        "include": [
+            {
+                "system": "http://nucc.org/provider-taxonomy",
+                "filter": [
+                    {
+                        "property": "abstract",
+                        "op": "=",
+                        "value": "false"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-smoking-status-observation-codes.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-smoking-status-observation-codes.json
@@ -1,51 +1,51 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-smoking-status-observation-codes",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include these codes as defined in <a href=\"http://loinc.org\"><code>http://loinc.org</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/72166-2.html\">72166-2</a></td><td>Tobacco smoking status NHIS</td><td/></tr></table></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-smoking-status-observation-codes",
-	"version": "3.1.1",
-	"name": "USCoreSmokingStatusObservationCodes",
-	"title": "US Core Smoking Status Observation Codes",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "other",
-					"value": "http://hl7.org/fhir"
-				}
-			]
-		}
-	],
-	"description": "The US Core Smoking Status Observation Codes Value Set is a 'starter set' of concepts to capture smoking status.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"copyright": "This material contains content from [LOINC](http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc",
-	"compose": {
-		"include": [
-			{
-				"system": "http://loinc.org",
-				"concept": [
-					{
-						"code": "72166-2",
-						"display": "Tobacco smoking status NHIS"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-smoking-status-observation-codes",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-smoking-status-observation-codes",
+    "version": "3.1.1",
+    "name": "USCoreSmokingStatusObservationCodes",
+    "title": "US Core Smoking Status Observation Codes",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "other",
+                    "value": "http://hl7.org/fhir"
+                }
+            ]
+        }
+    ],
+    "description": "The US Core Smoking Status Observation Codes Value Set is a 'starter set' of concepts to capture smoking status.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "copyright": "This material contains content from [LOINC](http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc",
+    "compose": {
+        "include": [
+            {
+                "system": "http://loinc.org",
+                "concept": [
+                    {
+                        "code": "72166-2",
+                        "display": "Tobacco smoking status NHIS"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-usps-state.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-usps-state.json
@@ -1,289 +1,289 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-usps-state",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include these codes as defined in <code>https://www.usps.com/</code><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td></tr><tr><td>AK</td><td>Alaska</td><td/></tr><tr><td>AL</td><td>Alabama</td><td/></tr><tr><td>AR</td><td>Arkansas</td><td/></tr><tr><td>AS</td><td>American Samoa</td><td/></tr><tr><td>AZ</td><td>Arizona</td><td/></tr><tr><td>CA</td><td>California</td><td/></tr><tr><td>CO</td><td>Colorado</td><td/></tr><tr><td>CT</td><td>Connecticut</td><td/></tr><tr><td>DC</td><td>District of Columbia</td><td/></tr><tr><td>DE</td><td>Delaware</td><td/></tr><tr><td>FL</td><td>Florida</td><td/></tr><tr><td>FM</td><td>Federated States of Micronesia</td><td/></tr><tr><td>GA</td><td>Georgia</td><td/></tr><tr><td>GU</td><td>Guam</td><td/></tr><tr><td>HI</td><td>Hawaii</td><td/></tr><tr><td>IA</td><td>Iowa</td><td/></tr><tr><td>ID</td><td>Idaho</td><td/></tr><tr><td>IL</td><td>Illinois</td><td/></tr><tr><td>IN</td><td>Indiana</td><td/></tr><tr><td>KS</td><td>Kansas</td><td/></tr><tr><td>KY</td><td>Kentucky</td><td/></tr><tr><td>LA</td><td>Louisiana</td><td/></tr><tr><td>MA</td><td>Massachusetts</td><td/></tr><tr><td>MD</td><td>Maryland</td><td/></tr><tr><td>ME</td><td>Maine</td><td/></tr><tr><td>MH</td><td>Marshall Islands</td><td/></tr><tr><td>MI</td><td>Michigan</td><td/></tr><tr><td>MN</td><td>Minnesota</td><td/></tr><tr><td>MO</td><td>Missouri</td><td/></tr><tr><td>MP</td><td>Northern Mariana Islands</td><td/></tr><tr><td>MS</td><td>Mississippi</td><td/></tr><tr><td>MT</td><td>Montana</td><td/></tr><tr><td>NC</td><td>North Carolina</td><td/></tr><tr><td>ND</td><td>North Dakota</td><td/></tr><tr><td>NE</td><td>Nebraska</td><td/></tr><tr><td>NH</td><td>New Hampshire</td><td/></tr><tr><td>NJ</td><td>New Jersey</td><td/></tr><tr><td>NM</td><td>New Mexico</td><td/></tr><tr><td>NV</td><td>Nevada</td><td/></tr><tr><td>NY</td><td>New York</td><td/></tr><tr><td>OH</td><td>Ohio</td><td/></tr><tr><td>OK</td><td>Oklahoma</td><td/></tr><tr><td>OR</td><td>Oregon</td><td/></tr><tr><td>PA</td><td>Pennsylvania</td><td/></tr><tr><td>PR</td><td>Puerto Rico</td><td/></tr><tr><td>PW</td><td>Palau</td><td/></tr><tr><td>RI</td><td>Rhode Island</td><td/></tr><tr><td>SC</td><td>South Carolina</td><td/></tr><tr><td>SD</td><td>South Dakota</td><td/></tr><tr><td>TN</td><td>Tennessee</td><td/></tr><tr><td>TX</td><td>Texas</td><td/></tr><tr><td>UT</td><td>Utah</td><td/></tr><tr><td>VA</td><td>Virginia</td><td/></tr><tr><td>VI</td><td>Virgin Islands of the U.S.</td><td/></tr><tr><td>VT</td><td>Vermont</td><td/></tr><tr><td>WA</td><td>Washington</td><td/></tr><tr><td>WI</td><td>Wisconsin</td><td/></tr><tr><td>WV</td><td>West Virginia</td><td/></tr><tr><td>WY</td><td>Wyoming</td><td/></tr></table></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state",
-	"identifier": [
-		{
-			"system": "urn:ietf:rfc:3986",
-			"value": "urn:oid:2.16.840.1.113883.4.642.3.40"
-		}
-	],
-	"version": "3.1.1",
-	"name": "UspsTwoLetterAlphabeticCodes",
-	"title": "USPS Two Letter Alphabetic Codes",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "other",
-					"value": "http://hl7.org/fhir"
-				}
-			]
-		}
-	],
-	"description": "This value set defines two letter USPS alphabetic codes.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"copyright": "On July 1, 1963, the Post Office Department implemented the five-digit ZIP Code, which was placed after the state name in the last line of an address. To provide room for the ZIP Code, the Department issued two-letter abbreviations for all states and territories. Publication 59, Abbreviations for Use with ZIP Code, issued by the Department in October 1963. There is no copyright restriction on this value set.",
-	"compose": {
-		"include": [
-			{
-				"system": "https://www.usps.com/",
-				"concept": [
-					{
-						"code": "AK",
-						"display": "Alaska"
-					},
-					{
-						"code": "AL",
-						"display": "Alabama"
-					},
-					{
-						"code": "AR",
-						"display": "Arkansas"
-					},
-					{
-						"code": "AS",
-						"display": "American Samoa"
-					},
-					{
-						"code": "AZ",
-						"display": "Arizona"
-					},
-					{
-						"code": "CA",
-						"display": "California"
-					},
-					{
-						"code": "CO",
-						"display": "Colorado"
-					},
-					{
-						"code": "CT",
-						"display": "Connecticut"
-					},
-					{
-						"code": "DC",
-						"display": "District of Columbia"
-					},
-					{
-						"code": "DE",
-						"display": "Delaware"
-					},
-					{
-						"code": "FL",
-						"display": "Florida"
-					},
-					{
-						"code": "FM",
-						"display": "Federated States of Micronesia"
-					},
-					{
-						"code": "GA",
-						"display": "Georgia"
-					},
-					{
-						"code": "GU",
-						"display": "Guam"
-					},
-					{
-						"code": "HI",
-						"display": "Hawaii"
-					},
-					{
-						"code": "IA",
-						"display": "Iowa"
-					},
-					{
-						"code": "ID",
-						"display": "Idaho"
-					},
-					{
-						"code": "IL",
-						"display": "Illinois"
-					},
-					{
-						"code": "IN",
-						"display": "Indiana"
-					},
-					{
-						"code": "KS",
-						"display": "Kansas"
-					},
-					{
-						"code": "KY",
-						"display": "Kentucky"
-					},
-					{
-						"code": "LA",
-						"display": "Louisiana"
-					},
-					{
-						"code": "MA",
-						"display": "Massachusetts"
-					},
-					{
-						"code": "MD",
-						"display": "Maryland"
-					},
-					{
-						"code": "ME",
-						"display": "Maine"
-					},
-					{
-						"code": "MH",
-						"display": "Marshall Islands"
-					},
-					{
-						"code": "MI",
-						"display": "Michigan"
-					},
-					{
-						"code": "MN",
-						"display": "Minnesota"
-					},
-					{
-						"code": "MO",
-						"display": "Missouri"
-					},
-					{
-						"code": "MP",
-						"display": "Northern Mariana Islands"
-					},
-					{
-						"code": "MS",
-						"display": "Mississippi"
-					},
-					{
-						"code": "MT",
-						"display": "Montana"
-					},
-					{
-						"code": "NC",
-						"display": "North Carolina"
-					},
-					{
-						"code": "ND",
-						"display": "North Dakota"
-					},
-					{
-						"code": "NE",
-						"display": "Nebraska"
-					},
-					{
-						"code": "NH",
-						"display": "New Hampshire"
-					},
-					{
-						"code": "NJ",
-						"display": "New Jersey"
-					},
-					{
-						"code": "NM",
-						"display": "New Mexico"
-					},
-					{
-						"code": "NV",
-						"display": "Nevada"
-					},
-					{
-						"code": "NY",
-						"display": "New York"
-					},
-					{
-						"code": "OH",
-						"display": "Ohio"
-					},
-					{
-						"code": "OK",
-						"display": "Oklahoma"
-					},
-					{
-						"code": "OR",
-						"display": "Oregon"
-					},
-					{
-						"code": "PA",
-						"display": "Pennsylvania"
-					},
-					{
-						"code": "PR",
-						"display": "Puerto Rico"
-					},
-					{
-						"code": "PW",
-						"display": "Palau"
-					},
-					{
-						"code": "RI",
-						"display": "Rhode Island"
-					},
-					{
-						"code": "SC",
-						"display": "South Carolina"
-					},
-					{
-						"code": "SD",
-						"display": "South Dakota"
-					},
-					{
-						"code": "TN",
-						"display": "Tennessee"
-					},
-					{
-						"code": "TX",
-						"display": "Texas"
-					},
-					{
-						"code": "UT",
-						"display": "Utah"
-					},
-					{
-						"code": "VA",
-						"display": "Virginia"
-					},
-					{
-						"code": "VI",
-						"display": "Virgin Islands of the U.S."
-					},
-					{
-						"code": "VT",
-						"display": "Vermont"
-					},
-					{
-						"code": "WA",
-						"display": "Washington"
-					},
-					{
-						"code": "WI",
-						"display": "Wisconsin"
-					},
-					{
-						"code": "WV",
-						"display": "West Virginia"
-					},
-					{
-						"code": "WY",
-						"display": "Wyoming"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-usps-state",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state",
+    "identifier": [
+        {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:oid:2.16.840.1.113883.4.642.3.40"
+        }
+    ],
+    "version": "3.1.1",
+    "name": "UspsTwoLetterAlphabeticCodes",
+    "title": "USPS Two Letter Alphabetic Codes",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "other",
+                    "value": "http://hl7.org/fhir"
+                }
+            ]
+        }
+    ],
+    "description": "This value set defines two letter USPS alphabetic codes.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "copyright": "On July 1, 1963, the Post Office Department implemented the five-digit ZIP Code, which was placed after the state name in the last line of an address. To provide room for the ZIP Code, the Department issued two-letter abbreviations for all states and territories. Publication 59, Abbreviations for Use with ZIP Code, issued by the Department in October 1963. There is no copyright restriction on this value set.",
+    "compose": {
+        "include": [
+            {
+                "system": "https://www.usps.com/",
+                "concept": [
+                    {
+                        "code": "AK",
+                        "display": "Alaska"
+                    },
+                    {
+                        "code": "AL",
+                        "display": "Alabama"
+                    },
+                    {
+                        "code": "AR",
+                        "display": "Arkansas"
+                    },
+                    {
+                        "code": "AS",
+                        "display": "American Samoa"
+                    },
+                    {
+                        "code": "AZ",
+                        "display": "Arizona"
+                    },
+                    {
+                        "code": "CA",
+                        "display": "California"
+                    },
+                    {
+                        "code": "CO",
+                        "display": "Colorado"
+                    },
+                    {
+                        "code": "CT",
+                        "display": "Connecticut"
+                    },
+                    {
+                        "code": "DC",
+                        "display": "District of Columbia"
+                    },
+                    {
+                        "code": "DE",
+                        "display": "Delaware"
+                    },
+                    {
+                        "code": "FL",
+                        "display": "Florida"
+                    },
+                    {
+                        "code": "FM",
+                        "display": "Federated States of Micronesia"
+                    },
+                    {
+                        "code": "GA",
+                        "display": "Georgia"
+                    },
+                    {
+                        "code": "GU",
+                        "display": "Guam"
+                    },
+                    {
+                        "code": "HI",
+                        "display": "Hawaii"
+                    },
+                    {
+                        "code": "IA",
+                        "display": "Iowa"
+                    },
+                    {
+                        "code": "ID",
+                        "display": "Idaho"
+                    },
+                    {
+                        "code": "IL",
+                        "display": "Illinois"
+                    },
+                    {
+                        "code": "IN",
+                        "display": "Indiana"
+                    },
+                    {
+                        "code": "KS",
+                        "display": "Kansas"
+                    },
+                    {
+                        "code": "KY",
+                        "display": "Kentucky"
+                    },
+                    {
+                        "code": "LA",
+                        "display": "Louisiana"
+                    },
+                    {
+                        "code": "MA",
+                        "display": "Massachusetts"
+                    },
+                    {
+                        "code": "MD",
+                        "display": "Maryland"
+                    },
+                    {
+                        "code": "ME",
+                        "display": "Maine"
+                    },
+                    {
+                        "code": "MH",
+                        "display": "Marshall Islands"
+                    },
+                    {
+                        "code": "MI",
+                        "display": "Michigan"
+                    },
+                    {
+                        "code": "MN",
+                        "display": "Minnesota"
+                    },
+                    {
+                        "code": "MO",
+                        "display": "Missouri"
+                    },
+                    {
+                        "code": "MP",
+                        "display": "Northern Mariana Islands"
+                    },
+                    {
+                        "code": "MS",
+                        "display": "Mississippi"
+                    },
+                    {
+                        "code": "MT",
+                        "display": "Montana"
+                    },
+                    {
+                        "code": "NC",
+                        "display": "North Carolina"
+                    },
+                    {
+                        "code": "ND",
+                        "display": "North Dakota"
+                    },
+                    {
+                        "code": "NE",
+                        "display": "Nebraska"
+                    },
+                    {
+                        "code": "NH",
+                        "display": "New Hampshire"
+                    },
+                    {
+                        "code": "NJ",
+                        "display": "New Jersey"
+                    },
+                    {
+                        "code": "NM",
+                        "display": "New Mexico"
+                    },
+                    {
+                        "code": "NV",
+                        "display": "Nevada"
+                    },
+                    {
+                        "code": "NY",
+                        "display": "New York"
+                    },
+                    {
+                        "code": "OH",
+                        "display": "Ohio"
+                    },
+                    {
+                        "code": "OK",
+                        "display": "Oklahoma"
+                    },
+                    {
+                        "code": "OR",
+                        "display": "Oregon"
+                    },
+                    {
+                        "code": "PA",
+                        "display": "Pennsylvania"
+                    },
+                    {
+                        "code": "PR",
+                        "display": "Puerto Rico"
+                    },
+                    {
+                        "code": "PW",
+                        "display": "Palau"
+                    },
+                    {
+                        "code": "RI",
+                        "display": "Rhode Island"
+                    },
+                    {
+                        "code": "SC",
+                        "display": "South Carolina"
+                    },
+                    {
+                        "code": "SD",
+                        "display": "South Dakota"
+                    },
+                    {
+                        "code": "TN",
+                        "display": "Tennessee"
+                    },
+                    {
+                        "code": "TX",
+                        "display": "Texas"
+                    },
+                    {
+                        "code": "UT",
+                        "display": "Utah"
+                    },
+                    {
+                        "code": "VA",
+                        "display": "Virginia"
+                    },
+                    {
+                        "code": "VI",
+                        "display": "Virgin Islands of the U.S."
+                    },
+                    {
+                        "code": "VT",
+                        "display": "Vermont"
+                    },
+                    {
+                        "code": "WA",
+                        "display": "Washington"
+                    },
+                    {
+                        "code": "WI",
+                        "display": "Wisconsin"
+                    },
+                    {
+                        "code": "WV",
+                        "display": "West Virginia"
+                    },
+                    {
+                        "code": "WY",
+                        "display": "Wyoming"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-vaccines-cvx.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ValueSet-us-core-vaccines-cvx.json
@@ -1,744 +1,744 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-vaccines-cvx",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include these codes as defined in <a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-CVX.html\"><code>http://hl7.org/fhir/sid/cvx</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td></tr><tr><td>01</td><td>diphtheria, tetanus toxoids and pertussis vaccine</td><td>DTP</td></tr><tr><td>02</td><td>trivalent poliovirus vaccine, live, oral</td><td>OPV</td></tr><tr><td>03</td><td>measles, mumps and rubella virus vaccine</td><td>MMR</td></tr><tr><td>04</td><td>measles and rubella virus vaccine</td><td>M/R</td></tr><tr><td>05</td><td>measles virus vaccine</td><td>measles</td></tr><tr><td>06</td><td>rubella virus vaccine</td><td>rubella</td></tr><tr><td>07</td><td>mumps virus vaccine</td><td>mumps</td></tr><tr><td>08</td><td>hepatitis B vaccine, pediatric or pediatric/adolescent dosage</td><td>Hep B, adolescent or pediatric</td></tr><tr><td>09</td><td>tetanus and diphtheria toxoids, adsorbed, preservative free, for adult use (2 Lf of tetanus toxoid and 2 Lf of diphtheria toxoid)</td><td>Td (adult)</td></tr><tr><td>10</td><td>poliovirus vaccine, inactivated</td><td>IPV</td></tr><tr><td>100</td><td>pneumococcal conjugate vaccine, 7 valent</td><td>pneumococcal conjugate</td></tr><tr><td>101</td><td>typhoid Vi capsular polysaccharide vaccine</td><td>typhoid, ViCPs</td></tr><tr><td>102</td><td>DTP- Haemophilus influenzae type b conjugate and hepatitis b vaccine</td><td>DTP-Hib-Hep B</td></tr><tr><td>103</td><td>meningococcal C conjugate vaccine</td><td>meningococcal C conjugate</td></tr><tr><td>104</td><td>hepatitis A and hepatitis B vaccine</td><td>Hep A-Hep B</td></tr><tr><td>105</td><td>vaccinia (smallpox) vaccine, diluted</td><td>vaccinia (smallpox) diluted</td></tr><tr><td>106</td><td>diphtheria, tetanus toxoids and acellular pertussis vaccine, 5 pertussis antigens</td><td>DTaP, 5 pertussis antigens6</td></tr><tr><td>107</td><td>diphtheria, tetanus toxoids and acellular pertussis vaccine, unspecified formulation</td><td>DTaP, NOS</td></tr><tr><td>108</td><td>meningococcal ACWY vaccine, unspecified formulation</td><td>meningococcal, NOS</td></tr><tr><td>109</td><td>pneumococcal vaccine, unspecified formulation</td><td>pneumococcal, NOS</td></tr><tr><td>11</td><td>pertussis vaccine</td><td>pertussis</td></tr><tr><td>110</td><td>DTaP-hepatitis B and poliovirus vaccine</td><td>DTaP-Hep B-IPV</td></tr><tr><td>111</td><td>influenza virus vaccine, live, attenuated, for intranasal use</td><td>influenza, live, intranasal</td></tr><tr><td>112</td><td>tetanus toxoid, unspecified formulation</td><td>tetanus toxoid, NOS</td></tr><tr><td>113</td><td>tetanus and diphtheria toxoids, adsorbed, preservative free, for adult use (5 Lf of tetanus toxoid and 2 Lf of diphtheria toxoid)</td><td>Td (adult)</td></tr><tr><td>114</td><td>meningococcal polysaccharide (groups A, C, Y and W-135) diphtheria toxoid conjugate vaccine (MCV4P)</td><td>meningococcal A,C,Y,W-135 diphtheria conjugate</td></tr><tr><td>115</td><td>tetanus toxoid, reduced diphtheria toxoid, and acellular pertussis vaccine, adsorbed</td><td>Tdap</td></tr><tr><td>116</td><td>rotavirus, live, pentavalent vaccine</td><td>rotavirus, pentavalent</td></tr><tr><td>117</td><td>varicella zoster immune globulin (Investigational New Drug)</td><td>VZIG (IND)</td></tr><tr><td>118</td><td>human papilloma virus vaccine, bivalent</td><td>HPV, bivalent</td></tr><tr><td>119</td><td>rotavirus, live, monovalent vaccine</td><td>rotavirus, monovalent</td></tr><tr><td>12</td><td>diphtheria antitoxin</td><td>diphtheria antitoxin</td></tr><tr><td>120</td><td>diphtheria, tetanus toxoids and acellular pertussis vaccine, Haemophilus influenzae type b conjugate, and poliovirus vaccine, inactivated (DTaP-Hib-IPV)</td><td>DTaP-Hib-IPV</td></tr><tr><td>121</td><td>zoster vaccine, live</td><td>zoster</td></tr><tr><td>122</td><td>rotavirus vaccine, unspecified formulation</td><td>rotavirus, NOS1</td></tr><tr><td>123</td><td>influenza virus vaccine, H5N1, A/Vietnam/1203/2004 (national stockpile)</td><td/></tr><tr><td>125</td><td>Novel Influenza-H1N1-09, live virus for nasal administration</td><td/></tr><tr><td>126</td><td>Novel influenza-H1N1-09, preservative-free, injectable</td><td/></tr><tr><td>127</td><td>Novel influenza-H1N1-09, injectable</td><td/></tr><tr><td>128</td><td>Novel influenza-H1N1-09, all formulations</td><td/></tr><tr><td>129</td><td>Japanese Encephalitis vaccine, unspecified formulation</td><td/></tr><tr><td>13</td><td>tetanus immune globulin</td><td>TIG</td></tr><tr><td>130</td><td>Diphtheria, tetanus toxoids and acellular pertussis vaccine, and poliovirus vaccine, inactivated</td><td/></tr><tr><td>131</td><td>Historical record of a typhus vaccination</td><td/></tr><tr><td>132</td><td>Historical diphtheria and tetanus toxoids and acellular pertussis, poliovirus, Haemophilus b conjugate and hepatitis B (recombinant) vaccine.</td><td/></tr><tr><td>133</td><td>pneumococcal conjugate vaccine, 13 valent</td><td/></tr><tr><td>134</td><td>Japanese Encephalitis vaccine for intramuscular administration</td><td/></tr><tr><td>135</td><td>influenza, high dose seasonal, preservative-free</td><td/></tr><tr><td>136</td><td>meningococcal oligosaccharide (groups A, C, Y and W-135) diphtheria toxoid conjugate vaccine (MCV4O)</td><td/></tr><tr><td>137</td><td>HPV, unspecified formulation</td><td/></tr><tr><td>138</td><td>tetanus and diphtheria toxoids, not adsorbed, for adult use</td><td/></tr><tr><td>139</td><td>Td(adult) unspecified formulation</td><td/></tr><tr><td>14</td><td>immune globulin, unspecified formulation</td><td>IG, NOS</td></tr><tr><td>140</td><td>Influenza, seasonal, injectable, preservative free</td><td/></tr><tr><td>141</td><td>Influenza, seasonal, injectable</td><td/></tr><tr><td>142</td><td>tetanus toxoid, not adsorbed</td><td/></tr><tr><td>143</td><td>Adenovirus, type 4 and type 7, live, oral</td><td/></tr><tr><td>144</td><td>seasonal influenza, intradermal, preservative free</td><td/></tr><tr><td>147</td><td>Meningococcal, MCV4, unspecified conjugate formulation(groups A, C, Y and W-135)</td><td/></tr><tr><td>148</td><td>Meningococcal Groups C and Y and Haemophilus b Tetanus Toxoid Conjugate Vaccine</td><td/></tr><tr><td>149</td><td>influenza, live, intranasal, quadrivalent</td><td/></tr><tr><td>15</td><td>influenza virus vaccine, split virus (incl. purified surface antigen)-retired CODE</td><td>influenza, split (incl. purified surface antigen)</td></tr><tr><td>150</td><td>Influenza, injectable, quadrivalent, preservative free</td><td/></tr><tr><td>151</td><td>influenza nasal, unspecified formulation</td><td/></tr><tr><td>152</td><td>Pneumococcal Conjugate, unspecified formulation</td><td/></tr><tr><td>153</td><td>Influenza, injectable, Madin Darby Canine Kidney, preservative free</td><td/></tr><tr><td>155</td><td>Seasonal, trivalent, recombinant, injectable influenza vaccine, preservative free</td><td/></tr><tr><td>156</td><td>Rho(D) Immune globulin- IV or IM</td><td/></tr><tr><td>157</td><td>Rho(D) Immune globulin - IM</td><td/></tr><tr><td>158</td><td>influenza, injectable, quadrivalent, contains preservative</td><td/></tr><tr><td>159</td><td>Rho(D) Unspecified formulation</td><td/></tr><tr><td>16</td><td>influenza virus vaccine, whole virus</td><td>influenza, whole</td></tr><tr><td>160</td><td>Influenza A monovalent (H5N1), adjuvanted, National stockpile 2013</td><td/></tr><tr><td>161</td><td>Influenza, injectable,quadrivalent, preservative free, pediatric</td><td/></tr><tr><td>162</td><td>meningococcal B vaccine, fully recombinant</td><td/></tr><tr><td>163</td><td>meningococcal B vaccine, recombinant, OMV, adjuvanted</td><td/></tr><tr><td>164</td><td>meningococcal B, unspecified formulation</td><td/></tr><tr><td>165</td><td>Human Papillomavirus 9-valent vaccine</td><td/></tr><tr><td>166</td><td>influenza, intradermal, quadrivalent, preservative free, injectable</td><td/></tr><tr><td>167</td><td>meningococcal vaccine of unknown formulation and unknown serogroups</td><td/></tr><tr><td>168</td><td>Seasonal trivalent influenza vaccine, adjuvanted, preservative free</td><td/></tr><tr><td>169</td><td>Hep A, live attenuated-IM</td><td/></tr><tr><td>17</td><td>Haemophilus influenzae type b vaccine, conjugate unspecified formulation</td><td>Hib, NOS</td></tr><tr><td>170</td><td>non-US diphtheria, tetanus toxoids and acellular pertussis vaccine, Haemophilus influenzae type b conjugate, and poliovirus vaccine, inactivated (DTaP-Hib-IPV)</td><td/></tr><tr><td>171</td><td>Influenza, injectable, Madin Darby Canine Kidney, preservative free, quadrivalent</td><td/></tr><tr><td>172</td><td>cholera, WC-rBS</td><td/></tr><tr><td>173</td><td>cholera, BivWC</td><td/></tr><tr><td>174</td><td>cholera, live attenuated</td><td/></tr><tr><td>175</td><td>Human Rabies vaccine from human diploid cell culture</td><td/></tr><tr><td>176</td><td>Human rabies vaccine from Chicken fibroblast culture</td><td/></tr><tr><td>177</td><td>pneumococcal conjugate vaccine, 10 valent</td><td/></tr><tr><td>178</td><td>Non-US bivalent oral polio vaccine (types 1 and 3)</td><td/></tr><tr><td>179</td><td>Non-US monovalent oral polio vaccine, unspecified formulation</td><td/></tr><tr><td>18</td><td>rabies vaccine, for intramuscular injection RETIRED CODE</td><td>rabies, intramuscular injection</td></tr><tr><td>180</td><td>tetanus immune globulin</td><td/></tr><tr><td>181</td><td>anthrax immune globulin</td><td/></tr><tr><td>182</td><td>Oral Polio Vaccine, Unspecified formulation</td><td/></tr><tr><td>183</td><td>Yellow fever vaccine alternative formulation</td><td/></tr><tr><td>184</td><td>Yellow fever vaccine, unspecified formulation</td><td/></tr><tr><td>185</td><td>Seasonal, quadrivalent, recombinant, injectable influenza vaccine, preservative free</td><td/></tr><tr><td>186</td><td>Influenza, injectable, Madin Darby Canine Kidney,  quadrivalent with preservative</td><td/></tr><tr><td>187</td><td>zoster vaccine recombinant</td><td/></tr><tr><td>188</td><td>zoster vaccine, unspecified formulation</td><td/></tr><tr><td>189</td><td>Hepatitis B vaccine (recombinant), CpG adjuvanted</td><td/></tr><tr><td>19</td><td>Bacillus Calmette-Guerin vaccine</td><td>BCG</td></tr><tr><td>20</td><td>diphtheria, tetanus toxoids and acellular pertussis vaccine</td><td>DTaP</td></tr><tr><td>21</td><td>varicella virus vaccine</td><td>varicella</td></tr><tr><td>22</td><td>DTP-Haemophilus influenzae type b conjugate vaccine</td><td>DTP-Hib</td></tr><tr><td>23</td><td>plague vaccine</td><td>plague</td></tr><tr><td>24</td><td>anthrax vaccine</td><td>anthrax</td></tr><tr><td>25</td><td>typhoid vaccine, live, oral</td><td>typhoid, oral</td></tr><tr><td>26</td><td>cholera vaccine, unspecified formulation</td><td>cholera</td></tr><tr><td>27</td><td>botulinum antitoxin</td><td>botulinum antitoxin</td></tr><tr><td>28</td><td>diphtheria and tetanus toxoids, adsorbed for pediatric use</td><td>DT (pediatric)</td></tr><tr><td>29</td><td>cytomegalovirus immune globulin, intravenous</td><td>CMVIG</td></tr><tr><td>30</td><td>hepatitis B immune globulin</td><td>HBIG</td></tr><tr><td>31</td><td>hepatitis A vaccine, pediatric dosage, unspecified formulation</td><td>Hep A, pediatric, NOS</td></tr><tr><td>32</td><td>meningococcal polysaccharide vaccine (MPSV4)</td><td>meningococcal</td></tr><tr><td>33</td><td>pneumococcal polysaccharide vaccine, 23 valent</td><td>pneumococcal</td></tr><tr><td>34</td><td>rabies immune globulin</td><td>RIG</td></tr><tr><td>35</td><td>tetanus toxoid, adsorbed</td><td>tetanus toxoid</td></tr><tr><td>36</td><td>varicella zoster immune globulin</td><td>VZIG</td></tr><tr><td>37</td><td>yellow fever vaccine</td><td>yellow fever</td></tr><tr><td>38</td><td>rubella and mumps virus vaccine</td><td>rubella/mumps</td></tr><tr><td>39</td><td>Japanese Encephalitis Vaccine SC</td><td>Japanese encephalitis</td></tr><tr><td>40</td><td>rabies vaccine, for intradermal injection</td><td>rabies, intradermal injection</td></tr><tr><td>41</td><td>typhoid vaccine, parenteral, other than acetone-killed, dried</td><td>typhoid, parenteral</td></tr><tr><td>42</td><td>hepatitis B vaccine, adolescent/high risk infant dosage</td><td>Hep B, adolescent/high risk infant2</td></tr><tr><td>43</td><td>hepatitis B vaccine, adult dosage</td><td>Hep B, adult4</td></tr><tr><td>44</td><td>hepatitis B vaccine, dialysis patient dosage</td><td>Hep B, dialysis</td></tr><tr><td>45</td><td>hepatitis B vaccine, unspecified formulation</td><td>Hep B, NOS</td></tr><tr><td>46</td><td>Haemophilus influenzae type b vaccine, PRP-D conjugate</td><td>Hib (PRP-D)</td></tr><tr><td>47</td><td>Haemophilus influenzae type b vaccine, HbOC conjugate</td><td>Hib (HbOC)</td></tr><tr><td>48</td><td>Haemophilus influenzae type b vaccine, PRP-T conjugate</td><td>Hib (PRP-T)</td></tr><tr><td>49</td><td>Haemophilus influenzae type b vaccine, PRP-OMP conjugate</td><td>Hib (PRP-OMP)</td></tr><tr><td>50</td><td>DTaP-Haemophilus influenzae type b conjugate vaccine</td><td>DTaP-Hib</td></tr><tr><td>51</td><td>Haemophilus influenzae type b conjugate and Hepatitis B vaccine</td><td>Hib-Hep B</td></tr><tr><td>52</td><td>hepatitis A vaccine, adult dosage</td><td>Hep A, adult</td></tr><tr><td>53</td><td>typhoid vaccine, parenteral, acetone-killed, dried (U.S. military)</td><td>typhoid, parenteral, AKD (U.S. military)</td></tr><tr><td>54</td><td>adenovirus vaccine, type 4, live, oral</td><td>adenovirus, type 4</td></tr><tr><td>55</td><td>adenovirus vaccine, type 7, live, oral</td><td>adenovirus, type 7</td></tr><tr><td>62</td><td>human papilloma virus vaccine, quadrivalent</td><td>HPV, quadrivalent</td></tr><tr><td>66</td><td>Lyme disease vaccine</td><td>Lyme disease</td></tr><tr><td>69</td><td>parainfluenza-3 virus vaccine</td><td>parainfluenza-3</td></tr><tr><td>71</td><td>respiratory syncytial virus immune globulin, intravenous</td><td>RSV-IGIV</td></tr><tr><td>74</td><td>rotavirus, live, tetravalent vaccine</td><td>rotavirus, tetravalent</td></tr><tr><td>75</td><td>vaccinia (smallpox) vaccine</td><td>vaccinia (smallpox)</td></tr><tr><td>76</td><td>Staphylococcus bacteriophage lysate</td><td>Staphylococcus bacterio lysate</td></tr><tr><td>77</td><td>tick-borne encephalitis vaccine</td><td>tick-borne encephalitis</td></tr><tr><td>78</td><td>tularemia vaccine</td><td>tularemia vaccine</td></tr><tr><td>79</td><td>vaccinia immune globulin</td><td>vaccinia immune globulin</td></tr><tr><td>80</td><td>Venezuelan equine encephalitis, live, attenuated</td><td>VEE, live</td></tr><tr><td>801</td><td>AS03 Adjuvant</td><td/></tr><tr><td>81</td><td>Venezuelan equine encephalitis, inactivated</td><td>VEE, inactivated</td></tr><tr><td>82</td><td>adenovirus vaccine, unspecified formulation</td><td>adenovirus, NOS1</td></tr><tr><td>83</td><td>hepatitis A vaccine, pediatric/adolescent dosage, 2 dose schedule</td><td>Hep A, ped/adol, 2 dose</td></tr><tr><td>84</td><td>hepatitis A vaccine, pediatric/adolescent dosage, 3 dose schedule</td><td>Hep A, ped/adol, 3 dose</td></tr><tr><td>85</td><td>hepatitis A vaccine, unspecified formulation</td><td>Hep A, NOS</td></tr><tr><td>86</td><td>immune globulin, intramuscular</td><td>IG</td></tr><tr><td>87</td><td>immune globulin, intravenous</td><td>IGIV</td></tr><tr><td>88</td><td>influenza virus vaccine, unspecified formulation</td><td>influenza, NOS</td></tr><tr><td>89</td><td>poliovirus vaccine, unspecified formulation</td><td>polio, NOS</td></tr><tr><td>90</td><td>rabies vaccine, unspecified formulation</td><td>rabies, NOS</td></tr><tr><td>91</td><td>typhoid vaccine, unspecified formulation</td><td>typhoid, NOS</td></tr><tr><td>92</td><td>Venezuelan equine encephalitis vaccine, unspecified formulation</td><td>VEE, NOS</td></tr><tr><td>93</td><td>respiratory syncytial virus monoclonal antibody (palivizumab), intramuscular</td><td>RSV-MAb</td></tr><tr><td>94</td><td>measles, mumps, rubella, and varicella virus vaccine</td><td>MMRV</td></tr><tr><td>95</td><td>tuberculin skin test; old tuberculin, multipuncture device</td><td>TST-OT tine test</td></tr><tr><td>96</td><td>tuberculin skin test; purified protein derivative solution, intradermal</td><td>TST-PPD intradermal</td></tr><tr><td>97</td><td>tuberculin skin test; purified protein derivative, multipuncture device</td><td>TST-PPD tine test</td></tr><tr><td>98</td><td>tuberculin skin test; unspecified formulation</td><td>TST, NOS</td></tr><tr><td>998</td><td>no vaccine administered</td><td>no vaccine administered5</td></tr></table></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-vaccines-cvx",
-	"identifier": [
-		{
-			"system": "urn:ietf:rfc:3986",
-			"value": "urn:oid:2.16.840.1.113762.1.4.1010.6"
-		},
-		{
-			"system": "urn:ietf:rfc:3986",
-			"value": "urn:oid:2.16.840.1.113883.3.88.12.80.22"
-		}
-	],
-	"version": "3.1.1",
-	"name": "USCoreVaccineAdministeredValueSetCvx",
-	"title": "US Core Vaccine Administered Value Set (CVX)",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "other",
-					"value": "http://hl7.org/fhir"
-				}
-			]
-		}
-	],
-	"description": "This identifies the vaccine substance administered - CVX codes. **Inclusion Criteria:**  Any CVX code with CVX  'status' (VSAC Property) = `Active`,` Inactive`, `Non-US` except  those noted in exclusions.  **Exclusion Criteria:**  CVX codes that have a CVX  'status' of either `Pending` or `Never Active` AND CVX  codes with CVX 'Nonvaccine' property = True.  Available at http://www2a.cdc.gov/vaccines/iis/iisstandards/vaccines.asp?rpt=cvx",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"compose": {
-		"include": [
-			{
-				"system": "http://hl7.org/fhir/sid/cvx",
-				"concept": [
-					{
-						"code": "01",
-						"display": "diphtheria, tetanus toxoids and pertussis vaccine"
-					},
-					{
-						"code": "02",
-						"display": "trivalent poliovirus vaccine, live, oral"
-					},
-					{
-						"code": "03",
-						"display": "measles, mumps and rubella virus vaccine"
-					},
-					{
-						"code": "04",
-						"display": "measles and rubella virus vaccine"
-					},
-					{
-						"code": "05",
-						"display": "measles virus vaccine"
-					},
-					{
-						"code": "06",
-						"display": "rubella virus vaccine"
-					},
-					{
-						"code": "07",
-						"display": "mumps virus vaccine"
-					},
-					{
-						"code": "08",
-						"display": "hepatitis B vaccine, pediatric or pediatric/adolescent dosage"
-					},
-					{
-						"code": "09",
-						"display": "tetanus and diphtheria toxoids, adsorbed, preservative free, for adult use (2 Lf of tetanus toxoid and 2 Lf of diphtheria toxoid)"
-					},
-					{
-						"code": "10",
-						"display": "poliovirus vaccine, inactivated"
-					},
-					{
-						"code": "100",
-						"display": "pneumococcal conjugate vaccine, 7 valent"
-					},
-					{
-						"code": "101",
-						"display": "typhoid Vi capsular polysaccharide vaccine"
-					},
-					{
-						"code": "102",
-						"display": "DTP- Haemophilus influenzae type b conjugate and hepatitis b vaccine"
-					},
-					{
-						"code": "103",
-						"display": "meningococcal C conjugate vaccine"
-					},
-					{
-						"code": "104",
-						"display": "hepatitis A and hepatitis B vaccine"
-					},
-					{
-						"code": "105",
-						"display": "vaccinia (smallpox) vaccine, diluted"
-					},
-					{
-						"code": "106",
-						"display": "diphtheria, tetanus toxoids and acellular pertussis vaccine, 5 pertussis antigens"
-					},
-					{
-						"code": "107",
-						"display": "diphtheria, tetanus toxoids and acellular pertussis vaccine, unspecified formulation"
-					},
-					{
-						"code": "108",
-						"display": "meningococcal ACWY vaccine, unspecified formulation"
-					},
-					{
-						"code": "109",
-						"display": "pneumococcal vaccine, unspecified formulation"
-					},
-					{
-						"code": "11",
-						"display": "pertussis vaccine"
-					},
-					{
-						"code": "110",
-						"display": "DTaP-hepatitis B and poliovirus vaccine"
-					},
-					{
-						"code": "111",
-						"display": "influenza virus vaccine, live, attenuated, for intranasal use"
-					},
-					{
-						"code": "112",
-						"display": "tetanus toxoid, unspecified formulation"
-					},
-					{
-						"code": "113",
-						"display": "tetanus and diphtheria toxoids, adsorbed, preservative free, for adult use (5 Lf of tetanus toxoid and 2 Lf of diphtheria toxoid)"
-					},
-					{
-						"code": "114",
-						"display": "meningococcal polysaccharide (groups A, C, Y and W-135) diphtheria toxoid conjugate vaccine (MCV4P)"
-					},
-					{
-						"code": "115",
-						"display": "tetanus toxoid, reduced diphtheria toxoid, and acellular pertussis vaccine, adsorbed"
-					},
-					{
-						"code": "116",
-						"display": "rotavirus, live, pentavalent vaccine"
-					},
-					{
-						"code": "117",
-						"display": "varicella zoster immune globulin (Investigational New Drug)"
-					},
-					{
-						"code": "118",
-						"display": "human papilloma virus vaccine, bivalent"
-					},
-					{
-						"code": "119",
-						"display": "rotavirus, live, monovalent vaccine"
-					},
-					{
-						"code": "12",
-						"display": "diphtheria antitoxin"
-					},
-					{
-						"code": "120",
-						"display": "diphtheria, tetanus toxoids and acellular pertussis vaccine, Haemophilus influenzae type b conjugate, and poliovirus vaccine, inactivated (DTaP-Hib-IPV)"
-					},
-					{
-						"code": "121",
-						"display": "zoster vaccine, live"
-					},
-					{
-						"code": "122",
-						"display": "rotavirus vaccine, unspecified formulation"
-					},
-					{
-						"code": "123",
-						"display": "influenza virus vaccine, H5N1, A/Vietnam/1203/2004 (national stockpile)"
-					},
-					{
-						"code": "125",
-						"display": "Novel Influenza-H1N1-09, live virus for nasal administration"
-					},
-					{
-						"code": "126",
-						"display": "Novel influenza-H1N1-09, preservative-free, injectable"
-					},
-					{
-						"code": "127",
-						"display": "Novel influenza-H1N1-09, injectable"
-					},
-					{
-						"code": "128",
-						"display": "Novel influenza-H1N1-09, all formulations"
-					},
-					{
-						"code": "129",
-						"display": "Japanese Encephalitis vaccine, unspecified formulation"
-					},
-					{
-						"code": "13",
-						"display": "tetanus immune globulin"
-					},
-					{
-						"code": "130",
-						"display": "Diphtheria, tetanus toxoids and acellular pertussis vaccine, and poliovirus vaccine, inactivated"
-					},
-					{
-						"code": "131",
-						"display": "Historical record of a typhus vaccination"
-					},
-					{
-						"code": "132",
-						"display": "Historical diphtheria and tetanus toxoids and acellular pertussis, poliovirus, Haemophilus b conjugate and hepatitis B (recombinant) vaccine."
-					},
-					{
-						"code": "133",
-						"display": "pneumococcal conjugate vaccine, 13 valent"
-					},
-					{
-						"code": "134",
-						"display": "Japanese Encephalitis vaccine for intramuscular administration"
-					},
-					{
-						"code": "135",
-						"display": "influenza, high dose seasonal, preservative-free"
-					},
-					{
-						"code": "136",
-						"display": "meningococcal oligosaccharide (groups A, C, Y and W-135) diphtheria toxoid conjugate vaccine (MCV4O)"
-					},
-					{
-						"code": "137",
-						"display": "HPV, unspecified formulation"
-					},
-					{
-						"code": "138",
-						"display": "tetanus and diphtheria toxoids, not adsorbed, for adult use"
-					},
-					{
-						"code": "139",
-						"display": "Td(adult) unspecified formulation"
-					},
-					{
-						"code": "14",
-						"display": "immune globulin, unspecified formulation"
-					},
-					{
-						"code": "140",
-						"display": "Influenza, seasonal, injectable, preservative free"
-					},
-					{
-						"code": "141",
-						"display": "Influenza, seasonal, injectable"
-					},
-					{
-						"code": "142",
-						"display": "tetanus toxoid, not adsorbed"
-					},
-					{
-						"code": "143",
-						"display": "Adenovirus, type 4 and type 7, live, oral"
-					},
-					{
-						"code": "144",
-						"display": "seasonal influenza, intradermal, preservative free"
-					},
-					{
-						"code": "147",
-						"display": "Meningococcal, MCV4, unspecified conjugate formulation(groups A, C, Y and W-135)"
-					},
-					{
-						"code": "148",
-						"display": "Meningococcal Groups C and Y and Haemophilus b Tetanus Toxoid Conjugate Vaccine"
-					},
-					{
-						"code": "149",
-						"display": "influenza, live, intranasal, quadrivalent"
-					},
-					{
-						"code": "15",
-						"display": "influenza virus vaccine, split virus (incl. purified surface antigen)-retired CODE"
-					},
-					{
-						"code": "150",
-						"display": "Influenza, injectable, quadrivalent, preservative free"
-					},
-					{
-						"code": "151",
-						"display": "influenza nasal, unspecified formulation"
-					},
-					{
-						"code": "152",
-						"display": "Pneumococcal Conjugate, unspecified formulation"
-					},
-					{
-						"code": "153",
-						"display": "Influenza, injectable, Madin Darby Canine Kidney, preservative free"
-					},
-					{
-						"code": "155",
-						"display": "Seasonal, trivalent, recombinant, injectable influenza vaccine, preservative free"
-					},
-					{
-						"code": "156",
-						"display": "Rho(D) Immune globulin- IV or IM"
-					},
-					{
-						"code": "157",
-						"display": "Rho(D) Immune globulin - IM"
-					},
-					{
-						"code": "158",
-						"display": "influenza, injectable, quadrivalent, contains preservative"
-					},
-					{
-						"code": "159",
-						"display": "Rho(D) Unspecified formulation"
-					},
-					{
-						"code": "16",
-						"display": "influenza virus vaccine, whole virus"
-					},
-					{
-						"code": "160",
-						"display": "Influenza A monovalent (H5N1), adjuvanted, National stockpile 2013"
-					},
-					{
-						"code": "161",
-						"display": "Influenza, injectable,quadrivalent, preservative free, pediatric"
-					},
-					{
-						"code": "162",
-						"display": "meningococcal B vaccine, fully recombinant"
-					},
-					{
-						"code": "163",
-						"display": "meningococcal B vaccine, recombinant, OMV, adjuvanted"
-					},
-					{
-						"code": "164",
-						"display": "meningococcal B, unspecified formulation"
-					},
-					{
-						"code": "165",
-						"display": "Human Papillomavirus 9-valent vaccine"
-					},
-					{
-						"code": "166",
-						"display": "influenza, intradermal, quadrivalent, preservative free, injectable"
-					},
-					{
-						"code": "167",
-						"display": "meningococcal vaccine of unknown formulation and unknown serogroups"
-					},
-					{
-						"code": "168",
-						"display": "Seasonal trivalent influenza vaccine, adjuvanted, preservative free"
-					},
-					{
-						"code": "169",
-						"display": "Hep A, live attenuated-IM"
-					},
-					{
-						"code": "17",
-						"display": "Haemophilus influenzae type b vaccine, conjugate unspecified formulation"
-					},
-					{
-						"code": "170",
-						"display": "non-US diphtheria, tetanus toxoids and acellular pertussis vaccine, Haemophilus influenzae type b conjugate, and poliovirus vaccine, inactivated (DTaP-Hib-IPV)"
-					},
-					{
-						"code": "171",
-						"display": "Influenza, injectable, Madin Darby Canine Kidney, preservative free, quadrivalent"
-					},
-					{
-						"code": "172",
-						"display": "cholera, WC-rBS"
-					},
-					{
-						"code": "173",
-						"display": "cholera, BivWC"
-					},
-					{
-						"code": "174",
-						"display": "cholera, live attenuated"
-					},
-					{
-						"code": "175",
-						"display": "Human Rabies vaccine from human diploid cell culture"
-					},
-					{
-						"code": "176",
-						"display": "Human rabies vaccine from Chicken fibroblast culture"
-					},
-					{
-						"code": "177",
-						"display": "pneumococcal conjugate vaccine, 10 valent"
-					},
-					{
-						"code": "178",
-						"display": "Non-US bivalent oral polio vaccine (types 1 and 3)"
-					},
-					{
-						"code": "179",
-						"display": "Non-US monovalent oral polio vaccine, unspecified formulation"
-					},
-					{
-						"code": "18",
-						"display": "rabies vaccine, for intramuscular injection RETIRED CODE"
-					},
-					{
-						"code": "180",
-						"display": "tetanus immune globulin"
-					},
-					{
-						"code": "181",
-						"display": "anthrax immune globulin"
-					},
-					{
-						"code": "182",
-						"display": "Oral Polio Vaccine, Unspecified formulation"
-					},
-					{
-						"code": "183",
-						"display": "Yellow fever vaccine alternative formulation"
-					},
-					{
-						"code": "184",
-						"display": "Yellow fever vaccine, unspecified formulation"
-					},
-					{
-						"code": "185",
-						"display": "Seasonal, quadrivalent, recombinant, injectable influenza vaccine, preservative free"
-					},
-					{
-						"code": "186",
-						"display": "Influenza, injectable, Madin Darby Canine Kidney,  quadrivalent with preservative"
-					},
-					{
-						"code": "187",
-						"display": "zoster vaccine recombinant"
-					},
-					{
-						"code": "188",
-						"display": "zoster vaccine, unspecified formulation"
-					},
-					{
-						"code": "189",
-						"display": "Hepatitis B vaccine (recombinant), CpG adjuvanted"
-					},
-					{
-						"code": "19",
-						"display": "Bacillus Calmette-Guerin vaccine"
-					},
-					{
-						"code": "20",
-						"display": "diphtheria, tetanus toxoids and acellular pertussis vaccine"
-					},
-					{
-						"code": "21",
-						"display": "varicella virus vaccine"
-					},
-					{
-						"code": "22",
-						"display": "DTP-Haemophilus influenzae type b conjugate vaccine"
-					},
-					{
-						"code": "23",
-						"display": "plague vaccine"
-					},
-					{
-						"code": "24",
-						"display": "anthrax vaccine"
-					},
-					{
-						"code": "25",
-						"display": "typhoid vaccine, live, oral"
-					},
-					{
-						"code": "26",
-						"display": "cholera vaccine, unspecified formulation"
-					},
-					{
-						"code": "27",
-						"display": "botulinum antitoxin"
-					},
-					{
-						"code": "28",
-						"display": "diphtheria and tetanus toxoids, adsorbed for pediatric use"
-					},
-					{
-						"code": "29",
-						"display": "cytomegalovirus immune globulin, intravenous"
-					},
-					{
-						"code": "30",
-						"display": "hepatitis B immune globulin"
-					},
-					{
-						"code": "31",
-						"display": "hepatitis A vaccine, pediatric dosage, unspecified formulation"
-					},
-					{
-						"code": "32",
-						"display": "meningococcal polysaccharide vaccine (MPSV4)"
-					},
-					{
-						"code": "33",
-						"display": "pneumococcal polysaccharide vaccine, 23 valent"
-					},
-					{
-						"code": "34",
-						"display": "rabies immune globulin"
-					},
-					{
-						"code": "35",
-						"display": "tetanus toxoid, adsorbed"
-					},
-					{
-						"code": "36",
-						"display": "varicella zoster immune globulin"
-					},
-					{
-						"code": "37",
-						"display": "yellow fever vaccine"
-					},
-					{
-						"code": "38",
-						"display": "rubella and mumps virus vaccine"
-					},
-					{
-						"code": "39",
-						"display": "Japanese Encephalitis Vaccine SC"
-					},
-					{
-						"code": "40",
-						"display": "rabies vaccine, for intradermal injection"
-					},
-					{
-						"code": "41",
-						"display": "typhoid vaccine, parenteral, other than acetone-killed, dried"
-					},
-					{
-						"code": "42",
-						"display": "hepatitis B vaccine, adolescent/high risk infant dosage"
-					},
-					{
-						"code": "43",
-						"display": "hepatitis B vaccine, adult dosage"
-					},
-					{
-						"code": "44",
-						"display": "hepatitis B vaccine, dialysis patient dosage"
-					},
-					{
-						"code": "45",
-						"display": "hepatitis B vaccine, unspecified formulation"
-					},
-					{
-						"code": "46",
-						"display": "Haemophilus influenzae type b vaccine, PRP-D conjugate"
-					},
-					{
-						"code": "47",
-						"display": "Haemophilus influenzae type b vaccine, HbOC conjugate"
-					},
-					{
-						"code": "48",
-						"display": "Haemophilus influenzae type b vaccine, PRP-T conjugate"
-					},
-					{
-						"code": "49",
-						"display": "Haemophilus influenzae type b vaccine, PRP-OMP conjugate"
-					},
-					{
-						"code": "50",
-						"display": "DTaP-Haemophilus influenzae type b conjugate vaccine"
-					},
-					{
-						"code": "51",
-						"display": "Haemophilus influenzae type b conjugate and Hepatitis B vaccine"
-					},
-					{
-						"code": "52",
-						"display": "hepatitis A vaccine, adult dosage"
-					},
-					{
-						"code": "53",
-						"display": "typhoid vaccine, parenteral, acetone-killed, dried (U.S. military)"
-					},
-					{
-						"code": "54",
-						"display": "adenovirus vaccine, type 4, live, oral"
-					},
-					{
-						"code": "55",
-						"display": "adenovirus vaccine, type 7, live, oral"
-					},
-					{
-						"code": "62",
-						"display": "human papilloma virus vaccine, quadrivalent"
-					},
-					{
-						"code": "66",
-						"display": "Lyme disease vaccine"
-					},
-					{
-						"code": "69",
-						"display": "parainfluenza-3 virus vaccine"
-					},
-					{
-						"code": "71",
-						"display": "respiratory syncytial virus immune globulin, intravenous"
-					},
-					{
-						"code": "74",
-						"display": "rotavirus, live, tetravalent vaccine"
-					},
-					{
-						"code": "75",
-						"display": "vaccinia (smallpox) vaccine"
-					},
-					{
-						"code": "76",
-						"display": "Staphylococcus bacteriophage lysate"
-					},
-					{
-						"code": "77",
-						"display": "tick-borne encephalitis vaccine"
-					},
-					{
-						"code": "78",
-						"display": "tularemia vaccine"
-					},
-					{
-						"code": "79",
-						"display": "vaccinia immune globulin"
-					},
-					{
-						"code": "80",
-						"display": "Venezuelan equine encephalitis, live, attenuated"
-					},
-					{
-						"code": "801",
-						"display": "AS03 Adjuvant"
-					},
-					{
-						"code": "81",
-						"display": "Venezuelan equine encephalitis, inactivated"
-					},
-					{
-						"code": "82",
-						"display": "adenovirus vaccine, unspecified formulation"
-					},
-					{
-						"code": "83",
-						"display": "hepatitis A vaccine, pediatric/adolescent dosage, 2 dose schedule"
-					},
-					{
-						"code": "84",
-						"display": "hepatitis A vaccine, pediatric/adolescent dosage, 3 dose schedule"
-					},
-					{
-						"code": "85",
-						"display": "hepatitis A vaccine, unspecified formulation"
-					},
-					{
-						"code": "86",
-						"display": "immune globulin, intramuscular"
-					},
-					{
-						"code": "87",
-						"display": "immune globulin, intravenous"
-					},
-					{
-						"code": "88",
-						"display": "influenza virus vaccine, unspecified formulation"
-					},
-					{
-						"code": "89",
-						"display": "poliovirus vaccine, unspecified formulation"
-					},
-					{
-						"code": "90",
-						"display": "rabies vaccine, unspecified formulation"
-					},
-					{
-						"code": "91",
-						"display": "typhoid vaccine, unspecified formulation"
-					},
-					{
-						"code": "92",
-						"display": "Venezuelan equine encephalitis vaccine, unspecified formulation"
-					},
-					{
-						"code": "93",
-						"display": "respiratory syncytial virus monoclonal antibody (palivizumab), intramuscular"
-					},
-					{
-						"code": "94",
-						"display": "measles, mumps, rubella, and varicella virus vaccine"
-					},
-					{
-						"code": "95",
-						"display": "tuberculin skin test; old tuberculin, multipuncture device"
-					},
-					{
-						"code": "96",
-						"display": "tuberculin skin test; purified protein derivative solution, intradermal"
-					},
-					{
-						"code": "97",
-						"display": "tuberculin skin test; purified protein derivative, multipuncture device"
-					},
-					{
-						"code": "98",
-						"display": "tuberculin skin test; unspecified formulation"
-					},
-					{
-						"code": "998",
-						"display": "no vaccine administered"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-vaccines-cvx",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-vaccines-cvx",
+    "identifier": [
+        {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:oid:2.16.840.1.113762.1.4.1010.6"
+        },
+        {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:oid:2.16.840.1.113883.3.88.12.80.22"
+        }
+    ],
+    "version": "3.1.1",
+    "name": "USCoreVaccineAdministeredValueSetCvx",
+    "title": "US Core Vaccine Administered Value Set (CVX)",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "other",
+                    "value": "http://hl7.org/fhir"
+                }
+            ]
+        }
+    ],
+    "description": "This identifies the vaccine substance administered - CVX codes. **Inclusion Criteria:**  Any CVX code with CVX  'status' (VSAC Property) = `Active`,` Inactive`, `Non-US` except  those noted in exclusions.  **Exclusion Criteria:**  CVX codes that have a CVX  'status' of either `Pending` or `Never Active` AND CVX  codes with CVX 'Nonvaccine' property = True.  Available at http://www2a.cdc.gov/vaccines/iis/iisstandards/vaccines.asp?rpt=cvx",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "compose": {
+        "include": [
+            {
+                "system": "http://hl7.org/fhir/sid/cvx",
+                "concept": [
+                    {
+                        "code": "01",
+                        "display": "diphtheria, tetanus toxoids and pertussis vaccine"
+                    },
+                    {
+                        "code": "02",
+                        "display": "trivalent poliovirus vaccine, live, oral"
+                    },
+                    {
+                        "code": "03",
+                        "display": "measles, mumps and rubella virus vaccine"
+                    },
+                    {
+                        "code": "04",
+                        "display": "measles and rubella virus vaccine"
+                    },
+                    {
+                        "code": "05",
+                        "display": "measles virus vaccine"
+                    },
+                    {
+                        "code": "06",
+                        "display": "rubella virus vaccine"
+                    },
+                    {
+                        "code": "07",
+                        "display": "mumps virus vaccine"
+                    },
+                    {
+                        "code": "08",
+                        "display": "hepatitis B vaccine, pediatric or pediatric/adolescent dosage"
+                    },
+                    {
+                        "code": "09",
+                        "display": "tetanus and diphtheria toxoids, adsorbed, preservative free, for adult use (2 Lf of tetanus toxoid and 2 Lf of diphtheria toxoid)"
+                    },
+                    {
+                        "code": "10",
+                        "display": "poliovirus vaccine, inactivated"
+                    },
+                    {
+                        "code": "100",
+                        "display": "pneumococcal conjugate vaccine, 7 valent"
+                    },
+                    {
+                        "code": "101",
+                        "display": "typhoid Vi capsular polysaccharide vaccine"
+                    },
+                    {
+                        "code": "102",
+                        "display": "DTP- Haemophilus influenzae type b conjugate and hepatitis b vaccine"
+                    },
+                    {
+                        "code": "103",
+                        "display": "meningococcal C conjugate vaccine"
+                    },
+                    {
+                        "code": "104",
+                        "display": "hepatitis A and hepatitis B vaccine"
+                    },
+                    {
+                        "code": "105",
+                        "display": "vaccinia (smallpox) vaccine, diluted"
+                    },
+                    {
+                        "code": "106",
+                        "display": "diphtheria, tetanus toxoids and acellular pertussis vaccine, 5 pertussis antigens"
+                    },
+                    {
+                        "code": "107",
+                        "display": "diphtheria, tetanus toxoids and acellular pertussis vaccine, unspecified formulation"
+                    },
+                    {
+                        "code": "108",
+                        "display": "meningococcal ACWY vaccine, unspecified formulation"
+                    },
+                    {
+                        "code": "109",
+                        "display": "pneumococcal vaccine, unspecified formulation"
+                    },
+                    {
+                        "code": "11",
+                        "display": "pertussis vaccine"
+                    },
+                    {
+                        "code": "110",
+                        "display": "DTaP-hepatitis B and poliovirus vaccine"
+                    },
+                    {
+                        "code": "111",
+                        "display": "influenza virus vaccine, live, attenuated, for intranasal use"
+                    },
+                    {
+                        "code": "112",
+                        "display": "tetanus toxoid, unspecified formulation"
+                    },
+                    {
+                        "code": "113",
+                        "display": "tetanus and diphtheria toxoids, adsorbed, preservative free, for adult use (5 Lf of tetanus toxoid and 2 Lf of diphtheria toxoid)"
+                    },
+                    {
+                        "code": "114",
+                        "display": "meningococcal polysaccharide (groups A, C, Y and W-135) diphtheria toxoid conjugate vaccine (MCV4P)"
+                    },
+                    {
+                        "code": "115",
+                        "display": "tetanus toxoid, reduced diphtheria toxoid, and acellular pertussis vaccine, adsorbed"
+                    },
+                    {
+                        "code": "116",
+                        "display": "rotavirus, live, pentavalent vaccine"
+                    },
+                    {
+                        "code": "117",
+                        "display": "varicella zoster immune globulin (Investigational New Drug)"
+                    },
+                    {
+                        "code": "118",
+                        "display": "human papilloma virus vaccine, bivalent"
+                    },
+                    {
+                        "code": "119",
+                        "display": "rotavirus, live, monovalent vaccine"
+                    },
+                    {
+                        "code": "12",
+                        "display": "diphtheria antitoxin"
+                    },
+                    {
+                        "code": "120",
+                        "display": "diphtheria, tetanus toxoids and acellular pertussis vaccine, Haemophilus influenzae type b conjugate, and poliovirus vaccine, inactivated (DTaP-Hib-IPV)"
+                    },
+                    {
+                        "code": "121",
+                        "display": "zoster vaccine, live"
+                    },
+                    {
+                        "code": "122",
+                        "display": "rotavirus vaccine, unspecified formulation"
+                    },
+                    {
+                        "code": "123",
+                        "display": "influenza virus vaccine, H5N1, A/Vietnam/1203/2004 (national stockpile)"
+                    },
+                    {
+                        "code": "125",
+                        "display": "Novel Influenza-H1N1-09, live virus for nasal administration"
+                    },
+                    {
+                        "code": "126",
+                        "display": "Novel influenza-H1N1-09, preservative-free, injectable"
+                    },
+                    {
+                        "code": "127",
+                        "display": "Novel influenza-H1N1-09, injectable"
+                    },
+                    {
+                        "code": "128",
+                        "display": "Novel influenza-H1N1-09, all formulations"
+                    },
+                    {
+                        "code": "129",
+                        "display": "Japanese Encephalitis vaccine, unspecified formulation"
+                    },
+                    {
+                        "code": "13",
+                        "display": "tetanus immune globulin"
+                    },
+                    {
+                        "code": "130",
+                        "display": "Diphtheria, tetanus toxoids and acellular pertussis vaccine, and poliovirus vaccine, inactivated"
+                    },
+                    {
+                        "code": "131",
+                        "display": "Historical record of a typhus vaccination"
+                    },
+                    {
+                        "code": "132",
+                        "display": "Historical diphtheria and tetanus toxoids and acellular pertussis, poliovirus, Haemophilus b conjugate and hepatitis B (recombinant) vaccine."
+                    },
+                    {
+                        "code": "133",
+                        "display": "pneumococcal conjugate vaccine, 13 valent"
+                    },
+                    {
+                        "code": "134",
+                        "display": "Japanese Encephalitis vaccine for intramuscular administration"
+                    },
+                    {
+                        "code": "135",
+                        "display": "influenza, high dose seasonal, preservative-free"
+                    },
+                    {
+                        "code": "136",
+                        "display": "meningococcal oligosaccharide (groups A, C, Y and W-135) diphtheria toxoid conjugate vaccine (MCV4O)"
+                    },
+                    {
+                        "code": "137",
+                        "display": "HPV, unspecified formulation"
+                    },
+                    {
+                        "code": "138",
+                        "display": "tetanus and diphtheria toxoids, not adsorbed, for adult use"
+                    },
+                    {
+                        "code": "139",
+                        "display": "Td(adult) unspecified formulation"
+                    },
+                    {
+                        "code": "14",
+                        "display": "immune globulin, unspecified formulation"
+                    },
+                    {
+                        "code": "140",
+                        "display": "Influenza, seasonal, injectable, preservative free"
+                    },
+                    {
+                        "code": "141",
+                        "display": "Influenza, seasonal, injectable"
+                    },
+                    {
+                        "code": "142",
+                        "display": "tetanus toxoid, not adsorbed"
+                    },
+                    {
+                        "code": "143",
+                        "display": "Adenovirus, type 4 and type 7, live, oral"
+                    },
+                    {
+                        "code": "144",
+                        "display": "seasonal influenza, intradermal, preservative free"
+                    },
+                    {
+                        "code": "147",
+                        "display": "Meningococcal, MCV4, unspecified conjugate formulation(groups A, C, Y and W-135)"
+                    },
+                    {
+                        "code": "148",
+                        "display": "Meningococcal Groups C and Y and Haemophilus b Tetanus Toxoid Conjugate Vaccine"
+                    },
+                    {
+                        "code": "149",
+                        "display": "influenza, live, intranasal, quadrivalent"
+                    },
+                    {
+                        "code": "15",
+                        "display": "influenza virus vaccine, split virus (incl. purified surface antigen)-retired CODE"
+                    },
+                    {
+                        "code": "150",
+                        "display": "Influenza, injectable, quadrivalent, preservative free"
+                    },
+                    {
+                        "code": "151",
+                        "display": "influenza nasal, unspecified formulation"
+                    },
+                    {
+                        "code": "152",
+                        "display": "Pneumococcal Conjugate, unspecified formulation"
+                    },
+                    {
+                        "code": "153",
+                        "display": "Influenza, injectable, Madin Darby Canine Kidney, preservative free"
+                    },
+                    {
+                        "code": "155",
+                        "display": "Seasonal, trivalent, recombinant, injectable influenza vaccine, preservative free"
+                    },
+                    {
+                        "code": "156",
+                        "display": "Rho(D) Immune globulin- IV or IM"
+                    },
+                    {
+                        "code": "157",
+                        "display": "Rho(D) Immune globulin - IM"
+                    },
+                    {
+                        "code": "158",
+                        "display": "influenza, injectable, quadrivalent, contains preservative"
+                    },
+                    {
+                        "code": "159",
+                        "display": "Rho(D) Unspecified formulation"
+                    },
+                    {
+                        "code": "16",
+                        "display": "influenza virus vaccine, whole virus"
+                    },
+                    {
+                        "code": "160",
+                        "display": "Influenza A monovalent (H5N1), adjuvanted, National stockpile 2013"
+                    },
+                    {
+                        "code": "161",
+                        "display": "Influenza, injectable,quadrivalent, preservative free, pediatric"
+                    },
+                    {
+                        "code": "162",
+                        "display": "meningococcal B vaccine, fully recombinant"
+                    },
+                    {
+                        "code": "163",
+                        "display": "meningococcal B vaccine, recombinant, OMV, adjuvanted"
+                    },
+                    {
+                        "code": "164",
+                        "display": "meningococcal B, unspecified formulation"
+                    },
+                    {
+                        "code": "165",
+                        "display": "Human Papillomavirus 9-valent vaccine"
+                    },
+                    {
+                        "code": "166",
+                        "display": "influenza, intradermal, quadrivalent, preservative free, injectable"
+                    },
+                    {
+                        "code": "167",
+                        "display": "meningococcal vaccine of unknown formulation and unknown serogroups"
+                    },
+                    {
+                        "code": "168",
+                        "display": "Seasonal trivalent influenza vaccine, adjuvanted, preservative free"
+                    },
+                    {
+                        "code": "169",
+                        "display": "Hep A, live attenuated-IM"
+                    },
+                    {
+                        "code": "17",
+                        "display": "Haemophilus influenzae type b vaccine, conjugate unspecified formulation"
+                    },
+                    {
+                        "code": "170",
+                        "display": "non-US diphtheria, tetanus toxoids and acellular pertussis vaccine, Haemophilus influenzae type b conjugate, and poliovirus vaccine, inactivated (DTaP-Hib-IPV)"
+                    },
+                    {
+                        "code": "171",
+                        "display": "Influenza, injectable, Madin Darby Canine Kidney, preservative free, quadrivalent"
+                    },
+                    {
+                        "code": "172",
+                        "display": "cholera, WC-rBS"
+                    },
+                    {
+                        "code": "173",
+                        "display": "cholera, BivWC"
+                    },
+                    {
+                        "code": "174",
+                        "display": "cholera, live attenuated"
+                    },
+                    {
+                        "code": "175",
+                        "display": "Human Rabies vaccine from human diploid cell culture"
+                    },
+                    {
+                        "code": "176",
+                        "display": "Human rabies vaccine from Chicken fibroblast culture"
+                    },
+                    {
+                        "code": "177",
+                        "display": "pneumococcal conjugate vaccine, 10 valent"
+                    },
+                    {
+                        "code": "178",
+                        "display": "Non-US bivalent oral polio vaccine (types 1 and 3)"
+                    },
+                    {
+                        "code": "179",
+                        "display": "Non-US monovalent oral polio vaccine, unspecified formulation"
+                    },
+                    {
+                        "code": "18",
+                        "display": "rabies vaccine, for intramuscular injection RETIRED CODE"
+                    },
+                    {
+                        "code": "180",
+                        "display": "tetanus immune globulin"
+                    },
+                    {
+                        "code": "181",
+                        "display": "anthrax immune globulin"
+                    },
+                    {
+                        "code": "182",
+                        "display": "Oral Polio Vaccine, Unspecified formulation"
+                    },
+                    {
+                        "code": "183",
+                        "display": "Yellow fever vaccine alternative formulation"
+                    },
+                    {
+                        "code": "184",
+                        "display": "Yellow fever vaccine, unspecified formulation"
+                    },
+                    {
+                        "code": "185",
+                        "display": "Seasonal, quadrivalent, recombinant, injectable influenza vaccine, preservative free"
+                    },
+                    {
+                        "code": "186",
+                        "display": "Influenza, injectable, Madin Darby Canine Kidney,  quadrivalent with preservative"
+                    },
+                    {
+                        "code": "187",
+                        "display": "zoster vaccine recombinant"
+                    },
+                    {
+                        "code": "188",
+                        "display": "zoster vaccine, unspecified formulation"
+                    },
+                    {
+                        "code": "189",
+                        "display": "Hepatitis B vaccine (recombinant), CpG adjuvanted"
+                    },
+                    {
+                        "code": "19",
+                        "display": "Bacillus Calmette-Guerin vaccine"
+                    },
+                    {
+                        "code": "20",
+                        "display": "diphtheria, tetanus toxoids and acellular pertussis vaccine"
+                    },
+                    {
+                        "code": "21",
+                        "display": "varicella virus vaccine"
+                    },
+                    {
+                        "code": "22",
+                        "display": "DTP-Haemophilus influenzae type b conjugate vaccine"
+                    },
+                    {
+                        "code": "23",
+                        "display": "plague vaccine"
+                    },
+                    {
+                        "code": "24",
+                        "display": "anthrax vaccine"
+                    },
+                    {
+                        "code": "25",
+                        "display": "typhoid vaccine, live, oral"
+                    },
+                    {
+                        "code": "26",
+                        "display": "cholera vaccine, unspecified formulation"
+                    },
+                    {
+                        "code": "27",
+                        "display": "botulinum antitoxin"
+                    },
+                    {
+                        "code": "28",
+                        "display": "diphtheria and tetanus toxoids, adsorbed for pediatric use"
+                    },
+                    {
+                        "code": "29",
+                        "display": "cytomegalovirus immune globulin, intravenous"
+                    },
+                    {
+                        "code": "30",
+                        "display": "hepatitis B immune globulin"
+                    },
+                    {
+                        "code": "31",
+                        "display": "hepatitis A vaccine, pediatric dosage, unspecified formulation"
+                    },
+                    {
+                        "code": "32",
+                        "display": "meningococcal polysaccharide vaccine (MPSV4)"
+                    },
+                    {
+                        "code": "33",
+                        "display": "pneumococcal polysaccharide vaccine, 23 valent"
+                    },
+                    {
+                        "code": "34",
+                        "display": "rabies immune globulin"
+                    },
+                    {
+                        "code": "35",
+                        "display": "tetanus toxoid, adsorbed"
+                    },
+                    {
+                        "code": "36",
+                        "display": "varicella zoster immune globulin"
+                    },
+                    {
+                        "code": "37",
+                        "display": "yellow fever vaccine"
+                    },
+                    {
+                        "code": "38",
+                        "display": "rubella and mumps virus vaccine"
+                    },
+                    {
+                        "code": "39",
+                        "display": "Japanese Encephalitis Vaccine SC"
+                    },
+                    {
+                        "code": "40",
+                        "display": "rabies vaccine, for intradermal injection"
+                    },
+                    {
+                        "code": "41",
+                        "display": "typhoid vaccine, parenteral, other than acetone-killed, dried"
+                    },
+                    {
+                        "code": "42",
+                        "display": "hepatitis B vaccine, adolescent/high risk infant dosage"
+                    },
+                    {
+                        "code": "43",
+                        "display": "hepatitis B vaccine, adult dosage"
+                    },
+                    {
+                        "code": "44",
+                        "display": "hepatitis B vaccine, dialysis patient dosage"
+                    },
+                    {
+                        "code": "45",
+                        "display": "hepatitis B vaccine, unspecified formulation"
+                    },
+                    {
+                        "code": "46",
+                        "display": "Haemophilus influenzae type b vaccine, PRP-D conjugate"
+                    },
+                    {
+                        "code": "47",
+                        "display": "Haemophilus influenzae type b vaccine, HbOC conjugate"
+                    },
+                    {
+                        "code": "48",
+                        "display": "Haemophilus influenzae type b vaccine, PRP-T conjugate"
+                    },
+                    {
+                        "code": "49",
+                        "display": "Haemophilus influenzae type b vaccine, PRP-OMP conjugate"
+                    },
+                    {
+                        "code": "50",
+                        "display": "DTaP-Haemophilus influenzae type b conjugate vaccine"
+                    },
+                    {
+                        "code": "51",
+                        "display": "Haemophilus influenzae type b conjugate and Hepatitis B vaccine"
+                    },
+                    {
+                        "code": "52",
+                        "display": "hepatitis A vaccine, adult dosage"
+                    },
+                    {
+                        "code": "53",
+                        "display": "typhoid vaccine, parenteral, acetone-killed, dried (U.S. military)"
+                    },
+                    {
+                        "code": "54",
+                        "display": "adenovirus vaccine, type 4, live, oral"
+                    },
+                    {
+                        "code": "55",
+                        "display": "adenovirus vaccine, type 7, live, oral"
+                    },
+                    {
+                        "code": "62",
+                        "display": "human papilloma virus vaccine, quadrivalent"
+                    },
+                    {
+                        "code": "66",
+                        "display": "Lyme disease vaccine"
+                    },
+                    {
+                        "code": "69",
+                        "display": "parainfluenza-3 virus vaccine"
+                    },
+                    {
+                        "code": "71",
+                        "display": "respiratory syncytial virus immune globulin, intravenous"
+                    },
+                    {
+                        "code": "74",
+                        "display": "rotavirus, live, tetravalent vaccine"
+                    },
+                    {
+                        "code": "75",
+                        "display": "vaccinia (smallpox) vaccine"
+                    },
+                    {
+                        "code": "76",
+                        "display": "Staphylococcus bacteriophage lysate"
+                    },
+                    {
+                        "code": "77",
+                        "display": "tick-borne encephalitis vaccine"
+                    },
+                    {
+                        "code": "78",
+                        "display": "tularemia vaccine"
+                    },
+                    {
+                        "code": "79",
+                        "display": "vaccinia immune globulin"
+                    },
+                    {
+                        "code": "80",
+                        "display": "Venezuelan equine encephalitis, live, attenuated"
+                    },
+                    {
+                        "code": "801",
+                        "display": "AS03 Adjuvant"
+                    },
+                    {
+                        "code": "81",
+                        "display": "Venezuelan equine encephalitis, inactivated"
+                    },
+                    {
+                        "code": "82",
+                        "display": "adenovirus vaccine, unspecified formulation"
+                    },
+                    {
+                        "code": "83",
+                        "display": "hepatitis A vaccine, pediatric/adolescent dosage, 2 dose schedule"
+                    },
+                    {
+                        "code": "84",
+                        "display": "hepatitis A vaccine, pediatric/adolescent dosage, 3 dose schedule"
+                    },
+                    {
+                        "code": "85",
+                        "display": "hepatitis A vaccine, unspecified formulation"
+                    },
+                    {
+                        "code": "86",
+                        "display": "immune globulin, intramuscular"
+                    },
+                    {
+                        "code": "87",
+                        "display": "immune globulin, intravenous"
+                    },
+                    {
+                        "code": "88",
+                        "display": "influenza virus vaccine, unspecified formulation"
+                    },
+                    {
+                        "code": "89",
+                        "display": "poliovirus vaccine, unspecified formulation"
+                    },
+                    {
+                        "code": "90",
+                        "display": "rabies vaccine, unspecified formulation"
+                    },
+                    {
+                        "code": "91",
+                        "display": "typhoid vaccine, unspecified formulation"
+                    },
+                    {
+                        "code": "92",
+                        "display": "Venezuelan equine encephalitis vaccine, unspecified formulation"
+                    },
+                    {
+                        "code": "93",
+                        "display": "respiratory syncytial virus monoclonal antibody (palivizumab), intramuscular"
+                    },
+                    {
+                        "code": "94",
+                        "display": "measles, mumps, rubella, and varicella virus vaccine"
+                    },
+                    {
+                        "code": "95",
+                        "display": "tuberculin skin test; old tuberculin, multipuncture device"
+                    },
+                    {
+                        "code": "96",
+                        "display": "tuberculin skin test; purified protein derivative solution, intradermal"
+                    },
+                    {
+                        "code": "97",
+                        "display": "tuberculin skin test; purified protein derivative, multipuncture device"
+                    },
+                    {
+                        "code": "98",
+                        "display": "tuberculin skin test; unspecified formulation"
+                    },
+                    {
+                        "code": "998",
+                        "display": "no vaccine administered"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ig-r4.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/311/package/ig-r4.json
@@ -1,4529 +1,4529 @@
 {
-	"resourceType": "ImplementationGuide",
-	"id": "hl7.fhir.us.core",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>USCore</h2><p>The official URL for this implementation guide is: </p><pre>http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core</pre></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core",
-	"version": "3.1.1",
-	"name": "USCore",
-	"title": "US Core",
-	"status": "active",
-	"date": "2020-08-28T10:54:27+10:00",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US",
-					"display": "United States of America"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"packageId": "hl7.fhir.us.core",
-	"license": "CC0-1.0",
-	"fhirVersion": [
-		"4.0.1"
-	],
-	"definition": {
-		"grouping": [
-			{
-				"name": "base"
-			}
-		],
-		"resource": [
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-glucose.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-glucose"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Procedure"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Procedure-rehab.html"
-					}
-				],
-				"reference": {
-					"reference": "Procedure/rehab"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CareTeam"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "CareTeam-example.html"
-					}
-				],
-				"reference": {
-					"reference": "CareTeam/example"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-leukocyte-esterase.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-leukocyte-esterase"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Bundle"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Bundle-66c8856b-ba11-4876-8aa8-467aad8c11a2.html"
-					}
-				],
-				"reference": {
-					"reference": "Bundle/66c8856b-ba11-4876-8aa8-467aad8c11a2"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-bilirubin.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-bilirubin"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Condition"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Condition-hc1.html"
-					}
-				],
-				"reference": {
-					"reference": "Condition/hc1"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-sediment.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-sediment"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Immunization"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Immunization-imm-1.html"
-					}
-				],
-				"reference": {
-					"reference": "Immunization/imm-1"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-pediatric-wt-example.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/pediatric-wt-example"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Organization"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Organization-saint-luke-w-endpoint.html"
-					}
-				],
-				"reference": {
-					"reference": "Organization/saint-luke-w-endpoint"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-ph.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-ph"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Encounter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Encounter-example-1.html"
-					}
-				],
-				"reference": {
-					"reference": "Encounter/example-1"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "DiagnosticReport"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "DiagnosticReport-chest-xray-report.html"
-					}
-				],
-				"reference": {
-					"reference": "DiagnosticReport/chest-xray-report"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-serum-sodium.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/serum-sodium"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "DiagnosticReport"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "DiagnosticReport-cbc.html"
-					}
-				],
-				"reference": {
-					"reference": "DiagnosticReport/cbc"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-serum-potassium.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/serum-potassium"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Encounter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Encounter-1036.html"
-					}
-				],
-				"reference": {
-					"reference": "Encounter/1036"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-some-day-smoker.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/some-day-smoker"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Location"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Location-hl7east.html"
-					}
-				],
-				"reference": {
-					"reference": "Location/hl7east"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-serum-co2.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/serum-co2"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-protein.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-protein"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Procedure"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Procedure-defib-implant.html"
-					}
-				],
-				"reference": {
-					"reference": "Procedure/defib-implant"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-usg.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/usg"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-serum-chloride.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/serum-chloride"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-serum-calcium.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/serum-calcium"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-color.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-color"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-bp-data-absent.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/bp-data-absent"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Patient"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Patient-example.html"
-					}
-				],
-				"reference": {
-					"reference": "Patient/example"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Patient"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Patient-child-example.html"
-					}
-				],
-				"reference": {
-					"reference": "Patient/child-example"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Patient"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Patient-infant-example.html"
-					}
-				],
-				"reference": {
-					"reference": "Patient/infant-example"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-temperature.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/temperature"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-bmi.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/bmi"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Medication"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Medication-uscore-med2.html"
-					}
-				],
-				"reference": {
-					"reference": "Medication/uscore-med2"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-cells.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-cells"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-length.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/length"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Device"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Device-udi-2.html"
-					}
-				],
-				"reference": {
-					"reference": "Device/udi-2"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "MedicationRequest"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "MedicationRequest-uscore-mo1.html"
-					}
-				],
-				"reference": {
-					"reference": "MedicationRequest/uscore-mo1"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Practitioner"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Practitioner-practitioner-2.html"
-					}
-				],
-				"reference": {
-					"reference": "Practitioner/practitioner-2"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Goal"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Goal-goal-1.html"
-					}
-				],
-				"reference": {
-					"reference": "Goal/goal-1"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-rbcs.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-rbcs"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urobilinogen.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urobilinogen"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Medication"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Medication-uscore-med1.html"
-					}
-				],
-				"reference": {
-					"reference": "Medication/uscore-med1"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-bacteria.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-bacteria"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Bundle"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Bundle-uscore-mo3.html"
-					}
-				],
-				"reference": {
-					"reference": "Bundle/uscore-mo3"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-ofc-percentile.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/ofc-percentile"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "MedicationRequest"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "MedicationRequest-self-tylenol.html"
-					}
-				],
-				"reference": {
-					"reference": "MedicationRequest/self-tylenol"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "DiagnosticReport"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "DiagnosticReport-metabolic-panel.html"
-					}
-				],
-				"reference": {
-					"reference": "DiagnosticReport/metabolic-panel"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Device"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Device-udi-3.html"
-					}
-				],
-				"reference": {
-					"reference": "Device/udi-3"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "MedicationRequest"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "MedicationRequest-uscore-mo2.html"
-					}
-				],
-				"reference": {
-					"reference": "MedicationRequest/uscore-mo2"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Bundle"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Bundle-c887e62f-6166-419f-8268-b5ecd6c7b901.html"
-					}
-				],
-				"reference": {
-					"reference": "Bundle/c887e62f-6166-419f-8268-b5ecd6c7b901"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-bun.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/bun"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Practitioner"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Practitioner-practitioner-1.html"
-					}
-				],
-				"reference": {
-					"reference": "Practitioner/practitioner-1"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-neutrophils.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/neutrophils"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-nitrite.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-nitrite"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-oxygen-saturation.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/oxygen-saturation"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "DiagnosticReport"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "DiagnosticReport-cardiology-report.html"
-					}
-				],
-				"reference": {
-					"reference": "DiagnosticReport/cardiology-report"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-vitals-panel.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/vitals-panel"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-blood-pressure.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/blood-pressure"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-wbcs.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-wbcs"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-height.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/height"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Organization"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Organization-acme-lab.html"
-					}
-				],
-				"reference": {
-					"reference": "Organization/acme-lab"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Device"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Device-udi-1.html"
-					}
-				],
-				"reference": {
-					"reference": "Device/udi-1"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-hemoglobin.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/hemoglobin"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "DocumentReference"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "DocumentReference-episode-summary.html"
-					}
-				],
-				"reference": {
-					"reference": "DocumentReference/episode-summary"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-hemoglobin.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-hemoglobin"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-heart-rate.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/heart-rate"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-epi-cells.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-epi-cells"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "AllergyIntolerance"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "AllergyIntolerance-example.html"
-					}
-				],
-				"reference": {
-					"reference": "AllergyIntolerance/example"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-blood-glucose.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/blood-glucose"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "DiagnosticReport"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "DiagnosticReport-urinalysis.html"
-					}
-				],
-				"reference": {
-					"reference": "DiagnosticReport/urinalysis"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Condition"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Condition-example.html"
-					}
-				],
-				"reference": {
-					"reference": "Condition/example"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-serum-creatinine.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/serum-creatinine"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-satO2-fiO2.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/satO2-fiO2"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-serum-total-bilirubin.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/serum-total-bilirubin"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-pediatric-bmi-example.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/pediatric-bmi-example"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Organization"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Organization-example-organization-2.html"
-					}
-				],
-				"reference": {
-					"reference": "Organization/example-organization-2"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-weight.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/weight"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-mchc.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/mchc"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-clarity.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-clarity"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CarePlan"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "CarePlan-colonoscopy.html"
-					}
-				],
-				"reference": {
-					"reference": "CarePlan/colonoscopy"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-erythrocytes.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/erythrocytes"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-urine-ketone.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-ketone"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "Observation-respiratory-rate.html"
-					}
-				],
-				"reference": {
-					"reference": "Observation/respiratory-rate"
-				},
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-medication-codes.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-medication-codes"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-immunization.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-immunization"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-location-address-state.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-location-address-state"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-practitionerrole-practitioner.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-practitionerrole-practitioner"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-observation-smokingstatus.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-observation-smokingstatus"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-observation-smokingstatus-max.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-observation-smokingstatus-max"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-omb-race-category.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/omb-race-category"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-practitionerrole.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-practitionerrole"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-allergy-substance.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-allergy-substance"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-narrative-status.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-narrative-status"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CodeSystem"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "CodeSystem-cdcrec.html"
-					}
-				],
-				"reference": {
-					"reference": "CodeSystem/cdcrec"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-organization-name.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-organization-name"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-observation-lab.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-observation-lab"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-diagnosticreport-code.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-diagnosticreport-code"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-pediatric-bmi-for-age.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/pediatric-bmi-for-age"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-head-occipital-frontal-circumference-percentile.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/head-occipital-frontal-circumference-percentile"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-allergyintolerance.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-allergyintolerance"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-goal-lifecycle-status.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-goal-lifecycle-status"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-procedure-code.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-procedure-code"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-documentreference-type.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-documentreference-type"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-provenance-participant-type.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-provenance-participant-type"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-patient-gender.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-patient-gender"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-practitioner.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-practitioner"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-diagnosticreport-note.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-diagnosticreport-note"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-omb-ethnicity-category.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/omb-ethnicity-category"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-provenance.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-provenance"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "OperationDefinition"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "OperationDefinition-docref.html"
-					}
-				],
-				"reference": {
-					"reference": "OperationDefinition/docref"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-condition-clinical-status.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-condition-clinical-status"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:extension"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-birthsex.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-birthsex"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-documentreference-id.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-documentreference-id"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-careplan-category.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-careplan-category"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-encounter-class.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-encounter-class"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-medicationrequest-patient.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-medicationrequest-patient"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CapabilityStatement"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "CapabilityStatement-us-core-server.html"
-					}
-				],
-				"reference": {
-					"reference": "CapabilityStatement/us-core-server"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-condition-category.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-condition-category"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-detailed-ethnicity.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/detailed-ethnicity"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-documentreference-patient.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-documentreference-patient"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-encounter.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-encounter"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-ndc-vaccine-codes.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-ndc-vaccine-codes"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-patient.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-patient"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-diagnosticreport-date.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-diagnosticreport-date"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-procedure-icd10pcs.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-procedure-icd10pcs"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-provider-specialty.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-provider-specialty"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-procedure-date.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-procedure-date"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-vaccines-cvx.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-vaccines-cvx"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-pulse-oximetry.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-pulse-oximetry"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-allergyintolerance-clinical-status.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-allergyintolerance-clinical-status"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-documentreference-date.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-documentreference-date"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-medicationrequest-intent.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-medicationrequest-intent"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-location.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-location"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-location-address.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-location-address"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-observation-smoking-status-status.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-observation-smoking-status-status"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-usps-state.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-usps-state"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-practitioner-name.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-practitioner-name"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-encounter-type.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-encounter-type"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-documentreference-period.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-documentreference-period"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-observation-code.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-observation-code"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-location-name.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-location-name"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-condition-onset-date.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-condition-onset-date"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-patient-given.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-patient-given"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-procedure.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-procedure"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-encounter-type.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-encounter-type"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-condition-code.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-condition-code"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CodeSystem"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "CodeSystem-condition-category.html"
-					}
-				],
-				"reference": {
-					"reference": "CodeSystem/condition-category"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-medicationrequest-encounter.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-medicationrequest-encounter"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-encounter-patient.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-encounter-patient"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-organization-address.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-organization-address"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-observation-category.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-observation-category"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-medication.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-medication"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-diagnosticreport-status.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-diagnosticreport-status"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-observation-date.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-observation-date"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-birthsex.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/birthsex"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-diagnosticreport-category.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-diagnosticreport-category"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-observation-status.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-observation-status"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-diagnosticreport-report-and-note-codes.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-diagnosticreport-report-and-note-codes"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-provider-role.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-provider-role"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-ethnicity.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-ethnicity"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-documentreference.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-documentreference"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:extension"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-direct.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-direct"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-smoking-status-observation-codes.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-smoking-status-observation-codes"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-careteam-provider-roles.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-careteam-provider-roles"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-documentreference-type.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-documentreference-type"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-encounter-date.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-encounter-date"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-diagnosticreport-category.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-diagnosticreport-category"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-patient-birthdate.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-patient-birthdate"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-careteam.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-careteam"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-procedure-status.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-procedure-status"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-clinical-note-type.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-clinical-note-type"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-encounter-status.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-encounter-status"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ConceptMap"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ConceptMap-ndc-cvx.html"
-					}
-				],
-				"reference": {
-					"reference": "ConceptMap/ndc-cvx"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:extension"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-ethnicity.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-ethnicity"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-careplan-status.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-careplan-status"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-careplan.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-careplan"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-condition-patient.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-condition-patient"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-allergyintolerance-patient.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-allergyintolerance-patient"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-device-patient.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-device-patient"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-condition-code.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-condition-code"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-observation-patient.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-observation-patient"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-race.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-race"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-careplan-patient.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-careplan-patient"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-patient-family.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-patient-family"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-smokingstatus.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-smokingstatus"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-medicationrequest-status.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-medicationrequest-status"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:extension"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-race.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-race"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-location-address-postalcode.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-location-address-postalcode"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-encounter-id.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-encounter-id"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-medicationrequest-authoredon.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-medicationrequest-authoredon"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-documentreference-status.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-documentreference-status"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-documentreference-category.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-documentreference-category"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-procedure-patient.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-procedure-patient"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-goal-target-date.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-goal-target-date"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-diagnosticreport-patient.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-diagnosticreport-patient"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-careplan-date.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-careplan-date"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-careteam-patient.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-careteam-patient"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-organization.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-organization"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-immunization-date.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-immunization-date"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-encounter-identifier.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-encounter-identifier"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-practitionerrole-specialty.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-practitionerrole-specialty"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-patient-name.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-patient-name"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-device-type.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-device-type"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-procedure-code.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-procedure-code"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-diagnosticreport-lab.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-diagnosticreport-lab"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-goal-patient.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-goal-patient"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-simple-language.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/simple-language"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-immunization-patient.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-immunization-patient"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-condition.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-condition"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-pediatric-weight-for-height.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/pediatric-weight-for-height"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-observation-value-codes.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-observation-value-codes"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-patient-id.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-patient-id"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-location-address-city.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-location-address-city"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-goal.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-goal"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-careteam-status.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-careteam-status"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CodeSystem"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "CodeSystem-us-core-documentreference-category.html"
-					}
-				],
-				"reference": {
-					"reference": "CodeSystem/us-core-documentreference-category"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CodeSystem"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "CodeSystem-us-core-provenance-participant-type.html"
-					}
-				],
-				"reference": {
-					"reference": "CodeSystem/us-core-provenance-participant-type"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-us-core-diagnosticreport-lab-codes.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-diagnosticreport-lab-codes"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CodeSystem"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "CodeSystem-careplan-category.html"
-					}
-				],
-				"reference": {
-					"reference": "CodeSystem/careplan-category"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-documentreference-category.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-documentreference-category"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CapabilityStatement"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "CapabilityStatement-us-core-client.html"
-					}
-				],
-				"reference": {
-					"reference": "CapabilityStatement/us-core-client"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-practitioner-identifier.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-practitioner-identifier"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-patient-identifier.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-patient-identifier"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-condition-category.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-condition-category"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "SearchParameter-us-core-immunization-status.html"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-immunization-status"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-medicationrequest.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-medicationrequest"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "StructureDefinition-us-core-implantable-device.html"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-implantable-device"
-				},
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					},
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
-						"valueUri": "ValueSet-detailed-race.html"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/detailed-race"
-				},
-				"exampleBoolean": false
-			}
-		],
-		"page": {
-			"nameUrl": "index.html",
-			"title": "Home",
-			"generation": "markdown",
-			"page": [
-				{
-					"nameUrl": "guidance.html",
-					"title": "Guidance",
-					"generation": "markdown",
-					"page": [
-						{
-							"nameUrl": "general-guidance.html",
-							"title": "General Guidance",
-							"generation": "markdown"
-						},
-						{
-							"nameUrl": "clinical-notes-guidance.html",
-							"title": "Clinical Notes Guidance",
-							"generation": "markdown"
-						},
-						{
-							"nameUrl": "all-meds.html",
-							"title": "Medication List Guidance",
-							"generation": "markdown"
-						},
-						{
-							"nameUrl": "basic-provenance.html",
-							"title": "Basic Provenance",
-							"generation": "markdown"
-						},
-						{
-							"nameUrl": "r2-r4-guidance.html",
-							"title": "DSTU2 to R4 Conversion",
-							"generation": "markdown"
-						},
-						{
-							"nameUrl": "future-of-us-core.html",
-							"title": "Future of US Core",
-							"generation": "markdown"
-						}
-					]
-				},
-				{
-					"nameUrl": "profiles.html",
-					"title": "Profiles and Extensions",
-					"generation": "markdown",
-					"page": [
-						{
-							"nameUrl": "StructureDefinition-us-core-immunization.html",
-							"title": "StructureDefinition US Core Immunization",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-practitionerrole.html",
-							"title": "StructureDefinition US Core PractitionerRole",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-observation-lab.html",
-							"title": "StructureDefinition US Core Observation Lab",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-pediatric-bmi-for-age.html",
-							"title": "StructureDefinition Pediatric BMI For Age",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-head-occipital-frontal-circumference-percentile.html",
-							"title": "StructureDefinition Pediatric Head Occipital-frontal Circumference Percentile",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-allergyintolerance.html",
-							"title": "StructureDefinition US Core AllergyIntolerance",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-practitioner.html",
-							"title": "StructureDefinition US Core Practitioner",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-diagnosticreport-note.html",
-							"title": "StructureDefinition US Core DiagnosticReport Note",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-provenance.html",
-							"title": "StructureDefinition US Core Provenance",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-birthsex.html",
-							"title": "StructureDefinition US Core Birthsex",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-encounter.html",
-							"title": "StructureDefinition US Core Encounter",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-patient.html",
-							"title": "StructureDefinition US Core Patient",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-pulse-oximetry.html",
-							"title": "StructureDefinition US Core Pulse Oximetry",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-location.html",
-							"title": "StructureDefinition US Core Location",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-procedure.html",
-							"title": "StructureDefinition US Core Procedure",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-medication.html",
-							"title": "StructureDefinition US Core Medication",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-documentreference.html",
-							"title": "StructureDefinition US Core DocumentReference",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-direct.html",
-							"title": "StructureDefinition US Core Direct",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-careteam.html",
-							"title": "StructureDefinition US Core CareTeam",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-ethnicity.html",
-							"title": "StructureDefinition US Core Ethnicity",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-careplan.html",
-							"title": "StructureDefinition US Core CarePlan",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-smokingstatus.html",
-							"title": "StructureDefinition US Core Smokingstatus",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-race.html",
-							"title": "StructureDefinition US Core Race",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-organization.html",
-							"title": "StructureDefinition US Core Organization",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-diagnosticreport-lab.html",
-							"title": "StructureDefinition US Core DiagnosticReport Lab",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-condition.html",
-							"title": "StructureDefinition US Core Condition",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-pediatric-weight-for-height.html",
-							"title": "StructureDefinition Pediatric Weight For Height",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-goal.html",
-							"title": "StructureDefinition US Core Goal",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-medicationrequest.html",
-							"title": "StructureDefinition US Core MedicationRequest",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "StructureDefinition-us-core-implantable-device.html",
-							"title": "StructureDefinition US Core Implantable Device",
-							"generation": "generated"
-						}
-					]
-				},
-				{
-					"nameUrl": "operations.html",
-					"title": "Operations",
-					"generation": "markdown",
-					"page": [
-						{
-							"nameUrl": "OperationDefinition-docref.html",
-							"title": "OperationDefinition Docref",
-							"generation": "generated"
-						}
-					]
-				},
-				{
-					"nameUrl": "terminology.html",
-					"title": "Terminology",
-					"generation": "markdown",
-					"page": [
-						{
-							"nameUrl": "ValueSet-us-core-medication-codes.html",
-							"title": "ValueSet US Core Medication Codes",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-observation-smokingstatus.html",
-							"title": "ValueSet US Core Observation Smokingstatus Preferred",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-observation-smokingstatus-max.html",
-							"title": "ValueSet US Core Observation Smokingstatus Max-Binding",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-omb-race-category.html",
-							"title": "ValueSet Omb Race Category",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-allergy-substance.html",
-							"title": "ValueSet US Core Allergy Substance",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-narrative-status.html",
-							"title": "ValueSet US Core Narrative Status",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-documentreference-type.html",
-							"title": "ValueSet US Core DocumentReference Type",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-omb-ethnicity-category.html",
-							"title": "ValueSet Omb Ethnicity Category",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-condition-category.html",
-							"title": "ValueSet US Core Condition Category",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-detailed-ethnicity.html",
-							"title": "ValueSet Detailed Ethnicity",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-ndc-vaccine-codes.html",
-							"title": "ValueSet US Core Ndc Vaccine Codes",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-procedure-icd10pcs.html",
-							"title": "ValueSet US Core Procedure Icd10pcs",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-provider-specialty.html",
-							"title": "ValueSet US Core Provider Specialty",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-vaccines-cvx.html",
-							"title": "ValueSet US Core Vaccines Cvx",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-observation-smoking-status-status.html",
-							"title": "ValueSet US Core Observation SmokingStatus Status",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-usps-state.html",
-							"title": "ValueSet US Core Usps State",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-encounter-type.html",
-							"title": "ValueSet US Core Encounter Type",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-condition-code.html",
-							"title": "ValueSet US Core Condition Code",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-birthsex.html",
-							"title": "ValueSet Birthsex",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-diagnosticreport-report-and-note-codes.html",
-							"title": "ValueSet US Core DiagnosticReport Report And Note Codes",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-provider-role.html",
-							"title": "ValueSet US Core Provider Role",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-smoking-status-observation-codes.html",
-							"title": "ValueSet US Core Smoking Status Observation Codes",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-careteam-provider-roles.html",
-							"title": "ValueSet US Core CareTeam Provider Roles",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-diagnosticreport-category.html",
-							"title": "ValueSet US Core DiagnosticReport Category",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-clinical-note-type.html",
-							"title": "ValueSet US Core Clinical Note Type",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-documentreference-category.html",
-							"title": "ValueSet US Core DocumentReference Category",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-procedure-code.html",
-							"title": "ValueSet US Core Procedure Code",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-simple-language.html",
-							"title": "ValueSet Simple Language",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-observation-value-codes.html",
-							"title": "ValueSet US Core Observation Value Codes",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-us-core-diagnosticreport-lab-codes.html",
-							"title": "ValueSet US Core DiagnosticReport Lab Codes",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ValueSet-detailed-race.html",
-							"title": "ValueSet Detailed Race",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "CodeSystem-cdcrec.html",
-							"title": "CodeSystem Cdcrec",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "CodeSystem-condition-category.html",
-							"title": "CodeSystem Condition Category",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "CodeSystem-us-core-documentreference-category.html",
-							"title": "CodeSystem US Core DocumentReference Category",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "CodeSystem-careplan-category.html",
-							"title": "CodeSystem CarePlan Category",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "ConceptMap-ndc-cvx.html",
-							"title": "ConceptMap Ndc Cvx",
-							"generation": "generated"
-						}
-					]
-				},
-				{
-					"nameUrl": "searchparameters.html",
-					"title": "Search Parameters",
-					"generation": "markdown",
-					"page": [
-						{
-							"nameUrl": "SearchParameter-us-core-location-address-state.html",
-							"title": "SearchParameter US Core Location Address State",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-practitionerrole-practitioner.html",
-							"title": "SearchParameter US Core PractitionerRole Practitioner",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-organization-name.html",
-							"title": "SearchParameter US Core Organization Name",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-diagnosticreport-code.html",
-							"title": "SearchParameter US Core DiagnosticReport Code",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-goal-lifecycle-status.html",
-							"title": "SearchParameter US Core Goal Lifecycle Status",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-procedure-code.html",
-							"title": "SearchParameter US Core Procedure Code",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-patient-gender.html",
-							"title": "SearchParameter US Core Patient Gender",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-condition-clinical-status.html",
-							"title": "SearchParameter US Core Condition Clinical Status",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-documentreference-id.html",
-							"title": "SearchParameter US Core DocumentReference Id",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-careplan-category.html",
-							"title": "SearchParameter US Core CarePlan Category",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-encounter-class.html",
-							"title": "SearchParameter US Core Encounter Class",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-medicationrequest-patient.html",
-							"title": "SearchParameter US Core MedicationRequest Patient",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-documentreference-patient.html",
-							"title": "SearchParameter US Core DocumentReference Patient",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-diagnosticreport-date.html",
-							"title": "SearchParameter US Core DiagnosticReport Date",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-procedure-date.html",
-							"title": "SearchParameter US Core Procedure Date",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-allergyintolerance-clinical-status.html",
-							"title": "SearchParameter US Core AllergyIntolerance Clinical Status",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-documentreference-date.html",
-							"title": "SearchParameter US Core DocumentReference Date",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-medicationrequest-intent.html",
-							"title": "SearchParameter US Core MedicationRequest Intent",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-location-address.html",
-							"title": "SearchParameter US Core Location Address",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-practitioner-name.html",
-							"title": "SearchParameter US Core Practitioner Name",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-documentreference-period.html",
-							"title": "SearchParameter US Core DocumentReference Period",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-observation-code.html",
-							"title": "SearchParameter US Core Observation Code",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-location-name.html",
-							"title": "SearchParameter US Core Location Name",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-condition-onset-date.html",
-							"title": "SearchParameter US Core Condition Onset Date",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-patient-given.html",
-							"title": "SearchParameter US Core Patient Given",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-encounter-type.html",
-							"title": "SearchParameter US Core Encounter Type",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-medicationrequest-encounter.html",
-							"title": "SearchParameter US Core MedicationRequest Encounter",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-encounter-patient.html",
-							"title": "SearchParameter US Core Encounter Patient",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-organization-address.html",
-							"title": "SearchParameter US Core Organization Address",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-observation-category.html",
-							"title": "SearchParameter US Core Observation Category",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-diagnosticreport-status.html",
-							"title": "SearchParameter US Core DiagnosticReport Status",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-observation-date.html",
-							"title": "SearchParameter US Core Observation Date",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-diagnosticreport-category.html",
-							"title": "SearchParameter US Core DiagnosticReport Category",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-observation-status.html",
-							"title": "SearchParameter US Core Observation Status",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-ethnicity.html",
-							"title": "SearchParameter US Core Ethnicity",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-documentreference-type.html",
-							"title": "SearchParameter US Core DocumentReference Type",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-encounter-date.html",
-							"title": "SearchParameter US Core Encounter Date",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-patient-birthdate.html",
-							"title": "SearchParameter US Core Patient Birthdate",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-procedure-status.html",
-							"title": "SearchParameter US Core Procedure Status",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-encounter-status.html",
-							"title": "SearchParameter US Core Encounter Status",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-careplan-status.html",
-							"title": "SearchParameter US Core CarePlan Status",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-condition-patient.html",
-							"title": "SearchParameter US Core Condition Patient",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-allergyintolerance-patient.html",
-							"title": "SearchParameter US Core AllergyIntolerance Patient",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-device-patient.html",
-							"title": "SearchParameter US Core Device Patient",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-condition-code.html",
-							"title": "SearchParameter US Core Condition Code",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-observation-patient.html",
-							"title": "SearchParameter US Core Observation Patient",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-race.html",
-							"title": "SearchParameter US Core Race",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-careplan-patient.html",
-							"title": "SearchParameter US Core CarePlan Patient",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-patient-family.html",
-							"title": "SearchParameter US Core Patient Family",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-medicationrequest-status.html",
-							"title": "SearchParameter US Core MedicationRequest Status",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-location-address-postalcode.html",
-							"title": "SearchParameter US Core Location Address Postalcode",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-encounter-id.html",
-							"title": "SearchParameter US Core Encounter Id",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-medicationrequest-authoredon.html",
-							"title": "SearchParameter US Core MedicationRequest Authoredon",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-documentreference-status.html",
-							"title": "SearchParameter US Core DocumentReference Status",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-procedure-patient.html",
-							"title": "SearchParameter US Core Procedure Patient",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-goal-target-date.html",
-							"title": "SearchParameter US Core Goal Target Date",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-diagnosticreport-patient.html",
-							"title": "SearchParameter US Core DiagnosticReport Patient",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-careplan-date.html",
-							"title": "SearchParameter US Core CarePlan Date",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-careteam-patient.html",
-							"title": "SearchParameter US Core CareTeam Patient",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-immunization-date.html",
-							"title": "SearchParameter US Core Immunization Date",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-encounter-identifier.html",
-							"title": "SearchParameter US Core Encounter Identifier",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-practitionerrole-specialty.html",
-							"title": "SearchParameter US Core PractitionerRole Specialty",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-patient-name.html",
-							"title": "SearchParameter US Core Patient Name",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-device-type.html",
-							"title": "SearchParameter US Core Device Type",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-goal-patient.html",
-							"title": "SearchParameter US Core Goal Patient",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-immunization-patient.html",
-							"title": "SearchParameter US Core Immunization Patient",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-patient-id.html",
-							"title": "SearchParameter US Core Patient Id",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-location-address-city.html",
-							"title": "SearchParameter US Core Location Address City",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-careteam-status.html",
-							"title": "SearchParameter US Core CareTeam Status",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-documentreference-category.html",
-							"title": "SearchParameter US Core DocumentReference Category",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-practitioner-identifier.html",
-							"title": "SearchParameter US Core Practitioner Identifier",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-patient-identifier.html",
-							"title": "SearchParameter US Core Patient Identifier",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-condition-category.html",
-							"title": "SearchParameter US Core Condition Category",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "SearchParameter-us-core-immunization-status.html",
-							"title": "SearchParameter US Core Immunization Status",
-							"generation": "generated"
-						}
-					]
-				},
-				{
-					"nameUrl": "capstatements.html",
-					"title": "Capability Statements",
-					"generation": "markdown",
-					"page": [
-						{
-							"nameUrl": "CapabilityStatement-us-core-server.html",
-							"title": "CapabilityStatement US Core Server",
-							"generation": "generated"
-						},
-						{
-							"nameUrl": "CapabilityStatement-us-core-client.html",
-							"title": "CapabilityStatement US Core Client",
-							"generation": "generated"
-						}
-					]
-				},
-				{
-					"nameUrl": "security.html",
-					"title": "Security",
-					"generation": "markdown"
-				},
-				{
-					"nameUrl": "downloads.html",
-					"title": "Downloads",
-					"generation": "markdown"
-				},
-				{
-					"nameUrl": "all-examples.html",
-					"title": "All Examples",
-					"generation": "markdown"
-				},
-				{
-					"nameUrl": "toc.html",
-					"title": "Table of Contents",
-					"generation": "html"
-				}
-			]
-		}
-	}
+    "resourceType": "ImplementationGuide",
+    "id": "hl7.fhir.us.core",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core",
+    "version": "3.1.1",
+    "name": "USCore",
+    "title": "US Core",
+    "status": "active",
+    "date": "2020-08-28T10:54:27+10:00",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US",
+                    "display": "United States of America"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "packageId": "hl7.fhir.us.core",
+    "license": "CC0-1.0",
+    "fhirVersion": [
+        "4.0.1"
+    ],
+    "definition": {
+        "grouping": [
+            {
+                "name": "base"
+            }
+        ],
+        "resource": [
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-glucose.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-glucose"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Procedure"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Procedure-rehab.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Procedure/rehab"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CareTeam"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "CareTeam-example.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "CareTeam/example"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-leukocyte-esterase.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-leukocyte-esterase"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Bundle"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Bundle-66c8856b-ba11-4876-8aa8-467aad8c11a2.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Bundle/66c8856b-ba11-4876-8aa8-467aad8c11a2"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-bilirubin.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-bilirubin"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Condition"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Condition-hc1.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Condition/hc1"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-sediment.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-sediment"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Immunization"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Immunization-imm-1.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Immunization/imm-1"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-pediatric-wt-example.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/pediatric-wt-example"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Organization"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Organization-saint-luke-w-endpoint.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Organization/saint-luke-w-endpoint"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-ph.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-ph"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Encounter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Encounter-example-1.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Encounter/example-1"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "DiagnosticReport"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "DiagnosticReport-chest-xray-report.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "DiagnosticReport/chest-xray-report"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-serum-sodium.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/serum-sodium"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "DiagnosticReport"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "DiagnosticReport-cbc.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "DiagnosticReport/cbc"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-serum-potassium.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/serum-potassium"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Encounter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Encounter-1036.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Encounter/1036"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-some-day-smoker.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/some-day-smoker"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Location"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Location-hl7east.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Location/hl7east"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-serum-co2.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/serum-co2"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-protein.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-protein"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Procedure"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Procedure-defib-implant.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Procedure/defib-implant"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-usg.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/usg"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-serum-chloride.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/serum-chloride"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-serum-calcium.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/serum-calcium"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-color.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-color"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-bp-data-absent.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/bp-data-absent"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Patient"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Patient-example.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Patient/example"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Patient"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Patient-child-example.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Patient/child-example"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Patient"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Patient-infant-example.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Patient/infant-example"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-temperature.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/temperature"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-bmi.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/bmi"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Medication"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Medication-uscore-med2.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Medication/uscore-med2"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-cells.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-cells"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-length.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/length"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Device"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Device-udi-2.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Device/udi-2"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "MedicationRequest"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "MedicationRequest-uscore-mo1.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "MedicationRequest/uscore-mo1"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Practitioner"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Practitioner-practitioner-2.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Practitioner/practitioner-2"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Goal"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Goal-goal-1.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Goal/goal-1"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-rbcs.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-rbcs"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urobilinogen.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urobilinogen"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Medication"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Medication-uscore-med1.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Medication/uscore-med1"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-bacteria.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-bacteria"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Bundle"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Bundle-uscore-mo3.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Bundle/uscore-mo3"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-ofc-percentile.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/ofc-percentile"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "MedicationRequest"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "MedicationRequest-self-tylenol.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "MedicationRequest/self-tylenol"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "DiagnosticReport"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "DiagnosticReport-metabolic-panel.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "DiagnosticReport/metabolic-panel"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Device"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Device-udi-3.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Device/udi-3"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "MedicationRequest"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "MedicationRequest-uscore-mo2.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "MedicationRequest/uscore-mo2"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Bundle"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Bundle-c887e62f-6166-419f-8268-b5ecd6c7b901.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Bundle/c887e62f-6166-419f-8268-b5ecd6c7b901"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-bun.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/bun"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Practitioner"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Practitioner-practitioner-1.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Practitioner/practitioner-1"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-neutrophils.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/neutrophils"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-nitrite.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-nitrite"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-oxygen-saturation.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/oxygen-saturation"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "DiagnosticReport"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "DiagnosticReport-cardiology-report.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "DiagnosticReport/cardiology-report"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-vitals-panel.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/vitals-panel"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-blood-pressure.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/blood-pressure"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-wbcs.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-wbcs"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-height.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/height"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Organization"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Organization-acme-lab.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Organization/acme-lab"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Device"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Device-udi-1.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Device/udi-1"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-hemoglobin.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/hemoglobin"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "DocumentReference"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "DocumentReference-episode-summary.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "DocumentReference/episode-summary"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-hemoglobin.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-hemoglobin"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-heart-rate.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/heart-rate"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-epi-cells.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-epi-cells"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "AllergyIntolerance"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "AllergyIntolerance-example.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "AllergyIntolerance/example"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-blood-glucose.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/blood-glucose"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "DiagnosticReport"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "DiagnosticReport-urinalysis.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "DiagnosticReport/urinalysis"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Condition"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Condition-example.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Condition/example"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-serum-creatinine.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/serum-creatinine"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-satO2-fiO2.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/satO2-fiO2"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-serum-total-bilirubin.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/serum-total-bilirubin"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-pediatric-bmi-example.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/pediatric-bmi-example"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Organization"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Organization-example-organization-2.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Organization/example-organization-2"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-weight.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/weight"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-mchc.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/mchc"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-clarity.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-clarity"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CarePlan"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "CarePlan-colonoscopy.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "CarePlan/colonoscopy"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-erythrocytes.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/erythrocytes"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-urine-ketone.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-ketone"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "Observation-respiratory-rate.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/respiratory-rate"
+                },
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-medication-codes.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-medication-codes"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-immunization.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-immunization"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-location-address-state.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-location-address-state"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-practitionerrole-practitioner.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-practitionerrole-practitioner"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-observation-smokingstatus.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-observation-smokingstatus"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-observation-smokingstatus-max.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-observation-smokingstatus-max"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-omb-race-category.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/omb-race-category"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-practitionerrole.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-practitionerrole"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-allergy-substance.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-allergy-substance"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-narrative-status.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-narrative-status"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CodeSystem"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "CodeSystem-cdcrec.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "CodeSystem/cdcrec"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-organization-name.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-organization-name"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-observation-lab.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-observation-lab"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-diagnosticreport-code.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-diagnosticreport-code"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-pediatric-bmi-for-age.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/pediatric-bmi-for-age"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-head-occipital-frontal-circumference-percentile.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/head-occipital-frontal-circumference-percentile"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-allergyintolerance.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-allergyintolerance"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-goal-lifecycle-status.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-goal-lifecycle-status"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-procedure-code.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-procedure-code"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-documentreference-type.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-documentreference-type"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-provenance-participant-type.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-provenance-participant-type"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-patient-gender.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-patient-gender"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-practitioner.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-practitioner"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-diagnosticreport-note.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-diagnosticreport-note"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-omb-ethnicity-category.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/omb-ethnicity-category"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-provenance.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-provenance"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "OperationDefinition"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "OperationDefinition-docref.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "OperationDefinition/docref"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-condition-clinical-status.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-condition-clinical-status"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:extension"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-birthsex.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-birthsex"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-documentreference-id.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-documentreference-id"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-careplan-category.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-careplan-category"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-encounter-class.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-encounter-class"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-medicationrequest-patient.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-medicationrequest-patient"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CapabilityStatement"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "CapabilityStatement-us-core-server.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "CapabilityStatement/us-core-server"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-condition-category.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-condition-category"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-detailed-ethnicity.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/detailed-ethnicity"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-documentreference-patient.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-documentreference-patient"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-encounter.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-encounter"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-ndc-vaccine-codes.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-ndc-vaccine-codes"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-patient.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-patient"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-diagnosticreport-date.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-diagnosticreport-date"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-procedure-icd10pcs.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-procedure-icd10pcs"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-provider-specialty.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-provider-specialty"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-procedure-date.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-procedure-date"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-vaccines-cvx.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-vaccines-cvx"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-pulse-oximetry.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-pulse-oximetry"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-allergyintolerance-clinical-status.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-allergyintolerance-clinical-status"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-documentreference-date.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-documentreference-date"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-medicationrequest-intent.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-medicationrequest-intent"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-location.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-location"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-location-address.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-location-address"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-observation-smoking-status-status.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-observation-smoking-status-status"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-usps-state.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-usps-state"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-practitioner-name.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-practitioner-name"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-encounter-type.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-encounter-type"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-documentreference-period.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-documentreference-period"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-observation-code.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-observation-code"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-location-name.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-location-name"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-condition-onset-date.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-condition-onset-date"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-patient-given.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-patient-given"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-procedure.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-procedure"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-encounter-type.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-encounter-type"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-condition-code.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-condition-code"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CodeSystem"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "CodeSystem-condition-category.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "CodeSystem/condition-category"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-medicationrequest-encounter.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-medicationrequest-encounter"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-encounter-patient.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-encounter-patient"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-organization-address.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-organization-address"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-observation-category.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-observation-category"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-medication.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-medication"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-diagnosticreport-status.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-diagnosticreport-status"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-observation-date.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-observation-date"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-birthsex.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/birthsex"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-diagnosticreport-category.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-diagnosticreport-category"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-observation-status.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-observation-status"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-diagnosticreport-report-and-note-codes.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-diagnosticreport-report-and-note-codes"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-provider-role.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-provider-role"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-ethnicity.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-ethnicity"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-documentreference.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-documentreference"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:extension"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-direct.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-direct"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-smoking-status-observation-codes.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-smoking-status-observation-codes"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-careteam-provider-roles.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-careteam-provider-roles"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-documentreference-type.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-documentreference-type"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-encounter-date.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-encounter-date"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-diagnosticreport-category.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-diagnosticreport-category"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-patient-birthdate.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-patient-birthdate"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-careteam.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-careteam"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-procedure-status.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-procedure-status"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-clinical-note-type.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-clinical-note-type"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-encounter-status.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-encounter-status"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ConceptMap"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ConceptMap-ndc-cvx.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ConceptMap/ndc-cvx"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:extension"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-ethnicity.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-ethnicity"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-careplan-status.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-careplan-status"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-careplan.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-careplan"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-condition-patient.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-condition-patient"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-allergyintolerance-patient.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-allergyintolerance-patient"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-device-patient.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-device-patient"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-condition-code.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-condition-code"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-observation-patient.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-observation-patient"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-race.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-race"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-careplan-patient.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-careplan-patient"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-patient-family.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-patient-family"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-smokingstatus.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-smokingstatus"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-medicationrequest-status.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-medicationrequest-status"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:extension"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-race.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-race"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-location-address-postalcode.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-location-address-postalcode"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-encounter-id.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-encounter-id"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-medicationrequest-authoredon.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-medicationrequest-authoredon"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-documentreference-status.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-documentreference-status"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-documentreference-category.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-documentreference-category"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-procedure-patient.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-procedure-patient"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-goal-target-date.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-goal-target-date"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-diagnosticreport-patient.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-diagnosticreport-patient"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-careplan-date.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-careplan-date"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-careteam-patient.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-careteam-patient"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-organization.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-organization"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-immunization-date.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-immunization-date"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-encounter-identifier.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-encounter-identifier"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-practitionerrole-specialty.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-practitionerrole-specialty"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-patient-name.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-patient-name"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-device-type.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-device-type"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-procedure-code.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-procedure-code"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-diagnosticreport-lab.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-diagnosticreport-lab"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-goal-patient.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-goal-patient"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-simple-language.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/simple-language"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-immunization-patient.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-immunization-patient"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-condition.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-condition"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-pediatric-weight-for-height.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/pediatric-weight-for-height"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-observation-value-codes.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-observation-value-codes"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-patient-id.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-patient-id"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-location-address-city.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-location-address-city"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-goal.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-goal"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-careteam-status.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-careteam-status"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CodeSystem"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "CodeSystem-us-core-documentreference-category.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "CodeSystem/us-core-documentreference-category"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CodeSystem"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "CodeSystem-us-core-provenance-participant-type.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "CodeSystem/us-core-provenance-participant-type"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-us-core-diagnosticreport-lab-codes.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-diagnosticreport-lab-codes"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CodeSystem"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "CodeSystem-careplan-category.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "CodeSystem/careplan-category"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-documentreference-category.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-documentreference-category"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CapabilityStatement"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "CapabilityStatement-us-core-client.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "CapabilityStatement/us-core-client"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-practitioner-identifier.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-practitioner-identifier"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-patient-identifier.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-patient-identifier"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-condition-category.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-condition-category"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "SearchParameter-us-core-immunization-status.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-immunization-status"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-medicationrequest.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-medicationrequest"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "StructureDefinition-us-core-implantable-device.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-implantable-device"
+                },
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/implementationguide-page",
+                        "valueUri": "ValueSet-detailed-race.html"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/detailed-race"
+                },
+                "exampleBoolean": false
+            }
+        ],
+        "page": {
+            "nameUrl": "index.html",
+            "title": "Home",
+            "generation": "markdown",
+            "page": [
+                {
+                    "nameUrl": "guidance.html",
+                    "title": "Guidance",
+                    "generation": "markdown",
+                    "page": [
+                        {
+                            "nameUrl": "general-guidance.html",
+                            "title": "General Guidance",
+                            "generation": "markdown"
+                        },
+                        {
+                            "nameUrl": "clinical-notes-guidance.html",
+                            "title": "Clinical Notes Guidance",
+                            "generation": "markdown"
+                        },
+                        {
+                            "nameUrl": "all-meds.html",
+                            "title": "Medication List Guidance",
+                            "generation": "markdown"
+                        },
+                        {
+                            "nameUrl": "basic-provenance.html",
+                            "title": "Basic Provenance",
+                            "generation": "markdown"
+                        },
+                        {
+                            "nameUrl": "r2-r4-guidance.html",
+                            "title": "DSTU2 to R4 Conversion",
+                            "generation": "markdown"
+                        },
+                        {
+                            "nameUrl": "future-of-us-core.html",
+                            "title": "Future of US Core",
+                            "generation": "markdown"
+                        }
+                    ]
+                },
+                {
+                    "nameUrl": "profiles.html",
+                    "title": "Profiles and Extensions",
+                    "generation": "markdown",
+                    "page": [
+                        {
+                            "nameUrl": "StructureDefinition-us-core-immunization.html",
+                            "title": "StructureDefinition US Core Immunization",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-practitionerrole.html",
+                            "title": "StructureDefinition US Core PractitionerRole",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-observation-lab.html",
+                            "title": "StructureDefinition US Core Observation Lab",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-pediatric-bmi-for-age.html",
+                            "title": "StructureDefinition Pediatric BMI For Age",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-head-occipital-frontal-circumference-percentile.html",
+                            "title": "StructureDefinition Pediatric Head Occipital-frontal Circumference Percentile",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-allergyintolerance.html",
+                            "title": "StructureDefinition US Core AllergyIntolerance",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-practitioner.html",
+                            "title": "StructureDefinition US Core Practitioner",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-diagnosticreport-note.html",
+                            "title": "StructureDefinition US Core DiagnosticReport Note",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-provenance.html",
+                            "title": "StructureDefinition US Core Provenance",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-birthsex.html",
+                            "title": "StructureDefinition US Core Birthsex",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-encounter.html",
+                            "title": "StructureDefinition US Core Encounter",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-patient.html",
+                            "title": "StructureDefinition US Core Patient",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-pulse-oximetry.html",
+                            "title": "StructureDefinition US Core Pulse Oximetry",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-location.html",
+                            "title": "StructureDefinition US Core Location",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-procedure.html",
+                            "title": "StructureDefinition US Core Procedure",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-medication.html",
+                            "title": "StructureDefinition US Core Medication",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-documentreference.html",
+                            "title": "StructureDefinition US Core DocumentReference",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-direct.html",
+                            "title": "StructureDefinition US Core Direct",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-careteam.html",
+                            "title": "StructureDefinition US Core CareTeam",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-ethnicity.html",
+                            "title": "StructureDefinition US Core Ethnicity",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-careplan.html",
+                            "title": "StructureDefinition US Core CarePlan",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-smokingstatus.html",
+                            "title": "StructureDefinition US Core Smokingstatus",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-race.html",
+                            "title": "StructureDefinition US Core Race",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-organization.html",
+                            "title": "StructureDefinition US Core Organization",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-diagnosticreport-lab.html",
+                            "title": "StructureDefinition US Core DiagnosticReport Lab",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-condition.html",
+                            "title": "StructureDefinition US Core Condition",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-pediatric-weight-for-height.html",
+                            "title": "StructureDefinition Pediatric Weight For Height",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-goal.html",
+                            "title": "StructureDefinition US Core Goal",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-medicationrequest.html",
+                            "title": "StructureDefinition US Core MedicationRequest",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "StructureDefinition-us-core-implantable-device.html",
+                            "title": "StructureDefinition US Core Implantable Device",
+                            "generation": "generated"
+                        }
+                    ]
+                },
+                {
+                    "nameUrl": "operations.html",
+                    "title": "Operations",
+                    "generation": "markdown",
+                    "page": [
+                        {
+                            "nameUrl": "OperationDefinition-docref.html",
+                            "title": "OperationDefinition Docref",
+                            "generation": "generated"
+                        }
+                    ]
+                },
+                {
+                    "nameUrl": "terminology.html",
+                    "title": "Terminology",
+                    "generation": "markdown",
+                    "page": [
+                        {
+                            "nameUrl": "ValueSet-us-core-medication-codes.html",
+                            "title": "ValueSet US Core Medication Codes",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-observation-smokingstatus.html",
+                            "title": "ValueSet US Core Observation Smokingstatus Preferred",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-observation-smokingstatus-max.html",
+                            "title": "ValueSet US Core Observation Smokingstatus Max-Binding",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-omb-race-category.html",
+                            "title": "ValueSet Omb Race Category",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-allergy-substance.html",
+                            "title": "ValueSet US Core Allergy Substance",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-narrative-status.html",
+                            "title": "ValueSet US Core Narrative Status",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-documentreference-type.html",
+                            "title": "ValueSet US Core DocumentReference Type",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-omb-ethnicity-category.html",
+                            "title": "ValueSet Omb Ethnicity Category",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-condition-category.html",
+                            "title": "ValueSet US Core Condition Category",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-detailed-ethnicity.html",
+                            "title": "ValueSet Detailed Ethnicity",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-ndc-vaccine-codes.html",
+                            "title": "ValueSet US Core Ndc Vaccine Codes",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-procedure-icd10pcs.html",
+                            "title": "ValueSet US Core Procedure Icd10pcs",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-provider-specialty.html",
+                            "title": "ValueSet US Core Provider Specialty",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-vaccines-cvx.html",
+                            "title": "ValueSet US Core Vaccines Cvx",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-observation-smoking-status-status.html",
+                            "title": "ValueSet US Core Observation SmokingStatus Status",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-usps-state.html",
+                            "title": "ValueSet US Core Usps State",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-encounter-type.html",
+                            "title": "ValueSet US Core Encounter Type",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-condition-code.html",
+                            "title": "ValueSet US Core Condition Code",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-birthsex.html",
+                            "title": "ValueSet Birthsex",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-diagnosticreport-report-and-note-codes.html",
+                            "title": "ValueSet US Core DiagnosticReport Report And Note Codes",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-provider-role.html",
+                            "title": "ValueSet US Core Provider Role",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-smoking-status-observation-codes.html",
+                            "title": "ValueSet US Core Smoking Status Observation Codes",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-careteam-provider-roles.html",
+                            "title": "ValueSet US Core CareTeam Provider Roles",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-diagnosticreport-category.html",
+                            "title": "ValueSet US Core DiagnosticReport Category",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-clinical-note-type.html",
+                            "title": "ValueSet US Core Clinical Note Type",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-documentreference-category.html",
+                            "title": "ValueSet US Core DocumentReference Category",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-procedure-code.html",
+                            "title": "ValueSet US Core Procedure Code",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-simple-language.html",
+                            "title": "ValueSet Simple Language",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-observation-value-codes.html",
+                            "title": "ValueSet US Core Observation Value Codes",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-us-core-diagnosticreport-lab-codes.html",
+                            "title": "ValueSet US Core DiagnosticReport Lab Codes",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ValueSet-detailed-race.html",
+                            "title": "ValueSet Detailed Race",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "CodeSystem-cdcrec.html",
+                            "title": "CodeSystem Cdcrec",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "CodeSystem-condition-category.html",
+                            "title": "CodeSystem Condition Category",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "CodeSystem-us-core-documentreference-category.html",
+                            "title": "CodeSystem US Core DocumentReference Category",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "CodeSystem-careplan-category.html",
+                            "title": "CodeSystem CarePlan Category",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "ConceptMap-ndc-cvx.html",
+                            "title": "ConceptMap Ndc Cvx",
+                            "generation": "generated"
+                        }
+                    ]
+                },
+                {
+                    "nameUrl": "searchparameters.html",
+                    "title": "Search Parameters",
+                    "generation": "markdown",
+                    "page": [
+                        {
+                            "nameUrl": "SearchParameter-us-core-location-address-state.html",
+                            "title": "SearchParameter US Core Location Address State",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-practitionerrole-practitioner.html",
+                            "title": "SearchParameter US Core PractitionerRole Practitioner",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-organization-name.html",
+                            "title": "SearchParameter US Core Organization Name",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-diagnosticreport-code.html",
+                            "title": "SearchParameter US Core DiagnosticReport Code",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-goal-lifecycle-status.html",
+                            "title": "SearchParameter US Core Goal Lifecycle Status",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-procedure-code.html",
+                            "title": "SearchParameter US Core Procedure Code",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-patient-gender.html",
+                            "title": "SearchParameter US Core Patient Gender",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-condition-clinical-status.html",
+                            "title": "SearchParameter US Core Condition Clinical Status",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-documentreference-id.html",
+                            "title": "SearchParameter US Core DocumentReference Id",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-careplan-category.html",
+                            "title": "SearchParameter US Core CarePlan Category",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-encounter-class.html",
+                            "title": "SearchParameter US Core Encounter Class",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-medicationrequest-patient.html",
+                            "title": "SearchParameter US Core MedicationRequest Patient",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-documentreference-patient.html",
+                            "title": "SearchParameter US Core DocumentReference Patient",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-diagnosticreport-date.html",
+                            "title": "SearchParameter US Core DiagnosticReport Date",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-procedure-date.html",
+                            "title": "SearchParameter US Core Procedure Date",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-allergyintolerance-clinical-status.html",
+                            "title": "SearchParameter US Core AllergyIntolerance Clinical Status",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-documentreference-date.html",
+                            "title": "SearchParameter US Core DocumentReference Date",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-medicationrequest-intent.html",
+                            "title": "SearchParameter US Core MedicationRequest Intent",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-location-address.html",
+                            "title": "SearchParameter US Core Location Address",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-practitioner-name.html",
+                            "title": "SearchParameter US Core Practitioner Name",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-documentreference-period.html",
+                            "title": "SearchParameter US Core DocumentReference Period",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-observation-code.html",
+                            "title": "SearchParameter US Core Observation Code",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-location-name.html",
+                            "title": "SearchParameter US Core Location Name",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-condition-onset-date.html",
+                            "title": "SearchParameter US Core Condition Onset Date",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-patient-given.html",
+                            "title": "SearchParameter US Core Patient Given",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-encounter-type.html",
+                            "title": "SearchParameter US Core Encounter Type",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-medicationrequest-encounter.html",
+                            "title": "SearchParameter US Core MedicationRequest Encounter",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-encounter-patient.html",
+                            "title": "SearchParameter US Core Encounter Patient",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-organization-address.html",
+                            "title": "SearchParameter US Core Organization Address",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-observation-category.html",
+                            "title": "SearchParameter US Core Observation Category",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-diagnosticreport-status.html",
+                            "title": "SearchParameter US Core DiagnosticReport Status",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-observation-date.html",
+                            "title": "SearchParameter US Core Observation Date",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-diagnosticreport-category.html",
+                            "title": "SearchParameter US Core DiagnosticReport Category",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-observation-status.html",
+                            "title": "SearchParameter US Core Observation Status",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-ethnicity.html",
+                            "title": "SearchParameter US Core Ethnicity",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-documentreference-type.html",
+                            "title": "SearchParameter US Core DocumentReference Type",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-encounter-date.html",
+                            "title": "SearchParameter US Core Encounter Date",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-patient-birthdate.html",
+                            "title": "SearchParameter US Core Patient Birthdate",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-procedure-status.html",
+                            "title": "SearchParameter US Core Procedure Status",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-encounter-status.html",
+                            "title": "SearchParameter US Core Encounter Status",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-careplan-status.html",
+                            "title": "SearchParameter US Core CarePlan Status",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-condition-patient.html",
+                            "title": "SearchParameter US Core Condition Patient",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-allergyintolerance-patient.html",
+                            "title": "SearchParameter US Core AllergyIntolerance Patient",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-device-patient.html",
+                            "title": "SearchParameter US Core Device Patient",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-condition-code.html",
+                            "title": "SearchParameter US Core Condition Code",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-observation-patient.html",
+                            "title": "SearchParameter US Core Observation Patient",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-race.html",
+                            "title": "SearchParameter US Core Race",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-careplan-patient.html",
+                            "title": "SearchParameter US Core CarePlan Patient",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-patient-family.html",
+                            "title": "SearchParameter US Core Patient Family",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-medicationrequest-status.html",
+                            "title": "SearchParameter US Core MedicationRequest Status",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-location-address-postalcode.html",
+                            "title": "SearchParameter US Core Location Address Postalcode",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-encounter-id.html",
+                            "title": "SearchParameter US Core Encounter Id",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-medicationrequest-authoredon.html",
+                            "title": "SearchParameter US Core MedicationRequest Authoredon",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-documentreference-status.html",
+                            "title": "SearchParameter US Core DocumentReference Status",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-procedure-patient.html",
+                            "title": "SearchParameter US Core Procedure Patient",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-goal-target-date.html",
+                            "title": "SearchParameter US Core Goal Target Date",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-diagnosticreport-patient.html",
+                            "title": "SearchParameter US Core DiagnosticReport Patient",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-careplan-date.html",
+                            "title": "SearchParameter US Core CarePlan Date",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-careteam-patient.html",
+                            "title": "SearchParameter US Core CareTeam Patient",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-immunization-date.html",
+                            "title": "SearchParameter US Core Immunization Date",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-encounter-identifier.html",
+                            "title": "SearchParameter US Core Encounter Identifier",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-practitionerrole-specialty.html",
+                            "title": "SearchParameter US Core PractitionerRole Specialty",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-patient-name.html",
+                            "title": "SearchParameter US Core Patient Name",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-device-type.html",
+                            "title": "SearchParameter US Core Device Type",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-goal-patient.html",
+                            "title": "SearchParameter US Core Goal Patient",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-immunization-patient.html",
+                            "title": "SearchParameter US Core Immunization Patient",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-patient-id.html",
+                            "title": "SearchParameter US Core Patient Id",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-location-address-city.html",
+                            "title": "SearchParameter US Core Location Address City",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-careteam-status.html",
+                            "title": "SearchParameter US Core CareTeam Status",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-documentreference-category.html",
+                            "title": "SearchParameter US Core DocumentReference Category",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-practitioner-identifier.html",
+                            "title": "SearchParameter US Core Practitioner Identifier",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-patient-identifier.html",
+                            "title": "SearchParameter US Core Patient Identifier",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-condition-category.html",
+                            "title": "SearchParameter US Core Condition Category",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "SearchParameter-us-core-immunization-status.html",
+                            "title": "SearchParameter US Core Immunization Status",
+                            "generation": "generated"
+                        }
+                    ]
+                },
+                {
+                    "nameUrl": "capstatements.html",
+                    "title": "Capability Statements",
+                    "generation": "markdown",
+                    "page": [
+                        {
+                            "nameUrl": "CapabilityStatement-us-core-server.html",
+                            "title": "CapabilityStatement US Core Server",
+                            "generation": "generated"
+                        },
+                        {
+                            "nameUrl": "CapabilityStatement-us-core-client.html",
+                            "title": "CapabilityStatement US Core Client",
+                            "generation": "generated"
+                        }
+                    ]
+                },
+                {
+                    "nameUrl": "security.html",
+                    "title": "Security",
+                    "generation": "markdown"
+                },
+                {
+                    "nameUrl": "downloads.html",
+                    "title": "Downloads",
+                    "generation": "markdown"
+                },
+                {
+                    "nameUrl": "all-examples.html",
+                    "title": "All Examples",
+                    "generation": "markdown"
+                },
+                {
+                    "nameUrl": "toc.html",
+                    "title": "Table of Contents",
+                    "generation": "html"
+                }
+            ]
+        }
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/CapabilityStatement-us-core-client.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/CapabilityStatement-us-core-client.json
@@ -1,4372 +1,4372 @@
 {
-	"resourceType": "CapabilityStatement",
-	"id": "us-core-client",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"> <h2 id=\"title\">US Core Client CapabilityStatement</h2></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/CapabilityStatement/us-core-client",
-	"version": "4.0.0",
-	"name": "UsCoreClientCapabilityStatement",
-	"title": "US Core Client CapabilityStatement",
-	"status": "active",
-	"experimental": false,
-	"date": "2021-06-17T14:23:50.993763-08:00",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "This Section describes the expected capabilities of the US Core Client which is responsible for creating and initiating the queries for information about an individual patient. The complete list of FHIR profiles, RESTful operations, and search parameters supported by US Core Servers are defined in the [Conformance Requirements for Server](CapabilityStatement-us-core-server.html). US Core Clients have the option of choosing from this list to access necessary data based on their local use cases and other contextual requirements.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"kind": "requirements",
-	"instantiates": [
-		"http://hl7.org/fhir/us/core/CapabilityStatement/us-core-client"
-	],
-	"_instantiates": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		}
-	],
-	"fhirVersion": "4.0.1",
-	"format": [
-		"json",
-		"xml"
-	],
-	"_format": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHOULD"
-				}
-			]
-		}
-	],
-	"patchFormat": [
-		"application/json-patch+json"
-	],
-	"_patchFormat": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHOULD"
-				}
-			]
-		}
-	],
-	"implementationGuide": [
-		"http://fhir-registry.smarthealthit.org",
-		"http://hl7.org/fhir/uv/bulkdata/ImplementationGuide/hl7.fhir.uv.bulkdata"
-	],
-	"_implementationGuide": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHOULD"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHOULD"
-				}
-			]
-		}
-	],
-	"rest": [
-		{
-			"mode": "client",
-			"documentation": "The US Core Client **SHALL**:\n\n1. Support fetching and querying of one or more US Core profile(s), using the supported RESTful interactions and search parameters declared in the US Core Server CapabilityStatement.\n",
-			"security": {
-				"description": "1. See the [General Security Considerations] section for requirements and recommendations."
-			},
-			"resource": [
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "clinical-status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "AllergyIntolerance",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"_searchRevInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							]
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "clinical-status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-clinical-status",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-patient",
-							"type": "reference",
-							"documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "CarePlan",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"documentation": "* Additional considerations for systems aligning with [HL7 Consolidated (C-CDA)](http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492) Care Plan requirements:\n    - US Core Goal **SHOULD** be present in CarePlan.goal\n    - US Core Condition **SHOULD** be present in CarePlan.addresses\n    - Assement and Plan **MAY** be included as narrative text",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"_searchRevInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							]
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "category",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-category",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-date",
-							"type": "date",
-							"documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-patient",
-							"type": "reference",
-							"documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-status",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "CareTeam",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"_searchRevInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							]
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-patient",
-							"type": "reference",
-							"documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-status",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "code"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "onset-date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "clinical-status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Condition",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"_searchRevInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							]
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "category",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-category",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "clinical-status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-clinical-status",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-patient",
-							"type": "reference",
-							"documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "onset-date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-onset-date",
-							"type": "date",
-							"documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "code",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-code",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "type"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Device",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"documentation": "* Implantable medical devices that have UDI information **SHALL** represent the UDI code in `Device.udiCarrier.carrierHRF`.\n   - All of the five UDI-PI elements that are present in the UDI code **SHALL** be represented in the corresponding US Core Implantable Device Profile element.\n   \n   UDI may not be present in all scenarios such as historical implantable devices, patient reported implant information, payer reported devices, or improperly documented implants. If UDI is not present and the manufacturer and/or model number information is available, they **SHOULD** be included to support historical reports of implantable medical devices as follows:\n\n    <table>\n    <thead>\n    <tr class=\"header\">\n    <th>data element</th>\n    <th>US Core Implantable Device Profile element</th>\n    </tr>\n    </thead>\n    <tbody>\n    <tr class=\"odd\">\n    <td>manufacturer</td>\n    <td>Device.manufacturer</td>\n    </tr>\n    <tr class=\"even\">\n    <td>model</td>\n    <td>Device.model</td>\n    </tr>\n    </tbody>\n    </table>\n\n* Servers **SHOULD** support query by Device.type to allow clients to request the patient's devices by a specific type. Note: The Device.type is too granular to differentiate implantable vs. non-implantable devices.  \n* In the Quick Start section below, searching for all devices is described. Records of implanted devices **MAY** be queried against UDI data including:\n\n    - UDI HRF string (`udi-carrier`)\n    - UDI Device Identifier (`udi-di`)\n    - Manufacturer (`manufacturer`)\n    - Model number (`model`)\n\n  Implementers **MAY** also adopt custom SearchParameters for searching by:\n\n    - lot numbers\n    - serial number\n    - expiration date\n    - manufacture date\n    - distinct identifier",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"_searchRevInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							]
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-patient",
-							"type": "reference",
-							"documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "type",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-type",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "code"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "code"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "DiagnosticReport",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab",
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "create",
-							"documentation": "This conformance expectation applies **only**  to the *US Core DiagnosticReport Profile for Report and Note exchange* profile.  The conformance expectation for the *US Core DiagnosticReport Profile for Laboratory Results Reporting* is  **MAY**."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"_searchRevInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							]
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-status",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient",
-							"type": "reference",
-							"documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "category",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-category",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "code",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-code",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-date",
-							"type": "date",
-							"documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "type"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "type"
-								},
-								{
-									"url": "required",
-									"valueString": "period"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "DocumentReference",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"documentation": "The DocumentReference.type binding SHALL support at a minimum the [5 Common Clinical Notes](ValueSet-us-core-clinical-note-type.html) and may extend to the full US Core DocumentReference Type Value Set",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"_searchRevInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							]
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "_id",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-id",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-status",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient",
-							"type": "reference",
-							"documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "category",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-category",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "type",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-type",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-date",
-							"type": "date",
-							"documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "period",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-period",
-							"type": "date",
-							"documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
-						}
-					],
-					"operation": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "docref",
-							"definition": "http://hl7.org/fhir/us/core/OperationDefinition/docref",
-							"documentation": "A client **SHOULD** be capable of transacting a $docref operation and capable of receiving at least a reference to a generated CCD document, and  **MAY** be able to receive other document types, if available.   **SHOULD**  be capable of receiving documents as included resources in response to the operation.\n\n`GET [base]/DocumentReference/$docref?patient=[id]`"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "type"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "class"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Encounter",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"documentation": "* The Encounter resource can represent a reason using either a code with `Encounter.reasonCode`, or a reference with `Encounter.reasonReference` to  Condition or other resource.\n   * Although both are marked as must support, the server systems are not required to support both a code and a reference, but they **SHALL** support *at least one* of these elements.\n   * The client application **SHALL** support both elements.\n   * if `Encounter.reasonReference` references an Observation, it **SHOULD** conform to a US Core Observation if applicable. (for example, a laboratory result should conform to the US Core Laboratory Result Observation Profile)\n* The intent of this profile is to support *where the encounter occurred*.  The location address can be represented by either by the Location referenced by `Encounter.location.location` or indirectly through the Organization referenced by `Encounter.serviceProvider`.\n  * Although both are marked as must support, the server systems are not required to support both `Encounter.location.location` and `Encounter.serviceProvider`, but they **SHALL** support *at least one* of these elements.\n  * The client application **SHALL** support both elements.\n  * if using `Encounter.locatison.location` it **SHOULD** conform to US Core Location.  However, as a result of implementation feedback, it **MAY**  reference the base FHIR Location resource.  See this guidance on [Referencing US Core Profiles]",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"_searchRevInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							]
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "_id",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-id",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "class",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-class",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-date",
-							"type": "date",
-							"documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "identifier",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-identifier",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-patient",
-							"type": "reference",
-							"documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-status",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "type",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-type",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "lifecycle-status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "target-date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Goal",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"_searchRevInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							]
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "lifecycle-status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-lifecycle-status",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-patient",
-							"type": "reference",
-							"documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "target-date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-target-date",
-							"type": "date",
-							"documentation": "A client **SHALL** provide a value precise to the *day*.\n\nA server **SHALL** support a value a value precise to the *day*."
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Immunization",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"documentation": "* Based upon the ONC U.S. Core Data for Interoperability (USCDI) v1 requirements, CVX vaccine codes are required and the NDC vaccine codes **SHOULD** be supported as translations to them.",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"_searchRevInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							]
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-patient",
-							"type": "reference",
-							"documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-status",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-date",
-							"type": "date",
-							"documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						}
-					],
-					"type": "Location",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-location"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"documentation": "* The US Core Location  and PractitionerRole Profiles are not explicitly referenced in any US Core Profile. However they **SHOULD** be used as the default profile if referenced by another US Core profile.",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "name",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-name",
-							"type": "string"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "address",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address",
-							"type": "string"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "address-city",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-city",
-							"type": "string"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "address-state",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-state",
-							"type": "string"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "address-postalcode",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-postalcode",
-							"type": "string"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						}
-					],
-					"type": "Medication",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"documentation": "* The  MedicationRequest resource can represent a medication, using an external reference to a Medication resource. If an external Medication Resource is used in a MedicationRequest, then the READ  **SHALL**  be supported.",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "intent"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "intent"
-								},
-								{
-									"url": "required",
-									"valueString": "authoredon"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "intent"
-								},
-								{
-									"url": "required",
-									"valueString": "encounter"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "intent"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "MedicationRequest",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"documentation": "* The MedicationRequest resources can represent a medication using either a code or refer to the Medication resource. When referencing Medication, the resource may be [contained](http://hl7.org/fhir/R4/references.html#contained) or an external resource. The server application **MAY** choose any one way or more than one method, but if an external reference to Medication is used, the server **SHALL** support the _include` parameter for searching this element. The client application must support all methods.\n\n For example, A server **SHALL** be capable of returning all medications for a patient using one of or both:\n\n `GET /MedicationRequest?patient=[id]`\n\n `GET /MedicationRequest?patient=[id]&_include=MedicationRequest:medication`\n\n* The MedicationRequest resource can represent that information is from a secondary source using either a boolean flag or reference in `MedicationRequest.reportedBoolean`, or a reference using `MedicationRequest.reportedReference` to Practitioner or other resource.\n   *   Although both are marked as must support, the server systems are not required to support both a boolean and a reference, but **SHALL** choose to support at least one of these elements.\n   *  The client application **SHALL** support both elements.",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchInclude": [
-						"MedicationRequest:medication"
-					],
-					"_searchInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							]
-						}
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"_searchRevInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							]
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-status",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "intent",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-intent",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-patient",
-							"type": "reference",
-							"documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "encounter",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-encounter",
-							"type": "reference",
-							"documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "authoredon",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-authoredon",
-							"type": "date",
-							"documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "code"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "code"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Observation",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab",
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure",
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-bmi",
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-head-circumference",
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-height",
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-weight",
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-temperature",
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate",
-						"http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age",
-						"http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile",
-						"http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height",
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry",
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-respiratory-rate",
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"documentation": "* Systems **SHOULD** support `Observation.effectivePeriod` to accurately represent laboratory tests that are collected over a period of time (for example, a 24-Hour Urine Collection test).\n* An Observation without a value, **SHALL** include a reason why the data is absent unless there are component observations, or references to other Observations that are grouped within it.",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"_searchRevInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							]
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-status",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "category",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-category",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "code",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-code",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-date",
-							"type": "date",
-							"documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient",
-							"type": "reference",
-							"documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						}
-					],
-					"type": "Organization",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "name",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-name",
-							"type": "string"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "address",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-address",
-							"type": "string"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "gender"
-								},
-								{
-									"url": "required",
-									"valueString": "name"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "family"
-								},
-								{
-									"url": "required",
-									"valueString": "gender"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "birthdate"
-								},
-								{
-									"url": "required",
-									"valueString": "family"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "birthdate"
-								},
-								{
-									"url": "required",
-									"valueString": "name"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Patient",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"documentation": "* For ONC's USCDI requirements, each Patient must support the following additional elements. These elements are included in the formal definition of the profile. The patient examples include all of these elements.\n\n1. contact detail (e.g. a telephone number or an email address)\n1. a communication language\n1. a race\n1. an ethnicity\n1. a birth sex*\n1. previous name\n   - Previous name is represented by providing an end date in the `Patient.name.period` element for a previous name.\n1. suffix\n   - Suffix is represented using the `Patient.name.suffix` element.\n\n",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"_searchRevInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							]
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "_id",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-id",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "birthdate",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-birthdate",
-							"type": "date",
-							"documentation": "A client **SHALL** provide a value precise to the *day*.\n\nA server **SHALL** support a value a value precise to the *day*."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "family",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-family",
-							"type": "string"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "gender",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-gender",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "given",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-given",
-							"type": "string"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "identifier",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-identifier",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "name",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-name",
-							"type": "string"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						}
-					],
-					"type": "Practitioner",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "name",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-name",
-							"type": "string"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "identifier",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-identifier",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						}
-					],
-					"type": "PractitionerRole",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"documentation": "* The US Core Location  and PractitionerRole Profiles are not explicitly referenced in any US Core Profile. However they **SHOULD** be used as the default profile if referenced by another US Core profile.",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchInclude": [
-						"PractitionerRole:endpoint",
-						"PractitionerRole:practitioner"
-					],
-					"_searchInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							]
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "specialty",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-specialty",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "practitioner",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-practitioner",
-							"type": "reference",
-							"documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "code"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Procedure",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"documentation": "*  A procedure including an implantable device **SHOULD** use `Procedure.focalDevice` with a reference to the [US Core Implantable Device Profile].",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"_searchRevInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							]
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-status",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-patient",
-							"type": "reference",
-							"documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-date",
-							"type": "date",
-							"documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "code",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-code",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						}
-					],
-					"type": "Provenance",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"documentation": "* If a system receives a provider in `Provenance.agent.who` as free text they must capture who sent them the information as the organization. On request they **SHALL** provide this organization as the source and **MAY** include the free text provider.\n* Systems that need to know the activity has occurred **SHOULD** populate the activity.",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						}
-					],
-					"type": "ValueSet",
-					"operation": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "expand",
-							"definition": "http://hl7.org/fhir/OperationDefinition/ValueSet-expand",
-							"documentation": "A  client can determine the note and report types support by a server by invoking the standard FHIR Value Set Expansion ($expand) operation defined in the FHIR R4 specification. Because servers may support different read and write formats, it also is used to determine the formats (for example, text, pdf) the server supports read and write transactions."
-						}
-					]
-				}
-			],
-			"interaction": [
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "MAY"
-						}
-					],
-					"code": "transaction"
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "MAY"
-						}
-					],
-					"code": "batch"
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "MAY"
-						}
-					],
-					"code": "search-system"
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "MAY"
-						}
-					],
-					"code": "history-system"
-				}
-			]
-		}
-	]
+    "resourceType": "CapabilityStatement",
+    "id": "us-core-client",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/CapabilityStatement/us-core-client",
+    "version": "4.0.0",
+    "name": "UsCoreClientCapabilityStatement",
+    "title": "US Core Client CapabilityStatement",
+    "status": "active",
+    "experimental": false,
+    "date": "2021-06-17T14:23:50.993763-08:00",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "This Section describes the expected capabilities of the US Core Client which is responsible for creating and initiating the queries for information about an individual patient. The complete list of FHIR profiles, RESTful operations, and search parameters supported by US Core Servers are defined in the [Conformance Requirements for Server](CapabilityStatement-us-core-server.html). US Core Clients have the option of choosing from this list to access necessary data based on their local use cases and other contextual requirements.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "kind": "requirements",
+    "instantiates": [
+        "http://hl7.org/fhir/us/core/CapabilityStatement/us-core-client"
+    ],
+    "_instantiates": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        }
+    ],
+    "fhirVersion": "4.0.1",
+    "format": [
+        "json",
+        "xml"
+    ],
+    "_format": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHOULD"
+                }
+            ]
+        }
+    ],
+    "patchFormat": [
+        "application/json-patch+json"
+    ],
+    "_patchFormat": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHOULD"
+                }
+            ]
+        }
+    ],
+    "implementationGuide": [
+        "http://fhir-registry.smarthealthit.org",
+        "http://hl7.org/fhir/uv/bulkdata/ImplementationGuide/hl7.fhir.uv.bulkdata"
+    ],
+    "_implementationGuide": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHOULD"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHOULD"
+                }
+            ]
+        }
+    ],
+    "rest": [
+        {
+            "mode": "client",
+            "documentation": "The US Core Client **SHALL**:\n\n1. Support fetching and querying of one or more US Core profile(s), using the supported RESTful interactions and search parameters declared in the US Core Server CapabilityStatement.\n",
+            "security": {
+                "description": "1. See the [General Security Considerations] section for requirements and recommendations."
+            },
+            "resource": [
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "clinical-status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "AllergyIntolerance",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "_searchRevInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "clinical-status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-clinical-status",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-patient",
+                            "type": "reference",
+                            "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "CarePlan",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "documentation": "* Additional considerations for systems aligning with [HL7 Consolidated (C-CDA)](http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492) Care Plan requirements:\n    - US Core Goal **SHOULD** be present in CarePlan.goal\n    - US Core Condition **SHOULD** be present in CarePlan.addresses\n    - Assement and Plan **MAY** be included as narrative text",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "_searchRevInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "category",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-category",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-date",
+                            "type": "date",
+                            "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-patient",
+                            "type": "reference",
+                            "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-status",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "CareTeam",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "_searchRevInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-patient",
+                            "type": "reference",
+                            "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-status",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "code"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "onset-date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "clinical-status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Condition",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "_searchRevInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "category",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-category",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "clinical-status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-clinical-status",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-patient",
+                            "type": "reference",
+                            "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "onset-date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-onset-date",
+                            "type": "date",
+                            "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "code",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-code",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "type"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Device",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "documentation": "* Implantable medical devices that have UDI information **SHALL** represent the UDI code in `Device.udiCarrier.carrierHRF`.\n   - All of the five UDI-PI elements that are present in the UDI code **SHALL** be represented in the corresponding US Core Implantable Device Profile element.\n   \n   UDI may not be present in all scenarios such as historical implantable devices, patient reported implant information, payer reported devices, or improperly documented implants. If UDI is not present and the manufacturer and/or model number information is available, they **SHOULD** be included to support historical reports of implantable medical devices as follows:\n\n    <table>\n    <thead>\n    <tr class=\"header\">\n    <th>data element</th>\n    <th>US Core Implantable Device Profile element</th>\n    </tr>\n    </thead>\n    <tbody>\n    <tr class=\"odd\">\n    <td>manufacturer</td>\n    <td>Device.manufacturer</td>\n    </tr>\n    <tr class=\"even\">\n    <td>model</td>\n    <td>Device.model</td>\n    </tr>\n    </tbody>\n    </table>\n\n* Servers **SHOULD** support query by Device.type to allow clients to request the patient's devices by a specific type. Note: The Device.type is too granular to differentiate implantable vs. non-implantable devices.  \n* In the Quick Start section below, searching for all devices is described. Records of implanted devices **MAY** be queried against UDI data including:\n\n    - UDI HRF string (`udi-carrier`)\n    - UDI Device Identifier (`udi-di`)\n    - Manufacturer (`manufacturer`)\n    - Model number (`model`)\n\n  Implementers **MAY** also adopt custom SearchParameters for searching by:\n\n    - lot numbers\n    - serial number\n    - expiration date\n    - manufacture date\n    - distinct identifier",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "_searchRevInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-patient",
+                            "type": "reference",
+                            "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "type",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-type",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "code"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "code"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "DiagnosticReport",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "create",
+                            "documentation": "This conformance expectation applies **only**  to the *US Core DiagnosticReport Profile for Report and Note exchange* profile.  The conformance expectation for the *US Core DiagnosticReport Profile for Laboratory Results Reporting* is  **MAY**."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "_searchRevInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-status",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient",
+                            "type": "reference",
+                            "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "category",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-category",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "code",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-code",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-date",
+                            "type": "date",
+                            "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "type"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "type"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "period"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "DocumentReference",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "documentation": "The DocumentReference.type binding SHALL support at a minimum the [5 Common Clinical Notes](ValueSet-us-core-clinical-note-type.html) and may extend to the full US Core DocumentReference Type Value Set",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "_searchRevInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "_id",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-id",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-status",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient",
+                            "type": "reference",
+                            "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "category",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-category",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "type",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-type",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-date",
+                            "type": "date",
+                            "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "period",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-period",
+                            "type": "date",
+                            "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+                        }
+                    ],
+                    "operation": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "docref",
+                            "definition": "http://hl7.org/fhir/us/core/OperationDefinition/docref",
+                            "documentation": "A client **SHOULD** be capable of transacting a $docref operation and capable of receiving at least a reference to a generated CCD document, and  **MAY** be able to receive other document types, if available.   **SHOULD**  be capable of receiving documents as included resources in response to the operation.\n\n`GET [base]/DocumentReference/$docref?patient=[id]`"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "type"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "class"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Encounter",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "documentation": "* The Encounter resource can represent a reason using either a code with `Encounter.reasonCode`, or a reference with `Encounter.reasonReference` to  Condition or other resource.\n   * Although both are marked as must support, the server systems are not required to support both a code and a reference, but they **SHALL** support *at least one* of these elements.\n   * The client application **SHALL** support both elements.\n   * if `Encounter.reasonReference` references an Observation, it **SHOULD** conform to a US Core Observation if applicable. (for example, a laboratory result should conform to the US Core Laboratory Result Observation Profile)\n* The intent of this profile is to support *where the encounter occurred*.  The location address can be represented by either by the Location referenced by `Encounter.location.location` or indirectly through the Organization referenced by `Encounter.serviceProvider`.\n  * Although both are marked as must support, the server systems are not required to support both `Encounter.location.location` and `Encounter.serviceProvider`, but they **SHALL** support *at least one* of these elements.\n  * The client application **SHALL** support both elements.\n  * if using `Encounter.locatison.location` it **SHOULD** conform to US Core Location.  However, as a result of implementation feedback, it **MAY**  reference the base FHIR Location resource.  See this guidance on [Referencing US Core Profiles]",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "_searchRevInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "_id",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-id",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "class",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-class",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-date",
+                            "type": "date",
+                            "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "identifier",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-identifier",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-patient",
+                            "type": "reference",
+                            "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-status",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "type",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-type",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "lifecycle-status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "target-date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Goal",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "_searchRevInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "lifecycle-status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-lifecycle-status",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-patient",
+                            "type": "reference",
+                            "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "target-date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-target-date",
+                            "type": "date",
+                            "documentation": "A client **SHALL** provide a value precise to the *day*.\n\nA server **SHALL** support a value a value precise to the *day*."
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Immunization",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "documentation": "* Based upon the ONC U.S. Core Data for Interoperability (USCDI) v1 requirements, CVX vaccine codes are required and the NDC vaccine codes **SHOULD** be supported as translations to them.",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "_searchRevInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-patient",
+                            "type": "reference",
+                            "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-status",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-date",
+                            "type": "date",
+                            "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        }
+                    ],
+                    "type": "Location",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-location"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "documentation": "* The US Core Location  and PractitionerRole Profiles are not explicitly referenced in any US Core Profile. However they **SHOULD** be used as the default profile if referenced by another US Core profile.",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "name",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-name",
+                            "type": "string"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "address",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address",
+                            "type": "string"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "address-city",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-city",
+                            "type": "string"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "address-state",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-state",
+                            "type": "string"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "address-postalcode",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-postalcode",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        }
+                    ],
+                    "type": "Medication",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "documentation": "* The  MedicationRequest resource can represent a medication, using an external reference to a Medication resource. If an external Medication Resource is used in a MedicationRequest, then the READ  **SHALL**  be supported.",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "intent"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "intent"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "authoredon"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "intent"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "encounter"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "intent"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "MedicationRequest",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "documentation": "* The MedicationRequest resources can represent a medication using either a code or refer to the Medication resource. When referencing Medication, the resource may be [contained](http://hl7.org/fhir/R4/references.html#contained) or an external resource. The server application **MAY** choose any one way or more than one method, but if an external reference to Medication is used, the server **SHALL** support the _include` parameter for searching this element. The client application must support all methods.\n\n For example, A server **SHALL** be capable of returning all medications for a patient using one of or both:\n\n `GET /MedicationRequest?patient=[id]`\n\n `GET /MedicationRequest?patient=[id]&_include=MedicationRequest:medication`\n\n* The MedicationRequest resource can represent that information is from a secondary source using either a boolean flag or reference in `MedicationRequest.reportedBoolean`, or a reference using `MedicationRequest.reportedReference` to Practitioner or other resource.\n   *   Although both are marked as must support, the server systems are not required to support both a boolean and a reference, but **SHALL** choose to support at least one of these elements.\n   *  The client application **SHALL** support both elements.",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchInclude": [
+                        "MedicationRequest:medication"
+                    ],
+                    "_searchInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "_searchRevInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-status",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "intent",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-intent",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-patient",
+                            "type": "reference",
+                            "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "encounter",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-encounter",
+                            "type": "reference",
+                            "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "authoredon",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-authoredon",
+                            "type": "date",
+                            "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "code"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "code"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Observation",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-bmi",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-head-circumference",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-height",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-weight",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-temperature",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-respiratory-rate",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "documentation": "* Systems **SHOULD** support `Observation.effectivePeriod` to accurately represent laboratory tests that are collected over a period of time (for example, a 24-Hour Urine Collection test).\n* An Observation without a value, **SHALL** include a reason why the data is absent unless there are component observations, or references to other Observations that are grouped within it.",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "_searchRevInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-status",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "category",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-category",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "code",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-code",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-date",
+                            "type": "date",
+                            "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient",
+                            "type": "reference",
+                            "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        }
+                    ],
+                    "type": "Organization",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "name",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-name",
+                            "type": "string"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "address",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-address",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "gender"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "name"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "family"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "gender"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "birthdate"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "family"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "birthdate"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "name"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Patient",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "documentation": "* For ONC's USCDI requirements, each Patient must support the following additional elements. These elements are included in the formal definition of the profile. The patient examples include all of these elements.\n\n1. contact detail (e.g. a telephone number or an email address)\n1. a communication language\n1. a race\n1. an ethnicity\n1. a birth sex*\n1. previous name\n   - Previous name is represented by providing an end date in the `Patient.name.period` element for a previous name.\n1. suffix\n   - Suffix is represented using the `Patient.name.suffix` element.\n\n",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "_searchRevInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "_id",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-id",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "birthdate",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-birthdate",
+                            "type": "date",
+                            "documentation": "A client **SHALL** provide a value precise to the *day*.\n\nA server **SHALL** support a value a value precise to the *day*."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "family",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-family",
+                            "type": "string"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "gender",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-gender",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "given",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-given",
+                            "type": "string"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "identifier",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-identifier",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "name",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-name",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        }
+                    ],
+                    "type": "Practitioner",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "name",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-name",
+                            "type": "string"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "identifier",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-identifier",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        }
+                    ],
+                    "type": "PractitionerRole",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "documentation": "* The US Core Location  and PractitionerRole Profiles are not explicitly referenced in any US Core Profile. However they **SHOULD** be used as the default profile if referenced by another US Core profile.",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchInclude": [
+                        "PractitionerRole:endpoint",
+                        "PractitionerRole:practitioner"
+                    ],
+                    "_searchInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "specialty",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-specialty",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "practitioner",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-practitioner",
+                            "type": "reference",
+                            "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "code"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Procedure",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "documentation": "*  A procedure including an implantable device **SHOULD** use `Procedure.focalDevice` with a reference to the [US Core Implantable Device Profile].",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "_searchRevInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-status",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-patient",
+                            "type": "reference",
+                            "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-date",
+                            "type": "date",
+                            "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "code",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-code",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        }
+                    ],
+                    "type": "Provenance",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "documentation": "* If a system receives a provider in `Provenance.agent.who` as free text they must capture who sent them the information as the organization. On request they **SHALL** provide this organization as the source and **MAY** include the free text provider.\n* Systems that need to know the activity has occurred **SHOULD** populate the activity.",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        }
+                    ],
+                    "type": "ValueSet",
+                    "operation": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "expand",
+                            "definition": "http://hl7.org/fhir/OperationDefinition/ValueSet-expand",
+                            "documentation": "A  client can determine the note and report types support by a server by invoking the standard FHIR Value Set Expansion ($expand) operation defined in the FHIR R4 specification. Because servers may support different read and write formats, it also is used to determine the formats (for example, text, pdf) the server supports read and write transactions."
+                        }
+                    ]
+                }
+            ],
+            "interaction": [
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ],
+                    "code": "transaction"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ],
+                    "code": "batch"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ],
+                    "code": "search-system"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ],
+                    "code": "history-system"
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/CapabilityStatement-us-core-server.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/CapabilityStatement-us-core-server.json
@@ -1,4433 +1,4433 @@
 {
-	"resourceType": "CapabilityStatement",
-	"id": "us-core-server",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"> <h2 id=\"title\">US Core Server CapabilityStatement</h2></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/CapabilityStatement/us-core-server",
-	"version": "4.0.0",
-	"name": "UsCoreServerCapabilityStatement",
-	"title": "US Core Server CapabilityStatement",
-	"status": "active",
-	"experimental": false,
-	"date": "2021-06-17T14:23:02.762610-08:00",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "This Section describes the expected capabilities of the US Core Server actor which is responsible for providing responses to the queries submitted by the US Core Requestors. The complete list of FHIR profiles, RESTful operations, and search parameters supported by US Core Servers are defined. Systems implementing this capability statement should meet the ONC 2015 Common Clinical Data Set (CCDS) access requirement for Patient Selection 170.315(g)(7) and Application Access - Data Category Request 170.315(g)(8) and and the ONC [U.S. Core Data for Interoperability (USCDI)](https://www.healthit.gov/isa/sites/isa/files/2020-03/USCDI-Version1-2020-Final-Standard.pdf).  US Core Clients have the option of choosing from this list to access necessary data based on their local use cases and other contextual requirements.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"kind": "requirements",
-	"instantiates": [
-		"http://hl7.org/fhir/us/core/CapabilityStatement/us-core-server"
-	],
-	"_instantiates": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		}
-	],
-	"fhirVersion": "4.0.1",
-	"format": [
-		"json",
-		"xml"
-	],
-	"_format": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHOULD"
-				}
-			]
-		}
-	],
-	"patchFormat": [
-		"application/json-patch+json"
-	],
-	"_patchFormat": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHOULD"
-				}
-			]
-		}
-	],
-	"implementationGuide": [
-		"http://fhir-registry.smarthealthit.org",
-		"http://hl7.org/fhir/uv/bulkdata/ImplementationGuide/hl7.fhir.uv.bulkdata"
-	],
-	"_implementationGuide": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHOULD"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHOULD"
-				}
-			]
-		}
-	],
-	"rest": [
-		{
-			"mode": "server",
-			"documentation": "The US Core Server **SHALL**:\n\n1. Support the US Core Patient resource profile.\n1. Support at least one additional resource profile from the list of US Core Profiles.\n1. Implement the RESTful behavior according to the FHIR specification.\n1. For all the supported search interactions in this guide, support the `GET` based search.\n1. Return the following response classes:\n   - (Status 400): invalid parameter\n   - (Status 401/4xx): unauthorized request\n   - (Status 403): insufficient scopes\n   - (Status 404): unknown resource\n1. Support json source formats for all US Core interactions.\n\nThe US Core Server **SHOULD**:\n\n1. Support xml source formats for all US Core interactions.\n1. Identify the US Core profiles supported as part of the FHIR `meta.profile` attribute for each instance.\n1. Support xml resource formats for all Argonaut questionnaire interactions.",
-			"security": {
-				"description": "1. See the [General Security Considerations](security.html) section for requirements and recommendations.\n1. A server **SHALL** reject any unauthorized requests by returning an `HTTP 401` unauthorized response code."
-			},
-			"resource": [
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "clinical-status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "AllergyIntolerance",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"_searchRevInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "clinical-status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-clinical-status",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-patient",
-							"type": "reference",
-							"documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "CarePlan",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"documentation": "* Additional considerations for systems aligning with [HL7 Consolidated (C-CDA)](http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492) Care Plan requirements:\n    - US Core Goal **SHOULD** be present in CarePlan.goal\n    - US Core Condition **SHOULD** be present in CarePlan.addresses\n    - Assement and Plan **MAY** be included as narrative text",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"_searchRevInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "category",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-category",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-date",
-							"type": "date",
-							"documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-patient",
-							"type": "reference",
-							"documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-status",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "CareTeam",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"_searchRevInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-patient",
-							"type": "reference",
-							"documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-status",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "code"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "onset-date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "clinical-status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Condition",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"_searchRevInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "category",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-category",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "clinical-status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-clinical-status",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-patient",
-							"type": "reference",
-							"documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "onset-date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-onset-date",
-							"type": "date",
-							"documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "code",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-code",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "type"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Device",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"documentation": "* Implantable medical devices that have UDI information **SHALL** represent the UDI code in `Device.udiCarrier.carrierHRF`.\n   - All of the five UDI-PI elements that are present in the UDI code **SHALL** be represented in the corresponding US Core Implantable Device Profile element.\n   \n   UDI may not be present in all scenarios such as historical implantable devices, patient reported implant information, payer reported devices, or improperly documented implants. If UDI is not present and the manufacturer and/or model number information is available, they **SHOULD** be included to support historical reports of implantable medical devices as follows:\n\n    <table>\n    <thead>\n    <tr class=\"header\">\n    <th>data element</th>\n    <th>US Core Implantable Device Profile element</th>\n    </tr>\n    </thead>\n    <tbody>\n    <tr class=\"odd\">\n    <td>manufacturer</td>\n    <td>Device.manufacturer</td>\n    </tr>\n    <tr class=\"even\">\n    <td>model</td>\n    <td>Device.model</td>\n    </tr>\n    </tbody>\n    </table>\n\n* Servers **SHOULD** support query by Device.type to allow clients to request the patient's devices by a specific type. Note: The Device.type is too granular to differentiate implantable vs. non-implantable devices.  \n* In the Quick Start section below, searching for all devices is described. Records of implanted devices **MAY** be queried against UDI data including:\n\n    - UDI HRF string (`udi-carrier`)\n    - UDI Device Identifier (`udi-di`)\n    - Manufacturer (`manufacturer`)\n    - Model number (`model`)\n\n  Implementers **MAY** also adopt custom SearchParameters for searching by:\n\n    - lot numbers\n    - serial number\n    - expiration date\n    - manufacture date\n    - distinct identifier",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"_searchRevInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-patient",
-							"type": "reference",
-							"documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "type",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-type",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "code"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "code"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "DiagnosticReport",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab",
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "create",
-							"documentation": "This conformance expectation applies **only**  to the *US Core DiagnosticReport Profile for Report and Note exchange* profile.  The conformance expectation for the *US Core DiagnosticReport Profile for Laboratory Results Reporting* is  **MAY**."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"_searchRevInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-status",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient",
-							"type": "reference",
-							"documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "category",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-category",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "code",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-code",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-date",
-							"type": "date",
-							"documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "type"
-								},
-								{
-									"url": "required",
-									"valueString": "period"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "type"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "DocumentReference",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"documentation": "The DocumentReference.type binding SHALL support at a minimum the [5 Common Clinical Notes](ValueSet-us-core-clinical-note-type.html) and may extend to the full US Core DocumentReference Type Value Set",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"_searchRevInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "_id",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-id",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-status",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient",
-							"type": "reference",
-							"documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "category",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-category",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "type",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-type",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-date",
-							"type": "date",
-							"documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "period",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-period",
-							"type": "date",
-							"documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
-						}
-					],
-					"operation": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "docref",
-							"definition": "http://hl7.org/fhir/us/core/OperationDefinition/docref",
-							"documentation": "A server **SHALL** be capable of responding to a $docref operation and  capable of returning at least a reference to a generated CCD document, if available. **MAY** provide references to other 'on-demand' and 'stable' documents (or 'delayed/deferred assembly') that meet the query parameters as well. If a context date range is supplied the server ** SHOULD**  provide references to any document that falls within the date range If no date range is supplied, then the server **SHALL** provide references to last or current encounter.  **SHOULD** document what resources, if any, are returned as included resources\n\n`GET [base]/DocumentReference/$docref?patient=[id]`"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "class"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "type"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Encounter",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"documentation": "* The Encounter resource can represent a reason using either a code with `Encounter.reasonCode`, or a reference with `Encounter.reasonReference` to  Condition or other resource.\n   * Although both are marked as must support, the server systems are not required to support both a code and a reference, but they **SHALL** support *at least one* of these elements.\n   * The client application **SHALL** support both elements.\n   * if `Encounter.reasonReference` references an Observation, it **SHOULD** conform to a US Core Observation if applicable. (for example, a laboratory result should conform to the US Core Laboratory Result Observation Profile)\n* The intent of this profile is to support *where the encounter occurred*.  The location address can be represented by either by the Location referenced by `Encounter.location.location` or indirectly through the Organization referenced by `Encounter.serviceProvider`.\n  * Although both are marked as must support, the server systems are not required to support both `Encounter.location.location` and `Encounter.serviceProvider`, but they **SHALL** support *at least one* of these elements.\n  * The client application **SHALL** support both elements.\n  * if using `Encounter.locatison.location` it **SHOULD** conform to US Core Location.  However, as a result of implementation feedback, it **MAY**  reference the base FHIR Location resource.  See this guidance on [Referencing US Core Profiles]",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"_searchRevInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "_id",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-id",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "class",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-class",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-date",
-							"type": "date",
-							"documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "identifier",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-identifier",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-patient",
-							"type": "reference",
-							"documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-status",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "type",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-type",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "lifecycle-status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "target-date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Goal",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"_searchRevInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "lifecycle-status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-lifecycle-status",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-patient",
-							"type": "reference",
-							"documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "target-date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-target-date",
-							"type": "date",
-							"documentation": "A client **SHALL** provide a value precise to the *day*.\n\nA server **SHALL** support a value a value precise to the *day*."
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Immunization",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"documentation": "* Based upon the ONC U.S. Core Data for Interoperability (USCDI) v1 requirements, CVX vaccine codes are required and the NDC vaccine codes **SHOULD** be supported as translations to them.",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"_searchRevInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-patient",
-							"type": "reference",
-							"documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-status",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-date",
-							"type": "date",
-							"documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						}
-					],
-					"type": "Location",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-location"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"documentation": "* The US Core Location  and PractitionerRole Profiles are not explicitly referenced in any US Core Profile. However they **SHOULD** be used as the default profile if referenced by another US Core profile.",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "name",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-name",
-							"type": "string"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "address",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address",
-							"type": "string"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "address-city",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-city",
-							"type": "string"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "address-state",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-state",
-							"type": "string"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "address-postalcode",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-postalcode",
-							"type": "string"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						}
-					],
-					"type": "Medication",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"documentation": "* The  MedicationRequest resource can represent a medication, using an external reference to a Medication resource. If an external Medication Resource is used in a MedicationRequest, then the READ  **SHALL**  be supported.",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "intent"
-								},
-								{
-									"url": "required",
-									"valueString": "authoredon"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "intent"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "intent"
-								},
-								{
-									"url": "required",
-									"valueString": "encounter"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "intent"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "MedicationRequest",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"documentation": "* The MedicationRequest resources can represent a medication using either a code or refer to the Medication resource. When referencing Medication, the resource may be [contained](http://hl7.org/fhir/R4/references.html#contained) or an external resource. The server application **MAY** choose any one way or more than one method, but if an external reference to Medication is used, the server **SHALL** support the _include` parameter for searching this element. The client application must support all methods.\n\n For example, A server **SHALL** be capable of returning all medications for a patient using one of or both:\n\n `GET /MedicationRequest?patient=[id]`\n\n `GET /MedicationRequest?patient=[id]&_include=MedicationRequest:medication`\n\n* The MedicationRequest resource can represent that information is from a secondary source using either a boolean flag or reference in `MedicationRequest.reportedBoolean`, or a reference using `MedicationRequest.reportedReference` to Practitioner or other resource.\n   *   Although both are marked as must support, the server systems are not required to support both a boolean and a reference, but **SHALL** choose to support at least one of these elements.\n   *  The client application **SHALL** support both elements.",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchInclude": [
-						"MedicationRequest:medication"
-					],
-					"_searchInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							]
-						}
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"_searchRevInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-status",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "intent",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-intent",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-patient",
-							"type": "reference",
-							"documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "encounter",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-encounter",
-							"type": "reference",
-							"documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "authoredon",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-authoredon",
-							"type": "date",
-							"documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "code"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "category"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "code"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Observation",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab",
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure",
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-bmi",
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-head-circumference",
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-height",
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-weight",
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-temperature",
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate",
-						"http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age",
-						"http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile",
-						"http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height",
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry",
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-respiratory-rate",
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"documentation": "* Systems **SHOULD** support `Observation.effectivePeriod` to accurately represent laboratory tests that are collected over a period of time (for example, a 24-Hour Urine Collection test).\n* An Observation without a value, **SHALL** include a reason why the data is absent unless there are component observations, or references to other Observations that are grouped within it.",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"_searchRevInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-status",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "category",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-category",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "code",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-code",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-date",
-							"type": "date",
-							"documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient",
-							"type": "reference",
-							"documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						}
-					],
-					"type": "Organization",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "name",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-name",
-							"type": "string"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "address",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-address",
-							"type": "string"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "family"
-								},
-								{
-									"url": "required",
-									"valueString": "gender"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "birthdate"
-								},
-								{
-									"url": "required",
-									"valueString": "family"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "birthdate"
-								},
-								{
-									"url": "required",
-									"valueString": "name"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "gender"
-								},
-								{
-									"url": "required",
-									"valueString": "name"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Patient",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"documentation": "* For ONC's USCDI requirements, each Patient must support the following additional elements. These elements are included in the formal definition of the profile. The patient examples include all of these elements.\n\n1. contact detail (e.g. a telephone number or an email address)\n1. a communication language\n1. a race\n1. an ethnicity\n1. a birth sex*\n1. previous name\n   - Previous name is represented by providing an end date in the `Patient.name.period` element for a previous name.\n1. suffix\n   - Suffix is represented using the `Patient.name.suffix` element.\n\n",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"_searchRevInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "_id",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-id",
-							"type": "token"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "birthdate",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-birthdate",
-							"type": "date",
-							"documentation": "A client **SHALL** provide a value precise to the *day*.\n\nA server **SHALL** support a value a value precise to the *day*."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "family",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-family",
-							"type": "string",
-							"documentation": "A server **SHALL** support a value precise to the *day*."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "gender",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-gender",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "given",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-given",
-							"type": "string"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "identifier",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-identifier",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "name",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-name",
-							"type": "string"
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						}
-					],
-					"type": "Practitioner",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "name",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-name",
-							"type": "string"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "identifier",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-identifier",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						}
-					],
-					"type": "PractitionerRole",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"documentation": "* The US Core Location  and PractitionerRole Profiles are not explicitly referenced in any US Core Profile. However they **SHOULD** be used as the default profile if referenced by another US Core profile.",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchInclude": [
-						"PractitionerRole:endpoint",
-						"PractitionerRole:practitioner"
-					],
-					"_searchInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							]
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							]
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "specialty",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-specialty",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "practitioner",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-practitioner",
-							"type": "reference",
-							"documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "code"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "date"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								},
-								{
-									"url": "required",
-									"valueString": "patient"
-								},
-								{
-									"url": "required",
-									"valueString": "status"
-								}
-							],
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
-						}
-					],
-					"type": "Procedure",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"documentation": "*  A procedure including an implantable device **SHOULD** use `Procedure.focalDevice` with a reference to the [US Core Implantable Device Profile].",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					],
-					"searchRevInclude": [
-						"Provenance:target"
-					],
-					"_searchRevInclude": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"searchParam": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "status",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-status",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"name": "patient",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-patient",
-							"type": "reference",
-							"documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "date",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-date",
-							"type": "date",
-							"documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"name": "code",
-							"definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-code",
-							"type": "token",
-							"documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
-						}
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHALL"
-						}
-					],
-					"type": "Provenance",
-					"supportedProfile": [
-						"http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance"
-					],
-					"_supportedProfile": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							]
-						}
-					],
-					"documentation": "* If a system receives a provider in `Provenance.agent.who` as free text they must capture who sent them the information as the organization. On request they **SHALL** provide this organization as the source and **MAY** include the free text provider.\n* Systems that need to know the activity has occurred **SHOULD** populate the activity.",
-					"interaction": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "create"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "search-type"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHALL"
-								}
-							],
-							"code": "read"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "vread"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "update"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "patch"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "delete"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"code": "history-instance"
-						},
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "MAY"
-								}
-							],
-							"code": "history-type"
-						}
-					],
-					"referencePolicy": [
-						"resolves"
-					]
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "SHOULD"
-						}
-					],
-					"type": "ValueSet",
-					"operation": [
-						{
-							"extension": [
-								{
-									"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-									"valueCode": "SHOULD"
-								}
-							],
-							"name": "expand",
-							"definition": "http://hl7.org/fhir/OperationDefinition/ValueSet-expand",
-							"documentation": "A  client can determine the note and report types support by a server by invoking the standard FHIR Value Set Expansion ($expand) operation defined in the FHIR R4 specification. Because servers may support different read and write formats, it also is used to determine the formats (for example, text, pdf) the server supports read and write transactions."
-						}
-					]
-				}
-			],
-			"interaction": [
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "MAY"
-						}
-					],
-					"code": "transaction"
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "MAY"
-						}
-					],
-					"code": "batch"
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "MAY"
-						}
-					],
-					"code": "search-system"
-				},
-				{
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-							"valueCode": "MAY"
-						}
-					],
-					"code": "history-system"
-				}
-			]
-		}
-	]
+    "resourceType": "CapabilityStatement",
+    "id": "us-core-server",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/CapabilityStatement/us-core-server",
+    "version": "4.0.0",
+    "name": "UsCoreServerCapabilityStatement",
+    "title": "US Core Server CapabilityStatement",
+    "status": "active",
+    "experimental": false,
+    "date": "2021-06-17T14:23:02.762610-08:00",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "This Section describes the expected capabilities of the US Core Server actor which is responsible for providing responses to the queries submitted by the US Core Requestors. The complete list of FHIR profiles, RESTful operations, and search parameters supported by US Core Servers are defined. Systems implementing this capability statement should meet the ONC 2015 Common Clinical Data Set (CCDS) access requirement for Patient Selection 170.315(g)(7) and Application Access - Data Category Request 170.315(g)(8) and and the ONC [U.S. Core Data for Interoperability (USCDI)](https://www.healthit.gov/isa/sites/isa/files/2020-03/USCDI-Version1-2020-Final-Standard.pdf).  US Core Clients have the option of choosing from this list to access necessary data based on their local use cases and other contextual requirements.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "kind": "requirements",
+    "instantiates": [
+        "http://hl7.org/fhir/us/core/CapabilityStatement/us-core-server"
+    ],
+    "_instantiates": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        }
+    ],
+    "fhirVersion": "4.0.1",
+    "format": [
+        "json",
+        "xml"
+    ],
+    "_format": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHOULD"
+                }
+            ]
+        }
+    ],
+    "patchFormat": [
+        "application/json-patch+json"
+    ],
+    "_patchFormat": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHOULD"
+                }
+            ]
+        }
+    ],
+    "implementationGuide": [
+        "http://fhir-registry.smarthealthit.org",
+        "http://hl7.org/fhir/uv/bulkdata/ImplementationGuide/hl7.fhir.uv.bulkdata"
+    ],
+    "_implementationGuide": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHOULD"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHOULD"
+                }
+            ]
+        }
+    ],
+    "rest": [
+        {
+            "mode": "server",
+            "documentation": "The US Core Server **SHALL**:\n\n1. Support the US Core Patient resource profile.\n1. Support at least one additional resource profile from the list of US Core Profiles.\n1. Implement the RESTful behavior according to the FHIR specification.\n1. For all the supported search interactions in this guide, support the `GET` based search.\n1. Return the following response classes:\n   - (Status 400): invalid parameter\n   - (Status 401/4xx): unauthorized request\n   - (Status 403): insufficient scopes\n   - (Status 404): unknown resource\n1. Support json source formats for all US Core interactions.\n\nThe US Core Server **SHOULD**:\n\n1. Support xml source formats for all US Core interactions.\n1. Identify the US Core profiles supported as part of the FHIR `meta.profile` attribute for each instance.\n1. Support xml resource formats for all Argonaut questionnaire interactions.",
+            "security": {
+                "description": "1. See the [General Security Considerations](security.html) section for requirements and recommendations.\n1. A server **SHALL** reject any unauthorized requests by returning an `HTTP 401` unauthorized response code."
+            },
+            "resource": [
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "clinical-status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "AllergyIntolerance",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "_searchRevInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "clinical-status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-clinical-status",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-patient",
+                            "type": "reference",
+                            "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "CarePlan",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "documentation": "* Additional considerations for systems aligning with [HL7 Consolidated (C-CDA)](http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492) Care Plan requirements:\n    - US Core Goal **SHOULD** be present in CarePlan.goal\n    - US Core Condition **SHOULD** be present in CarePlan.addresses\n    - Assement and Plan **MAY** be included as narrative text",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "_searchRevInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "category",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-category",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-date",
+                            "type": "date",
+                            "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-patient",
+                            "type": "reference",
+                            "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-status",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "CareTeam",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "_searchRevInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-patient",
+                            "type": "reference",
+                            "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-status",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "code"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "onset-date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "clinical-status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Condition",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "_searchRevInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "category",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-category",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "clinical-status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-clinical-status",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-patient",
+                            "type": "reference",
+                            "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "onset-date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-onset-date",
+                            "type": "date",
+                            "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "code",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-code",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "type"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Device",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "documentation": "* Implantable medical devices that have UDI information **SHALL** represent the UDI code in `Device.udiCarrier.carrierHRF`.\n   - All of the five UDI-PI elements that are present in the UDI code **SHALL** be represented in the corresponding US Core Implantable Device Profile element.\n   \n   UDI may not be present in all scenarios such as historical implantable devices, patient reported implant information, payer reported devices, or improperly documented implants. If UDI is not present and the manufacturer and/or model number information is available, they **SHOULD** be included to support historical reports of implantable medical devices as follows:\n\n    <table>\n    <thead>\n    <tr class=\"header\">\n    <th>data element</th>\n    <th>US Core Implantable Device Profile element</th>\n    </tr>\n    </thead>\n    <tbody>\n    <tr class=\"odd\">\n    <td>manufacturer</td>\n    <td>Device.manufacturer</td>\n    </tr>\n    <tr class=\"even\">\n    <td>model</td>\n    <td>Device.model</td>\n    </tr>\n    </tbody>\n    </table>\n\n* Servers **SHOULD** support query by Device.type to allow clients to request the patient's devices by a specific type. Note: The Device.type is too granular to differentiate implantable vs. non-implantable devices.  \n* In the Quick Start section below, searching for all devices is described. Records of implanted devices **MAY** be queried against UDI data including:\n\n    - UDI HRF string (`udi-carrier`)\n    - UDI Device Identifier (`udi-di`)\n    - Manufacturer (`manufacturer`)\n    - Model number (`model`)\n\n  Implementers **MAY** also adopt custom SearchParameters for searching by:\n\n    - lot numbers\n    - serial number\n    - expiration date\n    - manufacture date\n    - distinct identifier",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "_searchRevInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-patient",
+                            "type": "reference",
+                            "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "type",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-type",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "code"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "code"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "DiagnosticReport",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "create",
+                            "documentation": "This conformance expectation applies **only**  to the *US Core DiagnosticReport Profile for Report and Note exchange* profile.  The conformance expectation for the *US Core DiagnosticReport Profile for Laboratory Results Reporting* is  **MAY**."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "_searchRevInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-status",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient",
+                            "type": "reference",
+                            "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "category",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-category",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "code",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-code",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-date",
+                            "type": "date",
+                            "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "type"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "period"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "type"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "DocumentReference",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "documentation": "The DocumentReference.type binding SHALL support at a minimum the [5 Common Clinical Notes](ValueSet-us-core-clinical-note-type.html) and may extend to the full US Core DocumentReference Type Value Set",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "_searchRevInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "_id",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-id",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-status",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient",
+                            "type": "reference",
+                            "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "category",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-category",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "type",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-type",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-date",
+                            "type": "date",
+                            "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "period",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-period",
+                            "type": "date",
+                            "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+                        }
+                    ],
+                    "operation": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "docref",
+                            "definition": "http://hl7.org/fhir/us/core/OperationDefinition/docref",
+                            "documentation": "A server **SHALL** be capable of responding to a $docref operation and  capable of returning at least a reference to a generated CCD document, if available. **MAY** provide references to other 'on-demand' and 'stable' documents (or 'delayed/deferred assembly') that meet the query parameters as well. If a context date range is supplied the server ** SHOULD**  provide references to any document that falls within the date range If no date range is supplied, then the server **SHALL** provide references to last or current encounter.  **SHOULD** document what resources, if any, are returned as included resources\n\n`GET [base]/DocumentReference/$docref?patient=[id]`"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "class"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "type"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Encounter",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "documentation": "* The Encounter resource can represent a reason using either a code with `Encounter.reasonCode`, or a reference with `Encounter.reasonReference` to  Condition or other resource.\n   * Although both are marked as must support, the server systems are not required to support both a code and a reference, but they **SHALL** support *at least one* of these elements.\n   * The client application **SHALL** support both elements.\n   * if `Encounter.reasonReference` references an Observation, it **SHOULD** conform to a US Core Observation if applicable. (for example, a laboratory result should conform to the US Core Laboratory Result Observation Profile)\n* The intent of this profile is to support *where the encounter occurred*.  The location address can be represented by either by the Location referenced by `Encounter.location.location` or indirectly through the Organization referenced by `Encounter.serviceProvider`.\n  * Although both are marked as must support, the server systems are not required to support both `Encounter.location.location` and `Encounter.serviceProvider`, but they **SHALL** support *at least one* of these elements.\n  * The client application **SHALL** support both elements.\n  * if using `Encounter.locatison.location` it **SHOULD** conform to US Core Location.  However, as a result of implementation feedback, it **MAY**  reference the base FHIR Location resource.  See this guidance on [Referencing US Core Profiles]",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "_searchRevInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "_id",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-id",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "class",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-class",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-date",
+                            "type": "date",
+                            "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "identifier",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-identifier",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-patient",
+                            "type": "reference",
+                            "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-status",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "type",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-type",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "lifecycle-status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "target-date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Goal",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "_searchRevInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "lifecycle-status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-lifecycle-status",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-patient",
+                            "type": "reference",
+                            "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "target-date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-target-date",
+                            "type": "date",
+                            "documentation": "A client **SHALL** provide a value precise to the *day*.\n\nA server **SHALL** support a value a value precise to the *day*."
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Immunization",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "documentation": "* Based upon the ONC U.S. Core Data for Interoperability (USCDI) v1 requirements, CVX vaccine codes are required and the NDC vaccine codes **SHOULD** be supported as translations to them.",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "_searchRevInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-patient",
+                            "type": "reference",
+                            "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-status",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-date",
+                            "type": "date",
+                            "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        }
+                    ],
+                    "type": "Location",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-location"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "documentation": "* The US Core Location  and PractitionerRole Profiles are not explicitly referenced in any US Core Profile. However they **SHOULD** be used as the default profile if referenced by another US Core profile.",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "name",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-name",
+                            "type": "string"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "address",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address",
+                            "type": "string"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "address-city",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-city",
+                            "type": "string"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "address-state",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-state",
+                            "type": "string"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "address-postalcode",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-postalcode",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        }
+                    ],
+                    "type": "Medication",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "documentation": "* The  MedicationRequest resource can represent a medication, using an external reference to a Medication resource. If an external Medication Resource is used in a MedicationRequest, then the READ  **SHALL**  be supported.",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "intent"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "authoredon"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "intent"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "intent"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "encounter"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "intent"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "MedicationRequest",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "documentation": "* The MedicationRequest resources can represent a medication using either a code or refer to the Medication resource. When referencing Medication, the resource may be [contained](http://hl7.org/fhir/R4/references.html#contained) or an external resource. The server application **MAY** choose any one way or more than one method, but if an external reference to Medication is used, the server **SHALL** support the _include` parameter for searching this element. The client application must support all methods.\n\n For example, A server **SHALL** be capable of returning all medications for a patient using one of or both:\n\n `GET /MedicationRequest?patient=[id]`\n\n `GET /MedicationRequest?patient=[id]&_include=MedicationRequest:medication`\n\n* The MedicationRequest resource can represent that information is from a secondary source using either a boolean flag or reference in `MedicationRequest.reportedBoolean`, or a reference using `MedicationRequest.reportedReference` to Practitioner or other resource.\n   *   Although both are marked as must support, the server systems are not required to support both a boolean and a reference, but **SHALL** choose to support at least one of these elements.\n   *  The client application **SHALL** support both elements.",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchInclude": [
+                        "MedicationRequest:medication"
+                    ],
+                    "_searchInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "_searchRevInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-status",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "intent",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-intent",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-patient",
+                            "type": "reference",
+                            "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "encounter",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-encounter",
+                            "type": "reference",
+                            "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "authoredon",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-authoredon",
+                            "type": "date",
+                            "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "code"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "category"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "code"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Observation",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-bmi",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-head-circumference",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-height",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-weight",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-temperature",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-respiratory-rate",
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "documentation": "* Systems **SHOULD** support `Observation.effectivePeriod` to accurately represent laboratory tests that are collected over a period of time (for example, a 24-Hour Urine Collection test).\n* An Observation without a value, **SHALL** include a reason why the data is absent unless there are component observations, or references to other Observations that are grouped within it.",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "_searchRevInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-status",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "category",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-category",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "code",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-code",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-date",
+                            "type": "date",
+                            "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient",
+                            "type": "reference",
+                            "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        }
+                    ],
+                    "type": "Organization",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "name",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-name",
+                            "type": "string"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "address",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-address",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "family"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "gender"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "birthdate"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "family"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "birthdate"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "name"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "gender"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "name"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Patient",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "documentation": "* For ONC's USCDI requirements, each Patient must support the following additional elements. These elements are included in the formal definition of the profile. The patient examples include all of these elements.\n\n1. contact detail (e.g. a telephone number or an email address)\n1. a communication language\n1. a race\n1. an ethnicity\n1. a birth sex*\n1. previous name\n   - Previous name is represented by providing an end date in the `Patient.name.period` element for a previous name.\n1. suffix\n   - Suffix is represented using the `Patient.name.suffix` element.\n\n",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "_searchRevInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "_id",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-id",
+                            "type": "token"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "birthdate",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-birthdate",
+                            "type": "date",
+                            "documentation": "A client **SHALL** provide a value precise to the *day*.\n\nA server **SHALL** support a value a value precise to the *day*."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "family",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-family",
+                            "type": "string",
+                            "documentation": "A server **SHALL** support a value precise to the *day*."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "gender",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-gender",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "given",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-given",
+                            "type": "string"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "identifier",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-identifier",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "name",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-name",
+                            "type": "string"
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        }
+                    ],
+                    "type": "Practitioner",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "name",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-name",
+                            "type": "string"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "identifier",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-identifier",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        }
+                    ],
+                    "type": "PractitionerRole",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "documentation": "* The US Core Location  and PractitionerRole Profiles are not explicitly referenced in any US Core Profile. However they **SHOULD** be used as the default profile if referenced by another US Core profile.",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchInclude": [
+                        "PractitionerRole:endpoint",
+                        "PractitionerRole:practitioner"
+                    ],
+                    "_searchInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ]
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "specialty",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-specialty",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "practitioner",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-practitioner",
+                            "type": "reference",
+                            "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "code"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "date"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "patient"
+                                },
+                                {
+                                    "url": "required",
+                                    "valueString": "status"
+                                }
+                            ],
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+                        }
+                    ],
+                    "type": "Procedure",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "documentation": "*  A procedure including an implantable device **SHOULD** use `Procedure.focalDevice` with a reference to the [US Core Implantable Device Profile].",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ],
+                    "searchRevInclude": [
+                        "Provenance:target"
+                    ],
+                    "_searchRevInclude": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "searchParam": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "status",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-status",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "name": "patient",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-patient",
+                            "type": "reference",
+                            "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "date",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-date",
+                            "type": "date",
+                            "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "name": "code",
+                            "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-code",
+                            "type": "token",
+                            "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+                        }
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHALL"
+                        }
+                    ],
+                    "type": "Provenance",
+                    "supportedProfile": [
+                        "http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance"
+                    ],
+                    "_supportedProfile": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ]
+                        }
+                    ],
+                    "documentation": "* If a system receives a provider in `Provenance.agent.who` as free text they must capture who sent them the information as the organization. On request they **SHALL** provide this organization as the source and **MAY** include the free text provider.\n* Systems that need to know the activity has occurred **SHOULD** populate the activity.",
+                    "interaction": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "create"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "search-type"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHALL"
+                                }
+                            ],
+                            "code": "read"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "vread"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "update"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "patch"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "delete"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "code": "history-instance"
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "MAY"
+                                }
+                            ],
+                            "code": "history-type"
+                        }
+                    ],
+                    "referencePolicy": [
+                        "resolves"
+                    ]
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "SHOULD"
+                        }
+                    ],
+                    "type": "ValueSet",
+                    "operation": [
+                        {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                                    "valueCode": "SHOULD"
+                                }
+                            ],
+                            "name": "expand",
+                            "definition": "http://hl7.org/fhir/OperationDefinition/ValueSet-expand",
+                            "documentation": "A  client can determine the note and report types support by a server by invoking the standard FHIR Value Set Expansion ($expand) operation defined in the FHIR R4 specification. Because servers may support different read and write formats, it also is used to determine the formats (for example, text, pdf) the server supports read and write transactions."
+                        }
+                    ]
+                }
+            ],
+            "interaction": [
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ],
+                    "code": "transaction"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ],
+                    "code": "batch"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ],
+                    "code": "search-system"
+                },
+                {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                            "valueCode": "MAY"
+                        }
+                    ],
+                    "code": "history-system"
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/CodeSystem-careplan-category.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/CodeSystem-careplan-category.json
@@ -1,47 +1,47 @@
 {
-	"resourceType": "CodeSystem",
-	"id": "careplan-category",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This code system http://hl7.org/fhir/us/core/CodeSystem/careplan-category defines the following codes:</p><table class=\"codes\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td><td><b>Definition</b></td></tr><tr><td style=\"white-space:nowrap\">assess-plan<a name=\"careplan-category-assess-plan\"> </a></td><td>Assessment and Plan of Treatment</td><td>The clinical conclusions and assumptions that guide the patient's treatment and the clinical activities formulated for a patient.</td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/CodeSystem/careplan-category",
-	"version": "4.0.0",
-	"name": "USCoreCarePlanCategoryExtensionCodes",
-	"title": "US Core CarePlan Category Extension Codes",
-	"status": "active",
-	"date": "2021-06-28T19:10:06+00:00",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Set of codes that are needed for implementation of the US-Core CarePlan Profile. These codes are used as extensions to the FHIR ValueSet.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"caseSensitive": true,
-	"content": "complete",
-	"concept": [
-		{
-			"code": "assess-plan",
-			"display": "Assessment and Plan of Treatment",
-			"definition": "The clinical conclusions and assumptions that guide the patient's treatment and the clinical activities formulated for a patient."
-		}
-	]
+    "resourceType": "CodeSystem",
+    "id": "careplan-category",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/CodeSystem/careplan-category",
+    "version": "4.0.0",
+    "name": "USCoreCarePlanCategoryExtensionCodes",
+    "title": "US Core CarePlan Category Extension Codes",
+    "status": "active",
+    "date": "2021-06-28T19:10:06+00:00",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Set of codes that are needed for implementation of the US-Core CarePlan Profile. These codes are used as extensions to the FHIR ValueSet.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "caseSensitive": true,
+    "content": "complete",
+    "concept": [
+        {
+            "code": "assess-plan",
+            "display": "Assessment and Plan of Treatment",
+            "definition": "The clinical conclusions and assumptions that guide the patient's treatment and the clinical activities formulated for a patient."
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/CodeSystem-cdcrec.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/CodeSystem-cdcrec.json
@@ -1,4915 +1,4915 @@
 {
-	"resourceType": "CodeSystem",
-	"id": "cdcrec",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Properties</b></p><table class=\"grid\"><tr><td><b>Code</b></td><td><b>URL</b></td><td><b>Description</b></td><td><b>Type</b></td></tr><tr><td>abstract</td><td/><td>True if an element is considered 'abstract' - in other words, the code is not for use as a real concept</td><td>boolean</td></tr></table><p>This code system urn:oid:2.16.840.1.113883.6.238 defines the following codes:</p><table class=\"codes\"><tr><td><b>Lvl</b></td><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td><td><b>Definition</b></td></tr><tr><td>1</td><td style=\"white-space:nowrap\">1000-9<a name=\"cdcrec-1000-9\"> </a></td><td>Race</td><td>Race, Note that this is an abstract 'grouping' concept and not for use as a real concept</td></tr><tr><td>2</td><td style=\"white-space:nowrap\">  1002-5<a name=\"cdcrec-1002-5\"> </a></td><td>American Indian or Alaska Native</td><td>American Indian or Alaska Native</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1004-1<a name=\"cdcrec-1004-1\"> </a></td><td>American Indian</td><td>American Indian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1735-0<a name=\"cdcrec-1735-0\"> </a></td><td>Alaska Native</td><td>Alaska Native</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1006-6<a name=\"cdcrec-1006-6\"> </a></td><td>Abenaki</td><td>Abenaki</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1008-2<a name=\"cdcrec-1008-2\"> </a></td><td>Algonquian</td><td>Algonquian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1010-8<a name=\"cdcrec-1010-8\"> </a></td><td>Apache</td><td>Apache</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1021-5<a name=\"cdcrec-1021-5\"> </a></td><td>Arapaho</td><td>Arapaho</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1026-4<a name=\"cdcrec-1026-4\"> </a></td><td>Arikara</td><td>Arikara</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1028-0<a name=\"cdcrec-1028-0\"> </a></td><td>Assiniboine</td><td>Assiniboine</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1030-6<a name=\"cdcrec-1030-6\"> </a></td><td>Assiniboine Sioux</td><td>Assiniboine Sioux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1033-0<a name=\"cdcrec-1033-0\"> </a></td><td>Bannock</td><td>Bannock</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1035-5<a name=\"cdcrec-1035-5\"> </a></td><td>Blackfeet</td><td>Blackfeet</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1037-1<a name=\"cdcrec-1037-1\"> </a></td><td>Brotherton</td><td>Brotherton</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1039-7<a name=\"cdcrec-1039-7\"> </a></td><td>Burt Lake Band</td><td>Burt Lake Band</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1041-3<a name=\"cdcrec-1041-3\"> </a></td><td>Caddo</td><td>Caddo</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1044-7<a name=\"cdcrec-1044-7\"> </a></td><td>Cahuilla</td><td>Cahuilla</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1053-8<a name=\"cdcrec-1053-8\"> </a></td><td>California Tribes</td><td>California Tribes</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1068-6<a name=\"cdcrec-1068-6\"> </a></td><td>Canadian and Latin American Indian</td><td>Canadian and Latin American Indian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1076-9<a name=\"cdcrec-1076-9\"> </a></td><td>Catawba</td><td>Catawba</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1078-5<a name=\"cdcrec-1078-5\"> </a></td><td>Cayuse</td><td>Cayuse</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1080-1<a name=\"cdcrec-1080-1\"> </a></td><td>Chehalis</td><td>Chehalis</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1082-7<a name=\"cdcrec-1082-7\"> </a></td><td>Chemakuan</td><td>Chemakuan</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1086-8<a name=\"cdcrec-1086-8\"> </a></td><td>Chemehuevi</td><td>Chemehuevi</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1088-4<a name=\"cdcrec-1088-4\"> </a></td><td>Cherokee</td><td>Cherokee</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1100-7<a name=\"cdcrec-1100-7\"> </a></td><td>Cherokee Shawnee</td><td>Cherokee Shawnee</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1102-3<a name=\"cdcrec-1102-3\"> </a></td><td>Cheyenne</td><td>Cheyenne</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1106-4<a name=\"cdcrec-1106-4\"> </a></td><td>Cheyenne-Arapaho</td><td>Cheyenne-Arapaho</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1108-0<a name=\"cdcrec-1108-0\"> </a></td><td>Chickahominy</td><td>Chickahominy</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1112-2<a name=\"cdcrec-1112-2\"> </a></td><td>Chickasaw</td><td>Chickasaw</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1114-8<a name=\"cdcrec-1114-8\"> </a></td><td>Chinook</td><td>Chinook</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1123-9<a name=\"cdcrec-1123-9\"> </a></td><td>Chippewa</td><td>Chippewa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1150-2<a name=\"cdcrec-1150-2\"> </a></td><td>Chippewa Cree</td><td>Chippewa Cree</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1153-6<a name=\"cdcrec-1153-6\"> </a></td><td>Chitimacha</td><td>Chitimacha</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1155-1<a name=\"cdcrec-1155-1\"> </a></td><td>Choctaw</td><td>Choctaw</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1162-7<a name=\"cdcrec-1162-7\"> </a></td><td>Chumash</td><td>Chumash</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1165-0<a name=\"cdcrec-1165-0\"> </a></td><td>Clear Lake</td><td>Clear Lake</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1167-6<a name=\"cdcrec-1167-6\"> </a></td><td>Coeur D'Alene</td><td>Coeur D'Alene</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1169-2<a name=\"cdcrec-1169-2\"> </a></td><td>Coharie</td><td>Coharie</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1171-8<a name=\"cdcrec-1171-8\"> </a></td><td>Colorado River</td><td>Colorado River</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1173-4<a name=\"cdcrec-1173-4\"> </a></td><td>Colville</td><td>Colville</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1175-9<a name=\"cdcrec-1175-9\"> </a></td><td>Comanche</td><td>Comanche</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1178-3<a name=\"cdcrec-1178-3\"> </a></td><td>Coos, Lower Umpqua, Siuslaw</td><td>Coos, Lower Umpqua, Siuslaw</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1180-9<a name=\"cdcrec-1180-9\"> </a></td><td>Coos</td><td>Coos</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1182-5<a name=\"cdcrec-1182-5\"> </a></td><td>Coquilles</td><td>Coquilles</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1184-1<a name=\"cdcrec-1184-1\"> </a></td><td>Costanoan</td><td>Costanoan</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1186-6<a name=\"cdcrec-1186-6\"> </a></td><td>Coushatta</td><td>Coushatta</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1189-0<a name=\"cdcrec-1189-0\"> </a></td><td>Cowlitz</td><td>Cowlitz</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1191-6<a name=\"cdcrec-1191-6\"> </a></td><td>Cree</td><td>Cree</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1193-2<a name=\"cdcrec-1193-2\"> </a></td><td>Creek</td><td>Creek</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1207-0<a name=\"cdcrec-1207-0\"> </a></td><td>Croatan</td><td>Croatan</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1209-6<a name=\"cdcrec-1209-6\"> </a></td><td>Crow</td><td>Crow</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1211-2<a name=\"cdcrec-1211-2\"> </a></td><td>Cupeno</td><td>Cupeno</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1214-6<a name=\"cdcrec-1214-6\"> </a></td><td>Delaware</td><td>Delaware</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1222-9<a name=\"cdcrec-1222-9\"> </a></td><td>Diegueno</td><td>Diegueno</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1233-6<a name=\"cdcrec-1233-6\"> </a></td><td>Eastern Tribes</td><td>Eastern Tribes</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1250-0<a name=\"cdcrec-1250-0\"> </a></td><td>Esselen</td><td>Esselen</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1252-6<a name=\"cdcrec-1252-6\"> </a></td><td>Fort Belknap</td><td>Fort Belknap</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1254-2<a name=\"cdcrec-1254-2\"> </a></td><td>Fort Berthold</td><td>Fort Berthold</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1256-7<a name=\"cdcrec-1256-7\"> </a></td><td>Fort Mcdowell</td><td>Fort Mcdowell</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1258-3<a name=\"cdcrec-1258-3\"> </a></td><td>Fort Hall</td><td>Fort Hall</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1260-9<a name=\"cdcrec-1260-9\"> </a></td><td>Gabrieleno</td><td>Gabrieleno</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1262-5<a name=\"cdcrec-1262-5\"> </a></td><td>Grand Ronde</td><td>Grand Ronde</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1264-1<a name=\"cdcrec-1264-1\"> </a></td><td>Gros Ventres</td><td>Gros Ventres</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1267-4<a name=\"cdcrec-1267-4\"> </a></td><td>Haliwa</td><td>Haliwa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1269-0<a name=\"cdcrec-1269-0\"> </a></td><td>Hidatsa</td><td>Hidatsa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1271-6<a name=\"cdcrec-1271-6\"> </a></td><td>Hoopa</td><td>Hoopa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1275-7<a name=\"cdcrec-1275-7\"> </a></td><td>Hoopa Extension</td><td>Hoopa Extension</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1277-3<a name=\"cdcrec-1277-3\"> </a></td><td>Houma</td><td>Houma</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1279-9<a name=\"cdcrec-1279-9\"> </a></td><td>Inaja-Cosmit</td><td>Inaja-Cosmit</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1281-5<a name=\"cdcrec-1281-5\"> </a></td><td>Iowa</td><td>Iowa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1285-6<a name=\"cdcrec-1285-6\"> </a></td><td>Iroquois</td><td>Iroquois</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1297-1<a name=\"cdcrec-1297-1\"> </a></td><td>Juaneno</td><td>Juaneno</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1299-7<a name=\"cdcrec-1299-7\"> </a></td><td>Kalispel</td><td>Kalispel</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1301-1<a name=\"cdcrec-1301-1\"> </a></td><td>Karuk</td><td>Karuk</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1303-7<a name=\"cdcrec-1303-7\"> </a></td><td>Kaw</td><td>Kaw</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1305-2<a name=\"cdcrec-1305-2\"> </a></td><td>Kickapoo</td><td>Kickapoo</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1309-4<a name=\"cdcrec-1309-4\"> </a></td><td>Kiowa</td><td>Kiowa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1312-8<a name=\"cdcrec-1312-8\"> </a></td><td>Klallam</td><td>Klallam</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1317-7<a name=\"cdcrec-1317-7\"> </a></td><td>Klamath</td><td>Klamath</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1319-3<a name=\"cdcrec-1319-3\"> </a></td><td>Konkow</td><td>Konkow</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1321-9<a name=\"cdcrec-1321-9\"> </a></td><td>Kootenai</td><td>Kootenai</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1323-5<a name=\"cdcrec-1323-5\"> </a></td><td>Lassik</td><td>Lassik</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1325-0<a name=\"cdcrec-1325-0\"> </a></td><td>Long Island</td><td>Long Island</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1331-8<a name=\"cdcrec-1331-8\"> </a></td><td>Luiseno</td><td>Luiseno</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1340-9<a name=\"cdcrec-1340-9\"> </a></td><td>Lumbee</td><td>Lumbee</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1342-5<a name=\"cdcrec-1342-5\"> </a></td><td>Lummi</td><td>Lummi</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1344-1<a name=\"cdcrec-1344-1\"> </a></td><td>Maidu</td><td>Maidu</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1348-2<a name=\"cdcrec-1348-2\"> </a></td><td>Makah</td><td>Makah</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1350-8<a name=\"cdcrec-1350-8\"> </a></td><td>Maliseet</td><td>Maliseet</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1352-4<a name=\"cdcrec-1352-4\"> </a></td><td>Mandan</td><td>Mandan</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1354-0<a name=\"cdcrec-1354-0\"> </a></td><td>Mattaponi</td><td>Mattaponi</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1356-5<a name=\"cdcrec-1356-5\"> </a></td><td>Menominee</td><td>Menominee</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1358-1<a name=\"cdcrec-1358-1\"> </a></td><td>Miami</td><td>Miami</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1363-1<a name=\"cdcrec-1363-1\"> </a></td><td>Miccosukee</td><td>Miccosukee</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1365-6<a name=\"cdcrec-1365-6\"> </a></td><td>Micmac</td><td>Micmac</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1368-0<a name=\"cdcrec-1368-0\"> </a></td><td>Mission Indians</td><td>Mission Indians</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1370-6<a name=\"cdcrec-1370-6\"> </a></td><td>Miwok</td><td>Miwok</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1372-2<a name=\"cdcrec-1372-2\"> </a></td><td>Modoc</td><td>Modoc</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1374-8<a name=\"cdcrec-1374-8\"> </a></td><td>Mohegan</td><td>Mohegan</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1376-3<a name=\"cdcrec-1376-3\"> </a></td><td>Mono</td><td>Mono</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1378-9<a name=\"cdcrec-1378-9\"> </a></td><td>Nanticoke</td><td>Nanticoke</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1380-5<a name=\"cdcrec-1380-5\"> </a></td><td>Narragansett</td><td>Narragansett</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1382-1<a name=\"cdcrec-1382-1\"> </a></td><td>Navajo</td><td>Navajo</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1387-0<a name=\"cdcrec-1387-0\"> </a></td><td>Nez Perce</td><td>Nez Perce</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1389-6<a name=\"cdcrec-1389-6\"> </a></td><td>Nomalaki</td><td>Nomalaki</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1391-2<a name=\"cdcrec-1391-2\"> </a></td><td>Northwest Tribes</td><td>Northwest Tribes</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1403-5<a name=\"cdcrec-1403-5\"> </a></td><td>Omaha</td><td>Omaha</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1405-0<a name=\"cdcrec-1405-0\"> </a></td><td>Oregon Athabaskan</td><td>Oregon Athabaskan</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1407-6<a name=\"cdcrec-1407-6\"> </a></td><td>Osage</td><td>Osage</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1409-2<a name=\"cdcrec-1409-2\"> </a></td><td>Otoe-Missouria</td><td>Otoe-Missouria</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1411-8<a name=\"cdcrec-1411-8\"> </a></td><td>Ottawa</td><td>Ottawa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1416-7<a name=\"cdcrec-1416-7\"> </a></td><td>Paiute</td><td>Paiute</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1439-9<a name=\"cdcrec-1439-9\"> </a></td><td>Pamunkey</td><td>Pamunkey</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1441-5<a name=\"cdcrec-1441-5\"> </a></td><td>Passamaquoddy</td><td>Passamaquoddy</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1445-6<a name=\"cdcrec-1445-6\"> </a></td><td>Pawnee</td><td>Pawnee</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1448-0<a name=\"cdcrec-1448-0\"> </a></td><td>Penobscot</td><td>Penobscot</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1450-6<a name=\"cdcrec-1450-6\"> </a></td><td>Peoria</td><td>Peoria</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1453-0<a name=\"cdcrec-1453-0\"> </a></td><td>Pequot</td><td>Pequot</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1456-3<a name=\"cdcrec-1456-3\"> </a></td><td>Pima</td><td>Pima</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1460-5<a name=\"cdcrec-1460-5\"> </a></td><td>Piscataway</td><td>Piscataway</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1462-1<a name=\"cdcrec-1462-1\"> </a></td><td>Pit River</td><td>Pit River</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1464-7<a name=\"cdcrec-1464-7\"> </a></td><td>Pomo</td><td>Pomo</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1474-6<a name=\"cdcrec-1474-6\"> </a></td><td>Ponca</td><td>Ponca</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1478-7<a name=\"cdcrec-1478-7\"> </a></td><td>Potawatomi</td><td>Potawatomi</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1487-8<a name=\"cdcrec-1487-8\"> </a></td><td>Powhatan</td><td>Powhatan</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1489-4<a name=\"cdcrec-1489-4\"> </a></td><td>Pueblo</td><td>Pueblo</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1518-0<a name=\"cdcrec-1518-0\"> </a></td><td>Puget Sound Salish</td><td>Puget Sound Salish</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1541-2<a name=\"cdcrec-1541-2\"> </a></td><td>Quapaw</td><td>Quapaw</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1543-8<a name=\"cdcrec-1543-8\"> </a></td><td>Quinault</td><td>Quinault</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1545-3<a name=\"cdcrec-1545-3\"> </a></td><td>Rappahannock</td><td>Rappahannock</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1547-9<a name=\"cdcrec-1547-9\"> </a></td><td>Reno-Sparks</td><td>Reno-Sparks</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1549-5<a name=\"cdcrec-1549-5\"> </a></td><td>Round Valley</td><td>Round Valley</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1551-1<a name=\"cdcrec-1551-1\"> </a></td><td>Sac and Fox</td><td>Sac and Fox</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1556-0<a name=\"cdcrec-1556-0\"> </a></td><td>Salinan</td><td>Salinan</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1558-6<a name=\"cdcrec-1558-6\"> </a></td><td>Salish</td><td>Salish</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1560-2<a name=\"cdcrec-1560-2\"> </a></td><td>Salish and Kootenai</td><td>Salish and Kootenai</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1562-8<a name=\"cdcrec-1562-8\"> </a></td><td>Schaghticoke</td><td>Schaghticoke</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1564-4<a name=\"cdcrec-1564-4\"> </a></td><td>Scott Valley</td><td>Scott Valley</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1566-9<a name=\"cdcrec-1566-9\"> </a></td><td>Seminole</td><td>Seminole</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1573-5<a name=\"cdcrec-1573-5\"> </a></td><td>Serrano</td><td>Serrano</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1576-8<a name=\"cdcrec-1576-8\"> </a></td><td>Shasta</td><td>Shasta</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1578-4<a name=\"cdcrec-1578-4\"> </a></td><td>Shawnee</td><td>Shawnee</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1582-6<a name=\"cdcrec-1582-6\"> </a></td><td>Shinnecock</td><td>Shinnecock</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1584-2<a name=\"cdcrec-1584-2\"> </a></td><td>Shoalwater Bay</td><td>Shoalwater Bay</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1586-7<a name=\"cdcrec-1586-7\"> </a></td><td>Shoshone</td><td>Shoshone</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1602-2<a name=\"cdcrec-1602-2\"> </a></td><td>Shoshone Paiute</td><td>Shoshone Paiute</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1607-1<a name=\"cdcrec-1607-1\"> </a></td><td>Siletz</td><td>Siletz</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1609-7<a name=\"cdcrec-1609-7\"> </a></td><td>Sioux</td><td>Sioux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1643-6<a name=\"cdcrec-1643-6\"> </a></td><td>Siuslaw</td><td>Siuslaw</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1645-1<a name=\"cdcrec-1645-1\"> </a></td><td>Spokane</td><td>Spokane</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1647-7<a name=\"cdcrec-1647-7\"> </a></td><td>Stewart</td><td>Stewart</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1649-3<a name=\"cdcrec-1649-3\"> </a></td><td>Stockbridge</td><td>Stockbridge</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1651-9<a name=\"cdcrec-1651-9\"> </a></td><td>Susanville</td><td>Susanville</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1653-5<a name=\"cdcrec-1653-5\"> </a></td><td>Tohono O'Odham</td><td>Tohono O'Odham</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1659-2<a name=\"cdcrec-1659-2\"> </a></td><td>Tolowa</td><td>Tolowa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1661-8<a name=\"cdcrec-1661-8\"> </a></td><td>Tonkawa</td><td>Tonkawa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1663-4<a name=\"cdcrec-1663-4\"> </a></td><td>Tygh</td><td>Tygh</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1665-9<a name=\"cdcrec-1665-9\"> </a></td><td>Umatilla</td><td>Umatilla</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1667-5<a name=\"cdcrec-1667-5\"> </a></td><td>Umpqua</td><td>Umpqua</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1670-9<a name=\"cdcrec-1670-9\"> </a></td><td>Ute</td><td>Ute</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1675-8<a name=\"cdcrec-1675-8\"> </a></td><td>Wailaki</td><td>Wailaki</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1677-4<a name=\"cdcrec-1677-4\"> </a></td><td>Walla-Walla</td><td>Walla-Walla</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1679-0<a name=\"cdcrec-1679-0\"> </a></td><td>Wampanoag</td><td>Wampanoag</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1683-2<a name=\"cdcrec-1683-2\"> </a></td><td>Warm Springs</td><td>Warm Springs</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1685-7<a name=\"cdcrec-1685-7\"> </a></td><td>Wascopum</td><td>Wascopum</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1687-3<a name=\"cdcrec-1687-3\"> </a></td><td>Washoe</td><td>Washoe</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1692-3<a name=\"cdcrec-1692-3\"> </a></td><td>Wichita</td><td>Wichita</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1694-9<a name=\"cdcrec-1694-9\"> </a></td><td>Wind River</td><td>Wind River</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1696-4<a name=\"cdcrec-1696-4\"> </a></td><td>Winnebago</td><td>Winnebago</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1700-4<a name=\"cdcrec-1700-4\"> </a></td><td>Winnemucca</td><td>Winnemucca</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1702-0<a name=\"cdcrec-1702-0\"> </a></td><td>Wintun</td><td>Wintun</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1704-6<a name=\"cdcrec-1704-6\"> </a></td><td>Wiyot</td><td>Wiyot</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1707-9<a name=\"cdcrec-1707-9\"> </a></td><td>Yakama</td><td>Yakama</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1709-5<a name=\"cdcrec-1709-5\"> </a></td><td>Yakama Cowlitz</td><td>Yakama Cowlitz</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1711-1<a name=\"cdcrec-1711-1\"> </a></td><td>Yaqui</td><td>Yaqui</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1715-2<a name=\"cdcrec-1715-2\"> </a></td><td>Yavapai Apache</td><td>Yavapai Apache</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1717-8<a name=\"cdcrec-1717-8\"> </a></td><td>Yokuts</td><td>Yokuts</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1722-8<a name=\"cdcrec-1722-8\"> </a></td><td>Yuchi</td><td>Yuchi</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1724-4<a name=\"cdcrec-1724-4\"> </a></td><td>Yuman</td><td>Yuman</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1732-7<a name=\"cdcrec-1732-7\"> </a></td><td>Yurok</td><td>Yurok</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1011-6<a name=\"cdcrec-1011-6\"> </a></td><td>Chiricahua</td><td>Chiricahua</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1012-4<a name=\"cdcrec-1012-4\"> </a></td><td>Fort Sill Apache</td><td>Fort Sill Apache</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1013-2<a name=\"cdcrec-1013-2\"> </a></td><td>Jicarilla Apache</td><td>Jicarilla Apache</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1014-0<a name=\"cdcrec-1014-0\"> </a></td><td>Lipan Apache</td><td>Lipan Apache</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1015-7<a name=\"cdcrec-1015-7\"> </a></td><td>Mescalero Apache</td><td>Mescalero Apache</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1016-5<a name=\"cdcrec-1016-5\"> </a></td><td>Oklahoma Apache</td><td>Oklahoma Apache</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1017-3<a name=\"cdcrec-1017-3\"> </a></td><td>Payson Apache</td><td>Payson Apache</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1018-1<a name=\"cdcrec-1018-1\"> </a></td><td>San Carlos Apache</td><td>San Carlos Apache</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1019-9<a name=\"cdcrec-1019-9\"> </a></td><td>White Mountain Apache</td><td>White Mountain Apache</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1022-3<a name=\"cdcrec-1022-3\"> </a></td><td>Northern Arapaho</td><td>Northern Arapaho</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1023-1<a name=\"cdcrec-1023-1\"> </a></td><td>Southern Arapaho</td><td>Southern Arapaho</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1024-9<a name=\"cdcrec-1024-9\"> </a></td><td>Wind River Arapaho</td><td>Wind River Arapaho</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1031-4<a name=\"cdcrec-1031-4\"> </a></td><td>Fort Peck Assiniboine Sioux</td><td>Fort Peck Assiniboine Sioux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1042-1<a name=\"cdcrec-1042-1\"> </a></td><td>Oklahoma Cado</td><td>Oklahoma Cado</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1045-4<a name=\"cdcrec-1045-4\"> </a></td><td>Agua Caliente Cahuilla</td><td>Agua Caliente Cahuilla</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1046-2<a name=\"cdcrec-1046-2\"> </a></td><td>Augustine</td><td>Augustine</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1047-0<a name=\"cdcrec-1047-0\"> </a></td><td>Cabazon</td><td>Cabazon</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1048-8<a name=\"cdcrec-1048-8\"> </a></td><td>Los Coyotes</td><td>Los Coyotes</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1049-6<a name=\"cdcrec-1049-6\"> </a></td><td>Morongo</td><td>Morongo</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1050-4<a name=\"cdcrec-1050-4\"> </a></td><td>Santa Rosa Cahuilla</td><td>Santa Rosa Cahuilla</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1051-2<a name=\"cdcrec-1051-2\"> </a></td><td>Torres-Martinez</td><td>Torres-Martinez</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1054-6<a name=\"cdcrec-1054-6\"> </a></td><td>Cahto</td><td>Cahto</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1055-3<a name=\"cdcrec-1055-3\"> </a></td><td>Chimariko</td><td>Chimariko</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1056-1<a name=\"cdcrec-1056-1\"> </a></td><td>Coast Miwok</td><td>Coast Miwok</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1057-9<a name=\"cdcrec-1057-9\"> </a></td><td>Digger</td><td>Digger</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1058-7<a name=\"cdcrec-1058-7\"> </a></td><td>Kawaiisu</td><td>Kawaiisu</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1059-5<a name=\"cdcrec-1059-5\"> </a></td><td>Kern River</td><td>Kern River</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1060-3<a name=\"cdcrec-1060-3\"> </a></td><td>Mattole</td><td>Mattole</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1061-1<a name=\"cdcrec-1061-1\"> </a></td><td>Red Wood</td><td>Red Wood</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1062-9<a name=\"cdcrec-1062-9\"> </a></td><td>Santa Rosa</td><td>Santa Rosa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1063-7<a name=\"cdcrec-1063-7\"> </a></td><td>Takelma</td><td>Takelma</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1064-5<a name=\"cdcrec-1064-5\"> </a></td><td>Wappo</td><td>Wappo</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1065-2<a name=\"cdcrec-1065-2\"> </a></td><td>Yana</td><td>Yana</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1066-0<a name=\"cdcrec-1066-0\"> </a></td><td>Yuki</td><td>Yuki</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1069-4<a name=\"cdcrec-1069-4\"> </a></td><td>Canadian Indian</td><td>Canadian Indian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1070-2<a name=\"cdcrec-1070-2\"> </a></td><td>Central American Indian</td><td>Central American Indian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1071-0<a name=\"cdcrec-1071-0\"> </a></td><td>French American Indian</td><td>French American Indian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1072-8<a name=\"cdcrec-1072-8\"> </a></td><td>Mexican American Indian</td><td>Mexican American Indian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1073-6<a name=\"cdcrec-1073-6\"> </a></td><td>South American Indian</td><td>South American Indian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1074-4<a name=\"cdcrec-1074-4\"> </a></td><td>Spanish American Indian</td><td>Spanish American Indian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1083-5<a name=\"cdcrec-1083-5\"> </a></td><td>Hoh</td><td>Hoh</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1084-3<a name=\"cdcrec-1084-3\"> </a></td><td>Quileute</td><td>Quileute</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1089-2<a name=\"cdcrec-1089-2\"> </a></td><td>Cherokee Alabama</td><td>Cherokee Alabama</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1090-0<a name=\"cdcrec-1090-0\"> </a></td><td>Cherokees of Northeast Alabama</td><td>Cherokees of Northeast Alabama</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1091-8<a name=\"cdcrec-1091-8\"> </a></td><td>Cherokees of Southeast Alabama</td><td>Cherokees of Southeast Alabama</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1092-6<a name=\"cdcrec-1092-6\"> </a></td><td>Eastern Cherokee</td><td>Eastern Cherokee</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1093-4<a name=\"cdcrec-1093-4\"> </a></td><td>Echota Cherokee</td><td>Echota Cherokee</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1094-2<a name=\"cdcrec-1094-2\"> </a></td><td>Etowah Cherokee</td><td>Etowah Cherokee</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1095-9<a name=\"cdcrec-1095-9\"> </a></td><td>Northern Cherokee</td><td>Northern Cherokee</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1096-7<a name=\"cdcrec-1096-7\"> </a></td><td>Tuscola</td><td>Tuscola</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1097-5<a name=\"cdcrec-1097-5\"> </a></td><td>United Keetowah Band of Cherokee</td><td>United Keetowah Band of Cherokee</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1098-3<a name=\"cdcrec-1098-3\"> </a></td><td>Western Cherokee</td><td>Western Cherokee</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1103-1<a name=\"cdcrec-1103-1\"> </a></td><td>Northern Cheyenne</td><td>Northern Cheyenne</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1104-9<a name=\"cdcrec-1104-9\"> </a></td><td>Southern Cheyenne</td><td>Southern Cheyenne</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1109-8<a name=\"cdcrec-1109-8\"> </a></td><td>Eastern Chickahominy</td><td>Eastern Chickahominy</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1110-6<a name=\"cdcrec-1110-6\"> </a></td><td>Western Chickahominy</td><td>Western Chickahominy</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1115-5<a name=\"cdcrec-1115-5\"> </a></td><td>Clatsop</td><td>Clatsop</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1116-3<a name=\"cdcrec-1116-3\"> </a></td><td>Columbia River Chinook</td><td>Columbia River Chinook</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1117-1<a name=\"cdcrec-1117-1\"> </a></td><td>Kathlamet</td><td>Kathlamet</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1118-9<a name=\"cdcrec-1118-9\"> </a></td><td>Upper Chinook</td><td>Upper Chinook</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1119-7<a name=\"cdcrec-1119-7\"> </a></td><td>Wakiakum Chinook</td><td>Wakiakum Chinook</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1120-5<a name=\"cdcrec-1120-5\"> </a></td><td>Willapa Chinook</td><td>Willapa Chinook</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1121-3<a name=\"cdcrec-1121-3\"> </a></td><td>Wishram</td><td>Wishram</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1124-7<a name=\"cdcrec-1124-7\"> </a></td><td>Bad River</td><td>Bad River</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1125-4<a name=\"cdcrec-1125-4\"> </a></td><td>Bay Mills Chippewa</td><td>Bay Mills Chippewa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1126-2<a name=\"cdcrec-1126-2\"> </a></td><td>Bois Forte</td><td>Bois Forte</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1127-0<a name=\"cdcrec-1127-0\"> </a></td><td>Burt Lake Chippewa</td><td>Burt Lake Chippewa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1128-8<a name=\"cdcrec-1128-8\"> </a></td><td>Fond du Lac</td><td>Fond du Lac</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1129-6<a name=\"cdcrec-1129-6\"> </a></td><td>Grand Portage</td><td>Grand Portage</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1130-4<a name=\"cdcrec-1130-4\"> </a></td><td>Grand Traverse Band of Ottawa/Chippewa</td><td>Grand Traverse Band of Ottawa/Chippewa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1131-2<a name=\"cdcrec-1131-2\"> </a></td><td>Keweenaw</td><td>Keweenaw</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1132-0<a name=\"cdcrec-1132-0\"> </a></td><td>Lac Courte Oreilles</td><td>Lac Courte Oreilles</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1133-8<a name=\"cdcrec-1133-8\"> </a></td><td>Lac du Flambeau</td><td>Lac du Flambeau</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1134-6<a name=\"cdcrec-1134-6\"> </a></td><td>Lac Vieux Desert Chippewa</td><td>Lac Vieux Desert Chippewa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1135-3<a name=\"cdcrec-1135-3\"> </a></td><td>Lake Superior</td><td>Lake Superior</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1136-1<a name=\"cdcrec-1136-1\"> </a></td><td>Leech Lake</td><td>Leech Lake</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1137-9<a name=\"cdcrec-1137-9\"> </a></td><td>Little Shell Chippewa</td><td>Little Shell Chippewa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1138-7<a name=\"cdcrec-1138-7\"> </a></td><td>Mille Lacs</td><td>Mille Lacs</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1139-5<a name=\"cdcrec-1139-5\"> </a></td><td>Minnesota Chippewa</td><td>Minnesota Chippewa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1140-3<a name=\"cdcrec-1140-3\"> </a></td><td>Ontonagon</td><td>Ontonagon</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1141-1<a name=\"cdcrec-1141-1\"> </a></td><td>Red Cliff Chippewa</td><td>Red Cliff Chippewa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1142-9<a name=\"cdcrec-1142-9\"> </a></td><td>Red Lake Chippewa</td><td>Red Lake Chippewa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1143-7<a name=\"cdcrec-1143-7\"> </a></td><td>Saginaw Chippewa</td><td>Saginaw Chippewa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1144-5<a name=\"cdcrec-1144-5\"> </a></td><td>St. Croix Chippewa</td><td>St. Croix Chippewa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1145-2<a name=\"cdcrec-1145-2\"> </a></td><td>Sault Ste. Marie Chippewa</td><td>Sault Ste. Marie Chippewa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1146-0<a name=\"cdcrec-1146-0\"> </a></td><td>Sokoagon Chippewa</td><td>Sokoagon Chippewa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1147-8<a name=\"cdcrec-1147-8\"> </a></td><td>Turtle Mountain</td><td>Turtle Mountain</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1148-6<a name=\"cdcrec-1148-6\"> </a></td><td>White Earth</td><td>White Earth</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1151-0<a name=\"cdcrec-1151-0\"> </a></td><td>Rocky Boy's Chippewa Cree</td><td>Rocky Boy's Chippewa Cree</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1156-9<a name=\"cdcrec-1156-9\"> </a></td><td>Clifton Choctaw</td><td>Clifton Choctaw</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1157-7<a name=\"cdcrec-1157-7\"> </a></td><td>Jena Choctaw</td><td>Jena Choctaw</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1158-5<a name=\"cdcrec-1158-5\"> </a></td><td>Mississippi Choctaw</td><td>Mississippi Choctaw</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1159-3<a name=\"cdcrec-1159-3\"> </a></td><td>Mowa Band of Choctaw</td><td>Mowa Band of Choctaw</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1160-1<a name=\"cdcrec-1160-1\"> </a></td><td>Oklahoma Choctaw</td><td>Oklahoma Choctaw</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1163-5<a name=\"cdcrec-1163-5\"> </a></td><td>Santa Ynez</td><td>Santa Ynez</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1176-7<a name=\"cdcrec-1176-7\"> </a></td><td>Oklahoma Comanche</td><td>Oklahoma Comanche</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1187-4<a name=\"cdcrec-1187-4\"> </a></td><td>Alabama Coushatta</td><td>Alabama Coushatta</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1194-0<a name=\"cdcrec-1194-0\"> </a></td><td>Alabama Creek</td><td>Alabama Creek</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1195-7<a name=\"cdcrec-1195-7\"> </a></td><td>Alabama Quassarte</td><td>Alabama Quassarte</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1196-5<a name=\"cdcrec-1196-5\"> </a></td><td>Eastern Creek</td><td>Eastern Creek</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1197-3<a name=\"cdcrec-1197-3\"> </a></td><td>Eastern Muscogee</td><td>Eastern Muscogee</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1198-1<a name=\"cdcrec-1198-1\"> </a></td><td>Kialegee</td><td>Kialegee</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1199-9<a name=\"cdcrec-1199-9\"> </a></td><td>Lower Muscogee</td><td>Lower Muscogee</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1200-5<a name=\"cdcrec-1200-5\"> </a></td><td>Machis Lower Creek Indian</td><td>Machis Lower Creek Indian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1201-3<a name=\"cdcrec-1201-3\"> </a></td><td>Poarch Band</td><td>Poarch Band</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1202-1<a name=\"cdcrec-1202-1\"> </a></td><td>Principal Creek Indian Nation</td><td>Principal Creek Indian Nation</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1203-9<a name=\"cdcrec-1203-9\"> </a></td><td>Star Clan of Muscogee Creeks</td><td>Star Clan of Muscogee Creeks</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1204-7<a name=\"cdcrec-1204-7\"> </a></td><td>Thlopthlocco</td><td>Thlopthlocco</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1205-4<a name=\"cdcrec-1205-4\"> </a></td><td>Tuckabachee</td><td>Tuckabachee</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1212-0<a name=\"cdcrec-1212-0\"> </a></td><td>Agua Caliente</td><td>Agua Caliente</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1215-3<a name=\"cdcrec-1215-3\"> </a></td><td>Eastern Delaware</td><td>Eastern Delaware</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1216-1<a name=\"cdcrec-1216-1\"> </a></td><td>Lenni-Lenape</td><td>Lenni-Lenape</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1217-9<a name=\"cdcrec-1217-9\"> </a></td><td>Munsee</td><td>Munsee</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1218-7<a name=\"cdcrec-1218-7\"> </a></td><td>Oklahoma Delaware</td><td>Oklahoma Delaware</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1219-5<a name=\"cdcrec-1219-5\"> </a></td><td>Rampough Mountain</td><td>Rampough Mountain</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1220-3<a name=\"cdcrec-1220-3\"> </a></td><td>Sand Hill</td><td>Sand Hill</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1223-7<a name=\"cdcrec-1223-7\"> </a></td><td>Campo</td><td>Campo</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1224-5<a name=\"cdcrec-1224-5\"> </a></td><td>Capitan Grande</td><td>Capitan Grande</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1225-2<a name=\"cdcrec-1225-2\"> </a></td><td>Cuyapaipe</td><td>Cuyapaipe</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1226-0<a name=\"cdcrec-1226-0\"> </a></td><td>La Posta</td><td>La Posta</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1227-8<a name=\"cdcrec-1227-8\"> </a></td><td>Manzanita</td><td>Manzanita</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1228-6<a name=\"cdcrec-1228-6\"> </a></td><td>Mesa Grande</td><td>Mesa Grande</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1229-4<a name=\"cdcrec-1229-4\"> </a></td><td>San Pasqual</td><td>San Pasqual</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1230-2<a name=\"cdcrec-1230-2\"> </a></td><td>Santa Ysabel</td><td>Santa Ysabel</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1231-0<a name=\"cdcrec-1231-0\"> </a></td><td>Sycuan</td><td>Sycuan</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1234-4<a name=\"cdcrec-1234-4\"> </a></td><td>Attacapa</td><td>Attacapa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1235-1<a name=\"cdcrec-1235-1\"> </a></td><td>Biloxi</td><td>Biloxi</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1236-9<a name=\"cdcrec-1236-9\"> </a></td><td>Georgetown (Eastern Tribes)</td><td>Georgetown (Eastern Tribes)</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1237-7<a name=\"cdcrec-1237-7\"> </a></td><td>Moor</td><td>Moor</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1238-5<a name=\"cdcrec-1238-5\"> </a></td><td>Nansemond</td><td>Nansemond</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1239-3<a name=\"cdcrec-1239-3\"> </a></td><td>Natchez</td><td>Natchez</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1240-1<a name=\"cdcrec-1240-1\"> </a></td><td>Nausu Waiwash</td><td>Nausu Waiwash</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1241-9<a name=\"cdcrec-1241-9\"> </a></td><td>Nipmuc</td><td>Nipmuc</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1242-7<a name=\"cdcrec-1242-7\"> </a></td><td>Paugussett</td><td>Paugussett</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1243-5<a name=\"cdcrec-1243-5\"> </a></td><td>Pocomoke Acohonock</td><td>Pocomoke Acohonock</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1244-3<a name=\"cdcrec-1244-3\"> </a></td><td>Southeastern Indians</td><td>Southeastern Indians</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1245-0<a name=\"cdcrec-1245-0\"> </a></td><td>Susquehanock</td><td>Susquehanock</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1246-8<a name=\"cdcrec-1246-8\"> </a></td><td>Tunica Biloxi</td><td>Tunica Biloxi</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1247-6<a name=\"cdcrec-1247-6\"> </a></td><td>Waccamaw-Siousan</td><td>Waccamaw-Siousan</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1248-4<a name=\"cdcrec-1248-4\"> </a></td><td>Wicomico</td><td>Wicomico</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1265-8<a name=\"cdcrec-1265-8\"> </a></td><td>Atsina</td><td>Atsina</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1272-4<a name=\"cdcrec-1272-4\"> </a></td><td>Trinity</td><td>Trinity</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1273-2<a name=\"cdcrec-1273-2\"> </a></td><td>Whilkut</td><td>Whilkut</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1282-3<a name=\"cdcrec-1282-3\"> </a></td><td>Iowa of Kansas-Nebraska</td><td>Iowa of Kansas-Nebraska</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1283-1<a name=\"cdcrec-1283-1\"> </a></td><td>Iowa of Oklahoma</td><td>Iowa of Oklahoma</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1286-4<a name=\"cdcrec-1286-4\"> </a></td><td>Cayuga</td><td>Cayuga</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1287-2<a name=\"cdcrec-1287-2\"> </a></td><td>Mohawk</td><td>Mohawk</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1288-0<a name=\"cdcrec-1288-0\"> </a></td><td>Oneida</td><td>Oneida</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1289-8<a name=\"cdcrec-1289-8\"> </a></td><td>Onondaga</td><td>Onondaga</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1290-6<a name=\"cdcrec-1290-6\"> </a></td><td>Seneca</td><td>Seneca</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1291-4<a name=\"cdcrec-1291-4\"> </a></td><td>Seneca Nation</td><td>Seneca Nation</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1292-2<a name=\"cdcrec-1292-2\"> </a></td><td>Seneca-Cayuga</td><td>Seneca-Cayuga</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1293-0<a name=\"cdcrec-1293-0\"> </a></td><td>Tonawanda Seneca</td><td>Tonawanda Seneca</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1294-8<a name=\"cdcrec-1294-8\"> </a></td><td>Tuscarora</td><td>Tuscarora</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1295-5<a name=\"cdcrec-1295-5\"> </a></td><td>Wyandotte</td><td>Wyandotte</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1306-0<a name=\"cdcrec-1306-0\"> </a></td><td>Oklahoma Kickapoo</td><td>Oklahoma Kickapoo</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1307-8<a name=\"cdcrec-1307-8\"> </a></td><td>Texas Kickapoo</td><td>Texas Kickapoo</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1310-2<a name=\"cdcrec-1310-2\"> </a></td><td>Oklahoma Kiowa</td><td>Oklahoma Kiowa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1313-6<a name=\"cdcrec-1313-6\"> </a></td><td>Jamestown</td><td>Jamestown</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1314-4<a name=\"cdcrec-1314-4\"> </a></td><td>Lower Elwha</td><td>Lower Elwha</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1315-1<a name=\"cdcrec-1315-1\"> </a></td><td>Port Gamble Klallam</td><td>Port Gamble Klallam</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1326-8<a name=\"cdcrec-1326-8\"> </a></td><td>Matinecock</td><td>Matinecock</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1327-6<a name=\"cdcrec-1327-6\"> </a></td><td>Montauk</td><td>Montauk</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1328-4<a name=\"cdcrec-1328-4\"> </a></td><td>Poospatuck</td><td>Poospatuck</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1329-2<a name=\"cdcrec-1329-2\"> </a></td><td>Setauket</td><td>Setauket</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1332-6<a name=\"cdcrec-1332-6\"> </a></td><td>La Jolla</td><td>La Jolla</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1333-4<a name=\"cdcrec-1333-4\"> </a></td><td>Pala</td><td>Pala</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1334-2<a name=\"cdcrec-1334-2\"> </a></td><td>Pauma</td><td>Pauma</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1335-9<a name=\"cdcrec-1335-9\"> </a></td><td>Pechanga</td><td>Pechanga</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1336-7<a name=\"cdcrec-1336-7\"> </a></td><td>Soboba</td><td>Soboba</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1337-5<a name=\"cdcrec-1337-5\"> </a></td><td>Twenty-Nine Palms</td><td>Twenty-Nine Palms</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1338-3<a name=\"cdcrec-1338-3\"> </a></td><td>Temecula</td><td>Temecula</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1345-8<a name=\"cdcrec-1345-8\"> </a></td><td>Mountain Maidu</td><td>Mountain Maidu</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1346-6<a name=\"cdcrec-1346-6\"> </a></td><td>Nishinam</td><td>Nishinam</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1359-9<a name=\"cdcrec-1359-9\"> </a></td><td>Illinois Miami</td><td>Illinois Miami</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1360-7<a name=\"cdcrec-1360-7\"> </a></td><td>Indiana Miami</td><td>Indiana Miami</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1361-5<a name=\"cdcrec-1361-5\"> </a></td><td>Oklahoma Miami</td><td>Oklahoma Miami</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1366-4<a name=\"cdcrec-1366-4\"> </a></td><td>Aroostook</td><td>Aroostook</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1383-9<a name=\"cdcrec-1383-9\"> </a></td><td>Alamo Navajo</td><td>Alamo Navajo</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1384-7<a name=\"cdcrec-1384-7\"> </a></td><td>Canoncito Navajo</td><td>Canoncito Navajo</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1385-4<a name=\"cdcrec-1385-4\"> </a></td><td>Ramah Navajo</td><td>Ramah Navajo</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1392-0<a name=\"cdcrec-1392-0\"> </a></td><td>Alsea</td><td>Alsea</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1393-8<a name=\"cdcrec-1393-8\"> </a></td><td>Celilo</td><td>Celilo</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1394-6<a name=\"cdcrec-1394-6\"> </a></td><td>Columbia</td><td>Columbia</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1395-3<a name=\"cdcrec-1395-3\"> </a></td><td>Kalapuya</td><td>Kalapuya</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1396-1<a name=\"cdcrec-1396-1\"> </a></td><td>Molala</td><td>Molala</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1397-9<a name=\"cdcrec-1397-9\"> </a></td><td>Talakamish</td><td>Talakamish</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1398-7<a name=\"cdcrec-1398-7\"> </a></td><td>Tenino</td><td>Tenino</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1399-5<a name=\"cdcrec-1399-5\"> </a></td><td>Tillamook</td><td>Tillamook</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1400-1<a name=\"cdcrec-1400-1\"> </a></td><td>Wenatchee</td><td>Wenatchee</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1401-9<a name=\"cdcrec-1401-9\"> </a></td><td>Yahooskin</td><td>Yahooskin</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1412-6<a name=\"cdcrec-1412-6\"> </a></td><td>Burt Lake Ottawa</td><td>Burt Lake Ottawa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1413-4<a name=\"cdcrec-1413-4\"> </a></td><td>Michigan Ottawa</td><td>Michigan Ottawa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1414-2<a name=\"cdcrec-1414-2\"> </a></td><td>Oklahoma Ottawa</td><td>Oklahoma Ottawa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1417-5<a name=\"cdcrec-1417-5\"> </a></td><td>Bishop</td><td>Bishop</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1418-3<a name=\"cdcrec-1418-3\"> </a></td><td>Bridgeport</td><td>Bridgeport</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1419-1<a name=\"cdcrec-1419-1\"> </a></td><td>Burns Paiute</td><td>Burns Paiute</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1420-9<a name=\"cdcrec-1420-9\"> </a></td><td>Cedarville</td><td>Cedarville</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1421-7<a name=\"cdcrec-1421-7\"> </a></td><td>Fort Bidwell</td><td>Fort Bidwell</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1422-5<a name=\"cdcrec-1422-5\"> </a></td><td>Fort Independence</td><td>Fort Independence</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1423-3<a name=\"cdcrec-1423-3\"> </a></td><td>Kaibab</td><td>Kaibab</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1424-1<a name=\"cdcrec-1424-1\"> </a></td><td>Las Vegas</td><td>Las Vegas</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1425-8<a name=\"cdcrec-1425-8\"> </a></td><td>Lone Pine</td><td>Lone Pine</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1426-6<a name=\"cdcrec-1426-6\"> </a></td><td>Lovelock</td><td>Lovelock</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1427-4<a name=\"cdcrec-1427-4\"> </a></td><td>Malheur Paiute</td><td>Malheur Paiute</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1428-2<a name=\"cdcrec-1428-2\"> </a></td><td>Moapa</td><td>Moapa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1429-0<a name=\"cdcrec-1429-0\"> </a></td><td>Northern Paiute</td><td>Northern Paiute</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1430-8<a name=\"cdcrec-1430-8\"> </a></td><td>Owens Valley</td><td>Owens Valley</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1431-6<a name=\"cdcrec-1431-6\"> </a></td><td>Pyramid Lake</td><td>Pyramid Lake</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1432-4<a name=\"cdcrec-1432-4\"> </a></td><td>San Juan Southern Paiute</td><td>San Juan Southern Paiute</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1433-2<a name=\"cdcrec-1433-2\"> </a></td><td>Southern Paiute</td><td>Southern Paiute</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1434-0<a name=\"cdcrec-1434-0\"> </a></td><td>Summit Lake</td><td>Summit Lake</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1435-7<a name=\"cdcrec-1435-7\"> </a></td><td>Utu Utu Gwaitu Paiute</td><td>Utu Utu Gwaitu Paiute</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1436-5<a name=\"cdcrec-1436-5\"> </a></td><td>Walker River</td><td>Walker River</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1437-3<a name=\"cdcrec-1437-3\"> </a></td><td>Yerington Paiute</td><td>Yerington Paiute</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1442-3<a name=\"cdcrec-1442-3\"> </a></td><td>Indian Township</td><td>Indian Township</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1443-1<a name=\"cdcrec-1443-1\"> </a></td><td>Pleasant Point Passamaquoddy</td><td>Pleasant Point Passamaquoddy</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1446-4<a name=\"cdcrec-1446-4\"> </a></td><td>Oklahoma Pawnee</td><td>Oklahoma Pawnee</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1451-4<a name=\"cdcrec-1451-4\"> </a></td><td>Oklahoma Peoria</td><td>Oklahoma Peoria</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1454-8<a name=\"cdcrec-1454-8\"> </a></td><td>Marshantucket Pequot</td><td>Marshantucket Pequot</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1457-1<a name=\"cdcrec-1457-1\"> </a></td><td>Gila River Pima-Maricopa</td><td>Gila River Pima-Maricopa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1458-9<a name=\"cdcrec-1458-9\"> </a></td><td>Salt River Pima-Maricopa</td><td>Salt River Pima-Maricopa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1465-4<a name=\"cdcrec-1465-4\"> </a></td><td>Central Pomo</td><td>Central Pomo</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1466-2<a name=\"cdcrec-1466-2\"> </a></td><td>Dry Creek</td><td>Dry Creek</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1467-0<a name=\"cdcrec-1467-0\"> </a></td><td>Eastern Pomo</td><td>Eastern Pomo</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1468-8<a name=\"cdcrec-1468-8\"> </a></td><td>Kashia</td><td>Kashia</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1469-6<a name=\"cdcrec-1469-6\"> </a></td><td>Northern Pomo</td><td>Northern Pomo</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1470-4<a name=\"cdcrec-1470-4\"> </a></td><td>Scotts Valley</td><td>Scotts Valley</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1471-2<a name=\"cdcrec-1471-2\"> </a></td><td>Stonyford</td><td>Stonyford</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1472-0<a name=\"cdcrec-1472-0\"> </a></td><td>Sulphur Bank</td><td>Sulphur Bank</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1475-3<a name=\"cdcrec-1475-3\"> </a></td><td>Nebraska Ponca</td><td>Nebraska Ponca</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1476-1<a name=\"cdcrec-1476-1\"> </a></td><td>Oklahoma Ponca</td><td>Oklahoma Ponca</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1479-5<a name=\"cdcrec-1479-5\"> </a></td><td>Citizen Band Potawatomi</td><td>Citizen Band Potawatomi</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1480-3<a name=\"cdcrec-1480-3\"> </a></td><td>Forest County</td><td>Forest County</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1481-1<a name=\"cdcrec-1481-1\"> </a></td><td>Hannahville</td><td>Hannahville</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1482-9<a name=\"cdcrec-1482-9\"> </a></td><td>Huron Potawatomi</td><td>Huron Potawatomi</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1483-7<a name=\"cdcrec-1483-7\"> </a></td><td>Pokagon Potawatomi</td><td>Pokagon Potawatomi</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1484-5<a name=\"cdcrec-1484-5\"> </a></td><td>Prairie Band</td><td>Prairie Band</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1485-2<a name=\"cdcrec-1485-2\"> </a></td><td>Wisconsin Potawatomi</td><td>Wisconsin Potawatomi</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1490-2<a name=\"cdcrec-1490-2\"> </a></td><td>Acoma</td><td>Acoma</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1491-0<a name=\"cdcrec-1491-0\"> </a></td><td>Arizona Tewa</td><td>Arizona Tewa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1492-8<a name=\"cdcrec-1492-8\"> </a></td><td>Cochiti</td><td>Cochiti</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1493-6<a name=\"cdcrec-1493-6\"> </a></td><td>Hopi</td><td>Hopi</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1494-4<a name=\"cdcrec-1494-4\"> </a></td><td>Isleta</td><td>Isleta</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1495-1<a name=\"cdcrec-1495-1\"> </a></td><td>Jemez</td><td>Jemez</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1496-9<a name=\"cdcrec-1496-9\"> </a></td><td>Keres</td><td>Keres</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1497-7<a name=\"cdcrec-1497-7\"> </a></td><td>Laguna</td><td>Laguna</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1498-5<a name=\"cdcrec-1498-5\"> </a></td><td>Nambe</td><td>Nambe</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1499-3<a name=\"cdcrec-1499-3\"> </a></td><td>Picuris</td><td>Picuris</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1500-8<a name=\"cdcrec-1500-8\"> </a></td><td>Piro</td><td>Piro</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1501-6<a name=\"cdcrec-1501-6\"> </a></td><td>Pojoaque</td><td>Pojoaque</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1502-4<a name=\"cdcrec-1502-4\"> </a></td><td>San Felipe</td><td>San Felipe</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1503-2<a name=\"cdcrec-1503-2\"> </a></td><td>San Ildefonso</td><td>San Ildefonso</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1504-0<a name=\"cdcrec-1504-0\"> </a></td><td>San Juan Pueblo</td><td>San Juan Pueblo</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1505-7<a name=\"cdcrec-1505-7\"> </a></td><td>San Juan De</td><td>San Juan De</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1506-5<a name=\"cdcrec-1506-5\"> </a></td><td>San Juan</td><td>San Juan</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1507-3<a name=\"cdcrec-1507-3\"> </a></td><td>Sandia</td><td>Sandia</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1508-1<a name=\"cdcrec-1508-1\"> </a></td><td>Santa Ana</td><td>Santa Ana</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1509-9<a name=\"cdcrec-1509-9\"> </a></td><td>Santa Clara</td><td>Santa Clara</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1510-7<a name=\"cdcrec-1510-7\"> </a></td><td>Santo Domingo</td><td>Santo Domingo</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1511-5<a name=\"cdcrec-1511-5\"> </a></td><td>Taos</td><td>Taos</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1512-3<a name=\"cdcrec-1512-3\"> </a></td><td>Tesuque</td><td>Tesuque</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1513-1<a name=\"cdcrec-1513-1\"> </a></td><td>Tewa</td><td>Tewa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1514-9<a name=\"cdcrec-1514-9\"> </a></td><td>Tigua</td><td>Tigua</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1515-6<a name=\"cdcrec-1515-6\"> </a></td><td>Zia</td><td>Zia</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1516-4<a name=\"cdcrec-1516-4\"> </a></td><td>Zuni</td><td>Zuni</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1519-8<a name=\"cdcrec-1519-8\"> </a></td><td>Duwamish</td><td>Duwamish</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1520-6<a name=\"cdcrec-1520-6\"> </a></td><td>Kikiallus</td><td>Kikiallus</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1521-4<a name=\"cdcrec-1521-4\"> </a></td><td>Lower Skagit</td><td>Lower Skagit</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1522-2<a name=\"cdcrec-1522-2\"> </a></td><td>Muckleshoot</td><td>Muckleshoot</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1523-0<a name=\"cdcrec-1523-0\"> </a></td><td>Nisqually</td><td>Nisqually</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1524-8<a name=\"cdcrec-1524-8\"> </a></td><td>Nooksack</td><td>Nooksack</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1525-5<a name=\"cdcrec-1525-5\"> </a></td><td>Port Madison</td><td>Port Madison</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1526-3<a name=\"cdcrec-1526-3\"> </a></td><td>Puyallup</td><td>Puyallup</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1527-1<a name=\"cdcrec-1527-1\"> </a></td><td>Samish</td><td>Samish</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1528-9<a name=\"cdcrec-1528-9\"> </a></td><td>Sauk-Suiattle</td><td>Sauk-Suiattle</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1529-7<a name=\"cdcrec-1529-7\"> </a></td><td>Skokomish</td><td>Skokomish</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1530-5<a name=\"cdcrec-1530-5\"> </a></td><td>Skykomish</td><td>Skykomish</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1531-3<a name=\"cdcrec-1531-3\"> </a></td><td>Snohomish</td><td>Snohomish</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1532-1<a name=\"cdcrec-1532-1\"> </a></td><td>Snoqualmie</td><td>Snoqualmie</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1533-9<a name=\"cdcrec-1533-9\"> </a></td><td>Squaxin Island</td><td>Squaxin Island</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1534-7<a name=\"cdcrec-1534-7\"> </a></td><td>Steilacoom</td><td>Steilacoom</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1535-4<a name=\"cdcrec-1535-4\"> </a></td><td>Stillaguamish</td><td>Stillaguamish</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1536-2<a name=\"cdcrec-1536-2\"> </a></td><td>Suquamish</td><td>Suquamish</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1537-0<a name=\"cdcrec-1537-0\"> </a></td><td>Swinomish</td><td>Swinomish</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1538-8<a name=\"cdcrec-1538-8\"> </a></td><td>Tulalip</td><td>Tulalip</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1539-6<a name=\"cdcrec-1539-6\"> </a></td><td>Upper Skagit</td><td>Upper Skagit</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1552-9<a name=\"cdcrec-1552-9\"> </a></td><td>Iowa Sac and Fox</td><td>Iowa Sac and Fox</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1553-7<a name=\"cdcrec-1553-7\"> </a></td><td>Missouri Sac and Fox</td><td>Missouri Sac and Fox</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1554-5<a name=\"cdcrec-1554-5\"> </a></td><td>Oklahoma Sac and Fox</td><td>Oklahoma Sac and Fox</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1567-7<a name=\"cdcrec-1567-7\"> </a></td><td>Big Cypress</td><td>Big Cypress</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1568-5<a name=\"cdcrec-1568-5\"> </a></td><td>Brighton</td><td>Brighton</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1569-3<a name=\"cdcrec-1569-3\"> </a></td><td>Florida Seminole</td><td>Florida Seminole</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1570-1<a name=\"cdcrec-1570-1\"> </a></td><td>Hollywood Seminole</td><td>Hollywood Seminole</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1571-9<a name=\"cdcrec-1571-9\"> </a></td><td>Oklahoma Seminole</td><td>Oklahoma Seminole</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1574-3<a name=\"cdcrec-1574-3\"> </a></td><td>San Manual</td><td>San Manual</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1579-2<a name=\"cdcrec-1579-2\"> </a></td><td>Absentee Shawnee</td><td>Absentee Shawnee</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1580-0<a name=\"cdcrec-1580-0\"> </a></td><td>Eastern Shawnee</td><td>Eastern Shawnee</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1587-5<a name=\"cdcrec-1587-5\"> </a></td><td>Battle Mountain</td><td>Battle Mountain</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1588-3<a name=\"cdcrec-1588-3\"> </a></td><td>Duckwater</td><td>Duckwater</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1589-1<a name=\"cdcrec-1589-1\"> </a></td><td>Elko</td><td>Elko</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1590-9<a name=\"cdcrec-1590-9\"> </a></td><td>Ely</td><td>Ely</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1591-7<a name=\"cdcrec-1591-7\"> </a></td><td>Goshute</td><td>Goshute</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1592-5<a name=\"cdcrec-1592-5\"> </a></td><td>Panamint</td><td>Panamint</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1593-3<a name=\"cdcrec-1593-3\"> </a></td><td>Ruby Valley</td><td>Ruby Valley</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1594-1<a name=\"cdcrec-1594-1\"> </a></td><td>Skull Valley</td><td>Skull Valley</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1595-8<a name=\"cdcrec-1595-8\"> </a></td><td>South Fork Shoshone</td><td>South Fork Shoshone</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1596-6<a name=\"cdcrec-1596-6\"> </a></td><td>Te-Moak Western Shoshone</td><td>Te-Moak Western Shoshone</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1597-4<a name=\"cdcrec-1597-4\"> </a></td><td>Timbi-Sha Shoshone</td><td>Timbi-Sha Shoshone</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1598-2<a name=\"cdcrec-1598-2\"> </a></td><td>Washakie</td><td>Washakie</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1599-0<a name=\"cdcrec-1599-0\"> </a></td><td>Wind River Shoshone</td><td>Wind River Shoshone</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1600-6<a name=\"cdcrec-1600-6\"> </a></td><td>Yomba</td><td>Yomba</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1603-0<a name=\"cdcrec-1603-0\"> </a></td><td>Duck Valley</td><td>Duck Valley</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1604-8<a name=\"cdcrec-1604-8\"> </a></td><td>Fallon</td><td>Fallon</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1605-5<a name=\"cdcrec-1605-5\"> </a></td><td>Fort McDermitt</td><td>Fort McDermitt</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1610-5<a name=\"cdcrec-1610-5\"> </a></td><td>Blackfoot Sioux</td><td>Blackfoot Sioux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1611-3<a name=\"cdcrec-1611-3\"> </a></td><td>Brule Sioux</td><td>Brule Sioux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1612-1<a name=\"cdcrec-1612-1\"> </a></td><td>Cheyenne River Sioux</td><td>Cheyenne River Sioux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1613-9<a name=\"cdcrec-1613-9\"> </a></td><td>Crow Creek Sioux</td><td>Crow Creek Sioux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1614-7<a name=\"cdcrec-1614-7\"> </a></td><td>Dakota Sioux</td><td>Dakota Sioux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1615-4<a name=\"cdcrec-1615-4\"> </a></td><td>Flandreau Santee</td><td>Flandreau Santee</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1616-2<a name=\"cdcrec-1616-2\"> </a></td><td>Fort Peck</td><td>Fort Peck</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1617-0<a name=\"cdcrec-1617-0\"> </a></td><td>Lake Traverse Sioux</td><td>Lake Traverse Sioux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1618-8<a name=\"cdcrec-1618-8\"> </a></td><td>Lower Brule Sioux</td><td>Lower Brule Sioux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1619-6<a name=\"cdcrec-1619-6\"> </a></td><td>Lower Sioux</td><td>Lower Sioux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1620-4<a name=\"cdcrec-1620-4\"> </a></td><td>Mdewakanton Sioux</td><td>Mdewakanton Sioux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1621-2<a name=\"cdcrec-1621-2\"> </a></td><td>Miniconjou</td><td>Miniconjou</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1622-0<a name=\"cdcrec-1622-0\"> </a></td><td>Oglala Sioux</td><td>Oglala Sioux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1623-8<a name=\"cdcrec-1623-8\"> </a></td><td>Pine Ridge Sioux</td><td>Pine Ridge Sioux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1624-6<a name=\"cdcrec-1624-6\"> </a></td><td>Pipestone Sioux</td><td>Pipestone Sioux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1625-3<a name=\"cdcrec-1625-3\"> </a></td><td>Prairie Island Sioux</td><td>Prairie Island Sioux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1626-1<a name=\"cdcrec-1626-1\"> </a></td><td>Prior Lake Sioux</td><td>Prior Lake Sioux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1627-9<a name=\"cdcrec-1627-9\"> </a></td><td>Rosebud Sioux</td><td>Rosebud Sioux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1628-7<a name=\"cdcrec-1628-7\"> </a></td><td>Sans Arc Sioux</td><td>Sans Arc Sioux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1629-5<a name=\"cdcrec-1629-5\"> </a></td><td>Santee Sioux</td><td>Santee Sioux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1630-3<a name=\"cdcrec-1630-3\"> </a></td><td>Sisseton-Wahpeton</td><td>Sisseton-Wahpeton</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1631-1<a name=\"cdcrec-1631-1\"> </a></td><td>Sisseton Sioux</td><td>Sisseton Sioux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1632-9<a name=\"cdcrec-1632-9\"> </a></td><td>Spirit Lake Sioux</td><td>Spirit Lake Sioux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1633-7<a name=\"cdcrec-1633-7\"> </a></td><td>Standing Rock Sioux</td><td>Standing Rock Sioux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1634-5<a name=\"cdcrec-1634-5\"> </a></td><td>Teton Sioux</td><td>Teton Sioux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1635-2<a name=\"cdcrec-1635-2\"> </a></td><td>Two Kettle Sioux</td><td>Two Kettle Sioux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1636-0<a name=\"cdcrec-1636-0\"> </a></td><td>Upper Sioux</td><td>Upper Sioux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1637-8<a name=\"cdcrec-1637-8\"> </a></td><td>Wahpekute Sioux</td><td>Wahpekute Sioux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1638-6<a name=\"cdcrec-1638-6\"> </a></td><td>Wahpeton Sioux</td><td>Wahpeton Sioux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1639-4<a name=\"cdcrec-1639-4\"> </a></td><td>Wazhaza Sioux</td><td>Wazhaza Sioux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1640-2<a name=\"cdcrec-1640-2\"> </a></td><td>Yankton Sioux</td><td>Yankton Sioux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1641-0<a name=\"cdcrec-1641-0\"> </a></td><td>Yanktonai Sioux</td><td>Yanktonai Sioux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1654-3<a name=\"cdcrec-1654-3\"> </a></td><td>Ak-Chin</td><td>Ak-Chin</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1655-0<a name=\"cdcrec-1655-0\"> </a></td><td>Gila Bend</td><td>Gila Bend</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1656-8<a name=\"cdcrec-1656-8\"> </a></td><td>San Xavier</td><td>San Xavier</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1657-6<a name=\"cdcrec-1657-6\"> </a></td><td>Sells</td><td>Sells</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1668-3<a name=\"cdcrec-1668-3\"> </a></td><td>Cow Creek Umpqua</td><td>Cow Creek Umpqua</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1671-7<a name=\"cdcrec-1671-7\"> </a></td><td>Allen Canyon</td><td>Allen Canyon</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1672-5<a name=\"cdcrec-1672-5\"> </a></td><td>Uintah Ute</td><td>Uintah Ute</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1673-3<a name=\"cdcrec-1673-3\"> </a></td><td>Ute Mountain Ute</td><td>Ute Mountain Ute</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1680-8<a name=\"cdcrec-1680-8\"> </a></td><td>Gay Head Wampanoag</td><td>Gay Head Wampanoag</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1681-6<a name=\"cdcrec-1681-6\"> </a></td><td>Mashpee Wampanoag</td><td>Mashpee Wampanoag</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1688-1<a name=\"cdcrec-1688-1\"> </a></td><td>Alpine</td><td>Alpine</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1689-9<a name=\"cdcrec-1689-9\"> </a></td><td>Carson</td><td>Carson</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1690-7<a name=\"cdcrec-1690-7\"> </a></td><td>Dresslerville</td><td>Dresslerville</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1697-2<a name=\"cdcrec-1697-2\"> </a></td><td>Ho-chunk</td><td>Ho-chunk</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1698-0<a name=\"cdcrec-1698-0\"> </a></td><td>Nebraska Winnebago</td><td>Nebraska Winnebago</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1705-3<a name=\"cdcrec-1705-3\"> </a></td><td>Table Bluff</td><td>Table Bluff</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1712-9<a name=\"cdcrec-1712-9\"> </a></td><td>Barrio Libre</td><td>Barrio Libre</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1713-7<a name=\"cdcrec-1713-7\"> </a></td><td>Pascua Yaqui</td><td>Pascua Yaqui</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1718-6<a name=\"cdcrec-1718-6\"> </a></td><td>Chukchansi</td><td>Chukchansi</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1719-4<a name=\"cdcrec-1719-4\"> </a></td><td>Tachi</td><td>Tachi</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1720-2<a name=\"cdcrec-1720-2\"> </a></td><td>Tule River</td><td>Tule River</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1725-1<a name=\"cdcrec-1725-1\"> </a></td><td>Cocopah</td><td>Cocopah</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1726-9<a name=\"cdcrec-1726-9\"> </a></td><td>Havasupai</td><td>Havasupai</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1727-7<a name=\"cdcrec-1727-7\"> </a></td><td>Hualapai</td><td>Hualapai</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1728-5<a name=\"cdcrec-1728-5\"> </a></td><td>Maricopa</td><td>Maricopa</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1729-3<a name=\"cdcrec-1729-3\"> </a></td><td>Mohave</td><td>Mohave</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1730-1<a name=\"cdcrec-1730-1\"> </a></td><td>Quechan</td><td>Quechan</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1731-9<a name=\"cdcrec-1731-9\"> </a></td><td>Yavapai</td><td>Yavapai</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1733-5<a name=\"cdcrec-1733-5\"> </a></td><td>Coast Yurok</td><td>Coast Yurok</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1737-6<a name=\"cdcrec-1737-6\"> </a></td><td>Alaska Indian</td><td>Alaska Indian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1840-8<a name=\"cdcrec-1840-8\"> </a></td><td>Eskimo</td><td>Eskimo</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1966-1<a name=\"cdcrec-1966-1\"> </a></td><td>Aleut</td><td>Aleut</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1739-2<a name=\"cdcrec-1739-2\"> </a></td><td>Alaskan Athabascan</td><td>Alaskan Athabascan</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1811-9<a name=\"cdcrec-1811-9\"> </a></td><td>Southeast Alaska</td><td>Southeast Alaska</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1740-0<a name=\"cdcrec-1740-0\"> </a></td><td>Ahtna</td><td>Ahtna</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1741-8<a name=\"cdcrec-1741-8\"> </a></td><td>Alatna</td><td>Alatna</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1742-6<a name=\"cdcrec-1742-6\"> </a></td><td>Alexander</td><td>Alexander</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1743-4<a name=\"cdcrec-1743-4\"> </a></td><td>Allakaket</td><td>Allakaket</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1744-2<a name=\"cdcrec-1744-2\"> </a></td><td>Alanvik</td><td>Alanvik</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1745-9<a name=\"cdcrec-1745-9\"> </a></td><td>Anvik</td><td>Anvik</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1746-7<a name=\"cdcrec-1746-7\"> </a></td><td>Arctic</td><td>Arctic</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1747-5<a name=\"cdcrec-1747-5\"> </a></td><td>Beaver</td><td>Beaver</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1748-3<a name=\"cdcrec-1748-3\"> </a></td><td>Birch Creek</td><td>Birch Creek</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1749-1<a name=\"cdcrec-1749-1\"> </a></td><td>Cantwell</td><td>Cantwell</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1750-9<a name=\"cdcrec-1750-9\"> </a></td><td>Chalkyitsik</td><td>Chalkyitsik</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1751-7<a name=\"cdcrec-1751-7\"> </a></td><td>Chickaloon</td><td>Chickaloon</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1752-5<a name=\"cdcrec-1752-5\"> </a></td><td>Chistochina</td><td>Chistochina</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1753-3<a name=\"cdcrec-1753-3\"> </a></td><td>Chitina</td><td>Chitina</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1754-1<a name=\"cdcrec-1754-1\"> </a></td><td>Circle</td><td>Circle</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1755-8<a name=\"cdcrec-1755-8\"> </a></td><td>Cook Inlet</td><td>Cook Inlet</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1756-6<a name=\"cdcrec-1756-6\"> </a></td><td>Copper Center</td><td>Copper Center</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1757-4<a name=\"cdcrec-1757-4\"> </a></td><td>Copper River</td><td>Copper River</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1758-2<a name=\"cdcrec-1758-2\"> </a></td><td>Dot Lake</td><td>Dot Lake</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1759-0<a name=\"cdcrec-1759-0\"> </a></td><td>Doyon</td><td>Doyon</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1760-8<a name=\"cdcrec-1760-8\"> </a></td><td>Eagle</td><td>Eagle</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1761-6<a name=\"cdcrec-1761-6\"> </a></td><td>Eklutna</td><td>Eklutna</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1762-4<a name=\"cdcrec-1762-4\"> </a></td><td>Evansville</td><td>Evansville</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1763-2<a name=\"cdcrec-1763-2\"> </a></td><td>Fort Yukon</td><td>Fort Yukon</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1764-0<a name=\"cdcrec-1764-0\"> </a></td><td>Gakona</td><td>Gakona</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1765-7<a name=\"cdcrec-1765-7\"> </a></td><td>Galena</td><td>Galena</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1766-5<a name=\"cdcrec-1766-5\"> </a></td><td>Grayling</td><td>Grayling</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1767-3<a name=\"cdcrec-1767-3\"> </a></td><td>Gulkana</td><td>Gulkana</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1768-1<a name=\"cdcrec-1768-1\"> </a></td><td>Healy Lake</td><td>Healy Lake</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1769-9<a name=\"cdcrec-1769-9\"> </a></td><td>Holy Cross</td><td>Holy Cross</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1770-7<a name=\"cdcrec-1770-7\"> </a></td><td>Hughes</td><td>Hughes</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1771-5<a name=\"cdcrec-1771-5\"> </a></td><td>Huslia</td><td>Huslia</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1772-3<a name=\"cdcrec-1772-3\"> </a></td><td>Iliamna</td><td>Iliamna</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1773-1<a name=\"cdcrec-1773-1\"> </a></td><td>Kaltag</td><td>Kaltag</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1774-9<a name=\"cdcrec-1774-9\"> </a></td><td>Kluti Kaah</td><td>Kluti Kaah</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1775-6<a name=\"cdcrec-1775-6\"> </a></td><td>Knik</td><td>Knik</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1776-4<a name=\"cdcrec-1776-4\"> </a></td><td>Koyukuk</td><td>Koyukuk</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1777-2<a name=\"cdcrec-1777-2\"> </a></td><td>Lake Minchumina</td><td>Lake Minchumina</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1778-0<a name=\"cdcrec-1778-0\"> </a></td><td>Lime</td><td>Lime</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1779-8<a name=\"cdcrec-1779-8\"> </a></td><td>Mcgrath</td><td>Mcgrath</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1780-6<a name=\"cdcrec-1780-6\"> </a></td><td>Manley Hot Springs</td><td>Manley Hot Springs</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1781-4<a name=\"cdcrec-1781-4\"> </a></td><td>Mentasta Lake</td><td>Mentasta Lake</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1782-2<a name=\"cdcrec-1782-2\"> </a></td><td>Minto</td><td>Minto</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1783-0<a name=\"cdcrec-1783-0\"> </a></td><td>Nenana</td><td>Nenana</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1784-8<a name=\"cdcrec-1784-8\"> </a></td><td>Nikolai</td><td>Nikolai</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1785-5<a name=\"cdcrec-1785-5\"> </a></td><td>Ninilchik</td><td>Ninilchik</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1786-3<a name=\"cdcrec-1786-3\"> </a></td><td>Nondalton</td><td>Nondalton</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1787-1<a name=\"cdcrec-1787-1\"> </a></td><td>Northway</td><td>Northway</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1788-9<a name=\"cdcrec-1788-9\"> </a></td><td>Nulato</td><td>Nulato</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1789-7<a name=\"cdcrec-1789-7\"> </a></td><td>Pedro Bay</td><td>Pedro Bay</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1790-5<a name=\"cdcrec-1790-5\"> </a></td><td>Rampart</td><td>Rampart</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1791-3<a name=\"cdcrec-1791-3\"> </a></td><td>Ruby</td><td>Ruby</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1792-1<a name=\"cdcrec-1792-1\"> </a></td><td>Salamatof</td><td>Salamatof</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1793-9<a name=\"cdcrec-1793-9\"> </a></td><td>Seldovia</td><td>Seldovia</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1794-7<a name=\"cdcrec-1794-7\"> </a></td><td>Slana</td><td>Slana</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1795-4<a name=\"cdcrec-1795-4\"> </a></td><td>Shageluk</td><td>Shageluk</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1796-2<a name=\"cdcrec-1796-2\"> </a></td><td>Stevens</td><td>Stevens</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1797-0<a name=\"cdcrec-1797-0\"> </a></td><td>Stony River</td><td>Stony River</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1798-8<a name=\"cdcrec-1798-8\"> </a></td><td>Takotna</td><td>Takotna</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1799-6<a name=\"cdcrec-1799-6\"> </a></td><td>Tanacross</td><td>Tanacross</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1800-2<a name=\"cdcrec-1800-2\"> </a></td><td>Tanaina</td><td>Tanaina</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1801-0<a name=\"cdcrec-1801-0\"> </a></td><td>Tanana</td><td>Tanana</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1802-8<a name=\"cdcrec-1802-8\"> </a></td><td>Tanana Chiefs</td><td>Tanana Chiefs</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1803-6<a name=\"cdcrec-1803-6\"> </a></td><td>Tazlina</td><td>Tazlina</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1804-4<a name=\"cdcrec-1804-4\"> </a></td><td>Telida</td><td>Telida</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1805-1<a name=\"cdcrec-1805-1\"> </a></td><td>Tetlin</td><td>Tetlin</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1806-9<a name=\"cdcrec-1806-9\"> </a></td><td>Tok</td><td>Tok</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1807-7<a name=\"cdcrec-1807-7\"> </a></td><td>Tyonek</td><td>Tyonek</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1808-5<a name=\"cdcrec-1808-5\"> </a></td><td>Venetie</td><td>Venetie</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1809-3<a name=\"cdcrec-1809-3\"> </a></td><td>Wiseman</td><td>Wiseman</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1813-5<a name=\"cdcrec-1813-5\"> </a></td><td>Tlingit-Haida</td><td>Tlingit-Haida</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1837-4<a name=\"cdcrec-1837-4\"> </a></td><td>Tsimshian</td><td>Tsimshian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1814-3<a name=\"cdcrec-1814-3\"> </a></td><td>Angoon</td><td>Angoon</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1815-0<a name=\"cdcrec-1815-0\"> </a></td><td>Central Council of Tlingit and Haida Tribes</td><td>Central Council of Tlingit and Haida Tribes</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1816-8<a name=\"cdcrec-1816-8\"> </a></td><td>Chilkat</td><td>Chilkat</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1817-6<a name=\"cdcrec-1817-6\"> </a></td><td>Chilkoot</td><td>Chilkoot</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1818-4<a name=\"cdcrec-1818-4\"> </a></td><td>Craig</td><td>Craig</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1819-2<a name=\"cdcrec-1819-2\"> </a></td><td>Douglas</td><td>Douglas</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1820-0<a name=\"cdcrec-1820-0\"> </a></td><td>Haida</td><td>Haida</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1821-8<a name=\"cdcrec-1821-8\"> </a></td><td>Hoonah</td><td>Hoonah</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1822-6<a name=\"cdcrec-1822-6\"> </a></td><td>Hydaburg</td><td>Hydaburg</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1823-4<a name=\"cdcrec-1823-4\"> </a></td><td>Kake</td><td>Kake</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1824-2<a name=\"cdcrec-1824-2\"> </a></td><td>Kasaan</td><td>Kasaan</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1825-9<a name=\"cdcrec-1825-9\"> </a></td><td>Kenaitze</td><td>Kenaitze</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1826-7<a name=\"cdcrec-1826-7\"> </a></td><td>Ketchikan</td><td>Ketchikan</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1827-5<a name=\"cdcrec-1827-5\"> </a></td><td>Klawock</td><td>Klawock</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1828-3<a name=\"cdcrec-1828-3\"> </a></td><td>Pelican</td><td>Pelican</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1829-1<a name=\"cdcrec-1829-1\"> </a></td><td>Petersburg</td><td>Petersburg</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1830-9<a name=\"cdcrec-1830-9\"> </a></td><td>Saxman</td><td>Saxman</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1831-7<a name=\"cdcrec-1831-7\"> </a></td><td>Sitka</td><td>Sitka</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1832-5<a name=\"cdcrec-1832-5\"> </a></td><td>Tenakee Springs</td><td>Tenakee Springs</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1833-3<a name=\"cdcrec-1833-3\"> </a></td><td>Tlingit</td><td>Tlingit</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1834-1<a name=\"cdcrec-1834-1\"> </a></td><td>Wrangell</td><td>Wrangell</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1835-8<a name=\"cdcrec-1835-8\"> </a></td><td>Yakutat</td><td>Yakutat</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1838-2<a name=\"cdcrec-1838-2\"> </a></td><td>Metlakatla</td><td>Metlakatla</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1842-4<a name=\"cdcrec-1842-4\"> </a></td><td>Greenland Eskimo</td><td>Greenland Eskimo</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1844-0<a name=\"cdcrec-1844-0\"> </a></td><td>Inupiat Eskimo</td><td>Inupiat Eskimo</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1891-1<a name=\"cdcrec-1891-1\"> </a></td><td>Siberian Eskimo</td><td>Siberian Eskimo</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1896-0<a name=\"cdcrec-1896-0\"> </a></td><td>Yupik Eskimo</td><td>Yupik Eskimo</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1845-7<a name=\"cdcrec-1845-7\"> </a></td><td>Ambler</td><td>Ambler</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1846-5<a name=\"cdcrec-1846-5\"> </a></td><td>Anaktuvuk</td><td>Anaktuvuk</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1847-3<a name=\"cdcrec-1847-3\"> </a></td><td>Anaktuvuk Pass</td><td>Anaktuvuk Pass</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1848-1<a name=\"cdcrec-1848-1\"> </a></td><td>Arctic Slope Inupiat</td><td>Arctic Slope Inupiat</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1849-9<a name=\"cdcrec-1849-9\"> </a></td><td>Arctic Slope Corporation</td><td>Arctic Slope Corporation</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1850-7<a name=\"cdcrec-1850-7\"> </a></td><td>Atqasuk</td><td>Atqasuk</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1851-5<a name=\"cdcrec-1851-5\"> </a></td><td>Barrow</td><td>Barrow</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1852-3<a name=\"cdcrec-1852-3\"> </a></td><td>Bering Straits Inupiat</td><td>Bering Straits Inupiat</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1853-1<a name=\"cdcrec-1853-1\"> </a></td><td>Brevig Mission</td><td>Brevig Mission</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1854-9<a name=\"cdcrec-1854-9\"> </a></td><td>Buckland</td><td>Buckland</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1855-6<a name=\"cdcrec-1855-6\"> </a></td><td>Chinik</td><td>Chinik</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1856-4<a name=\"cdcrec-1856-4\"> </a></td><td>Council</td><td>Council</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1857-2<a name=\"cdcrec-1857-2\"> </a></td><td>Deering</td><td>Deering</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1858-0<a name=\"cdcrec-1858-0\"> </a></td><td>Elim</td><td>Elim</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1859-8<a name=\"cdcrec-1859-8\"> </a></td><td>Golovin</td><td>Golovin</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1860-6<a name=\"cdcrec-1860-6\"> </a></td><td>Inalik Diomede</td><td>Inalik Diomede</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1861-4<a name=\"cdcrec-1861-4\"> </a></td><td>Inupiaq</td><td>Inupiaq</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1862-2<a name=\"cdcrec-1862-2\"> </a></td><td>Kaktovik</td><td>Kaktovik</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1863-0<a name=\"cdcrec-1863-0\"> </a></td><td>Kawerak</td><td>Kawerak</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1864-8<a name=\"cdcrec-1864-8\"> </a></td><td>Kiana</td><td>Kiana</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1865-5<a name=\"cdcrec-1865-5\"> </a></td><td>Kivalina</td><td>Kivalina</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1866-3<a name=\"cdcrec-1866-3\"> </a></td><td>Kobuk</td><td>Kobuk</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1867-1<a name=\"cdcrec-1867-1\"> </a></td><td>Kotzebue</td><td>Kotzebue</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1868-9<a name=\"cdcrec-1868-9\"> </a></td><td>Koyuk</td><td>Koyuk</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1869-7<a name=\"cdcrec-1869-7\"> </a></td><td>Kwiguk</td><td>Kwiguk</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1870-5<a name=\"cdcrec-1870-5\"> </a></td><td>Mauneluk Inupiat</td><td>Mauneluk Inupiat</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1871-3<a name=\"cdcrec-1871-3\"> </a></td><td>Nana Inupiat</td><td>Nana Inupiat</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1872-1<a name=\"cdcrec-1872-1\"> </a></td><td>Noatak</td><td>Noatak</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1873-9<a name=\"cdcrec-1873-9\"> </a></td><td>Nome</td><td>Nome</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1874-7<a name=\"cdcrec-1874-7\"> </a></td><td>Noorvik</td><td>Noorvik</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1875-4<a name=\"cdcrec-1875-4\"> </a></td><td>Nuiqsut</td><td>Nuiqsut</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1876-2<a name=\"cdcrec-1876-2\"> </a></td><td>Point Hope</td><td>Point Hope</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1877-0<a name=\"cdcrec-1877-0\"> </a></td><td>Point Lay</td><td>Point Lay</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1878-8<a name=\"cdcrec-1878-8\"> </a></td><td>Selawik</td><td>Selawik</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1879-6<a name=\"cdcrec-1879-6\"> </a></td><td>Shaktoolik</td><td>Shaktoolik</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1880-4<a name=\"cdcrec-1880-4\"> </a></td><td>Shishmaref</td><td>Shishmaref</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1881-2<a name=\"cdcrec-1881-2\"> </a></td><td>Shungnak</td><td>Shungnak</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1882-0<a name=\"cdcrec-1882-0\"> </a></td><td>Solomon</td><td>Solomon</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1883-8<a name=\"cdcrec-1883-8\"> </a></td><td>Teller</td><td>Teller</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1884-6<a name=\"cdcrec-1884-6\"> </a></td><td>Unalakleet</td><td>Unalakleet</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1885-3<a name=\"cdcrec-1885-3\"> </a></td><td>Wainwright</td><td>Wainwright</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1886-1<a name=\"cdcrec-1886-1\"> </a></td><td>Wales</td><td>Wales</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1887-9<a name=\"cdcrec-1887-9\"> </a></td><td>White Mountain</td><td>White Mountain</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1888-7<a name=\"cdcrec-1888-7\"> </a></td><td>White Mountain Inupiat</td><td>White Mountain Inupiat</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1889-5<a name=\"cdcrec-1889-5\"> </a></td><td>Mary's Igloo</td><td>Mary's Igloo</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1892-9<a name=\"cdcrec-1892-9\"> </a></td><td>Gambell</td><td>Gambell</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1893-7<a name=\"cdcrec-1893-7\"> </a></td><td>Savoonga</td><td>Savoonga</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1894-5<a name=\"cdcrec-1894-5\"> </a></td><td>Siberian Yupik</td><td>Siberian Yupik</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1897-8<a name=\"cdcrec-1897-8\"> </a></td><td>Akiachak</td><td>Akiachak</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1898-6<a name=\"cdcrec-1898-6\"> </a></td><td>Akiak</td><td>Akiak</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1899-4<a name=\"cdcrec-1899-4\"> </a></td><td>Alakanuk</td><td>Alakanuk</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1900-0<a name=\"cdcrec-1900-0\"> </a></td><td>Aleknagik</td><td>Aleknagik</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1901-8<a name=\"cdcrec-1901-8\"> </a></td><td>Andreafsky</td><td>Andreafsky</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1902-6<a name=\"cdcrec-1902-6\"> </a></td><td>Aniak</td><td>Aniak</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1903-4<a name=\"cdcrec-1903-4\"> </a></td><td>Atmautluak</td><td>Atmautluak</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1904-2<a name=\"cdcrec-1904-2\"> </a></td><td>Bethel</td><td>Bethel</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1905-9<a name=\"cdcrec-1905-9\"> </a></td><td>Bill Moore's Slough</td><td>Bill Moore's Slough</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1906-7<a name=\"cdcrec-1906-7\"> </a></td><td>Bristol Bay Yupik</td><td>Bristol Bay Yupik</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1907-5<a name=\"cdcrec-1907-5\"> </a></td><td>Calista Yupik</td><td>Calista Yupik</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1908-3<a name=\"cdcrec-1908-3\"> </a></td><td>Chefornak</td><td>Chefornak</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1909-1<a name=\"cdcrec-1909-1\"> </a></td><td>Chevak</td><td>Chevak</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1910-9<a name=\"cdcrec-1910-9\"> </a></td><td>Chuathbaluk</td><td>Chuathbaluk</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1911-7<a name=\"cdcrec-1911-7\"> </a></td><td>Clark's Point</td><td>Clark's Point</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1912-5<a name=\"cdcrec-1912-5\"> </a></td><td>Crooked Creek</td><td>Crooked Creek</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1913-3<a name=\"cdcrec-1913-3\"> </a></td><td>Dillingham</td><td>Dillingham</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1914-1<a name=\"cdcrec-1914-1\"> </a></td><td>Eek</td><td>Eek</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1915-8<a name=\"cdcrec-1915-8\"> </a></td><td>Ekuk</td><td>Ekuk</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1916-6<a name=\"cdcrec-1916-6\"> </a></td><td>Ekwok</td><td>Ekwok</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1917-4<a name=\"cdcrec-1917-4\"> </a></td><td>Emmonak</td><td>Emmonak</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1918-2<a name=\"cdcrec-1918-2\"> </a></td><td>Goodnews Bay</td><td>Goodnews Bay</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1919-0<a name=\"cdcrec-1919-0\"> </a></td><td>Hooper Bay</td><td>Hooper Bay</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1920-8<a name=\"cdcrec-1920-8\"> </a></td><td>Iqurmuit (Russian Mission)</td><td>Iqurmuit (Russian Mission)</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1921-6<a name=\"cdcrec-1921-6\"> </a></td><td>Kalskag</td><td>Kalskag</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1922-4<a name=\"cdcrec-1922-4\"> </a></td><td>Kasigluk</td><td>Kasigluk</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1923-2<a name=\"cdcrec-1923-2\"> </a></td><td>Kipnuk</td><td>Kipnuk</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1924-0<a name=\"cdcrec-1924-0\"> </a></td><td>Koliganek</td><td>Koliganek</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1925-7<a name=\"cdcrec-1925-7\"> </a></td><td>Kongiganak</td><td>Kongiganak</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1926-5<a name=\"cdcrec-1926-5\"> </a></td><td>Kotlik</td><td>Kotlik</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1927-3<a name=\"cdcrec-1927-3\"> </a></td><td>Kwethluk</td><td>Kwethluk</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1928-1<a name=\"cdcrec-1928-1\"> </a></td><td>Kwigillingok</td><td>Kwigillingok</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1929-9<a name=\"cdcrec-1929-9\"> </a></td><td>Levelock</td><td>Levelock</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1930-7<a name=\"cdcrec-1930-7\"> </a></td><td>Lower Kalskag</td><td>Lower Kalskag</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1931-5<a name=\"cdcrec-1931-5\"> </a></td><td>Manokotak</td><td>Manokotak</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1932-3<a name=\"cdcrec-1932-3\"> </a></td><td>Marshall</td><td>Marshall</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1933-1<a name=\"cdcrec-1933-1\"> </a></td><td>Mekoryuk</td><td>Mekoryuk</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1934-9<a name=\"cdcrec-1934-9\"> </a></td><td>Mountain Village</td><td>Mountain Village</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1935-6<a name=\"cdcrec-1935-6\"> </a></td><td>Naknek</td><td>Naknek</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1936-4<a name=\"cdcrec-1936-4\"> </a></td><td>Napaumute</td><td>Napaumute</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1937-2<a name=\"cdcrec-1937-2\"> </a></td><td>Napakiak</td><td>Napakiak</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1938-0<a name=\"cdcrec-1938-0\"> </a></td><td>Napaskiak</td><td>Napaskiak</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1939-8<a name=\"cdcrec-1939-8\"> </a></td><td>Newhalen</td><td>Newhalen</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1940-6<a name=\"cdcrec-1940-6\"> </a></td><td>New Stuyahok</td><td>New Stuyahok</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1941-4<a name=\"cdcrec-1941-4\"> </a></td><td>Newtok</td><td>Newtok</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1942-2<a name=\"cdcrec-1942-2\"> </a></td><td>Nightmute</td><td>Nightmute</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1943-0<a name=\"cdcrec-1943-0\"> </a></td><td>Nunapitchukv</td><td>Nunapitchukv</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1944-8<a name=\"cdcrec-1944-8\"> </a></td><td>Oscarville</td><td>Oscarville</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1945-5<a name=\"cdcrec-1945-5\"> </a></td><td>Pilot Station</td><td>Pilot Station</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1946-3<a name=\"cdcrec-1946-3\"> </a></td><td>Pitkas Point</td><td>Pitkas Point</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1947-1<a name=\"cdcrec-1947-1\"> </a></td><td>Platinum</td><td>Platinum</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1948-9<a name=\"cdcrec-1948-9\"> </a></td><td>Portage Creek</td><td>Portage Creek</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1949-7<a name=\"cdcrec-1949-7\"> </a></td><td>Quinhagak</td><td>Quinhagak</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1950-5<a name=\"cdcrec-1950-5\"> </a></td><td>Red Devil</td><td>Red Devil</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1951-3<a name=\"cdcrec-1951-3\"> </a></td><td>St. Michael</td><td>St. Michael</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1952-1<a name=\"cdcrec-1952-1\"> </a></td><td>Scammon Bay</td><td>Scammon Bay</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1953-9<a name=\"cdcrec-1953-9\"> </a></td><td>Sheldon's Point</td><td>Sheldon's Point</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1954-7<a name=\"cdcrec-1954-7\"> </a></td><td>Sleetmute</td><td>Sleetmute</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1955-4<a name=\"cdcrec-1955-4\"> </a></td><td>Stebbins</td><td>Stebbins</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1956-2<a name=\"cdcrec-1956-2\"> </a></td><td>Togiak</td><td>Togiak</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1957-0<a name=\"cdcrec-1957-0\"> </a></td><td>Toksook</td><td>Toksook</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1958-8<a name=\"cdcrec-1958-8\"> </a></td><td>Tulukskak</td><td>Tulukskak</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1959-6<a name=\"cdcrec-1959-6\"> </a></td><td>Tuntutuliak</td><td>Tuntutuliak</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1960-4<a name=\"cdcrec-1960-4\"> </a></td><td>Tununak</td><td>Tununak</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1961-2<a name=\"cdcrec-1961-2\"> </a></td><td>Twin Hills</td><td>Twin Hills</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1962-0<a name=\"cdcrec-1962-0\"> </a></td><td>Georgetown (Yupik-Eskimo)</td><td>Georgetown (Yupik-Eskimo)</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1963-8<a name=\"cdcrec-1963-8\"> </a></td><td>St. Mary's</td><td>St. Mary's</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1964-6<a name=\"cdcrec-1964-6\"> </a></td><td>Umkumiate</td><td>Umkumiate</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1968-7<a name=\"cdcrec-1968-7\"> </a></td><td>Alutiiq Aleut</td><td>Alutiiq Aleut</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1972-9<a name=\"cdcrec-1972-9\"> </a></td><td>Bristol Bay Aleut</td><td>Bristol Bay Aleut</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1984-4<a name=\"cdcrec-1984-4\"> </a></td><td>Chugach Aleut</td><td>Chugach Aleut</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1990-1<a name=\"cdcrec-1990-1\"> </a></td><td>Eyak</td><td>Eyak</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1992-7<a name=\"cdcrec-1992-7\"> </a></td><td>Koniag Aleut</td><td>Koniag Aleut</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2002-4<a name=\"cdcrec-2002-4\"> </a></td><td>Sugpiaq</td><td>Sugpiaq</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2004-0<a name=\"cdcrec-2004-0\"> </a></td><td>Suqpigaq</td><td>Suqpigaq</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2006-5<a name=\"cdcrec-2006-5\"> </a></td><td>Unangan Aleut</td><td>Unangan Aleut</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1969-5<a name=\"cdcrec-1969-5\"> </a></td><td>Tatitlek</td><td>Tatitlek</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1970-3<a name=\"cdcrec-1970-3\"> </a></td><td>Ugashik</td><td>Ugashik</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1973-7<a name=\"cdcrec-1973-7\"> </a></td><td>Chignik</td><td>Chignik</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1974-5<a name=\"cdcrec-1974-5\"> </a></td><td>Chignik Lake</td><td>Chignik Lake</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1975-2<a name=\"cdcrec-1975-2\"> </a></td><td>Egegik</td><td>Egegik</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1976-0<a name=\"cdcrec-1976-0\"> </a></td><td>Igiugig</td><td>Igiugig</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1977-8<a name=\"cdcrec-1977-8\"> </a></td><td>Ivanof Bay</td><td>Ivanof Bay</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1978-6<a name=\"cdcrec-1978-6\"> </a></td><td>King Salmon</td><td>King Salmon</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1979-4<a name=\"cdcrec-1979-4\"> </a></td><td>Kokhanok</td><td>Kokhanok</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1980-2<a name=\"cdcrec-1980-2\"> </a></td><td>Perryville</td><td>Perryville</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1981-0<a name=\"cdcrec-1981-0\"> </a></td><td>Pilot Point</td><td>Pilot Point</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1982-8<a name=\"cdcrec-1982-8\"> </a></td><td>Port Heiden</td><td>Port Heiden</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1985-1<a name=\"cdcrec-1985-1\"> </a></td><td>Chenega</td><td>Chenega</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1986-9<a name=\"cdcrec-1986-9\"> </a></td><td>Chugach Corporation</td><td>Chugach Corporation</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1987-7<a name=\"cdcrec-1987-7\"> </a></td><td>English Bay</td><td>English Bay</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1988-5<a name=\"cdcrec-1988-5\"> </a></td><td>Port Graham</td><td>Port Graham</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1993-5<a name=\"cdcrec-1993-5\"> </a></td><td>Akhiok</td><td>Akhiok</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1994-3<a name=\"cdcrec-1994-3\"> </a></td><td>Agdaagux</td><td>Agdaagux</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1995-0<a name=\"cdcrec-1995-0\"> </a></td><td>Karluk</td><td>Karluk</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1996-8<a name=\"cdcrec-1996-8\"> </a></td><td>Kodiak</td><td>Kodiak</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1997-6<a name=\"cdcrec-1997-6\"> </a></td><td>Larsen Bay</td><td>Larsen Bay</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1998-4<a name=\"cdcrec-1998-4\"> </a></td><td>Old Harbor</td><td>Old Harbor</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    1999-2<a name=\"cdcrec-1999-2\"> </a></td><td>Ouzinkie</td><td>Ouzinkie</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2000-8<a name=\"cdcrec-2000-8\"> </a></td><td>Port Lions</td><td>Port Lions</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2007-3<a name=\"cdcrec-2007-3\"> </a></td><td>Akutan</td><td>Akutan</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2008-1<a name=\"cdcrec-2008-1\"> </a></td><td>Aleut Corporation</td><td>Aleut Corporation</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2009-9<a name=\"cdcrec-2009-9\"> </a></td><td>Aleutian</td><td>Aleutian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2010-7<a name=\"cdcrec-2010-7\"> </a></td><td>Aleutian Islander</td><td>Aleutian Islander</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2011-5<a name=\"cdcrec-2011-5\"> </a></td><td>Atka</td><td>Atka</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2012-3<a name=\"cdcrec-2012-3\"> </a></td><td>Belkofski</td><td>Belkofski</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2013-1<a name=\"cdcrec-2013-1\"> </a></td><td>Chignik Lagoon</td><td>Chignik Lagoon</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2014-9<a name=\"cdcrec-2014-9\"> </a></td><td>King Cove</td><td>King Cove</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2015-6<a name=\"cdcrec-2015-6\"> </a></td><td>False Pass</td><td>False Pass</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2016-4<a name=\"cdcrec-2016-4\"> </a></td><td>Nelson Lagoon</td><td>Nelson Lagoon</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2017-2<a name=\"cdcrec-2017-2\"> </a></td><td>Nikolski</td><td>Nikolski</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2018-0<a name=\"cdcrec-2018-0\"> </a></td><td>Pauloff Harbor</td><td>Pauloff Harbor</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2019-8<a name=\"cdcrec-2019-8\"> </a></td><td>Qagan Toyagungin</td><td>Qagan Toyagungin</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2020-6<a name=\"cdcrec-2020-6\"> </a></td><td>Qawalangin</td><td>Qawalangin</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2021-4<a name=\"cdcrec-2021-4\"> </a></td><td>St. George</td><td>St. George</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2022-2<a name=\"cdcrec-2022-2\"> </a></td><td>St. Paul</td><td>St. Paul</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2023-0<a name=\"cdcrec-2023-0\"> </a></td><td>Sand Point</td><td>Sand Point</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2024-8<a name=\"cdcrec-2024-8\"> </a></td><td>South Naknek</td><td>South Naknek</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2025-5<a name=\"cdcrec-2025-5\"> </a></td><td>Unalaska</td><td>Unalaska</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2026-3<a name=\"cdcrec-2026-3\"> </a></td><td>Unga</td><td>Unga</td></tr><tr><td>2</td><td style=\"white-space:nowrap\">  2028-9<a name=\"cdcrec-2028-9\"> </a></td><td>Asian</td><td>Asian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2029-7<a name=\"cdcrec-2029-7\"> </a></td><td>Asian Indian</td><td>Asian Indian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2030-5<a name=\"cdcrec-2030-5\"> </a></td><td>Bangladeshi</td><td>Bangladeshi</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2031-3<a name=\"cdcrec-2031-3\"> </a></td><td>Bhutanese</td><td>Bhutanese</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2032-1<a name=\"cdcrec-2032-1\"> </a></td><td>Burmese</td><td>Burmese</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2033-9<a name=\"cdcrec-2033-9\"> </a></td><td>Cambodian</td><td>Cambodian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2034-7<a name=\"cdcrec-2034-7\"> </a></td><td>Chinese</td><td>Chinese</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2035-4<a name=\"cdcrec-2035-4\"> </a></td><td>Taiwanese</td><td>Taiwanese</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2036-2<a name=\"cdcrec-2036-2\"> </a></td><td>Filipino</td><td>Filipino</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2037-0<a name=\"cdcrec-2037-0\"> </a></td><td>Hmong</td><td>Hmong</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2038-8<a name=\"cdcrec-2038-8\"> </a></td><td>Indonesian</td><td>Indonesian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2039-6<a name=\"cdcrec-2039-6\"> </a></td><td>Japanese</td><td>Japanese</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2040-4<a name=\"cdcrec-2040-4\"> </a></td><td>Korean</td><td>Korean</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2041-2<a name=\"cdcrec-2041-2\"> </a></td><td>Laotian</td><td>Laotian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2042-0<a name=\"cdcrec-2042-0\"> </a></td><td>Malaysian</td><td>Malaysian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2043-8<a name=\"cdcrec-2043-8\"> </a></td><td>Okinawan</td><td>Okinawan</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2044-6<a name=\"cdcrec-2044-6\"> </a></td><td>Pakistani</td><td>Pakistani</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2045-3<a name=\"cdcrec-2045-3\"> </a></td><td>Sri Lankan</td><td>Sri Lankan</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2046-1<a name=\"cdcrec-2046-1\"> </a></td><td>Thai</td><td>Thai</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2047-9<a name=\"cdcrec-2047-9\"> </a></td><td>Vietnamese</td><td>Vietnamese</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2048-7<a name=\"cdcrec-2048-7\"> </a></td><td>Iwo Jiman</td><td>Iwo Jiman</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2049-5<a name=\"cdcrec-2049-5\"> </a></td><td>Maldivian</td><td>Maldivian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2050-3<a name=\"cdcrec-2050-3\"> </a></td><td>Nepalese</td><td>Nepalese</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2051-1<a name=\"cdcrec-2051-1\"> </a></td><td>Singaporean</td><td>Singaporean</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2052-9<a name=\"cdcrec-2052-9\"> </a></td><td>Madagascar</td><td>Madagascar</td></tr><tr><td>2</td><td style=\"white-space:nowrap\">  2054-5<a name=\"cdcrec-2054-5\"> </a></td><td>Black or African American</td><td>Black or African American</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2056-0<a name=\"cdcrec-2056-0\"> </a></td><td>Black</td><td>Black</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2058-6<a name=\"cdcrec-2058-6\"> </a></td><td>African American</td><td>African American</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2060-2<a name=\"cdcrec-2060-2\"> </a></td><td>African</td><td>African</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2067-7<a name=\"cdcrec-2067-7\"> </a></td><td>Bahamian</td><td>Bahamian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2068-5<a name=\"cdcrec-2068-5\"> </a></td><td>Barbadian</td><td>Barbadian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2069-3<a name=\"cdcrec-2069-3\"> </a></td><td>Dominican</td><td>Dominican</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2070-1<a name=\"cdcrec-2070-1\"> </a></td><td>Dominica Islander</td><td>Dominica Islander</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2071-9<a name=\"cdcrec-2071-9\"> </a></td><td>Haitian</td><td>Haitian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2072-7<a name=\"cdcrec-2072-7\"> </a></td><td>Jamaican</td><td>Jamaican</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2073-5<a name=\"cdcrec-2073-5\"> </a></td><td>Tobagoan</td><td>Tobagoan</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2074-3<a name=\"cdcrec-2074-3\"> </a></td><td>Trinidadian</td><td>Trinidadian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2075-0<a name=\"cdcrec-2075-0\"> </a></td><td>West Indian</td><td>West Indian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2061-0<a name=\"cdcrec-2061-0\"> </a></td><td>Botswanan</td><td>Botswanan</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2062-8<a name=\"cdcrec-2062-8\"> </a></td><td>Ethiopian</td><td>Ethiopian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2063-6<a name=\"cdcrec-2063-6\"> </a></td><td>Liberian</td><td>Liberian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2064-4<a name=\"cdcrec-2064-4\"> </a></td><td>Namibian</td><td>Namibian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2065-1<a name=\"cdcrec-2065-1\"> </a></td><td>Nigerian</td><td>Nigerian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2066-9<a name=\"cdcrec-2066-9\"> </a></td><td>Zairean</td><td>Zairean</td></tr><tr><td>2</td><td style=\"white-space:nowrap\">  2076-8<a name=\"cdcrec-2076-8\"> </a></td><td>Native Hawaiian or Other Pacific Islander</td><td>Native Hawaiian or Other Pacific Islander</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2078-4<a name=\"cdcrec-2078-4\"> </a></td><td>Polynesian</td><td>Polynesian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2085-9<a name=\"cdcrec-2085-9\"> </a></td><td>Micronesian</td><td>Micronesian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2100-6<a name=\"cdcrec-2100-6\"> </a></td><td>Melanesian</td><td>Melanesian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2500-7<a name=\"cdcrec-2500-7\"> </a></td><td>Other Pacific Islander</td><td>Other Pacific Islander</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2079-2<a name=\"cdcrec-2079-2\"> </a></td><td>Native Hawaiian</td><td>Native Hawaiian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2080-0<a name=\"cdcrec-2080-0\"> </a></td><td>Samoan</td><td>Samoan</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2081-8<a name=\"cdcrec-2081-8\"> </a></td><td>Tahitian</td><td>Tahitian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2082-6<a name=\"cdcrec-2082-6\"> </a></td><td>Tongan</td><td>Tongan</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2083-4<a name=\"cdcrec-2083-4\"> </a></td><td>Tokelauan</td><td>Tokelauan</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2086-7<a name=\"cdcrec-2086-7\"> </a></td><td>Guamanian or Chamorro</td><td>Guamanian or Chamorro</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2087-5<a name=\"cdcrec-2087-5\"> </a></td><td>Guamanian</td><td>Guamanian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2088-3<a name=\"cdcrec-2088-3\"> </a></td><td>Chamorro</td><td>Chamorro</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2089-1<a name=\"cdcrec-2089-1\"> </a></td><td>Mariana Islander</td><td>Mariana Islander</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2090-9<a name=\"cdcrec-2090-9\"> </a></td><td>Marshallese</td><td>Marshallese</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2091-7<a name=\"cdcrec-2091-7\"> </a></td><td>Palauan</td><td>Palauan</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2092-5<a name=\"cdcrec-2092-5\"> </a></td><td>Carolinian</td><td>Carolinian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2093-3<a name=\"cdcrec-2093-3\"> </a></td><td>Kosraean</td><td>Kosraean</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2094-1<a name=\"cdcrec-2094-1\"> </a></td><td>Pohnpeian</td><td>Pohnpeian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2095-8<a name=\"cdcrec-2095-8\"> </a></td><td>Saipanese</td><td>Saipanese</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2096-6<a name=\"cdcrec-2096-6\"> </a></td><td>Kiribati</td><td>Kiribati</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2097-4<a name=\"cdcrec-2097-4\"> </a></td><td>Chuukese</td><td>Chuukese</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2098-2<a name=\"cdcrec-2098-2\"> </a></td><td>Yapese</td><td>Yapese</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2101-4<a name=\"cdcrec-2101-4\"> </a></td><td>Fijian</td><td>Fijian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2102-2<a name=\"cdcrec-2102-2\"> </a></td><td>Papua New Guinean</td><td>Papua New Guinean</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2103-0<a name=\"cdcrec-2103-0\"> </a></td><td>Solomon Islander</td><td>Solomon Islander</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2104-8<a name=\"cdcrec-2104-8\"> </a></td><td>New Hebrides</td><td>New Hebrides</td></tr><tr><td>2</td><td style=\"white-space:nowrap\">  2106-3<a name=\"cdcrec-2106-3\"> </a></td><td>White</td><td>White</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2108-9<a name=\"cdcrec-2108-9\"> </a></td><td>European</td><td>European</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2118-8<a name=\"cdcrec-2118-8\"> </a></td><td>Middle Eastern or North African</td><td>Middle Eastern or North African</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2129-5<a name=\"cdcrec-2129-5\"> </a></td><td>Arab</td><td>Arab</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2109-7<a name=\"cdcrec-2109-7\"> </a></td><td>Armenian</td><td>Armenian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2110-5<a name=\"cdcrec-2110-5\"> </a></td><td>English</td><td>English</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2111-3<a name=\"cdcrec-2111-3\"> </a></td><td>French</td><td>French</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2112-1<a name=\"cdcrec-2112-1\"> </a></td><td>German</td><td>German</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2113-9<a name=\"cdcrec-2113-9\"> </a></td><td>Irish</td><td>Irish</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2114-7<a name=\"cdcrec-2114-7\"> </a></td><td>Italian</td><td>Italian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2115-4<a name=\"cdcrec-2115-4\"> </a></td><td>Polish</td><td>Polish</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2116-2<a name=\"cdcrec-2116-2\"> </a></td><td>Scottish</td><td>Scottish</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2119-6<a name=\"cdcrec-2119-6\"> </a></td><td>Assyrian</td><td>Assyrian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2120-4<a name=\"cdcrec-2120-4\"> </a></td><td>Egyptian</td><td>Egyptian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2121-2<a name=\"cdcrec-2121-2\"> </a></td><td>Iranian</td><td>Iranian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2122-0<a name=\"cdcrec-2122-0\"> </a></td><td>Iraqi</td><td>Iraqi</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2123-8<a name=\"cdcrec-2123-8\"> </a></td><td>Lebanese</td><td>Lebanese</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2124-6<a name=\"cdcrec-2124-6\"> </a></td><td>Palestinian</td><td>Palestinian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2125-3<a name=\"cdcrec-2125-3\"> </a></td><td>Syrian</td><td>Syrian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2126-1<a name=\"cdcrec-2126-1\"> </a></td><td>Afghanistani</td><td>Afghanistani</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2127-9<a name=\"cdcrec-2127-9\"> </a></td><td>Israeili</td><td>Israeili</td></tr><tr><td>2</td><td style=\"white-space:nowrap\">  2131-1<a name=\"cdcrec-2131-1\"> </a></td><td>Other Race</td><td>Note that this term remains in the table for completeness, even though within HL7, the notion of Other code is deprecated.</td></tr><tr><td>1</td><td style=\"white-space:nowrap\">2133-7<a name=\"cdcrec-2133-7\"> </a></td><td>Ethnicity</td><td>Ethnicity Note that this is an abstract 'grouping' concept and not for use as a real concept</td></tr><tr><td>2</td><td style=\"white-space:nowrap\">  2135-2<a name=\"cdcrec-2135-2\"> </a></td><td>Hispanic or Latino</td><td>Hispanic or Latino</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2137-8<a name=\"cdcrec-2137-8\"> </a></td><td>Spaniard</td><td>Spaniard</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2148-5<a name=\"cdcrec-2148-5\"> </a></td><td>Mexican</td><td>Mexican</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2155-0<a name=\"cdcrec-2155-0\"> </a></td><td>Central American</td><td>Central American</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2165-9<a name=\"cdcrec-2165-9\"> </a></td><td>South American</td><td>South American</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2178-2<a name=\"cdcrec-2178-2\"> </a></td><td>Latin American</td><td>Latin American</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2180-8<a name=\"cdcrec-2180-8\"> </a></td><td>Puerto Rican</td><td>Puerto Rican</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2182-4<a name=\"cdcrec-2182-4\"> </a></td><td>Cuban</td><td>Cuban</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2184-0<a name=\"cdcrec-2184-0\"> </a></td><td>Dominican</td><td>Dominican</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2138-6<a name=\"cdcrec-2138-6\"> </a></td><td>Andalusian</td><td>Andalusian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2139-4<a name=\"cdcrec-2139-4\"> </a></td><td>Asturian</td><td>Asturian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2140-2<a name=\"cdcrec-2140-2\"> </a></td><td>Castillian</td><td>Castillian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2141-0<a name=\"cdcrec-2141-0\"> </a></td><td>Catalonian</td><td>Catalonian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2142-8<a name=\"cdcrec-2142-8\"> </a></td><td>Belearic Islander</td><td>Belearic Islander</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2143-6<a name=\"cdcrec-2143-6\"> </a></td><td>Gallego</td><td>Gallego</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2144-4<a name=\"cdcrec-2144-4\"> </a></td><td>Valencian</td><td>Valencian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2145-1<a name=\"cdcrec-2145-1\"> </a></td><td>Canarian</td><td>Canarian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2146-9<a name=\"cdcrec-2146-9\"> </a></td><td>Spanish Basque</td><td>Spanish Basque</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2149-3<a name=\"cdcrec-2149-3\"> </a></td><td>Mexican American</td><td>Mexican American</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2150-1<a name=\"cdcrec-2150-1\"> </a></td><td>Mexicano</td><td>Mexicano</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2151-9<a name=\"cdcrec-2151-9\"> </a></td><td>Chicano</td><td>Chicano</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2152-7<a name=\"cdcrec-2152-7\"> </a></td><td>La Raza</td><td>La Raza</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2153-5<a name=\"cdcrec-2153-5\"> </a></td><td>Mexican American Indian</td><td>Mexican American Indian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2156-8<a name=\"cdcrec-2156-8\"> </a></td><td>Costa Rican</td><td>Costa Rican</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2157-6<a name=\"cdcrec-2157-6\"> </a></td><td>Guatemalan</td><td>Guatemalan</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2158-4<a name=\"cdcrec-2158-4\"> </a></td><td>Honduran</td><td>Honduran</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2159-2<a name=\"cdcrec-2159-2\"> </a></td><td>Nicaraguan</td><td>Nicaraguan</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2160-0<a name=\"cdcrec-2160-0\"> </a></td><td>Panamanian</td><td>Panamanian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2161-8<a name=\"cdcrec-2161-8\"> </a></td><td>Salvadoran</td><td>Salvadoran</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2162-6<a name=\"cdcrec-2162-6\"> </a></td><td>Central American Indian</td><td>Central American Indian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2163-4<a name=\"cdcrec-2163-4\"> </a></td><td>Canal Zone</td><td>Canal Zone</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2166-7<a name=\"cdcrec-2166-7\"> </a></td><td>Argentinean</td><td>Argentinean</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2167-5<a name=\"cdcrec-2167-5\"> </a></td><td>Bolivian</td><td>Bolivian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2168-3<a name=\"cdcrec-2168-3\"> </a></td><td>Chilean</td><td>Chilean</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2169-1<a name=\"cdcrec-2169-1\"> </a></td><td>Colombian</td><td>Colombian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2170-9<a name=\"cdcrec-2170-9\"> </a></td><td>Ecuadorian</td><td>Ecuadorian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2171-7<a name=\"cdcrec-2171-7\"> </a></td><td>Paraguayan</td><td>Paraguayan</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2172-5<a name=\"cdcrec-2172-5\"> </a></td><td>Peruvian</td><td>Peruvian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2173-3<a name=\"cdcrec-2173-3\"> </a></td><td>Uruguayan</td><td>Uruguayan</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2174-1<a name=\"cdcrec-2174-1\"> </a></td><td>Venezuelan</td><td>Venezuelan</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2175-8<a name=\"cdcrec-2175-8\"> </a></td><td>South American Indian</td><td>South American Indian</td></tr><tr><td>3</td><td style=\"white-space:nowrap\">    2176-6<a name=\"cdcrec-2176-6\"> </a></td><td>Criollo</td><td>Criollo</td></tr><tr><td>2</td><td style=\"white-space:nowrap\">  2186-5<a name=\"cdcrec-2186-5\"> </a></td><td>Not Hispanic or Latino</td><td>Note that this term remains in the table for completeness, even though within HL7, the notion of &quot;not otherwise coded&quot; term is deprecated.</td></tr></table></div>"
-	},
-	"url": "urn:oid:2.16.840.1.113883.6.238",
-	"identifier": [
-		{
-			"value": "2.16.840.1.113883.6.238"
-		}
-	],
-	"version": "4.0.0",
-	"name": "RaceAndEthnicityCDC",
-	"title": "Race & Ethnicity - CDC",
-	"status": "active",
-	"experimental": false,
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The U.S. Centers for Disease Control and Prevention (CDC) has prepared a code set for use in codingrace and ethnicity data. This code set is based on current federal standards for classifying data onrace and ethnicity, specifically the minimum race and ethnicity categories defined by the U.S. Office ofManagement and Budget (OMB) and a more detailed set of race and ethnicity categories maintainedby the U.S. Bureau of the Census (BC). The main purpose of the code set is to facilitate use of federalstandards for classifying data on race and ethnicity when these data are exchanged, stored, retrieved,or analyzed in electronic form. At the same time, the code set can be applied to paper-based recordsystems to the extent that these systems are used to collect, maintain, and report data on race andethnicity in accordance with current federal standards. Source: [Race and Ethnicity Code Set Version 1.0](https://www.cdc.gov/phin/resources/vocabulary/documents/cdc-race--ethnicity-background-and-purpose.pdf).",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"caseSensitive": true,
-	"hierarchyMeaning": "is-a",
-	"content": "complete",
-	"count": 966,
-	"property": [
-		{
-			"code": "abstract",
-			"description": "True if an element is considered 'abstract' - in other words, the code is not for use as a real concept",
-			"type": "boolean"
-		}
-	],
-	"concept": [
-		{
-			"code": "1000-9",
-			"display": "Race",
-			"definition": "Race, Note that this is an abstract 'grouping' concept and not for use as a real concept",
-			"property": [
-				{
-					"code": "abstract",
-					"valueBoolean": true
-				}
-			],
-			"concept": [
-				{
-					"code": "1002-5",
-					"display": "American Indian or Alaska Native",
-					"definition": "American Indian or Alaska Native",
-					"concept": [
-						{
-							"code": "1004-1",
-							"display": "American Indian",
-							"definition": "American Indian"
-						},
-						{
-							"code": "1735-0",
-							"display": "Alaska Native",
-							"definition": "Alaska Native"
-						},
-						{
-							"code": "1006-6",
-							"display": "Abenaki",
-							"definition": "Abenaki"
-						},
-						{
-							"code": "1008-2",
-							"display": "Algonquian",
-							"definition": "Algonquian"
-						},
-						{
-							"code": "1010-8",
-							"display": "Apache",
-							"definition": "Apache"
-						},
-						{
-							"code": "1021-5",
-							"display": "Arapaho",
-							"definition": "Arapaho"
-						},
-						{
-							"code": "1026-4",
-							"display": "Arikara",
-							"definition": "Arikara"
-						},
-						{
-							"code": "1028-0",
-							"display": "Assiniboine",
-							"definition": "Assiniboine"
-						},
-						{
-							"code": "1030-6",
-							"display": "Assiniboine Sioux",
-							"definition": "Assiniboine Sioux"
-						},
-						{
-							"code": "1033-0",
-							"display": "Bannock",
-							"definition": "Bannock"
-						},
-						{
-							"code": "1035-5",
-							"display": "Blackfeet",
-							"definition": "Blackfeet"
-						},
-						{
-							"code": "1037-1",
-							"display": "Brotherton",
-							"definition": "Brotherton"
-						},
-						{
-							"code": "1039-7",
-							"display": "Burt Lake Band",
-							"definition": "Burt Lake Band"
-						},
-						{
-							"code": "1041-3",
-							"display": "Caddo",
-							"definition": "Caddo"
-						},
-						{
-							"code": "1044-7",
-							"display": "Cahuilla",
-							"definition": "Cahuilla"
-						},
-						{
-							"code": "1053-8",
-							"display": "California Tribes",
-							"definition": "California Tribes"
-						},
-						{
-							"code": "1068-6",
-							"display": "Canadian and Latin American Indian",
-							"definition": "Canadian and Latin American Indian"
-						},
-						{
-							"code": "1076-9",
-							"display": "Catawba",
-							"definition": "Catawba"
-						},
-						{
-							"code": "1078-5",
-							"display": "Cayuse",
-							"definition": "Cayuse"
-						},
-						{
-							"code": "1080-1",
-							"display": "Chehalis",
-							"definition": "Chehalis"
-						},
-						{
-							"code": "1082-7",
-							"display": "Chemakuan",
-							"definition": "Chemakuan"
-						},
-						{
-							"code": "1086-8",
-							"display": "Chemehuevi",
-							"definition": "Chemehuevi"
-						},
-						{
-							"code": "1088-4",
-							"display": "Cherokee",
-							"definition": "Cherokee"
-						},
-						{
-							"code": "1100-7",
-							"display": "Cherokee Shawnee",
-							"definition": "Cherokee Shawnee"
-						},
-						{
-							"code": "1102-3",
-							"display": "Cheyenne",
-							"definition": "Cheyenne"
-						},
-						{
-							"code": "1106-4",
-							"display": "Cheyenne-Arapaho",
-							"definition": "Cheyenne-Arapaho"
-						},
-						{
-							"code": "1108-0",
-							"display": "Chickahominy",
-							"definition": "Chickahominy"
-						},
-						{
-							"code": "1112-2",
-							"display": "Chickasaw",
-							"definition": "Chickasaw"
-						},
-						{
-							"code": "1114-8",
-							"display": "Chinook",
-							"definition": "Chinook"
-						},
-						{
-							"code": "1123-9",
-							"display": "Chippewa",
-							"definition": "Chippewa"
-						},
-						{
-							"code": "1150-2",
-							"display": "Chippewa Cree",
-							"definition": "Chippewa Cree"
-						},
-						{
-							"code": "1153-6",
-							"display": "Chitimacha",
-							"definition": "Chitimacha"
-						},
-						{
-							"code": "1155-1",
-							"display": "Choctaw",
-							"definition": "Choctaw"
-						},
-						{
-							"code": "1162-7",
-							"display": "Chumash",
-							"definition": "Chumash"
-						},
-						{
-							"code": "1165-0",
-							"display": "Clear Lake",
-							"definition": "Clear Lake"
-						},
-						{
-							"code": "1167-6",
-							"display": "Coeur D'Alene",
-							"definition": "Coeur D'Alene"
-						},
-						{
-							"code": "1169-2",
-							"display": "Coharie",
-							"definition": "Coharie"
-						},
-						{
-							"code": "1171-8",
-							"display": "Colorado River",
-							"definition": "Colorado River"
-						},
-						{
-							"code": "1173-4",
-							"display": "Colville",
-							"definition": "Colville"
-						},
-						{
-							"code": "1175-9",
-							"display": "Comanche",
-							"definition": "Comanche"
-						},
-						{
-							"code": "1178-3",
-							"display": "Coos, Lower Umpqua, Siuslaw",
-							"definition": "Coos, Lower Umpqua, Siuslaw"
-						},
-						{
-							"code": "1180-9",
-							"display": "Coos",
-							"definition": "Coos"
-						},
-						{
-							"code": "1182-5",
-							"display": "Coquilles",
-							"definition": "Coquilles"
-						},
-						{
-							"code": "1184-1",
-							"display": "Costanoan",
-							"definition": "Costanoan"
-						},
-						{
-							"code": "1186-6",
-							"display": "Coushatta",
-							"definition": "Coushatta"
-						},
-						{
-							"code": "1189-0",
-							"display": "Cowlitz",
-							"definition": "Cowlitz"
-						},
-						{
-							"code": "1191-6",
-							"display": "Cree",
-							"definition": "Cree"
-						},
-						{
-							"code": "1193-2",
-							"display": "Creek",
-							"definition": "Creek"
-						},
-						{
-							"code": "1207-0",
-							"display": "Croatan",
-							"definition": "Croatan"
-						},
-						{
-							"code": "1209-6",
-							"display": "Crow",
-							"definition": "Crow"
-						},
-						{
-							"code": "1211-2",
-							"display": "Cupeno",
-							"definition": "Cupeno"
-						},
-						{
-							"code": "1214-6",
-							"display": "Delaware",
-							"definition": "Delaware"
-						},
-						{
-							"code": "1222-9",
-							"display": "Diegueno",
-							"definition": "Diegueno"
-						},
-						{
-							"code": "1233-6",
-							"display": "Eastern Tribes",
-							"definition": "Eastern Tribes"
-						},
-						{
-							"code": "1250-0",
-							"display": "Esselen",
-							"definition": "Esselen"
-						},
-						{
-							"code": "1252-6",
-							"display": "Fort Belknap",
-							"definition": "Fort Belknap"
-						},
-						{
-							"code": "1254-2",
-							"display": "Fort Berthold",
-							"definition": "Fort Berthold"
-						},
-						{
-							"code": "1256-7",
-							"display": "Fort Mcdowell",
-							"definition": "Fort Mcdowell"
-						},
-						{
-							"code": "1258-3",
-							"display": "Fort Hall",
-							"definition": "Fort Hall"
-						},
-						{
-							"code": "1260-9",
-							"display": "Gabrieleno",
-							"definition": "Gabrieleno"
-						},
-						{
-							"code": "1262-5",
-							"display": "Grand Ronde",
-							"definition": "Grand Ronde"
-						},
-						{
-							"code": "1264-1",
-							"display": "Gros Ventres",
-							"definition": "Gros Ventres"
-						},
-						{
-							"code": "1267-4",
-							"display": "Haliwa",
-							"definition": "Haliwa"
-						},
-						{
-							"code": "1269-0",
-							"display": "Hidatsa",
-							"definition": "Hidatsa"
-						},
-						{
-							"code": "1271-6",
-							"display": "Hoopa",
-							"definition": "Hoopa"
-						},
-						{
-							"code": "1275-7",
-							"display": "Hoopa Extension",
-							"definition": "Hoopa Extension"
-						},
-						{
-							"code": "1277-3",
-							"display": "Houma",
-							"definition": "Houma"
-						},
-						{
-							"code": "1279-9",
-							"display": "Inaja-Cosmit",
-							"definition": "Inaja-Cosmit"
-						},
-						{
-							"code": "1281-5",
-							"display": "Iowa",
-							"definition": "Iowa"
-						},
-						{
-							"code": "1285-6",
-							"display": "Iroquois",
-							"definition": "Iroquois"
-						},
-						{
-							"code": "1297-1",
-							"display": "Juaneno",
-							"definition": "Juaneno"
-						},
-						{
-							"code": "1299-7",
-							"display": "Kalispel",
-							"definition": "Kalispel"
-						},
-						{
-							"code": "1301-1",
-							"display": "Karuk",
-							"definition": "Karuk"
-						},
-						{
-							"code": "1303-7",
-							"display": "Kaw",
-							"definition": "Kaw"
-						},
-						{
-							"code": "1305-2",
-							"display": "Kickapoo",
-							"definition": "Kickapoo"
-						},
-						{
-							"code": "1309-4",
-							"display": "Kiowa",
-							"definition": "Kiowa"
-						},
-						{
-							"code": "1312-8",
-							"display": "Klallam",
-							"definition": "Klallam"
-						},
-						{
-							"code": "1317-7",
-							"display": "Klamath",
-							"definition": "Klamath"
-						},
-						{
-							"code": "1319-3",
-							"display": "Konkow",
-							"definition": "Konkow"
-						},
-						{
-							"code": "1321-9",
-							"display": "Kootenai",
-							"definition": "Kootenai"
-						},
-						{
-							"code": "1323-5",
-							"display": "Lassik",
-							"definition": "Lassik"
-						},
-						{
-							"code": "1325-0",
-							"display": "Long Island",
-							"definition": "Long Island"
-						},
-						{
-							"code": "1331-8",
-							"display": "Luiseno",
-							"definition": "Luiseno"
-						},
-						{
-							"code": "1340-9",
-							"display": "Lumbee",
-							"definition": "Lumbee"
-						},
-						{
-							"code": "1342-5",
-							"display": "Lummi",
-							"definition": "Lummi"
-						},
-						{
-							"code": "1344-1",
-							"display": "Maidu",
-							"definition": "Maidu"
-						},
-						{
-							"code": "1348-2",
-							"display": "Makah",
-							"definition": "Makah"
-						},
-						{
-							"code": "1350-8",
-							"display": "Maliseet",
-							"definition": "Maliseet"
-						},
-						{
-							"code": "1352-4",
-							"display": "Mandan",
-							"definition": "Mandan"
-						},
-						{
-							"code": "1354-0",
-							"display": "Mattaponi",
-							"definition": "Mattaponi"
-						},
-						{
-							"code": "1356-5",
-							"display": "Menominee",
-							"definition": "Menominee"
-						},
-						{
-							"code": "1358-1",
-							"display": "Miami",
-							"definition": "Miami"
-						},
-						{
-							"code": "1363-1",
-							"display": "Miccosukee",
-							"definition": "Miccosukee"
-						},
-						{
-							"code": "1365-6",
-							"display": "Micmac",
-							"definition": "Micmac"
-						},
-						{
-							"code": "1368-0",
-							"display": "Mission Indians",
-							"definition": "Mission Indians"
-						},
-						{
-							"code": "1370-6",
-							"display": "Miwok",
-							"definition": "Miwok"
-						},
-						{
-							"code": "1372-2",
-							"display": "Modoc",
-							"definition": "Modoc"
-						},
-						{
-							"code": "1374-8",
-							"display": "Mohegan",
-							"definition": "Mohegan"
-						},
-						{
-							"code": "1376-3",
-							"display": "Mono",
-							"definition": "Mono"
-						},
-						{
-							"code": "1378-9",
-							"display": "Nanticoke",
-							"definition": "Nanticoke"
-						},
-						{
-							"code": "1380-5",
-							"display": "Narragansett",
-							"definition": "Narragansett"
-						},
-						{
-							"code": "1382-1",
-							"display": "Navajo",
-							"definition": "Navajo"
-						},
-						{
-							"code": "1387-0",
-							"display": "Nez Perce",
-							"definition": "Nez Perce"
-						},
-						{
-							"code": "1389-6",
-							"display": "Nomalaki",
-							"definition": "Nomalaki"
-						},
-						{
-							"code": "1391-2",
-							"display": "Northwest Tribes",
-							"definition": "Northwest Tribes"
-						},
-						{
-							"code": "1403-5",
-							"display": "Omaha",
-							"definition": "Omaha"
-						},
-						{
-							"code": "1405-0",
-							"display": "Oregon Athabaskan",
-							"definition": "Oregon Athabaskan"
-						},
-						{
-							"code": "1407-6",
-							"display": "Osage",
-							"definition": "Osage"
-						},
-						{
-							"code": "1409-2",
-							"display": "Otoe-Missouria",
-							"definition": "Otoe-Missouria"
-						},
-						{
-							"code": "1411-8",
-							"display": "Ottawa",
-							"definition": "Ottawa"
-						},
-						{
-							"code": "1416-7",
-							"display": "Paiute",
-							"definition": "Paiute"
-						},
-						{
-							"code": "1439-9",
-							"display": "Pamunkey",
-							"definition": "Pamunkey"
-						},
-						{
-							"code": "1441-5",
-							"display": "Passamaquoddy",
-							"definition": "Passamaquoddy"
-						},
-						{
-							"code": "1445-6",
-							"display": "Pawnee",
-							"definition": "Pawnee"
-						},
-						{
-							"code": "1448-0",
-							"display": "Penobscot",
-							"definition": "Penobscot"
-						},
-						{
-							"code": "1450-6",
-							"display": "Peoria",
-							"definition": "Peoria"
-						},
-						{
-							"code": "1453-0",
-							"display": "Pequot",
-							"definition": "Pequot"
-						},
-						{
-							"code": "1456-3",
-							"display": "Pima",
-							"definition": "Pima"
-						},
-						{
-							"code": "1460-5",
-							"display": "Piscataway",
-							"definition": "Piscataway"
-						},
-						{
-							"code": "1462-1",
-							"display": "Pit River",
-							"definition": "Pit River"
-						},
-						{
-							"code": "1464-7",
-							"display": "Pomo",
-							"definition": "Pomo"
-						},
-						{
-							"code": "1474-6",
-							"display": "Ponca",
-							"definition": "Ponca"
-						},
-						{
-							"code": "1478-7",
-							"display": "Potawatomi",
-							"definition": "Potawatomi"
-						},
-						{
-							"code": "1487-8",
-							"display": "Powhatan",
-							"definition": "Powhatan"
-						},
-						{
-							"code": "1489-4",
-							"display": "Pueblo",
-							"definition": "Pueblo"
-						},
-						{
-							"code": "1518-0",
-							"display": "Puget Sound Salish",
-							"definition": "Puget Sound Salish"
-						},
-						{
-							"code": "1541-2",
-							"display": "Quapaw",
-							"definition": "Quapaw"
-						},
-						{
-							"code": "1543-8",
-							"display": "Quinault",
-							"definition": "Quinault"
-						},
-						{
-							"code": "1545-3",
-							"display": "Rappahannock",
-							"definition": "Rappahannock"
-						},
-						{
-							"code": "1547-9",
-							"display": "Reno-Sparks",
-							"definition": "Reno-Sparks"
-						},
-						{
-							"code": "1549-5",
-							"display": "Round Valley",
-							"definition": "Round Valley"
-						},
-						{
-							"code": "1551-1",
-							"display": "Sac and Fox",
-							"definition": "Sac and Fox"
-						},
-						{
-							"code": "1556-0",
-							"display": "Salinan",
-							"definition": "Salinan"
-						},
-						{
-							"code": "1558-6",
-							"display": "Salish",
-							"definition": "Salish"
-						},
-						{
-							"code": "1560-2",
-							"display": "Salish and Kootenai",
-							"definition": "Salish and Kootenai"
-						},
-						{
-							"code": "1562-8",
-							"display": "Schaghticoke",
-							"definition": "Schaghticoke"
-						},
-						{
-							"code": "1564-4",
-							"display": "Scott Valley",
-							"definition": "Scott Valley"
-						},
-						{
-							"code": "1566-9",
-							"display": "Seminole",
-							"definition": "Seminole"
-						},
-						{
-							"code": "1573-5",
-							"display": "Serrano",
-							"definition": "Serrano"
-						},
-						{
-							"code": "1576-8",
-							"display": "Shasta",
-							"definition": "Shasta"
-						},
-						{
-							"code": "1578-4",
-							"display": "Shawnee",
-							"definition": "Shawnee"
-						},
-						{
-							"code": "1582-6",
-							"display": "Shinnecock",
-							"definition": "Shinnecock"
-						},
-						{
-							"code": "1584-2",
-							"display": "Shoalwater Bay",
-							"definition": "Shoalwater Bay"
-						},
-						{
-							"code": "1586-7",
-							"display": "Shoshone",
-							"definition": "Shoshone"
-						},
-						{
-							"code": "1602-2",
-							"display": "Shoshone Paiute",
-							"definition": "Shoshone Paiute"
-						},
-						{
-							"code": "1607-1",
-							"display": "Siletz",
-							"definition": "Siletz"
-						},
-						{
-							"code": "1609-7",
-							"display": "Sioux",
-							"definition": "Sioux"
-						},
-						{
-							"code": "1643-6",
-							"display": "Siuslaw",
-							"definition": "Siuslaw"
-						},
-						{
-							"code": "1645-1",
-							"display": "Spokane",
-							"definition": "Spokane"
-						},
-						{
-							"code": "1647-7",
-							"display": "Stewart",
-							"definition": "Stewart"
-						},
-						{
-							"code": "1649-3",
-							"display": "Stockbridge",
-							"definition": "Stockbridge"
-						},
-						{
-							"code": "1651-9",
-							"display": "Susanville",
-							"definition": "Susanville"
-						},
-						{
-							"code": "1653-5",
-							"display": "Tohono O'Odham",
-							"definition": "Tohono O'Odham"
-						},
-						{
-							"code": "1659-2",
-							"display": "Tolowa",
-							"definition": "Tolowa"
-						},
-						{
-							"code": "1661-8",
-							"display": "Tonkawa",
-							"definition": "Tonkawa"
-						},
-						{
-							"code": "1663-4",
-							"display": "Tygh",
-							"definition": "Tygh"
-						},
-						{
-							"code": "1665-9",
-							"display": "Umatilla",
-							"definition": "Umatilla"
-						},
-						{
-							"code": "1667-5",
-							"display": "Umpqua",
-							"definition": "Umpqua"
-						},
-						{
-							"code": "1670-9",
-							"display": "Ute",
-							"definition": "Ute"
-						},
-						{
-							"code": "1675-8",
-							"display": "Wailaki",
-							"definition": "Wailaki"
-						},
-						{
-							"code": "1677-4",
-							"display": "Walla-Walla",
-							"definition": "Walla-Walla"
-						},
-						{
-							"code": "1679-0",
-							"display": "Wampanoag",
-							"definition": "Wampanoag"
-						},
-						{
-							"code": "1683-2",
-							"display": "Warm Springs",
-							"definition": "Warm Springs"
-						},
-						{
-							"code": "1685-7",
-							"display": "Wascopum",
-							"definition": "Wascopum"
-						},
-						{
-							"code": "1687-3",
-							"display": "Washoe",
-							"definition": "Washoe"
-						},
-						{
-							"code": "1692-3",
-							"display": "Wichita",
-							"definition": "Wichita"
-						},
-						{
-							"code": "1694-9",
-							"display": "Wind River",
-							"definition": "Wind River"
-						},
-						{
-							"code": "1696-4",
-							"display": "Winnebago",
-							"definition": "Winnebago"
-						},
-						{
-							"code": "1700-4",
-							"display": "Winnemucca",
-							"definition": "Winnemucca"
-						},
-						{
-							"code": "1702-0",
-							"display": "Wintun",
-							"definition": "Wintun"
-						},
-						{
-							"code": "1704-6",
-							"display": "Wiyot",
-							"definition": "Wiyot"
-						},
-						{
-							"code": "1707-9",
-							"display": "Yakama",
-							"definition": "Yakama"
-						},
-						{
-							"code": "1709-5",
-							"display": "Yakama Cowlitz",
-							"definition": "Yakama Cowlitz"
-						},
-						{
-							"code": "1711-1",
-							"display": "Yaqui",
-							"definition": "Yaqui"
-						},
-						{
-							"code": "1715-2",
-							"display": "Yavapai Apache",
-							"definition": "Yavapai Apache"
-						},
-						{
-							"code": "1717-8",
-							"display": "Yokuts",
-							"definition": "Yokuts"
-						},
-						{
-							"code": "1722-8",
-							"display": "Yuchi",
-							"definition": "Yuchi"
-						},
-						{
-							"code": "1724-4",
-							"display": "Yuman",
-							"definition": "Yuman"
-						},
-						{
-							"code": "1732-7",
-							"display": "Yurok",
-							"definition": "Yurok"
-						},
-						{
-							"code": "1011-6",
-							"display": "Chiricahua",
-							"definition": "Chiricahua"
-						},
-						{
-							"code": "1012-4",
-							"display": "Fort Sill Apache",
-							"definition": "Fort Sill Apache"
-						},
-						{
-							"code": "1013-2",
-							"display": "Jicarilla Apache",
-							"definition": "Jicarilla Apache"
-						},
-						{
-							"code": "1014-0",
-							"display": "Lipan Apache",
-							"definition": "Lipan Apache"
-						},
-						{
-							"code": "1015-7",
-							"display": "Mescalero Apache",
-							"definition": "Mescalero Apache"
-						},
-						{
-							"code": "1016-5",
-							"display": "Oklahoma Apache",
-							"definition": "Oklahoma Apache"
-						},
-						{
-							"code": "1017-3",
-							"display": "Payson Apache",
-							"definition": "Payson Apache"
-						},
-						{
-							"code": "1018-1",
-							"display": "San Carlos Apache",
-							"definition": "San Carlos Apache"
-						},
-						{
-							"code": "1019-9",
-							"display": "White Mountain Apache",
-							"definition": "White Mountain Apache"
-						},
-						{
-							"code": "1022-3",
-							"display": "Northern Arapaho",
-							"definition": "Northern Arapaho"
-						},
-						{
-							"code": "1023-1",
-							"display": "Southern Arapaho",
-							"definition": "Southern Arapaho"
-						},
-						{
-							"code": "1024-9",
-							"display": "Wind River Arapaho",
-							"definition": "Wind River Arapaho"
-						},
-						{
-							"code": "1031-4",
-							"display": "Fort Peck Assiniboine Sioux",
-							"definition": "Fort Peck Assiniboine Sioux"
-						},
-						{
-							"code": "1042-1",
-							"display": "Oklahoma Cado",
-							"definition": "Oklahoma Cado"
-						},
-						{
-							"code": "1045-4",
-							"display": "Agua Caliente Cahuilla",
-							"definition": "Agua Caliente Cahuilla"
-						},
-						{
-							"code": "1046-2",
-							"display": "Augustine",
-							"definition": "Augustine"
-						},
-						{
-							"code": "1047-0",
-							"display": "Cabazon",
-							"definition": "Cabazon"
-						},
-						{
-							"code": "1048-8",
-							"display": "Los Coyotes",
-							"definition": "Los Coyotes"
-						},
-						{
-							"code": "1049-6",
-							"display": "Morongo",
-							"definition": "Morongo"
-						},
-						{
-							"code": "1050-4",
-							"display": "Santa Rosa Cahuilla",
-							"definition": "Santa Rosa Cahuilla"
-						},
-						{
-							"code": "1051-2",
-							"display": "Torres-Martinez",
-							"definition": "Torres-Martinez"
-						},
-						{
-							"code": "1054-6",
-							"display": "Cahto",
-							"definition": "Cahto"
-						},
-						{
-							"code": "1055-3",
-							"display": "Chimariko",
-							"definition": "Chimariko"
-						},
-						{
-							"code": "1056-1",
-							"display": "Coast Miwok",
-							"definition": "Coast Miwok"
-						},
-						{
-							"code": "1057-9",
-							"display": "Digger",
-							"definition": "Digger"
-						},
-						{
-							"code": "1058-7",
-							"display": "Kawaiisu",
-							"definition": "Kawaiisu"
-						},
-						{
-							"code": "1059-5",
-							"display": "Kern River",
-							"definition": "Kern River"
-						},
-						{
-							"code": "1060-3",
-							"display": "Mattole",
-							"definition": "Mattole"
-						},
-						{
-							"code": "1061-1",
-							"display": "Red Wood",
-							"definition": "Red Wood"
-						},
-						{
-							"code": "1062-9",
-							"display": "Santa Rosa",
-							"definition": "Santa Rosa"
-						},
-						{
-							"code": "1063-7",
-							"display": "Takelma",
-							"definition": "Takelma"
-						},
-						{
-							"code": "1064-5",
-							"display": "Wappo",
-							"definition": "Wappo"
-						},
-						{
-							"code": "1065-2",
-							"display": "Yana",
-							"definition": "Yana"
-						},
-						{
-							"code": "1066-0",
-							"display": "Yuki",
-							"definition": "Yuki"
-						},
-						{
-							"code": "1069-4",
-							"display": "Canadian Indian",
-							"definition": "Canadian Indian"
-						},
-						{
-							"code": "1070-2",
-							"display": "Central American Indian",
-							"definition": "Central American Indian"
-						},
-						{
-							"code": "1071-0",
-							"display": "French American Indian",
-							"definition": "French American Indian"
-						},
-						{
-							"code": "1072-8",
-							"display": "Mexican American Indian",
-							"definition": "Mexican American Indian"
-						},
-						{
-							"code": "1073-6",
-							"display": "South American Indian",
-							"definition": "South American Indian"
-						},
-						{
-							"code": "1074-4",
-							"display": "Spanish American Indian",
-							"definition": "Spanish American Indian"
-						},
-						{
-							"code": "1083-5",
-							"display": "Hoh",
-							"definition": "Hoh"
-						},
-						{
-							"code": "1084-3",
-							"display": "Quileute",
-							"definition": "Quileute"
-						},
-						{
-							"code": "1089-2",
-							"display": "Cherokee Alabama",
-							"definition": "Cherokee Alabama"
-						},
-						{
-							"code": "1090-0",
-							"display": "Cherokees of Northeast Alabama",
-							"definition": "Cherokees of Northeast Alabama"
-						},
-						{
-							"code": "1091-8",
-							"display": "Cherokees of Southeast Alabama",
-							"definition": "Cherokees of Southeast Alabama"
-						},
-						{
-							"code": "1092-6",
-							"display": "Eastern Cherokee",
-							"definition": "Eastern Cherokee"
-						},
-						{
-							"code": "1093-4",
-							"display": "Echota Cherokee",
-							"definition": "Echota Cherokee"
-						},
-						{
-							"code": "1094-2",
-							"display": "Etowah Cherokee",
-							"definition": "Etowah Cherokee"
-						},
-						{
-							"code": "1095-9",
-							"display": "Northern Cherokee",
-							"definition": "Northern Cherokee"
-						},
-						{
-							"code": "1096-7",
-							"display": "Tuscola",
-							"definition": "Tuscola"
-						},
-						{
-							"code": "1097-5",
-							"display": "United Keetowah Band of Cherokee",
-							"definition": "United Keetowah Band of Cherokee"
-						},
-						{
-							"code": "1098-3",
-							"display": "Western Cherokee",
-							"definition": "Western Cherokee"
-						},
-						{
-							"code": "1103-1",
-							"display": "Northern Cheyenne",
-							"definition": "Northern Cheyenne"
-						},
-						{
-							"code": "1104-9",
-							"display": "Southern Cheyenne",
-							"definition": "Southern Cheyenne"
-						},
-						{
-							"code": "1109-8",
-							"display": "Eastern Chickahominy",
-							"definition": "Eastern Chickahominy"
-						},
-						{
-							"code": "1110-6",
-							"display": "Western Chickahominy",
-							"definition": "Western Chickahominy"
-						},
-						{
-							"code": "1115-5",
-							"display": "Clatsop",
-							"definition": "Clatsop"
-						},
-						{
-							"code": "1116-3",
-							"display": "Columbia River Chinook",
-							"definition": "Columbia River Chinook"
-						},
-						{
-							"code": "1117-1",
-							"display": "Kathlamet",
-							"definition": "Kathlamet"
-						},
-						{
-							"code": "1118-9",
-							"display": "Upper Chinook",
-							"definition": "Upper Chinook"
-						},
-						{
-							"code": "1119-7",
-							"display": "Wakiakum Chinook",
-							"definition": "Wakiakum Chinook"
-						},
-						{
-							"code": "1120-5",
-							"display": "Willapa Chinook",
-							"definition": "Willapa Chinook"
-						},
-						{
-							"code": "1121-3",
-							"display": "Wishram",
-							"definition": "Wishram"
-						},
-						{
-							"code": "1124-7",
-							"display": "Bad River",
-							"definition": "Bad River"
-						},
-						{
-							"code": "1125-4",
-							"display": "Bay Mills Chippewa",
-							"definition": "Bay Mills Chippewa"
-						},
-						{
-							"code": "1126-2",
-							"display": "Bois Forte",
-							"definition": "Bois Forte"
-						},
-						{
-							"code": "1127-0",
-							"display": "Burt Lake Chippewa",
-							"definition": "Burt Lake Chippewa"
-						},
-						{
-							"code": "1128-8",
-							"display": "Fond du Lac",
-							"definition": "Fond du Lac"
-						},
-						{
-							"code": "1129-6",
-							"display": "Grand Portage",
-							"definition": "Grand Portage"
-						},
-						{
-							"code": "1130-4",
-							"display": "Grand Traverse Band of Ottawa/Chippewa",
-							"definition": "Grand Traverse Band of Ottawa/Chippewa"
-						},
-						{
-							"code": "1131-2",
-							"display": "Keweenaw",
-							"definition": "Keweenaw"
-						},
-						{
-							"code": "1132-0",
-							"display": "Lac Courte Oreilles",
-							"definition": "Lac Courte Oreilles"
-						},
-						{
-							"code": "1133-8",
-							"display": "Lac du Flambeau",
-							"definition": "Lac du Flambeau"
-						},
-						{
-							"code": "1134-6",
-							"display": "Lac Vieux Desert Chippewa",
-							"definition": "Lac Vieux Desert Chippewa"
-						},
-						{
-							"code": "1135-3",
-							"display": "Lake Superior",
-							"definition": "Lake Superior"
-						},
-						{
-							"code": "1136-1",
-							"display": "Leech Lake",
-							"definition": "Leech Lake"
-						},
-						{
-							"code": "1137-9",
-							"display": "Little Shell Chippewa",
-							"definition": "Little Shell Chippewa"
-						},
-						{
-							"code": "1138-7",
-							"display": "Mille Lacs",
-							"definition": "Mille Lacs"
-						},
-						{
-							"code": "1139-5",
-							"display": "Minnesota Chippewa",
-							"definition": "Minnesota Chippewa"
-						},
-						{
-							"code": "1140-3",
-							"display": "Ontonagon",
-							"definition": "Ontonagon"
-						},
-						{
-							"code": "1141-1",
-							"display": "Red Cliff Chippewa",
-							"definition": "Red Cliff Chippewa"
-						},
-						{
-							"code": "1142-9",
-							"display": "Red Lake Chippewa",
-							"definition": "Red Lake Chippewa"
-						},
-						{
-							"code": "1143-7",
-							"display": "Saginaw Chippewa",
-							"definition": "Saginaw Chippewa"
-						},
-						{
-							"code": "1144-5",
-							"display": "St. Croix Chippewa",
-							"definition": "St. Croix Chippewa"
-						},
-						{
-							"code": "1145-2",
-							"display": "Sault Ste. Marie Chippewa",
-							"definition": "Sault Ste. Marie Chippewa"
-						},
-						{
-							"code": "1146-0",
-							"display": "Sokoagon Chippewa",
-							"definition": "Sokoagon Chippewa"
-						},
-						{
-							"code": "1147-8",
-							"display": "Turtle Mountain",
-							"definition": "Turtle Mountain"
-						},
-						{
-							"code": "1148-6",
-							"display": "White Earth",
-							"definition": "White Earth"
-						},
-						{
-							"code": "1151-0",
-							"display": "Rocky Boy's Chippewa Cree",
-							"definition": "Rocky Boy's Chippewa Cree"
-						},
-						{
-							"code": "1156-9",
-							"display": "Clifton Choctaw",
-							"definition": "Clifton Choctaw"
-						},
-						{
-							"code": "1157-7",
-							"display": "Jena Choctaw",
-							"definition": "Jena Choctaw"
-						},
-						{
-							"code": "1158-5",
-							"display": "Mississippi Choctaw",
-							"definition": "Mississippi Choctaw"
-						},
-						{
-							"code": "1159-3",
-							"display": "Mowa Band of Choctaw",
-							"definition": "Mowa Band of Choctaw"
-						},
-						{
-							"code": "1160-1",
-							"display": "Oklahoma Choctaw",
-							"definition": "Oklahoma Choctaw"
-						},
-						{
-							"code": "1163-5",
-							"display": "Santa Ynez",
-							"definition": "Santa Ynez"
-						},
-						{
-							"code": "1176-7",
-							"display": "Oklahoma Comanche",
-							"definition": "Oklahoma Comanche"
-						},
-						{
-							"code": "1187-4",
-							"display": "Alabama Coushatta",
-							"definition": "Alabama Coushatta"
-						},
-						{
-							"code": "1194-0",
-							"display": "Alabama Creek",
-							"definition": "Alabama Creek"
-						},
-						{
-							"code": "1195-7",
-							"display": "Alabama Quassarte",
-							"definition": "Alabama Quassarte"
-						},
-						{
-							"code": "1196-5",
-							"display": "Eastern Creek",
-							"definition": "Eastern Creek"
-						},
-						{
-							"code": "1197-3",
-							"display": "Eastern Muscogee",
-							"definition": "Eastern Muscogee"
-						},
-						{
-							"code": "1198-1",
-							"display": "Kialegee",
-							"definition": "Kialegee"
-						},
-						{
-							"code": "1199-9",
-							"display": "Lower Muscogee",
-							"definition": "Lower Muscogee"
-						},
-						{
-							"code": "1200-5",
-							"display": "Machis Lower Creek Indian",
-							"definition": "Machis Lower Creek Indian"
-						},
-						{
-							"code": "1201-3",
-							"display": "Poarch Band",
-							"definition": "Poarch Band"
-						},
-						{
-							"code": "1202-1",
-							"display": "Principal Creek Indian Nation",
-							"definition": "Principal Creek Indian Nation"
-						},
-						{
-							"code": "1203-9",
-							"display": "Star Clan of Muscogee Creeks",
-							"definition": "Star Clan of Muscogee Creeks"
-						},
-						{
-							"code": "1204-7",
-							"display": "Thlopthlocco",
-							"definition": "Thlopthlocco"
-						},
-						{
-							"code": "1205-4",
-							"display": "Tuckabachee",
-							"definition": "Tuckabachee"
-						},
-						{
-							"code": "1212-0",
-							"display": "Agua Caliente",
-							"definition": "Agua Caliente"
-						},
-						{
-							"code": "1215-3",
-							"display": "Eastern Delaware",
-							"definition": "Eastern Delaware"
-						},
-						{
-							"code": "1216-1",
-							"display": "Lenni-Lenape",
-							"definition": "Lenni-Lenape"
-						},
-						{
-							"code": "1217-9",
-							"display": "Munsee",
-							"definition": "Munsee"
-						},
-						{
-							"code": "1218-7",
-							"display": "Oklahoma Delaware",
-							"definition": "Oklahoma Delaware"
-						},
-						{
-							"code": "1219-5",
-							"display": "Rampough Mountain",
-							"definition": "Rampough Mountain"
-						},
-						{
-							"code": "1220-3",
-							"display": "Sand Hill",
-							"definition": "Sand Hill"
-						},
-						{
-							"code": "1223-7",
-							"display": "Campo",
-							"definition": "Campo"
-						},
-						{
-							"code": "1224-5",
-							"display": "Capitan Grande",
-							"definition": "Capitan Grande"
-						},
-						{
-							"code": "1225-2",
-							"display": "Cuyapaipe",
-							"definition": "Cuyapaipe"
-						},
-						{
-							"code": "1226-0",
-							"display": "La Posta",
-							"definition": "La Posta"
-						},
-						{
-							"code": "1227-8",
-							"display": "Manzanita",
-							"definition": "Manzanita"
-						},
-						{
-							"code": "1228-6",
-							"display": "Mesa Grande",
-							"definition": "Mesa Grande"
-						},
-						{
-							"code": "1229-4",
-							"display": "San Pasqual",
-							"definition": "San Pasqual"
-						},
-						{
-							"code": "1230-2",
-							"display": "Santa Ysabel",
-							"definition": "Santa Ysabel"
-						},
-						{
-							"code": "1231-0",
-							"display": "Sycuan",
-							"definition": "Sycuan"
-						},
-						{
-							"code": "1234-4",
-							"display": "Attacapa",
-							"definition": "Attacapa"
-						},
-						{
-							"code": "1235-1",
-							"display": "Biloxi",
-							"definition": "Biloxi"
-						},
-						{
-							"code": "1236-9",
-							"display": "Georgetown (Eastern Tribes)",
-							"definition": "Georgetown (Eastern Tribes)"
-						},
-						{
-							"code": "1237-7",
-							"display": "Moor",
-							"definition": "Moor"
-						},
-						{
-							"code": "1238-5",
-							"display": "Nansemond",
-							"definition": "Nansemond"
-						},
-						{
-							"code": "1239-3",
-							"display": "Natchez",
-							"definition": "Natchez"
-						},
-						{
-							"code": "1240-1",
-							"display": "Nausu Waiwash",
-							"definition": "Nausu Waiwash"
-						},
-						{
-							"code": "1241-9",
-							"display": "Nipmuc",
-							"definition": "Nipmuc"
-						},
-						{
-							"code": "1242-7",
-							"display": "Paugussett",
-							"definition": "Paugussett"
-						},
-						{
-							"code": "1243-5",
-							"display": "Pocomoke Acohonock",
-							"definition": "Pocomoke Acohonock"
-						},
-						{
-							"code": "1244-3",
-							"display": "Southeastern Indians",
-							"definition": "Southeastern Indians"
-						},
-						{
-							"code": "1245-0",
-							"display": "Susquehanock",
-							"definition": "Susquehanock"
-						},
-						{
-							"code": "1246-8",
-							"display": "Tunica Biloxi",
-							"definition": "Tunica Biloxi"
-						},
-						{
-							"code": "1247-6",
-							"display": "Waccamaw-Siousan",
-							"definition": "Waccamaw-Siousan"
-						},
-						{
-							"code": "1248-4",
-							"display": "Wicomico",
-							"definition": "Wicomico"
-						},
-						{
-							"code": "1265-8",
-							"display": "Atsina",
-							"definition": "Atsina"
-						},
-						{
-							"code": "1272-4",
-							"display": "Trinity",
-							"definition": "Trinity"
-						},
-						{
-							"code": "1273-2",
-							"display": "Whilkut",
-							"definition": "Whilkut"
-						},
-						{
-							"code": "1282-3",
-							"display": "Iowa of Kansas-Nebraska",
-							"definition": "Iowa of Kansas-Nebraska"
-						},
-						{
-							"code": "1283-1",
-							"display": "Iowa of Oklahoma",
-							"definition": "Iowa of Oklahoma"
-						},
-						{
-							"code": "1286-4",
-							"display": "Cayuga",
-							"definition": "Cayuga"
-						},
-						{
-							"code": "1287-2",
-							"display": "Mohawk",
-							"definition": "Mohawk"
-						},
-						{
-							"code": "1288-0",
-							"display": "Oneida",
-							"definition": "Oneida"
-						},
-						{
-							"code": "1289-8",
-							"display": "Onondaga",
-							"definition": "Onondaga"
-						},
-						{
-							"code": "1290-6",
-							"display": "Seneca",
-							"definition": "Seneca"
-						},
-						{
-							"code": "1291-4",
-							"display": "Seneca Nation",
-							"definition": "Seneca Nation"
-						},
-						{
-							"code": "1292-2",
-							"display": "Seneca-Cayuga",
-							"definition": "Seneca-Cayuga"
-						},
-						{
-							"code": "1293-0",
-							"display": "Tonawanda Seneca",
-							"definition": "Tonawanda Seneca"
-						},
-						{
-							"code": "1294-8",
-							"display": "Tuscarora",
-							"definition": "Tuscarora"
-						},
-						{
-							"code": "1295-5",
-							"display": "Wyandotte",
-							"definition": "Wyandotte"
-						},
-						{
-							"code": "1306-0",
-							"display": "Oklahoma Kickapoo",
-							"definition": "Oklahoma Kickapoo"
-						},
-						{
-							"code": "1307-8",
-							"display": "Texas Kickapoo",
-							"definition": "Texas Kickapoo"
-						},
-						{
-							"code": "1310-2",
-							"display": "Oklahoma Kiowa",
-							"definition": "Oklahoma Kiowa"
-						},
-						{
-							"code": "1313-6",
-							"display": "Jamestown",
-							"definition": "Jamestown"
-						},
-						{
-							"code": "1314-4",
-							"display": "Lower Elwha",
-							"definition": "Lower Elwha"
-						},
-						{
-							"code": "1315-1",
-							"display": "Port Gamble Klallam",
-							"definition": "Port Gamble Klallam"
-						},
-						{
-							"code": "1326-8",
-							"display": "Matinecock",
-							"definition": "Matinecock"
-						},
-						{
-							"code": "1327-6",
-							"display": "Montauk",
-							"definition": "Montauk"
-						},
-						{
-							"code": "1328-4",
-							"display": "Poospatuck",
-							"definition": "Poospatuck"
-						},
-						{
-							"code": "1329-2",
-							"display": "Setauket",
-							"definition": "Setauket"
-						},
-						{
-							"code": "1332-6",
-							"display": "La Jolla",
-							"definition": "La Jolla"
-						},
-						{
-							"code": "1333-4",
-							"display": "Pala",
-							"definition": "Pala"
-						},
-						{
-							"code": "1334-2",
-							"display": "Pauma",
-							"definition": "Pauma"
-						},
-						{
-							"code": "1335-9",
-							"display": "Pechanga",
-							"definition": "Pechanga"
-						},
-						{
-							"code": "1336-7",
-							"display": "Soboba",
-							"definition": "Soboba"
-						},
-						{
-							"code": "1337-5",
-							"display": "Twenty-Nine Palms",
-							"definition": "Twenty-Nine Palms"
-						},
-						{
-							"code": "1338-3",
-							"display": "Temecula",
-							"definition": "Temecula"
-						},
-						{
-							"code": "1345-8",
-							"display": "Mountain Maidu",
-							"definition": "Mountain Maidu"
-						},
-						{
-							"code": "1346-6",
-							"display": "Nishinam",
-							"definition": "Nishinam"
-						},
-						{
-							"code": "1359-9",
-							"display": "Illinois Miami",
-							"definition": "Illinois Miami"
-						},
-						{
-							"code": "1360-7",
-							"display": "Indiana Miami",
-							"definition": "Indiana Miami"
-						},
-						{
-							"code": "1361-5",
-							"display": "Oklahoma Miami",
-							"definition": "Oklahoma Miami"
-						},
-						{
-							"code": "1366-4",
-							"display": "Aroostook",
-							"definition": "Aroostook"
-						},
-						{
-							"code": "1383-9",
-							"display": "Alamo Navajo",
-							"definition": "Alamo Navajo"
-						},
-						{
-							"code": "1384-7",
-							"display": "Canoncito Navajo",
-							"definition": "Canoncito Navajo"
-						},
-						{
-							"code": "1385-4",
-							"display": "Ramah Navajo",
-							"definition": "Ramah Navajo"
-						},
-						{
-							"code": "1392-0",
-							"display": "Alsea",
-							"definition": "Alsea"
-						},
-						{
-							"code": "1393-8",
-							"display": "Celilo",
-							"definition": "Celilo"
-						},
-						{
-							"code": "1394-6",
-							"display": "Columbia",
-							"definition": "Columbia"
-						},
-						{
-							"code": "1395-3",
-							"display": "Kalapuya",
-							"definition": "Kalapuya"
-						},
-						{
-							"code": "1396-1",
-							"display": "Molala",
-							"definition": "Molala"
-						},
-						{
-							"code": "1397-9",
-							"display": "Talakamish",
-							"definition": "Talakamish"
-						},
-						{
-							"code": "1398-7",
-							"display": "Tenino",
-							"definition": "Tenino"
-						},
-						{
-							"code": "1399-5",
-							"display": "Tillamook",
-							"definition": "Tillamook"
-						},
-						{
-							"code": "1400-1",
-							"display": "Wenatchee",
-							"definition": "Wenatchee"
-						},
-						{
-							"code": "1401-9",
-							"display": "Yahooskin",
-							"definition": "Yahooskin"
-						},
-						{
-							"code": "1412-6",
-							"display": "Burt Lake Ottawa",
-							"definition": "Burt Lake Ottawa"
-						},
-						{
-							"code": "1413-4",
-							"display": "Michigan Ottawa",
-							"definition": "Michigan Ottawa"
-						},
-						{
-							"code": "1414-2",
-							"display": "Oklahoma Ottawa",
-							"definition": "Oklahoma Ottawa"
-						},
-						{
-							"code": "1417-5",
-							"display": "Bishop",
-							"definition": "Bishop"
-						},
-						{
-							"code": "1418-3",
-							"display": "Bridgeport",
-							"definition": "Bridgeport"
-						},
-						{
-							"code": "1419-1",
-							"display": "Burns Paiute",
-							"definition": "Burns Paiute"
-						},
-						{
-							"code": "1420-9",
-							"display": "Cedarville",
-							"definition": "Cedarville"
-						},
-						{
-							"code": "1421-7",
-							"display": "Fort Bidwell",
-							"definition": "Fort Bidwell"
-						},
-						{
-							"code": "1422-5",
-							"display": "Fort Independence",
-							"definition": "Fort Independence"
-						},
-						{
-							"code": "1423-3",
-							"display": "Kaibab",
-							"definition": "Kaibab"
-						},
-						{
-							"code": "1424-1",
-							"display": "Las Vegas",
-							"definition": "Las Vegas"
-						},
-						{
-							"code": "1425-8",
-							"display": "Lone Pine",
-							"definition": "Lone Pine"
-						},
-						{
-							"code": "1426-6",
-							"display": "Lovelock",
-							"definition": "Lovelock"
-						},
-						{
-							"code": "1427-4",
-							"display": "Malheur Paiute",
-							"definition": "Malheur Paiute"
-						},
-						{
-							"code": "1428-2",
-							"display": "Moapa",
-							"definition": "Moapa"
-						},
-						{
-							"code": "1429-0",
-							"display": "Northern Paiute",
-							"definition": "Northern Paiute"
-						},
-						{
-							"code": "1430-8",
-							"display": "Owens Valley",
-							"definition": "Owens Valley"
-						},
-						{
-							"code": "1431-6",
-							"display": "Pyramid Lake",
-							"definition": "Pyramid Lake"
-						},
-						{
-							"code": "1432-4",
-							"display": "San Juan Southern Paiute",
-							"definition": "San Juan Southern Paiute"
-						},
-						{
-							"code": "1433-2",
-							"display": "Southern Paiute",
-							"definition": "Southern Paiute"
-						},
-						{
-							"code": "1434-0",
-							"display": "Summit Lake",
-							"definition": "Summit Lake"
-						},
-						{
-							"code": "1435-7",
-							"display": "Utu Utu Gwaitu Paiute",
-							"definition": "Utu Utu Gwaitu Paiute"
-						},
-						{
-							"code": "1436-5",
-							"display": "Walker River",
-							"definition": "Walker River"
-						},
-						{
-							"code": "1437-3",
-							"display": "Yerington Paiute",
-							"definition": "Yerington Paiute"
-						},
-						{
-							"code": "1442-3",
-							"display": "Indian Township",
-							"definition": "Indian Township"
-						},
-						{
-							"code": "1443-1",
-							"display": "Pleasant Point Passamaquoddy",
-							"definition": "Pleasant Point Passamaquoddy"
-						},
-						{
-							"code": "1446-4",
-							"display": "Oklahoma Pawnee",
-							"definition": "Oklahoma Pawnee"
-						},
-						{
-							"code": "1451-4",
-							"display": "Oklahoma Peoria",
-							"definition": "Oklahoma Peoria"
-						},
-						{
-							"code": "1454-8",
-							"display": "Marshantucket Pequot",
-							"definition": "Marshantucket Pequot"
-						},
-						{
-							"code": "1457-1",
-							"display": "Gila River Pima-Maricopa",
-							"definition": "Gila River Pima-Maricopa"
-						},
-						{
-							"code": "1458-9",
-							"display": "Salt River Pima-Maricopa",
-							"definition": "Salt River Pima-Maricopa"
-						},
-						{
-							"code": "1465-4",
-							"display": "Central Pomo",
-							"definition": "Central Pomo"
-						},
-						{
-							"code": "1466-2",
-							"display": "Dry Creek",
-							"definition": "Dry Creek"
-						},
-						{
-							"code": "1467-0",
-							"display": "Eastern Pomo",
-							"definition": "Eastern Pomo"
-						},
-						{
-							"code": "1468-8",
-							"display": "Kashia",
-							"definition": "Kashia"
-						},
-						{
-							"code": "1469-6",
-							"display": "Northern Pomo",
-							"definition": "Northern Pomo"
-						},
-						{
-							"code": "1470-4",
-							"display": "Scotts Valley",
-							"definition": "Scotts Valley"
-						},
-						{
-							"code": "1471-2",
-							"display": "Stonyford",
-							"definition": "Stonyford"
-						},
-						{
-							"code": "1472-0",
-							"display": "Sulphur Bank",
-							"definition": "Sulphur Bank"
-						},
-						{
-							"code": "1475-3",
-							"display": "Nebraska Ponca",
-							"definition": "Nebraska Ponca"
-						},
-						{
-							"code": "1476-1",
-							"display": "Oklahoma Ponca",
-							"definition": "Oklahoma Ponca"
-						},
-						{
-							"code": "1479-5",
-							"display": "Citizen Band Potawatomi",
-							"definition": "Citizen Band Potawatomi"
-						},
-						{
-							"code": "1480-3",
-							"display": "Forest County",
-							"definition": "Forest County"
-						},
-						{
-							"code": "1481-1",
-							"display": "Hannahville",
-							"definition": "Hannahville"
-						},
-						{
-							"code": "1482-9",
-							"display": "Huron Potawatomi",
-							"definition": "Huron Potawatomi"
-						},
-						{
-							"code": "1483-7",
-							"display": "Pokagon Potawatomi",
-							"definition": "Pokagon Potawatomi"
-						},
-						{
-							"code": "1484-5",
-							"display": "Prairie Band",
-							"definition": "Prairie Band"
-						},
-						{
-							"code": "1485-2",
-							"display": "Wisconsin Potawatomi",
-							"definition": "Wisconsin Potawatomi"
-						},
-						{
-							"code": "1490-2",
-							"display": "Acoma",
-							"definition": "Acoma"
-						},
-						{
-							"code": "1491-0",
-							"display": "Arizona Tewa",
-							"definition": "Arizona Tewa"
-						},
-						{
-							"code": "1492-8",
-							"display": "Cochiti",
-							"definition": "Cochiti"
-						},
-						{
-							"code": "1493-6",
-							"display": "Hopi",
-							"definition": "Hopi"
-						},
-						{
-							"code": "1494-4",
-							"display": "Isleta",
-							"definition": "Isleta"
-						},
-						{
-							"code": "1495-1",
-							"display": "Jemez",
-							"definition": "Jemez"
-						},
-						{
-							"code": "1496-9",
-							"display": "Keres",
-							"definition": "Keres"
-						},
-						{
-							"code": "1497-7",
-							"display": "Laguna",
-							"definition": "Laguna"
-						},
-						{
-							"code": "1498-5",
-							"display": "Nambe",
-							"definition": "Nambe"
-						},
-						{
-							"code": "1499-3",
-							"display": "Picuris",
-							"definition": "Picuris"
-						},
-						{
-							"code": "1500-8",
-							"display": "Piro",
-							"definition": "Piro"
-						},
-						{
-							"code": "1501-6",
-							"display": "Pojoaque",
-							"definition": "Pojoaque"
-						},
-						{
-							"code": "1502-4",
-							"display": "San Felipe",
-							"definition": "San Felipe"
-						},
-						{
-							"code": "1503-2",
-							"display": "San Ildefonso",
-							"definition": "San Ildefonso"
-						},
-						{
-							"code": "1504-0",
-							"display": "San Juan Pueblo",
-							"definition": "San Juan Pueblo"
-						},
-						{
-							"code": "1505-7",
-							"display": "San Juan De",
-							"definition": "San Juan De"
-						},
-						{
-							"code": "1506-5",
-							"display": "San Juan",
-							"definition": "San Juan"
-						},
-						{
-							"code": "1507-3",
-							"display": "Sandia",
-							"definition": "Sandia"
-						},
-						{
-							"code": "1508-1",
-							"display": "Santa Ana",
-							"definition": "Santa Ana"
-						},
-						{
-							"code": "1509-9",
-							"display": "Santa Clara",
-							"definition": "Santa Clara"
-						},
-						{
-							"code": "1510-7",
-							"display": "Santo Domingo",
-							"definition": "Santo Domingo"
-						},
-						{
-							"code": "1511-5",
-							"display": "Taos",
-							"definition": "Taos"
-						},
-						{
-							"code": "1512-3",
-							"display": "Tesuque",
-							"definition": "Tesuque"
-						},
-						{
-							"code": "1513-1",
-							"display": "Tewa",
-							"definition": "Tewa"
-						},
-						{
-							"code": "1514-9",
-							"display": "Tigua",
-							"definition": "Tigua"
-						},
-						{
-							"code": "1515-6",
-							"display": "Zia",
-							"definition": "Zia"
-						},
-						{
-							"code": "1516-4",
-							"display": "Zuni",
-							"definition": "Zuni"
-						},
-						{
-							"code": "1519-8",
-							"display": "Duwamish",
-							"definition": "Duwamish"
-						},
-						{
-							"code": "1520-6",
-							"display": "Kikiallus",
-							"definition": "Kikiallus"
-						},
-						{
-							"code": "1521-4",
-							"display": "Lower Skagit",
-							"definition": "Lower Skagit"
-						},
-						{
-							"code": "1522-2",
-							"display": "Muckleshoot",
-							"definition": "Muckleshoot"
-						},
-						{
-							"code": "1523-0",
-							"display": "Nisqually",
-							"definition": "Nisqually"
-						},
-						{
-							"code": "1524-8",
-							"display": "Nooksack",
-							"definition": "Nooksack"
-						},
-						{
-							"code": "1525-5",
-							"display": "Port Madison",
-							"definition": "Port Madison"
-						},
-						{
-							"code": "1526-3",
-							"display": "Puyallup",
-							"definition": "Puyallup"
-						},
-						{
-							"code": "1527-1",
-							"display": "Samish",
-							"definition": "Samish"
-						},
-						{
-							"code": "1528-9",
-							"display": "Sauk-Suiattle",
-							"definition": "Sauk-Suiattle"
-						},
-						{
-							"code": "1529-7",
-							"display": "Skokomish",
-							"definition": "Skokomish"
-						},
-						{
-							"code": "1530-5",
-							"display": "Skykomish",
-							"definition": "Skykomish"
-						},
-						{
-							"code": "1531-3",
-							"display": "Snohomish",
-							"definition": "Snohomish"
-						},
-						{
-							"code": "1532-1",
-							"display": "Snoqualmie",
-							"definition": "Snoqualmie"
-						},
-						{
-							"code": "1533-9",
-							"display": "Squaxin Island",
-							"definition": "Squaxin Island"
-						},
-						{
-							"code": "1534-7",
-							"display": "Steilacoom",
-							"definition": "Steilacoom"
-						},
-						{
-							"code": "1535-4",
-							"display": "Stillaguamish",
-							"definition": "Stillaguamish"
-						},
-						{
-							"code": "1536-2",
-							"display": "Suquamish",
-							"definition": "Suquamish"
-						},
-						{
-							"code": "1537-0",
-							"display": "Swinomish",
-							"definition": "Swinomish"
-						},
-						{
-							"code": "1538-8",
-							"display": "Tulalip",
-							"definition": "Tulalip"
-						},
-						{
-							"code": "1539-6",
-							"display": "Upper Skagit",
-							"definition": "Upper Skagit"
-						},
-						{
-							"code": "1552-9",
-							"display": "Iowa Sac and Fox",
-							"definition": "Iowa Sac and Fox"
-						},
-						{
-							"code": "1553-7",
-							"display": "Missouri Sac and Fox",
-							"definition": "Missouri Sac and Fox"
-						},
-						{
-							"code": "1554-5",
-							"display": "Oklahoma Sac and Fox",
-							"definition": "Oklahoma Sac and Fox"
-						},
-						{
-							"code": "1567-7",
-							"display": "Big Cypress",
-							"definition": "Big Cypress"
-						},
-						{
-							"code": "1568-5",
-							"display": "Brighton",
-							"definition": "Brighton"
-						},
-						{
-							"code": "1569-3",
-							"display": "Florida Seminole",
-							"definition": "Florida Seminole"
-						},
-						{
-							"code": "1570-1",
-							"display": "Hollywood Seminole",
-							"definition": "Hollywood Seminole"
-						},
-						{
-							"code": "1571-9",
-							"display": "Oklahoma Seminole",
-							"definition": "Oklahoma Seminole"
-						},
-						{
-							"code": "1574-3",
-							"display": "San Manual",
-							"definition": "San Manual"
-						},
-						{
-							"code": "1579-2",
-							"display": "Absentee Shawnee",
-							"definition": "Absentee Shawnee"
-						},
-						{
-							"code": "1580-0",
-							"display": "Eastern Shawnee",
-							"definition": "Eastern Shawnee"
-						},
-						{
-							"code": "1587-5",
-							"display": "Battle Mountain",
-							"definition": "Battle Mountain"
-						},
-						{
-							"code": "1588-3",
-							"display": "Duckwater",
-							"definition": "Duckwater"
-						},
-						{
-							"code": "1589-1",
-							"display": "Elko",
-							"definition": "Elko"
-						},
-						{
-							"code": "1590-9",
-							"display": "Ely",
-							"definition": "Ely"
-						},
-						{
-							"code": "1591-7",
-							"display": "Goshute",
-							"definition": "Goshute"
-						},
-						{
-							"code": "1592-5",
-							"display": "Panamint",
-							"definition": "Panamint"
-						},
-						{
-							"code": "1593-3",
-							"display": "Ruby Valley",
-							"definition": "Ruby Valley"
-						},
-						{
-							"code": "1594-1",
-							"display": "Skull Valley",
-							"definition": "Skull Valley"
-						},
-						{
-							"code": "1595-8",
-							"display": "South Fork Shoshone",
-							"definition": "South Fork Shoshone"
-						},
-						{
-							"code": "1596-6",
-							"display": "Te-Moak Western Shoshone",
-							"definition": "Te-Moak Western Shoshone"
-						},
-						{
-							"code": "1597-4",
-							"display": "Timbi-Sha Shoshone",
-							"definition": "Timbi-Sha Shoshone"
-						},
-						{
-							"code": "1598-2",
-							"display": "Washakie",
-							"definition": "Washakie"
-						},
-						{
-							"code": "1599-0",
-							"display": "Wind River Shoshone",
-							"definition": "Wind River Shoshone"
-						},
-						{
-							"code": "1600-6",
-							"display": "Yomba",
-							"definition": "Yomba"
-						},
-						{
-							"code": "1603-0",
-							"display": "Duck Valley",
-							"definition": "Duck Valley"
-						},
-						{
-							"code": "1604-8",
-							"display": "Fallon",
-							"definition": "Fallon"
-						},
-						{
-							"code": "1605-5",
-							"display": "Fort McDermitt",
-							"definition": "Fort McDermitt"
-						},
-						{
-							"code": "1610-5",
-							"display": "Blackfoot Sioux",
-							"definition": "Blackfoot Sioux"
-						},
-						{
-							"code": "1611-3",
-							"display": "Brule Sioux",
-							"definition": "Brule Sioux"
-						},
-						{
-							"code": "1612-1",
-							"display": "Cheyenne River Sioux",
-							"definition": "Cheyenne River Sioux"
-						},
-						{
-							"code": "1613-9",
-							"display": "Crow Creek Sioux",
-							"definition": "Crow Creek Sioux"
-						},
-						{
-							"code": "1614-7",
-							"display": "Dakota Sioux",
-							"definition": "Dakota Sioux"
-						},
-						{
-							"code": "1615-4",
-							"display": "Flandreau Santee",
-							"definition": "Flandreau Santee"
-						},
-						{
-							"code": "1616-2",
-							"display": "Fort Peck",
-							"definition": "Fort Peck"
-						},
-						{
-							"code": "1617-0",
-							"display": "Lake Traverse Sioux",
-							"definition": "Lake Traverse Sioux"
-						},
-						{
-							"code": "1618-8",
-							"display": "Lower Brule Sioux",
-							"definition": "Lower Brule Sioux"
-						},
-						{
-							"code": "1619-6",
-							"display": "Lower Sioux",
-							"definition": "Lower Sioux"
-						},
-						{
-							"code": "1620-4",
-							"display": "Mdewakanton Sioux",
-							"definition": "Mdewakanton Sioux"
-						},
-						{
-							"code": "1621-2",
-							"display": "Miniconjou",
-							"definition": "Miniconjou"
-						},
-						{
-							"code": "1622-0",
-							"display": "Oglala Sioux",
-							"definition": "Oglala Sioux"
-						},
-						{
-							"code": "1623-8",
-							"display": "Pine Ridge Sioux",
-							"definition": "Pine Ridge Sioux"
-						},
-						{
-							"code": "1624-6",
-							"display": "Pipestone Sioux",
-							"definition": "Pipestone Sioux"
-						},
-						{
-							"code": "1625-3",
-							"display": "Prairie Island Sioux",
-							"definition": "Prairie Island Sioux"
-						},
-						{
-							"code": "1626-1",
-							"display": "Prior Lake Sioux",
-							"definition": "Prior Lake Sioux"
-						},
-						{
-							"code": "1627-9",
-							"display": "Rosebud Sioux",
-							"definition": "Rosebud Sioux"
-						},
-						{
-							"code": "1628-7",
-							"display": "Sans Arc Sioux",
-							"definition": "Sans Arc Sioux"
-						},
-						{
-							"code": "1629-5",
-							"display": "Santee Sioux",
-							"definition": "Santee Sioux"
-						},
-						{
-							"code": "1630-3",
-							"display": "Sisseton-Wahpeton",
-							"definition": "Sisseton-Wahpeton"
-						},
-						{
-							"code": "1631-1",
-							"display": "Sisseton Sioux",
-							"definition": "Sisseton Sioux"
-						},
-						{
-							"code": "1632-9",
-							"display": "Spirit Lake Sioux",
-							"definition": "Spirit Lake Sioux"
-						},
-						{
-							"code": "1633-7",
-							"display": "Standing Rock Sioux",
-							"definition": "Standing Rock Sioux"
-						},
-						{
-							"code": "1634-5",
-							"display": "Teton Sioux",
-							"definition": "Teton Sioux"
-						},
-						{
-							"code": "1635-2",
-							"display": "Two Kettle Sioux",
-							"definition": "Two Kettle Sioux"
-						},
-						{
-							"code": "1636-0",
-							"display": "Upper Sioux",
-							"definition": "Upper Sioux"
-						},
-						{
-							"code": "1637-8",
-							"display": "Wahpekute Sioux",
-							"definition": "Wahpekute Sioux"
-						},
-						{
-							"code": "1638-6",
-							"display": "Wahpeton Sioux",
-							"definition": "Wahpeton Sioux"
-						},
-						{
-							"code": "1639-4",
-							"display": "Wazhaza Sioux",
-							"definition": "Wazhaza Sioux"
-						},
-						{
-							"code": "1640-2",
-							"display": "Yankton Sioux",
-							"definition": "Yankton Sioux"
-						},
-						{
-							"code": "1641-0",
-							"display": "Yanktonai Sioux",
-							"definition": "Yanktonai Sioux"
-						},
-						{
-							"code": "1654-3",
-							"display": "Ak-Chin",
-							"definition": "Ak-Chin"
-						},
-						{
-							"code": "1655-0",
-							"display": "Gila Bend",
-							"definition": "Gila Bend"
-						},
-						{
-							"code": "1656-8",
-							"display": "San Xavier",
-							"definition": "San Xavier"
-						},
-						{
-							"code": "1657-6",
-							"display": "Sells",
-							"definition": "Sells"
-						},
-						{
-							"code": "1668-3",
-							"display": "Cow Creek Umpqua",
-							"definition": "Cow Creek Umpqua"
-						},
-						{
-							"code": "1671-7",
-							"display": "Allen Canyon",
-							"definition": "Allen Canyon"
-						},
-						{
-							"code": "1672-5",
-							"display": "Uintah Ute",
-							"definition": "Uintah Ute"
-						},
-						{
-							"code": "1673-3",
-							"display": "Ute Mountain Ute",
-							"definition": "Ute Mountain Ute"
-						},
-						{
-							"code": "1680-8",
-							"display": "Gay Head Wampanoag",
-							"definition": "Gay Head Wampanoag"
-						},
-						{
-							"code": "1681-6",
-							"display": "Mashpee Wampanoag",
-							"definition": "Mashpee Wampanoag"
-						},
-						{
-							"code": "1688-1",
-							"display": "Alpine",
-							"definition": "Alpine"
-						},
-						{
-							"code": "1689-9",
-							"display": "Carson",
-							"definition": "Carson"
-						},
-						{
-							"code": "1690-7",
-							"display": "Dresslerville",
-							"definition": "Dresslerville"
-						},
-						{
-							"code": "1697-2",
-							"display": "Ho-chunk",
-							"definition": "Ho-chunk"
-						},
-						{
-							"code": "1698-0",
-							"display": "Nebraska Winnebago",
-							"definition": "Nebraska Winnebago"
-						},
-						{
-							"code": "1705-3",
-							"display": "Table Bluff",
-							"definition": "Table Bluff"
-						},
-						{
-							"code": "1712-9",
-							"display": "Barrio Libre",
-							"definition": "Barrio Libre"
-						},
-						{
-							"code": "1713-7",
-							"display": "Pascua Yaqui",
-							"definition": "Pascua Yaqui"
-						},
-						{
-							"code": "1718-6",
-							"display": "Chukchansi",
-							"definition": "Chukchansi"
-						},
-						{
-							"code": "1719-4",
-							"display": "Tachi",
-							"definition": "Tachi"
-						},
-						{
-							"code": "1720-2",
-							"display": "Tule River",
-							"definition": "Tule River"
-						},
-						{
-							"code": "1725-1",
-							"display": "Cocopah",
-							"definition": "Cocopah"
-						},
-						{
-							"code": "1726-9",
-							"display": "Havasupai",
-							"definition": "Havasupai"
-						},
-						{
-							"code": "1727-7",
-							"display": "Hualapai",
-							"definition": "Hualapai"
-						},
-						{
-							"code": "1728-5",
-							"display": "Maricopa",
-							"definition": "Maricopa"
-						},
-						{
-							"code": "1729-3",
-							"display": "Mohave",
-							"definition": "Mohave"
-						},
-						{
-							"code": "1730-1",
-							"display": "Quechan",
-							"definition": "Quechan"
-						},
-						{
-							"code": "1731-9",
-							"display": "Yavapai",
-							"definition": "Yavapai"
-						},
-						{
-							"code": "1733-5",
-							"display": "Coast Yurok",
-							"definition": "Coast Yurok"
-						},
-						{
-							"code": "1737-6",
-							"display": "Alaska Indian",
-							"definition": "Alaska Indian"
-						},
-						{
-							"code": "1840-8",
-							"display": "Eskimo",
-							"definition": "Eskimo"
-						},
-						{
-							"code": "1966-1",
-							"display": "Aleut",
-							"definition": "Aleut"
-						},
-						{
-							"code": "1739-2",
-							"display": "Alaskan Athabascan",
-							"definition": "Alaskan Athabascan"
-						},
-						{
-							"code": "1811-9",
-							"display": "Southeast Alaska",
-							"definition": "Southeast Alaska"
-						},
-						{
-							"code": "1740-0",
-							"display": "Ahtna",
-							"definition": "Ahtna"
-						},
-						{
-							"code": "1741-8",
-							"display": "Alatna",
-							"definition": "Alatna"
-						},
-						{
-							"code": "1742-6",
-							"display": "Alexander",
-							"definition": "Alexander"
-						},
-						{
-							"code": "1743-4",
-							"display": "Allakaket",
-							"definition": "Allakaket"
-						},
-						{
-							"code": "1744-2",
-							"display": "Alanvik",
-							"definition": "Alanvik"
-						},
-						{
-							"code": "1745-9",
-							"display": "Anvik",
-							"definition": "Anvik"
-						},
-						{
-							"code": "1746-7",
-							"display": "Arctic",
-							"definition": "Arctic"
-						},
-						{
-							"code": "1747-5",
-							"display": "Beaver",
-							"definition": "Beaver"
-						},
-						{
-							"code": "1748-3",
-							"display": "Birch Creek",
-							"definition": "Birch Creek"
-						},
-						{
-							"code": "1749-1",
-							"display": "Cantwell",
-							"definition": "Cantwell"
-						},
-						{
-							"code": "1750-9",
-							"display": "Chalkyitsik",
-							"definition": "Chalkyitsik"
-						},
-						{
-							"code": "1751-7",
-							"display": "Chickaloon",
-							"definition": "Chickaloon"
-						},
-						{
-							"code": "1752-5",
-							"display": "Chistochina",
-							"definition": "Chistochina"
-						},
-						{
-							"code": "1753-3",
-							"display": "Chitina",
-							"definition": "Chitina"
-						},
-						{
-							"code": "1754-1",
-							"display": "Circle",
-							"definition": "Circle"
-						},
-						{
-							"code": "1755-8",
-							"display": "Cook Inlet",
-							"definition": "Cook Inlet"
-						},
-						{
-							"code": "1756-6",
-							"display": "Copper Center",
-							"definition": "Copper Center"
-						},
-						{
-							"code": "1757-4",
-							"display": "Copper River",
-							"definition": "Copper River"
-						},
-						{
-							"code": "1758-2",
-							"display": "Dot Lake",
-							"definition": "Dot Lake"
-						},
-						{
-							"code": "1759-0",
-							"display": "Doyon",
-							"definition": "Doyon"
-						},
-						{
-							"code": "1760-8",
-							"display": "Eagle",
-							"definition": "Eagle"
-						},
-						{
-							"code": "1761-6",
-							"display": "Eklutna",
-							"definition": "Eklutna"
-						},
-						{
-							"code": "1762-4",
-							"display": "Evansville",
-							"definition": "Evansville"
-						},
-						{
-							"code": "1763-2",
-							"display": "Fort Yukon",
-							"definition": "Fort Yukon"
-						},
-						{
-							"code": "1764-0",
-							"display": "Gakona",
-							"definition": "Gakona"
-						},
-						{
-							"code": "1765-7",
-							"display": "Galena",
-							"definition": "Galena"
-						},
-						{
-							"code": "1766-5",
-							"display": "Grayling",
-							"definition": "Grayling"
-						},
-						{
-							"code": "1767-3",
-							"display": "Gulkana",
-							"definition": "Gulkana"
-						},
-						{
-							"code": "1768-1",
-							"display": "Healy Lake",
-							"definition": "Healy Lake"
-						},
-						{
-							"code": "1769-9",
-							"display": "Holy Cross",
-							"definition": "Holy Cross"
-						},
-						{
-							"code": "1770-7",
-							"display": "Hughes",
-							"definition": "Hughes"
-						},
-						{
-							"code": "1771-5",
-							"display": "Huslia",
-							"definition": "Huslia"
-						},
-						{
-							"code": "1772-3",
-							"display": "Iliamna",
-							"definition": "Iliamna"
-						},
-						{
-							"code": "1773-1",
-							"display": "Kaltag",
-							"definition": "Kaltag"
-						},
-						{
-							"code": "1774-9",
-							"display": "Kluti Kaah",
-							"definition": "Kluti Kaah"
-						},
-						{
-							"code": "1775-6",
-							"display": "Knik",
-							"definition": "Knik"
-						},
-						{
-							"code": "1776-4",
-							"display": "Koyukuk",
-							"definition": "Koyukuk"
-						},
-						{
-							"code": "1777-2",
-							"display": "Lake Minchumina",
-							"definition": "Lake Minchumina"
-						},
-						{
-							"code": "1778-0",
-							"display": "Lime",
-							"definition": "Lime"
-						},
-						{
-							"code": "1779-8",
-							"display": "Mcgrath",
-							"definition": "Mcgrath"
-						},
-						{
-							"code": "1780-6",
-							"display": "Manley Hot Springs",
-							"definition": "Manley Hot Springs"
-						},
-						{
-							"code": "1781-4",
-							"display": "Mentasta Lake",
-							"definition": "Mentasta Lake"
-						},
-						{
-							"code": "1782-2",
-							"display": "Minto",
-							"definition": "Minto"
-						},
-						{
-							"code": "1783-0",
-							"display": "Nenana",
-							"definition": "Nenana"
-						},
-						{
-							"code": "1784-8",
-							"display": "Nikolai",
-							"definition": "Nikolai"
-						},
-						{
-							"code": "1785-5",
-							"display": "Ninilchik",
-							"definition": "Ninilchik"
-						},
-						{
-							"code": "1786-3",
-							"display": "Nondalton",
-							"definition": "Nondalton"
-						},
-						{
-							"code": "1787-1",
-							"display": "Northway",
-							"definition": "Northway"
-						},
-						{
-							"code": "1788-9",
-							"display": "Nulato",
-							"definition": "Nulato"
-						},
-						{
-							"code": "1789-7",
-							"display": "Pedro Bay",
-							"definition": "Pedro Bay"
-						},
-						{
-							"code": "1790-5",
-							"display": "Rampart",
-							"definition": "Rampart"
-						},
-						{
-							"code": "1791-3",
-							"display": "Ruby",
-							"definition": "Ruby"
-						},
-						{
-							"code": "1792-1",
-							"display": "Salamatof",
-							"definition": "Salamatof"
-						},
-						{
-							"code": "1793-9",
-							"display": "Seldovia",
-							"definition": "Seldovia"
-						},
-						{
-							"code": "1794-7",
-							"display": "Slana",
-							"definition": "Slana"
-						},
-						{
-							"code": "1795-4",
-							"display": "Shageluk",
-							"definition": "Shageluk"
-						},
-						{
-							"code": "1796-2",
-							"display": "Stevens",
-							"definition": "Stevens"
-						},
-						{
-							"code": "1797-0",
-							"display": "Stony River",
-							"definition": "Stony River"
-						},
-						{
-							"code": "1798-8",
-							"display": "Takotna",
-							"definition": "Takotna"
-						},
-						{
-							"code": "1799-6",
-							"display": "Tanacross",
-							"definition": "Tanacross"
-						},
-						{
-							"code": "1800-2",
-							"display": "Tanaina",
-							"definition": "Tanaina"
-						},
-						{
-							"code": "1801-0",
-							"display": "Tanana",
-							"definition": "Tanana"
-						},
-						{
-							"code": "1802-8",
-							"display": "Tanana Chiefs",
-							"definition": "Tanana Chiefs"
-						},
-						{
-							"code": "1803-6",
-							"display": "Tazlina",
-							"definition": "Tazlina"
-						},
-						{
-							"code": "1804-4",
-							"display": "Telida",
-							"definition": "Telida"
-						},
-						{
-							"code": "1805-1",
-							"display": "Tetlin",
-							"definition": "Tetlin"
-						},
-						{
-							"code": "1806-9",
-							"display": "Tok",
-							"definition": "Tok"
-						},
-						{
-							"code": "1807-7",
-							"display": "Tyonek",
-							"definition": "Tyonek"
-						},
-						{
-							"code": "1808-5",
-							"display": "Venetie",
-							"definition": "Venetie"
-						},
-						{
-							"code": "1809-3",
-							"display": "Wiseman",
-							"definition": "Wiseman"
-						},
-						{
-							"code": "1813-5",
-							"display": "Tlingit-Haida",
-							"definition": "Tlingit-Haida"
-						},
-						{
-							"code": "1837-4",
-							"display": "Tsimshian",
-							"definition": "Tsimshian"
-						},
-						{
-							"code": "1814-3",
-							"display": "Angoon",
-							"definition": "Angoon"
-						},
-						{
-							"code": "1815-0",
-							"display": "Central Council of Tlingit and Haida Tribes",
-							"definition": "Central Council of Tlingit and Haida Tribes"
-						},
-						{
-							"code": "1816-8",
-							"display": "Chilkat",
-							"definition": "Chilkat"
-						},
-						{
-							"code": "1817-6",
-							"display": "Chilkoot",
-							"definition": "Chilkoot"
-						},
-						{
-							"code": "1818-4",
-							"display": "Craig",
-							"definition": "Craig"
-						},
-						{
-							"code": "1819-2",
-							"display": "Douglas",
-							"definition": "Douglas"
-						},
-						{
-							"code": "1820-0",
-							"display": "Haida",
-							"definition": "Haida"
-						},
-						{
-							"code": "1821-8",
-							"display": "Hoonah",
-							"definition": "Hoonah"
-						},
-						{
-							"code": "1822-6",
-							"display": "Hydaburg",
-							"definition": "Hydaburg"
-						},
-						{
-							"code": "1823-4",
-							"display": "Kake",
-							"definition": "Kake"
-						},
-						{
-							"code": "1824-2",
-							"display": "Kasaan",
-							"definition": "Kasaan"
-						},
-						{
-							"code": "1825-9",
-							"display": "Kenaitze",
-							"definition": "Kenaitze"
-						},
-						{
-							"code": "1826-7",
-							"display": "Ketchikan",
-							"definition": "Ketchikan"
-						},
-						{
-							"code": "1827-5",
-							"display": "Klawock",
-							"definition": "Klawock"
-						},
-						{
-							"code": "1828-3",
-							"display": "Pelican",
-							"definition": "Pelican"
-						},
-						{
-							"code": "1829-1",
-							"display": "Petersburg",
-							"definition": "Petersburg"
-						},
-						{
-							"code": "1830-9",
-							"display": "Saxman",
-							"definition": "Saxman"
-						},
-						{
-							"code": "1831-7",
-							"display": "Sitka",
-							"definition": "Sitka"
-						},
-						{
-							"code": "1832-5",
-							"display": "Tenakee Springs",
-							"definition": "Tenakee Springs"
-						},
-						{
-							"code": "1833-3",
-							"display": "Tlingit",
-							"definition": "Tlingit"
-						},
-						{
-							"code": "1834-1",
-							"display": "Wrangell",
-							"definition": "Wrangell"
-						},
-						{
-							"code": "1835-8",
-							"display": "Yakutat",
-							"definition": "Yakutat"
-						},
-						{
-							"code": "1838-2",
-							"display": "Metlakatla",
-							"definition": "Metlakatla"
-						},
-						{
-							"code": "1842-4",
-							"display": "Greenland Eskimo",
-							"definition": "Greenland Eskimo"
-						},
-						{
-							"code": "1844-0",
-							"display": "Inupiat Eskimo",
-							"definition": "Inupiat Eskimo"
-						},
-						{
-							"code": "1891-1",
-							"display": "Siberian Eskimo",
-							"definition": "Siberian Eskimo"
-						},
-						{
-							"code": "1896-0",
-							"display": "Yupik Eskimo",
-							"definition": "Yupik Eskimo"
-						},
-						{
-							"code": "1845-7",
-							"display": "Ambler",
-							"definition": "Ambler"
-						},
-						{
-							"code": "1846-5",
-							"display": "Anaktuvuk",
-							"definition": "Anaktuvuk"
-						},
-						{
-							"code": "1847-3",
-							"display": "Anaktuvuk Pass",
-							"definition": "Anaktuvuk Pass"
-						},
-						{
-							"code": "1848-1",
-							"display": "Arctic Slope Inupiat",
-							"definition": "Arctic Slope Inupiat"
-						},
-						{
-							"code": "1849-9",
-							"display": "Arctic Slope Corporation",
-							"definition": "Arctic Slope Corporation"
-						},
-						{
-							"code": "1850-7",
-							"display": "Atqasuk",
-							"definition": "Atqasuk"
-						},
-						{
-							"code": "1851-5",
-							"display": "Barrow",
-							"definition": "Barrow"
-						},
-						{
-							"code": "1852-3",
-							"display": "Bering Straits Inupiat",
-							"definition": "Bering Straits Inupiat"
-						},
-						{
-							"code": "1853-1",
-							"display": "Brevig Mission",
-							"definition": "Brevig Mission"
-						},
-						{
-							"code": "1854-9",
-							"display": "Buckland",
-							"definition": "Buckland"
-						},
-						{
-							"code": "1855-6",
-							"display": "Chinik",
-							"definition": "Chinik"
-						},
-						{
-							"code": "1856-4",
-							"display": "Council",
-							"definition": "Council"
-						},
-						{
-							"code": "1857-2",
-							"display": "Deering",
-							"definition": "Deering"
-						},
-						{
-							"code": "1858-0",
-							"display": "Elim",
-							"definition": "Elim"
-						},
-						{
-							"code": "1859-8",
-							"display": "Golovin",
-							"definition": "Golovin"
-						},
-						{
-							"code": "1860-6",
-							"display": "Inalik Diomede",
-							"definition": "Inalik Diomede"
-						},
-						{
-							"code": "1861-4",
-							"display": "Inupiaq",
-							"definition": "Inupiaq"
-						},
-						{
-							"code": "1862-2",
-							"display": "Kaktovik",
-							"definition": "Kaktovik"
-						},
-						{
-							"code": "1863-0",
-							"display": "Kawerak",
-							"definition": "Kawerak"
-						},
-						{
-							"code": "1864-8",
-							"display": "Kiana",
-							"definition": "Kiana"
-						},
-						{
-							"code": "1865-5",
-							"display": "Kivalina",
-							"definition": "Kivalina"
-						},
-						{
-							"code": "1866-3",
-							"display": "Kobuk",
-							"definition": "Kobuk"
-						},
-						{
-							"code": "1867-1",
-							"display": "Kotzebue",
-							"definition": "Kotzebue"
-						},
-						{
-							"code": "1868-9",
-							"display": "Koyuk",
-							"definition": "Koyuk"
-						},
-						{
-							"code": "1869-7",
-							"display": "Kwiguk",
-							"definition": "Kwiguk"
-						},
-						{
-							"code": "1870-5",
-							"display": "Mauneluk Inupiat",
-							"definition": "Mauneluk Inupiat"
-						},
-						{
-							"code": "1871-3",
-							"display": "Nana Inupiat",
-							"definition": "Nana Inupiat"
-						},
-						{
-							"code": "1872-1",
-							"display": "Noatak",
-							"definition": "Noatak"
-						},
-						{
-							"code": "1873-9",
-							"display": "Nome",
-							"definition": "Nome"
-						},
-						{
-							"code": "1874-7",
-							"display": "Noorvik",
-							"definition": "Noorvik"
-						},
-						{
-							"code": "1875-4",
-							"display": "Nuiqsut",
-							"definition": "Nuiqsut"
-						},
-						{
-							"code": "1876-2",
-							"display": "Point Hope",
-							"definition": "Point Hope"
-						},
-						{
-							"code": "1877-0",
-							"display": "Point Lay",
-							"definition": "Point Lay"
-						},
-						{
-							"code": "1878-8",
-							"display": "Selawik",
-							"definition": "Selawik"
-						},
-						{
-							"code": "1879-6",
-							"display": "Shaktoolik",
-							"definition": "Shaktoolik"
-						},
-						{
-							"code": "1880-4",
-							"display": "Shishmaref",
-							"definition": "Shishmaref"
-						},
-						{
-							"code": "1881-2",
-							"display": "Shungnak",
-							"definition": "Shungnak"
-						},
-						{
-							"code": "1882-0",
-							"display": "Solomon",
-							"definition": "Solomon"
-						},
-						{
-							"code": "1883-8",
-							"display": "Teller",
-							"definition": "Teller"
-						},
-						{
-							"code": "1884-6",
-							"display": "Unalakleet",
-							"definition": "Unalakleet"
-						},
-						{
-							"code": "1885-3",
-							"display": "Wainwright",
-							"definition": "Wainwright"
-						},
-						{
-							"code": "1886-1",
-							"display": "Wales",
-							"definition": "Wales"
-						},
-						{
-							"code": "1887-9",
-							"display": "White Mountain",
-							"definition": "White Mountain"
-						},
-						{
-							"code": "1888-7",
-							"display": "White Mountain Inupiat",
-							"definition": "White Mountain Inupiat"
-						},
-						{
-							"code": "1889-5",
-							"display": "Mary's Igloo",
-							"definition": "Mary's Igloo"
-						},
-						{
-							"code": "1892-9",
-							"display": "Gambell",
-							"definition": "Gambell"
-						},
-						{
-							"code": "1893-7",
-							"display": "Savoonga",
-							"definition": "Savoonga"
-						},
-						{
-							"code": "1894-5",
-							"display": "Siberian Yupik",
-							"definition": "Siberian Yupik"
-						},
-						{
-							"code": "1897-8",
-							"display": "Akiachak",
-							"definition": "Akiachak"
-						},
-						{
-							"code": "1898-6",
-							"display": "Akiak",
-							"definition": "Akiak"
-						},
-						{
-							"code": "1899-4",
-							"display": "Alakanuk",
-							"definition": "Alakanuk"
-						},
-						{
-							"code": "1900-0",
-							"display": "Aleknagik",
-							"definition": "Aleknagik"
-						},
-						{
-							"code": "1901-8",
-							"display": "Andreafsky",
-							"definition": "Andreafsky"
-						},
-						{
-							"code": "1902-6",
-							"display": "Aniak",
-							"definition": "Aniak"
-						},
-						{
-							"code": "1903-4",
-							"display": "Atmautluak",
-							"definition": "Atmautluak"
-						},
-						{
-							"code": "1904-2",
-							"display": "Bethel",
-							"definition": "Bethel"
-						},
-						{
-							"code": "1905-9",
-							"display": "Bill Moore's Slough",
-							"definition": "Bill Moore's Slough"
-						},
-						{
-							"code": "1906-7",
-							"display": "Bristol Bay Yupik",
-							"definition": "Bristol Bay Yupik"
-						},
-						{
-							"code": "1907-5",
-							"display": "Calista Yupik",
-							"definition": "Calista Yupik"
-						},
-						{
-							"code": "1908-3",
-							"display": "Chefornak",
-							"definition": "Chefornak"
-						},
-						{
-							"code": "1909-1",
-							"display": "Chevak",
-							"definition": "Chevak"
-						},
-						{
-							"code": "1910-9",
-							"display": "Chuathbaluk",
-							"definition": "Chuathbaluk"
-						},
-						{
-							"code": "1911-7",
-							"display": "Clark's Point",
-							"definition": "Clark's Point"
-						},
-						{
-							"code": "1912-5",
-							"display": "Crooked Creek",
-							"definition": "Crooked Creek"
-						},
-						{
-							"code": "1913-3",
-							"display": "Dillingham",
-							"definition": "Dillingham"
-						},
-						{
-							"code": "1914-1",
-							"display": "Eek",
-							"definition": "Eek"
-						},
-						{
-							"code": "1915-8",
-							"display": "Ekuk",
-							"definition": "Ekuk"
-						},
-						{
-							"code": "1916-6",
-							"display": "Ekwok",
-							"definition": "Ekwok"
-						},
-						{
-							"code": "1917-4",
-							"display": "Emmonak",
-							"definition": "Emmonak"
-						},
-						{
-							"code": "1918-2",
-							"display": "Goodnews Bay",
-							"definition": "Goodnews Bay"
-						},
-						{
-							"code": "1919-0",
-							"display": "Hooper Bay",
-							"definition": "Hooper Bay"
-						},
-						{
-							"code": "1920-8",
-							"display": "Iqurmuit (Russian Mission)",
-							"definition": "Iqurmuit (Russian Mission)"
-						},
-						{
-							"code": "1921-6",
-							"display": "Kalskag",
-							"definition": "Kalskag"
-						},
-						{
-							"code": "1922-4",
-							"display": "Kasigluk",
-							"definition": "Kasigluk"
-						},
-						{
-							"code": "1923-2",
-							"display": "Kipnuk",
-							"definition": "Kipnuk"
-						},
-						{
-							"code": "1924-0",
-							"display": "Koliganek",
-							"definition": "Koliganek"
-						},
-						{
-							"code": "1925-7",
-							"display": "Kongiganak",
-							"definition": "Kongiganak"
-						},
-						{
-							"code": "1926-5",
-							"display": "Kotlik",
-							"definition": "Kotlik"
-						},
-						{
-							"code": "1927-3",
-							"display": "Kwethluk",
-							"definition": "Kwethluk"
-						},
-						{
-							"code": "1928-1",
-							"display": "Kwigillingok",
-							"definition": "Kwigillingok"
-						},
-						{
-							"code": "1929-9",
-							"display": "Levelock",
-							"definition": "Levelock"
-						},
-						{
-							"code": "1930-7",
-							"display": "Lower Kalskag",
-							"definition": "Lower Kalskag"
-						},
-						{
-							"code": "1931-5",
-							"display": "Manokotak",
-							"definition": "Manokotak"
-						},
-						{
-							"code": "1932-3",
-							"display": "Marshall",
-							"definition": "Marshall"
-						},
-						{
-							"code": "1933-1",
-							"display": "Mekoryuk",
-							"definition": "Mekoryuk"
-						},
-						{
-							"code": "1934-9",
-							"display": "Mountain Village",
-							"definition": "Mountain Village"
-						},
-						{
-							"code": "1935-6",
-							"display": "Naknek",
-							"definition": "Naknek"
-						},
-						{
-							"code": "1936-4",
-							"display": "Napaumute",
-							"definition": "Napaumute"
-						},
-						{
-							"code": "1937-2",
-							"display": "Napakiak",
-							"definition": "Napakiak"
-						},
-						{
-							"code": "1938-0",
-							"display": "Napaskiak",
-							"definition": "Napaskiak"
-						},
-						{
-							"code": "1939-8",
-							"display": "Newhalen",
-							"definition": "Newhalen"
-						},
-						{
-							"code": "1940-6",
-							"display": "New Stuyahok",
-							"definition": "New Stuyahok"
-						},
-						{
-							"code": "1941-4",
-							"display": "Newtok",
-							"definition": "Newtok"
-						},
-						{
-							"code": "1942-2",
-							"display": "Nightmute",
-							"definition": "Nightmute"
-						},
-						{
-							"code": "1943-0",
-							"display": "Nunapitchukv",
-							"definition": "Nunapitchukv"
-						},
-						{
-							"code": "1944-8",
-							"display": "Oscarville",
-							"definition": "Oscarville"
-						},
-						{
-							"code": "1945-5",
-							"display": "Pilot Station",
-							"definition": "Pilot Station"
-						},
-						{
-							"code": "1946-3",
-							"display": "Pitkas Point",
-							"definition": "Pitkas Point"
-						},
-						{
-							"code": "1947-1",
-							"display": "Platinum",
-							"definition": "Platinum"
-						},
-						{
-							"code": "1948-9",
-							"display": "Portage Creek",
-							"definition": "Portage Creek"
-						},
-						{
-							"code": "1949-7",
-							"display": "Quinhagak",
-							"definition": "Quinhagak"
-						},
-						{
-							"code": "1950-5",
-							"display": "Red Devil",
-							"definition": "Red Devil"
-						},
-						{
-							"code": "1951-3",
-							"display": "St. Michael",
-							"definition": "St. Michael"
-						},
-						{
-							"code": "1952-1",
-							"display": "Scammon Bay",
-							"definition": "Scammon Bay"
-						},
-						{
-							"code": "1953-9",
-							"display": "Sheldon's Point",
-							"definition": "Sheldon's Point"
-						},
-						{
-							"code": "1954-7",
-							"display": "Sleetmute",
-							"definition": "Sleetmute"
-						},
-						{
-							"code": "1955-4",
-							"display": "Stebbins",
-							"definition": "Stebbins"
-						},
-						{
-							"code": "1956-2",
-							"display": "Togiak",
-							"definition": "Togiak"
-						},
-						{
-							"code": "1957-0",
-							"display": "Toksook",
-							"definition": "Toksook"
-						},
-						{
-							"code": "1958-8",
-							"display": "Tulukskak",
-							"definition": "Tulukskak"
-						},
-						{
-							"code": "1959-6",
-							"display": "Tuntutuliak",
-							"definition": "Tuntutuliak"
-						},
-						{
-							"code": "1960-4",
-							"display": "Tununak",
-							"definition": "Tununak"
-						},
-						{
-							"code": "1961-2",
-							"display": "Twin Hills",
-							"definition": "Twin Hills"
-						},
-						{
-							"code": "1962-0",
-							"display": "Georgetown (Yupik-Eskimo)",
-							"definition": "Georgetown (Yupik-Eskimo)"
-						},
-						{
-							"code": "1963-8",
-							"display": "St. Mary's",
-							"definition": "St. Mary's"
-						},
-						{
-							"code": "1964-6",
-							"display": "Umkumiate",
-							"definition": "Umkumiate"
-						},
-						{
-							"code": "1968-7",
-							"display": "Alutiiq Aleut",
-							"definition": "Alutiiq Aleut"
-						},
-						{
-							"code": "1972-9",
-							"display": "Bristol Bay Aleut",
-							"definition": "Bristol Bay Aleut"
-						},
-						{
-							"code": "1984-4",
-							"display": "Chugach Aleut",
-							"definition": "Chugach Aleut"
-						},
-						{
-							"code": "1990-1",
-							"display": "Eyak",
-							"definition": "Eyak"
-						},
-						{
-							"code": "1992-7",
-							"display": "Koniag Aleut",
-							"definition": "Koniag Aleut"
-						},
-						{
-							"code": "2002-4",
-							"display": "Sugpiaq",
-							"definition": "Sugpiaq"
-						},
-						{
-							"code": "2004-0",
-							"display": "Suqpigaq",
-							"definition": "Suqpigaq"
-						},
-						{
-							"code": "2006-5",
-							"display": "Unangan Aleut",
-							"definition": "Unangan Aleut"
-						},
-						{
-							"code": "1969-5",
-							"display": "Tatitlek",
-							"definition": "Tatitlek"
-						},
-						{
-							"code": "1970-3",
-							"display": "Ugashik",
-							"definition": "Ugashik"
-						},
-						{
-							"code": "1973-7",
-							"display": "Chignik",
-							"definition": "Chignik"
-						},
-						{
-							"code": "1974-5",
-							"display": "Chignik Lake",
-							"definition": "Chignik Lake"
-						},
-						{
-							"code": "1975-2",
-							"display": "Egegik",
-							"definition": "Egegik"
-						},
-						{
-							"code": "1976-0",
-							"display": "Igiugig",
-							"definition": "Igiugig"
-						},
-						{
-							"code": "1977-8",
-							"display": "Ivanof Bay",
-							"definition": "Ivanof Bay"
-						},
-						{
-							"code": "1978-6",
-							"display": "King Salmon",
-							"definition": "King Salmon"
-						},
-						{
-							"code": "1979-4",
-							"display": "Kokhanok",
-							"definition": "Kokhanok"
-						},
-						{
-							"code": "1980-2",
-							"display": "Perryville",
-							"definition": "Perryville"
-						},
-						{
-							"code": "1981-0",
-							"display": "Pilot Point",
-							"definition": "Pilot Point"
-						},
-						{
-							"code": "1982-8",
-							"display": "Port Heiden",
-							"definition": "Port Heiden"
-						},
-						{
-							"code": "1985-1",
-							"display": "Chenega",
-							"definition": "Chenega"
-						},
-						{
-							"code": "1986-9",
-							"display": "Chugach Corporation",
-							"definition": "Chugach Corporation"
-						},
-						{
-							"code": "1987-7",
-							"display": "English Bay",
-							"definition": "English Bay"
-						},
-						{
-							"code": "1988-5",
-							"display": "Port Graham",
-							"definition": "Port Graham"
-						},
-						{
-							"code": "1993-5",
-							"display": "Akhiok",
-							"definition": "Akhiok"
-						},
-						{
-							"code": "1994-3",
-							"display": "Agdaagux",
-							"definition": "Agdaagux"
-						},
-						{
-							"code": "1995-0",
-							"display": "Karluk",
-							"definition": "Karluk"
-						},
-						{
-							"code": "1996-8",
-							"display": "Kodiak",
-							"definition": "Kodiak"
-						},
-						{
-							"code": "1997-6",
-							"display": "Larsen Bay",
-							"definition": "Larsen Bay"
-						},
-						{
-							"code": "1998-4",
-							"display": "Old Harbor",
-							"definition": "Old Harbor"
-						},
-						{
-							"code": "1999-2",
-							"display": "Ouzinkie",
-							"definition": "Ouzinkie"
-						},
-						{
-							"code": "2000-8",
-							"display": "Port Lions",
-							"definition": "Port Lions"
-						},
-						{
-							"code": "2007-3",
-							"display": "Akutan",
-							"definition": "Akutan"
-						},
-						{
-							"code": "2008-1",
-							"display": "Aleut Corporation",
-							"definition": "Aleut Corporation"
-						},
-						{
-							"code": "2009-9",
-							"display": "Aleutian",
-							"definition": "Aleutian"
-						},
-						{
-							"code": "2010-7",
-							"display": "Aleutian Islander",
-							"definition": "Aleutian Islander"
-						},
-						{
-							"code": "2011-5",
-							"display": "Atka",
-							"definition": "Atka"
-						},
-						{
-							"code": "2012-3",
-							"display": "Belkofski",
-							"definition": "Belkofski"
-						},
-						{
-							"code": "2013-1",
-							"display": "Chignik Lagoon",
-							"definition": "Chignik Lagoon"
-						},
-						{
-							"code": "2014-9",
-							"display": "King Cove",
-							"definition": "King Cove"
-						},
-						{
-							"code": "2015-6",
-							"display": "False Pass",
-							"definition": "False Pass"
-						},
-						{
-							"code": "2016-4",
-							"display": "Nelson Lagoon",
-							"definition": "Nelson Lagoon"
-						},
-						{
-							"code": "2017-2",
-							"display": "Nikolski",
-							"definition": "Nikolski"
-						},
-						{
-							"code": "2018-0",
-							"display": "Pauloff Harbor",
-							"definition": "Pauloff Harbor"
-						},
-						{
-							"code": "2019-8",
-							"display": "Qagan Toyagungin",
-							"definition": "Qagan Toyagungin"
-						},
-						{
-							"code": "2020-6",
-							"display": "Qawalangin",
-							"definition": "Qawalangin"
-						},
-						{
-							"code": "2021-4",
-							"display": "St. George",
-							"definition": "St. George"
-						},
-						{
-							"code": "2022-2",
-							"display": "St. Paul",
-							"definition": "St. Paul"
-						},
-						{
-							"code": "2023-0",
-							"display": "Sand Point",
-							"definition": "Sand Point"
-						},
-						{
-							"code": "2024-8",
-							"display": "South Naknek",
-							"definition": "South Naknek"
-						},
-						{
-							"code": "2025-5",
-							"display": "Unalaska",
-							"definition": "Unalaska"
-						},
-						{
-							"code": "2026-3",
-							"display": "Unga",
-							"definition": "Unga"
-						}
-					]
-				},
-				{
-					"code": "2028-9",
-					"display": "Asian",
-					"definition": "Asian",
-					"concept": [
-						{
-							"code": "2029-7",
-							"display": "Asian Indian",
-							"definition": "Asian Indian"
-						},
-						{
-							"code": "2030-5",
-							"display": "Bangladeshi",
-							"definition": "Bangladeshi"
-						},
-						{
-							"code": "2031-3",
-							"display": "Bhutanese",
-							"definition": "Bhutanese"
-						},
-						{
-							"code": "2032-1",
-							"display": "Burmese",
-							"definition": "Burmese"
-						},
-						{
-							"code": "2033-9",
-							"display": "Cambodian",
-							"definition": "Cambodian"
-						},
-						{
-							"code": "2034-7",
-							"display": "Chinese",
-							"definition": "Chinese"
-						},
-						{
-							"code": "2035-4",
-							"display": "Taiwanese",
-							"definition": "Taiwanese"
-						},
-						{
-							"code": "2036-2",
-							"display": "Filipino",
-							"definition": "Filipino"
-						},
-						{
-							"code": "2037-0",
-							"display": "Hmong",
-							"definition": "Hmong"
-						},
-						{
-							"code": "2038-8",
-							"display": "Indonesian",
-							"definition": "Indonesian"
-						},
-						{
-							"code": "2039-6",
-							"display": "Japanese",
-							"definition": "Japanese"
-						},
-						{
-							"code": "2040-4",
-							"display": "Korean",
-							"definition": "Korean"
-						},
-						{
-							"code": "2041-2",
-							"display": "Laotian",
-							"definition": "Laotian"
-						},
-						{
-							"code": "2042-0",
-							"display": "Malaysian",
-							"definition": "Malaysian"
-						},
-						{
-							"code": "2043-8",
-							"display": "Okinawan",
-							"definition": "Okinawan"
-						},
-						{
-							"code": "2044-6",
-							"display": "Pakistani",
-							"definition": "Pakistani"
-						},
-						{
-							"code": "2045-3",
-							"display": "Sri Lankan",
-							"definition": "Sri Lankan"
-						},
-						{
-							"code": "2046-1",
-							"display": "Thai",
-							"definition": "Thai"
-						},
-						{
-							"code": "2047-9",
-							"display": "Vietnamese",
-							"definition": "Vietnamese"
-						},
-						{
-							"code": "2048-7",
-							"display": "Iwo Jiman",
-							"definition": "Iwo Jiman"
-						},
-						{
-							"code": "2049-5",
-							"display": "Maldivian",
-							"definition": "Maldivian"
-						},
-						{
-							"code": "2050-3",
-							"display": "Nepalese",
-							"definition": "Nepalese"
-						},
-						{
-							"code": "2051-1",
-							"display": "Singaporean",
-							"definition": "Singaporean"
-						},
-						{
-							"code": "2052-9",
-							"display": "Madagascar",
-							"definition": "Madagascar"
-						}
-					]
-				},
-				{
-					"code": "2054-5",
-					"display": "Black or African American",
-					"definition": "Black or African American",
-					"concept": [
-						{
-							"code": "2056-0",
-							"display": "Black",
-							"definition": "Black"
-						},
-						{
-							"code": "2058-6",
-							"display": "African American",
-							"definition": "African American"
-						},
-						{
-							"code": "2060-2",
-							"display": "African",
-							"definition": "African"
-						},
-						{
-							"code": "2067-7",
-							"display": "Bahamian",
-							"definition": "Bahamian"
-						},
-						{
-							"code": "2068-5",
-							"display": "Barbadian",
-							"definition": "Barbadian"
-						},
-						{
-							"code": "2069-3",
-							"display": "Dominican",
-							"definition": "Dominican"
-						},
-						{
-							"code": "2070-1",
-							"display": "Dominica Islander",
-							"definition": "Dominica Islander"
-						},
-						{
-							"code": "2071-9",
-							"display": "Haitian",
-							"definition": "Haitian"
-						},
-						{
-							"code": "2072-7",
-							"display": "Jamaican",
-							"definition": "Jamaican"
-						},
-						{
-							"code": "2073-5",
-							"display": "Tobagoan",
-							"definition": "Tobagoan"
-						},
-						{
-							"code": "2074-3",
-							"display": "Trinidadian",
-							"definition": "Trinidadian"
-						},
-						{
-							"code": "2075-0",
-							"display": "West Indian",
-							"definition": "West Indian"
-						},
-						{
-							"code": "2061-0",
-							"display": "Botswanan",
-							"definition": "Botswanan"
-						},
-						{
-							"code": "2062-8",
-							"display": "Ethiopian",
-							"definition": "Ethiopian"
-						},
-						{
-							"code": "2063-6",
-							"display": "Liberian",
-							"definition": "Liberian"
-						},
-						{
-							"code": "2064-4",
-							"display": "Namibian",
-							"definition": "Namibian"
-						},
-						{
-							"code": "2065-1",
-							"display": "Nigerian",
-							"definition": "Nigerian"
-						},
-						{
-							"code": "2066-9",
-							"display": "Zairean",
-							"definition": "Zairean"
-						}
-					]
-				},
-				{
-					"code": "2076-8",
-					"display": "Native Hawaiian or Other Pacific Islander",
-					"definition": "Native Hawaiian or Other Pacific Islander",
-					"concept": [
-						{
-							"code": "2078-4",
-							"display": "Polynesian",
-							"definition": "Polynesian"
-						},
-						{
-							"code": "2085-9",
-							"display": "Micronesian",
-							"definition": "Micronesian"
-						},
-						{
-							"code": "2100-6",
-							"display": "Melanesian",
-							"definition": "Melanesian"
-						},
-						{
-							"code": "2500-7",
-							"display": "Other Pacific Islander",
-							"definition": "Other Pacific Islander"
-						},
-						{
-							"code": "2079-2",
-							"display": "Native Hawaiian",
-							"definition": "Native Hawaiian"
-						},
-						{
-							"code": "2080-0",
-							"display": "Samoan",
-							"definition": "Samoan"
-						},
-						{
-							"code": "2081-8",
-							"display": "Tahitian",
-							"definition": "Tahitian"
-						},
-						{
-							"code": "2082-6",
-							"display": "Tongan",
-							"definition": "Tongan"
-						},
-						{
-							"code": "2083-4",
-							"display": "Tokelauan",
-							"definition": "Tokelauan"
-						},
-						{
-							"code": "2086-7",
-							"display": "Guamanian or Chamorro",
-							"definition": "Guamanian or Chamorro"
-						},
-						{
-							"code": "2087-5",
-							"display": "Guamanian",
-							"definition": "Guamanian"
-						},
-						{
-							"code": "2088-3",
-							"display": "Chamorro",
-							"definition": "Chamorro"
-						},
-						{
-							"code": "2089-1",
-							"display": "Mariana Islander",
-							"definition": "Mariana Islander"
-						},
-						{
-							"code": "2090-9",
-							"display": "Marshallese",
-							"definition": "Marshallese"
-						},
-						{
-							"code": "2091-7",
-							"display": "Palauan",
-							"definition": "Palauan"
-						},
-						{
-							"code": "2092-5",
-							"display": "Carolinian",
-							"definition": "Carolinian"
-						},
-						{
-							"code": "2093-3",
-							"display": "Kosraean",
-							"definition": "Kosraean"
-						},
-						{
-							"code": "2094-1",
-							"display": "Pohnpeian",
-							"definition": "Pohnpeian"
-						},
-						{
-							"code": "2095-8",
-							"display": "Saipanese",
-							"definition": "Saipanese"
-						},
-						{
-							"code": "2096-6",
-							"display": "Kiribati",
-							"definition": "Kiribati"
-						},
-						{
-							"code": "2097-4",
-							"display": "Chuukese",
-							"definition": "Chuukese"
-						},
-						{
-							"code": "2098-2",
-							"display": "Yapese",
-							"definition": "Yapese"
-						},
-						{
-							"code": "2101-4",
-							"display": "Fijian",
-							"definition": "Fijian"
-						},
-						{
-							"code": "2102-2",
-							"display": "Papua New Guinean",
-							"definition": "Papua New Guinean"
-						},
-						{
-							"code": "2103-0",
-							"display": "Solomon Islander",
-							"definition": "Solomon Islander"
-						},
-						{
-							"code": "2104-8",
-							"display": "New Hebrides",
-							"definition": "New Hebrides"
-						}
-					]
-				},
-				{
-					"code": "2106-3",
-					"display": "White",
-					"definition": "White",
-					"concept": [
-						{
-							"code": "2108-9",
-							"display": "European",
-							"definition": "European"
-						},
-						{
-							"code": "2118-8",
-							"display": "Middle Eastern or North African",
-							"definition": "Middle Eastern or North African"
-						},
-						{
-							"code": "2129-5",
-							"display": "Arab",
-							"definition": "Arab"
-						},
-						{
-							"code": "2109-7",
-							"display": "Armenian",
-							"definition": "Armenian"
-						},
-						{
-							"code": "2110-5",
-							"display": "English",
-							"definition": "English"
-						},
-						{
-							"code": "2111-3",
-							"display": "French",
-							"definition": "French"
-						},
-						{
-							"code": "2112-1",
-							"display": "German",
-							"definition": "German"
-						},
-						{
-							"code": "2113-9",
-							"display": "Irish",
-							"definition": "Irish"
-						},
-						{
-							"code": "2114-7",
-							"display": "Italian",
-							"definition": "Italian"
-						},
-						{
-							"code": "2115-4",
-							"display": "Polish",
-							"definition": "Polish"
-						},
-						{
-							"code": "2116-2",
-							"display": "Scottish",
-							"definition": "Scottish"
-						},
-						{
-							"code": "2119-6",
-							"display": "Assyrian",
-							"definition": "Assyrian"
-						},
-						{
-							"code": "2120-4",
-							"display": "Egyptian",
-							"definition": "Egyptian"
-						},
-						{
-							"code": "2121-2",
-							"display": "Iranian",
-							"definition": "Iranian"
-						},
-						{
-							"code": "2122-0",
-							"display": "Iraqi",
-							"definition": "Iraqi"
-						},
-						{
-							"code": "2123-8",
-							"display": "Lebanese",
-							"definition": "Lebanese"
-						},
-						{
-							"code": "2124-6",
-							"display": "Palestinian",
-							"definition": "Palestinian"
-						},
-						{
-							"code": "2125-3",
-							"display": "Syrian",
-							"definition": "Syrian"
-						},
-						{
-							"code": "2126-1",
-							"display": "Afghanistani",
-							"definition": "Afghanistani"
-						},
-						{
-							"code": "2127-9",
-							"display": "Israeili",
-							"definition": "Israeili"
-						}
-					]
-				},
-				{
-					"code": "2131-1",
-					"display": "Other Race",
-					"definition": "Note that this term remains in the table for completeness, even though within HL7, the notion of Other code is deprecated."
-				}
-			]
-		},
-		{
-			"code": "2133-7",
-			"display": "Ethnicity",
-			"definition": "Ethnicity Note that this is an abstract 'grouping' concept and not for use as a real concept",
-			"property": [
-				{
-					"code": "abstract",
-					"valueBoolean": true
-				}
-			],
-			"concept": [
-				{
-					"code": "2135-2",
-					"display": "Hispanic or Latino",
-					"definition": "Hispanic or Latino",
-					"concept": [
-						{
-							"code": "2137-8",
-							"display": "Spaniard",
-							"definition": "Spaniard"
-						},
-						{
-							"code": "2148-5",
-							"display": "Mexican",
-							"definition": "Mexican"
-						},
-						{
-							"code": "2155-0",
-							"display": "Central American",
-							"definition": "Central American"
-						},
-						{
-							"code": "2165-9",
-							"display": "South American",
-							"definition": "South American"
-						},
-						{
-							"code": "2178-2",
-							"display": "Latin American",
-							"definition": "Latin American"
-						},
-						{
-							"code": "2180-8",
-							"display": "Puerto Rican",
-							"definition": "Puerto Rican"
-						},
-						{
-							"code": "2182-4",
-							"display": "Cuban",
-							"definition": "Cuban"
-						},
-						{
-							"code": "2184-0",
-							"display": "Dominican",
-							"definition": "Dominican"
-						},
-						{
-							"code": "2138-6",
-							"display": "Andalusian",
-							"definition": "Andalusian"
-						},
-						{
-							"code": "2139-4",
-							"display": "Asturian",
-							"definition": "Asturian"
-						},
-						{
-							"code": "2140-2",
-							"display": "Castillian",
-							"definition": "Castillian"
-						},
-						{
-							"code": "2141-0",
-							"display": "Catalonian",
-							"definition": "Catalonian"
-						},
-						{
-							"code": "2142-8",
-							"display": "Belearic Islander",
-							"definition": "Belearic Islander"
-						},
-						{
-							"code": "2143-6",
-							"display": "Gallego",
-							"definition": "Gallego"
-						},
-						{
-							"code": "2144-4",
-							"display": "Valencian",
-							"definition": "Valencian"
-						},
-						{
-							"code": "2145-1",
-							"display": "Canarian",
-							"definition": "Canarian"
-						},
-						{
-							"code": "2146-9",
-							"display": "Spanish Basque",
-							"definition": "Spanish Basque"
-						},
-						{
-							"code": "2149-3",
-							"display": "Mexican American",
-							"definition": "Mexican American"
-						},
-						{
-							"code": "2150-1",
-							"display": "Mexicano",
-							"definition": "Mexicano"
-						},
-						{
-							"code": "2151-9",
-							"display": "Chicano",
-							"definition": "Chicano"
-						},
-						{
-							"code": "2152-7",
-							"display": "La Raza",
-							"definition": "La Raza"
-						},
-						{
-							"code": "2153-5",
-							"display": "Mexican American Indian",
-							"definition": "Mexican American Indian"
-						},
-						{
-							"code": "2156-8",
-							"display": "Costa Rican",
-							"definition": "Costa Rican"
-						},
-						{
-							"code": "2157-6",
-							"display": "Guatemalan",
-							"definition": "Guatemalan"
-						},
-						{
-							"code": "2158-4",
-							"display": "Honduran",
-							"definition": "Honduran"
-						},
-						{
-							"code": "2159-2",
-							"display": "Nicaraguan",
-							"definition": "Nicaraguan"
-						},
-						{
-							"code": "2160-0",
-							"display": "Panamanian",
-							"definition": "Panamanian"
-						},
-						{
-							"code": "2161-8",
-							"display": "Salvadoran",
-							"definition": "Salvadoran"
-						},
-						{
-							"code": "2162-6",
-							"display": "Central American Indian",
-							"definition": "Central American Indian"
-						},
-						{
-							"code": "2163-4",
-							"display": "Canal Zone",
-							"definition": "Canal Zone"
-						},
-						{
-							"code": "2166-7",
-							"display": "Argentinean",
-							"definition": "Argentinean"
-						},
-						{
-							"code": "2167-5",
-							"display": "Bolivian",
-							"definition": "Bolivian"
-						},
-						{
-							"code": "2168-3",
-							"display": "Chilean",
-							"definition": "Chilean"
-						},
-						{
-							"code": "2169-1",
-							"display": "Colombian",
-							"definition": "Colombian"
-						},
-						{
-							"code": "2170-9",
-							"display": "Ecuadorian",
-							"definition": "Ecuadorian"
-						},
-						{
-							"code": "2171-7",
-							"display": "Paraguayan",
-							"definition": "Paraguayan"
-						},
-						{
-							"code": "2172-5",
-							"display": "Peruvian",
-							"definition": "Peruvian"
-						},
-						{
-							"code": "2173-3",
-							"display": "Uruguayan",
-							"definition": "Uruguayan"
-						},
-						{
-							"code": "2174-1",
-							"display": "Venezuelan",
-							"definition": "Venezuelan"
-						},
-						{
-							"code": "2175-8",
-							"display": "South American Indian",
-							"definition": "South American Indian"
-						},
-						{
-							"code": "2176-6",
-							"display": "Criollo",
-							"definition": "Criollo"
-						}
-					]
-				},
-				{
-					"code": "2186-5",
-					"display": "Not Hispanic or Latino",
-					"definition": "Note that this term remains in the table for completeness, even though within HL7, the notion of \"not otherwise coded\" term is deprecated."
-				}
-			]
-		}
-	]
+    "resourceType": "CodeSystem",
+    "id": "cdcrec",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "urn:oid:2.16.840.1.113883.6.238",
+    "identifier": [
+        {
+            "value": "2.16.840.1.113883.6.238"
+        }
+    ],
+    "version": "4.0.0",
+    "name": "RaceAndEthnicityCDC",
+    "title": "Race & Ethnicity - CDC",
+    "status": "active",
+    "experimental": false,
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The U.S. Centers for Disease Control and Prevention (CDC) has prepared a code set for use in codingrace and ethnicity data. This code set is based on current federal standards for classifying data onrace and ethnicity, specifically the minimum race and ethnicity categories defined by the U.S. Office ofManagement and Budget (OMB) and a more detailed set of race and ethnicity categories maintainedby the U.S. Bureau of the Census (BC). The main purpose of the code set is to facilitate use of federalstandards for classifying data on race and ethnicity when these data are exchanged, stored, retrieved,or analyzed in electronic form. At the same time, the code set can be applied to paper-based recordsystems to the extent that these systems are used to collect, maintain, and report data on race andethnicity in accordance with current federal standards. Source: [Race and Ethnicity Code Set Version 1.0](https://www.cdc.gov/phin/resources/vocabulary/documents/cdc-race--ethnicity-background-and-purpose.pdf).",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "caseSensitive": true,
+    "hierarchyMeaning": "is-a",
+    "content": "complete",
+    "count": 966,
+    "property": [
+        {
+            "code": "abstract",
+            "description": "True if an element is considered 'abstract' - in other words, the code is not for use as a real concept",
+            "type": "boolean"
+        }
+    ],
+    "concept": [
+        {
+            "code": "1000-9",
+            "display": "Race",
+            "definition": "Race, Note that this is an abstract 'grouping' concept and not for use as a real concept",
+            "property": [
+                {
+                    "code": "abstract",
+                    "valueBoolean": true
+                }
+            ],
+            "concept": [
+                {
+                    "code": "1002-5",
+                    "display": "American Indian or Alaska Native",
+                    "definition": "American Indian or Alaska Native",
+                    "concept": [
+                        {
+                            "code": "1004-1",
+                            "display": "American Indian",
+                            "definition": "American Indian"
+                        },
+                        {
+                            "code": "1735-0",
+                            "display": "Alaska Native",
+                            "definition": "Alaska Native"
+                        },
+                        {
+                            "code": "1006-6",
+                            "display": "Abenaki",
+                            "definition": "Abenaki"
+                        },
+                        {
+                            "code": "1008-2",
+                            "display": "Algonquian",
+                            "definition": "Algonquian"
+                        },
+                        {
+                            "code": "1010-8",
+                            "display": "Apache",
+                            "definition": "Apache"
+                        },
+                        {
+                            "code": "1021-5",
+                            "display": "Arapaho",
+                            "definition": "Arapaho"
+                        },
+                        {
+                            "code": "1026-4",
+                            "display": "Arikara",
+                            "definition": "Arikara"
+                        },
+                        {
+                            "code": "1028-0",
+                            "display": "Assiniboine",
+                            "definition": "Assiniboine"
+                        },
+                        {
+                            "code": "1030-6",
+                            "display": "Assiniboine Sioux",
+                            "definition": "Assiniboine Sioux"
+                        },
+                        {
+                            "code": "1033-0",
+                            "display": "Bannock",
+                            "definition": "Bannock"
+                        },
+                        {
+                            "code": "1035-5",
+                            "display": "Blackfeet",
+                            "definition": "Blackfeet"
+                        },
+                        {
+                            "code": "1037-1",
+                            "display": "Brotherton",
+                            "definition": "Brotherton"
+                        },
+                        {
+                            "code": "1039-7",
+                            "display": "Burt Lake Band",
+                            "definition": "Burt Lake Band"
+                        },
+                        {
+                            "code": "1041-3",
+                            "display": "Caddo",
+                            "definition": "Caddo"
+                        },
+                        {
+                            "code": "1044-7",
+                            "display": "Cahuilla",
+                            "definition": "Cahuilla"
+                        },
+                        {
+                            "code": "1053-8",
+                            "display": "California Tribes",
+                            "definition": "California Tribes"
+                        },
+                        {
+                            "code": "1068-6",
+                            "display": "Canadian and Latin American Indian",
+                            "definition": "Canadian and Latin American Indian"
+                        },
+                        {
+                            "code": "1076-9",
+                            "display": "Catawba",
+                            "definition": "Catawba"
+                        },
+                        {
+                            "code": "1078-5",
+                            "display": "Cayuse",
+                            "definition": "Cayuse"
+                        },
+                        {
+                            "code": "1080-1",
+                            "display": "Chehalis",
+                            "definition": "Chehalis"
+                        },
+                        {
+                            "code": "1082-7",
+                            "display": "Chemakuan",
+                            "definition": "Chemakuan"
+                        },
+                        {
+                            "code": "1086-8",
+                            "display": "Chemehuevi",
+                            "definition": "Chemehuevi"
+                        },
+                        {
+                            "code": "1088-4",
+                            "display": "Cherokee",
+                            "definition": "Cherokee"
+                        },
+                        {
+                            "code": "1100-7",
+                            "display": "Cherokee Shawnee",
+                            "definition": "Cherokee Shawnee"
+                        },
+                        {
+                            "code": "1102-3",
+                            "display": "Cheyenne",
+                            "definition": "Cheyenne"
+                        },
+                        {
+                            "code": "1106-4",
+                            "display": "Cheyenne-Arapaho",
+                            "definition": "Cheyenne-Arapaho"
+                        },
+                        {
+                            "code": "1108-0",
+                            "display": "Chickahominy",
+                            "definition": "Chickahominy"
+                        },
+                        {
+                            "code": "1112-2",
+                            "display": "Chickasaw",
+                            "definition": "Chickasaw"
+                        },
+                        {
+                            "code": "1114-8",
+                            "display": "Chinook",
+                            "definition": "Chinook"
+                        },
+                        {
+                            "code": "1123-9",
+                            "display": "Chippewa",
+                            "definition": "Chippewa"
+                        },
+                        {
+                            "code": "1150-2",
+                            "display": "Chippewa Cree",
+                            "definition": "Chippewa Cree"
+                        },
+                        {
+                            "code": "1153-6",
+                            "display": "Chitimacha",
+                            "definition": "Chitimacha"
+                        },
+                        {
+                            "code": "1155-1",
+                            "display": "Choctaw",
+                            "definition": "Choctaw"
+                        },
+                        {
+                            "code": "1162-7",
+                            "display": "Chumash",
+                            "definition": "Chumash"
+                        },
+                        {
+                            "code": "1165-0",
+                            "display": "Clear Lake",
+                            "definition": "Clear Lake"
+                        },
+                        {
+                            "code": "1167-6",
+                            "display": "Coeur D'Alene",
+                            "definition": "Coeur D'Alene"
+                        },
+                        {
+                            "code": "1169-2",
+                            "display": "Coharie",
+                            "definition": "Coharie"
+                        },
+                        {
+                            "code": "1171-8",
+                            "display": "Colorado River",
+                            "definition": "Colorado River"
+                        },
+                        {
+                            "code": "1173-4",
+                            "display": "Colville",
+                            "definition": "Colville"
+                        },
+                        {
+                            "code": "1175-9",
+                            "display": "Comanche",
+                            "definition": "Comanche"
+                        },
+                        {
+                            "code": "1178-3",
+                            "display": "Coos, Lower Umpqua, Siuslaw",
+                            "definition": "Coos, Lower Umpqua, Siuslaw"
+                        },
+                        {
+                            "code": "1180-9",
+                            "display": "Coos",
+                            "definition": "Coos"
+                        },
+                        {
+                            "code": "1182-5",
+                            "display": "Coquilles",
+                            "definition": "Coquilles"
+                        },
+                        {
+                            "code": "1184-1",
+                            "display": "Costanoan",
+                            "definition": "Costanoan"
+                        },
+                        {
+                            "code": "1186-6",
+                            "display": "Coushatta",
+                            "definition": "Coushatta"
+                        },
+                        {
+                            "code": "1189-0",
+                            "display": "Cowlitz",
+                            "definition": "Cowlitz"
+                        },
+                        {
+                            "code": "1191-6",
+                            "display": "Cree",
+                            "definition": "Cree"
+                        },
+                        {
+                            "code": "1193-2",
+                            "display": "Creek",
+                            "definition": "Creek"
+                        },
+                        {
+                            "code": "1207-0",
+                            "display": "Croatan",
+                            "definition": "Croatan"
+                        },
+                        {
+                            "code": "1209-6",
+                            "display": "Crow",
+                            "definition": "Crow"
+                        },
+                        {
+                            "code": "1211-2",
+                            "display": "Cupeno",
+                            "definition": "Cupeno"
+                        },
+                        {
+                            "code": "1214-6",
+                            "display": "Delaware",
+                            "definition": "Delaware"
+                        },
+                        {
+                            "code": "1222-9",
+                            "display": "Diegueno",
+                            "definition": "Diegueno"
+                        },
+                        {
+                            "code": "1233-6",
+                            "display": "Eastern Tribes",
+                            "definition": "Eastern Tribes"
+                        },
+                        {
+                            "code": "1250-0",
+                            "display": "Esselen",
+                            "definition": "Esselen"
+                        },
+                        {
+                            "code": "1252-6",
+                            "display": "Fort Belknap",
+                            "definition": "Fort Belknap"
+                        },
+                        {
+                            "code": "1254-2",
+                            "display": "Fort Berthold",
+                            "definition": "Fort Berthold"
+                        },
+                        {
+                            "code": "1256-7",
+                            "display": "Fort Mcdowell",
+                            "definition": "Fort Mcdowell"
+                        },
+                        {
+                            "code": "1258-3",
+                            "display": "Fort Hall",
+                            "definition": "Fort Hall"
+                        },
+                        {
+                            "code": "1260-9",
+                            "display": "Gabrieleno",
+                            "definition": "Gabrieleno"
+                        },
+                        {
+                            "code": "1262-5",
+                            "display": "Grand Ronde",
+                            "definition": "Grand Ronde"
+                        },
+                        {
+                            "code": "1264-1",
+                            "display": "Gros Ventres",
+                            "definition": "Gros Ventres"
+                        },
+                        {
+                            "code": "1267-4",
+                            "display": "Haliwa",
+                            "definition": "Haliwa"
+                        },
+                        {
+                            "code": "1269-0",
+                            "display": "Hidatsa",
+                            "definition": "Hidatsa"
+                        },
+                        {
+                            "code": "1271-6",
+                            "display": "Hoopa",
+                            "definition": "Hoopa"
+                        },
+                        {
+                            "code": "1275-7",
+                            "display": "Hoopa Extension",
+                            "definition": "Hoopa Extension"
+                        },
+                        {
+                            "code": "1277-3",
+                            "display": "Houma",
+                            "definition": "Houma"
+                        },
+                        {
+                            "code": "1279-9",
+                            "display": "Inaja-Cosmit",
+                            "definition": "Inaja-Cosmit"
+                        },
+                        {
+                            "code": "1281-5",
+                            "display": "Iowa",
+                            "definition": "Iowa"
+                        },
+                        {
+                            "code": "1285-6",
+                            "display": "Iroquois",
+                            "definition": "Iroquois"
+                        },
+                        {
+                            "code": "1297-1",
+                            "display": "Juaneno",
+                            "definition": "Juaneno"
+                        },
+                        {
+                            "code": "1299-7",
+                            "display": "Kalispel",
+                            "definition": "Kalispel"
+                        },
+                        {
+                            "code": "1301-1",
+                            "display": "Karuk",
+                            "definition": "Karuk"
+                        },
+                        {
+                            "code": "1303-7",
+                            "display": "Kaw",
+                            "definition": "Kaw"
+                        },
+                        {
+                            "code": "1305-2",
+                            "display": "Kickapoo",
+                            "definition": "Kickapoo"
+                        },
+                        {
+                            "code": "1309-4",
+                            "display": "Kiowa",
+                            "definition": "Kiowa"
+                        },
+                        {
+                            "code": "1312-8",
+                            "display": "Klallam",
+                            "definition": "Klallam"
+                        },
+                        {
+                            "code": "1317-7",
+                            "display": "Klamath",
+                            "definition": "Klamath"
+                        },
+                        {
+                            "code": "1319-3",
+                            "display": "Konkow",
+                            "definition": "Konkow"
+                        },
+                        {
+                            "code": "1321-9",
+                            "display": "Kootenai",
+                            "definition": "Kootenai"
+                        },
+                        {
+                            "code": "1323-5",
+                            "display": "Lassik",
+                            "definition": "Lassik"
+                        },
+                        {
+                            "code": "1325-0",
+                            "display": "Long Island",
+                            "definition": "Long Island"
+                        },
+                        {
+                            "code": "1331-8",
+                            "display": "Luiseno",
+                            "definition": "Luiseno"
+                        },
+                        {
+                            "code": "1340-9",
+                            "display": "Lumbee",
+                            "definition": "Lumbee"
+                        },
+                        {
+                            "code": "1342-5",
+                            "display": "Lummi",
+                            "definition": "Lummi"
+                        },
+                        {
+                            "code": "1344-1",
+                            "display": "Maidu",
+                            "definition": "Maidu"
+                        },
+                        {
+                            "code": "1348-2",
+                            "display": "Makah",
+                            "definition": "Makah"
+                        },
+                        {
+                            "code": "1350-8",
+                            "display": "Maliseet",
+                            "definition": "Maliseet"
+                        },
+                        {
+                            "code": "1352-4",
+                            "display": "Mandan",
+                            "definition": "Mandan"
+                        },
+                        {
+                            "code": "1354-0",
+                            "display": "Mattaponi",
+                            "definition": "Mattaponi"
+                        },
+                        {
+                            "code": "1356-5",
+                            "display": "Menominee",
+                            "definition": "Menominee"
+                        },
+                        {
+                            "code": "1358-1",
+                            "display": "Miami",
+                            "definition": "Miami"
+                        },
+                        {
+                            "code": "1363-1",
+                            "display": "Miccosukee",
+                            "definition": "Miccosukee"
+                        },
+                        {
+                            "code": "1365-6",
+                            "display": "Micmac",
+                            "definition": "Micmac"
+                        },
+                        {
+                            "code": "1368-0",
+                            "display": "Mission Indians",
+                            "definition": "Mission Indians"
+                        },
+                        {
+                            "code": "1370-6",
+                            "display": "Miwok",
+                            "definition": "Miwok"
+                        },
+                        {
+                            "code": "1372-2",
+                            "display": "Modoc",
+                            "definition": "Modoc"
+                        },
+                        {
+                            "code": "1374-8",
+                            "display": "Mohegan",
+                            "definition": "Mohegan"
+                        },
+                        {
+                            "code": "1376-3",
+                            "display": "Mono",
+                            "definition": "Mono"
+                        },
+                        {
+                            "code": "1378-9",
+                            "display": "Nanticoke",
+                            "definition": "Nanticoke"
+                        },
+                        {
+                            "code": "1380-5",
+                            "display": "Narragansett",
+                            "definition": "Narragansett"
+                        },
+                        {
+                            "code": "1382-1",
+                            "display": "Navajo",
+                            "definition": "Navajo"
+                        },
+                        {
+                            "code": "1387-0",
+                            "display": "Nez Perce",
+                            "definition": "Nez Perce"
+                        },
+                        {
+                            "code": "1389-6",
+                            "display": "Nomalaki",
+                            "definition": "Nomalaki"
+                        },
+                        {
+                            "code": "1391-2",
+                            "display": "Northwest Tribes",
+                            "definition": "Northwest Tribes"
+                        },
+                        {
+                            "code": "1403-5",
+                            "display": "Omaha",
+                            "definition": "Omaha"
+                        },
+                        {
+                            "code": "1405-0",
+                            "display": "Oregon Athabaskan",
+                            "definition": "Oregon Athabaskan"
+                        },
+                        {
+                            "code": "1407-6",
+                            "display": "Osage",
+                            "definition": "Osage"
+                        },
+                        {
+                            "code": "1409-2",
+                            "display": "Otoe-Missouria",
+                            "definition": "Otoe-Missouria"
+                        },
+                        {
+                            "code": "1411-8",
+                            "display": "Ottawa",
+                            "definition": "Ottawa"
+                        },
+                        {
+                            "code": "1416-7",
+                            "display": "Paiute",
+                            "definition": "Paiute"
+                        },
+                        {
+                            "code": "1439-9",
+                            "display": "Pamunkey",
+                            "definition": "Pamunkey"
+                        },
+                        {
+                            "code": "1441-5",
+                            "display": "Passamaquoddy",
+                            "definition": "Passamaquoddy"
+                        },
+                        {
+                            "code": "1445-6",
+                            "display": "Pawnee",
+                            "definition": "Pawnee"
+                        },
+                        {
+                            "code": "1448-0",
+                            "display": "Penobscot",
+                            "definition": "Penobscot"
+                        },
+                        {
+                            "code": "1450-6",
+                            "display": "Peoria",
+                            "definition": "Peoria"
+                        },
+                        {
+                            "code": "1453-0",
+                            "display": "Pequot",
+                            "definition": "Pequot"
+                        },
+                        {
+                            "code": "1456-3",
+                            "display": "Pima",
+                            "definition": "Pima"
+                        },
+                        {
+                            "code": "1460-5",
+                            "display": "Piscataway",
+                            "definition": "Piscataway"
+                        },
+                        {
+                            "code": "1462-1",
+                            "display": "Pit River",
+                            "definition": "Pit River"
+                        },
+                        {
+                            "code": "1464-7",
+                            "display": "Pomo",
+                            "definition": "Pomo"
+                        },
+                        {
+                            "code": "1474-6",
+                            "display": "Ponca",
+                            "definition": "Ponca"
+                        },
+                        {
+                            "code": "1478-7",
+                            "display": "Potawatomi",
+                            "definition": "Potawatomi"
+                        },
+                        {
+                            "code": "1487-8",
+                            "display": "Powhatan",
+                            "definition": "Powhatan"
+                        },
+                        {
+                            "code": "1489-4",
+                            "display": "Pueblo",
+                            "definition": "Pueblo"
+                        },
+                        {
+                            "code": "1518-0",
+                            "display": "Puget Sound Salish",
+                            "definition": "Puget Sound Salish"
+                        },
+                        {
+                            "code": "1541-2",
+                            "display": "Quapaw",
+                            "definition": "Quapaw"
+                        },
+                        {
+                            "code": "1543-8",
+                            "display": "Quinault",
+                            "definition": "Quinault"
+                        },
+                        {
+                            "code": "1545-3",
+                            "display": "Rappahannock",
+                            "definition": "Rappahannock"
+                        },
+                        {
+                            "code": "1547-9",
+                            "display": "Reno-Sparks",
+                            "definition": "Reno-Sparks"
+                        },
+                        {
+                            "code": "1549-5",
+                            "display": "Round Valley",
+                            "definition": "Round Valley"
+                        },
+                        {
+                            "code": "1551-1",
+                            "display": "Sac and Fox",
+                            "definition": "Sac and Fox"
+                        },
+                        {
+                            "code": "1556-0",
+                            "display": "Salinan",
+                            "definition": "Salinan"
+                        },
+                        {
+                            "code": "1558-6",
+                            "display": "Salish",
+                            "definition": "Salish"
+                        },
+                        {
+                            "code": "1560-2",
+                            "display": "Salish and Kootenai",
+                            "definition": "Salish and Kootenai"
+                        },
+                        {
+                            "code": "1562-8",
+                            "display": "Schaghticoke",
+                            "definition": "Schaghticoke"
+                        },
+                        {
+                            "code": "1564-4",
+                            "display": "Scott Valley",
+                            "definition": "Scott Valley"
+                        },
+                        {
+                            "code": "1566-9",
+                            "display": "Seminole",
+                            "definition": "Seminole"
+                        },
+                        {
+                            "code": "1573-5",
+                            "display": "Serrano",
+                            "definition": "Serrano"
+                        },
+                        {
+                            "code": "1576-8",
+                            "display": "Shasta",
+                            "definition": "Shasta"
+                        },
+                        {
+                            "code": "1578-4",
+                            "display": "Shawnee",
+                            "definition": "Shawnee"
+                        },
+                        {
+                            "code": "1582-6",
+                            "display": "Shinnecock",
+                            "definition": "Shinnecock"
+                        },
+                        {
+                            "code": "1584-2",
+                            "display": "Shoalwater Bay",
+                            "definition": "Shoalwater Bay"
+                        },
+                        {
+                            "code": "1586-7",
+                            "display": "Shoshone",
+                            "definition": "Shoshone"
+                        },
+                        {
+                            "code": "1602-2",
+                            "display": "Shoshone Paiute",
+                            "definition": "Shoshone Paiute"
+                        },
+                        {
+                            "code": "1607-1",
+                            "display": "Siletz",
+                            "definition": "Siletz"
+                        },
+                        {
+                            "code": "1609-7",
+                            "display": "Sioux",
+                            "definition": "Sioux"
+                        },
+                        {
+                            "code": "1643-6",
+                            "display": "Siuslaw",
+                            "definition": "Siuslaw"
+                        },
+                        {
+                            "code": "1645-1",
+                            "display": "Spokane",
+                            "definition": "Spokane"
+                        },
+                        {
+                            "code": "1647-7",
+                            "display": "Stewart",
+                            "definition": "Stewart"
+                        },
+                        {
+                            "code": "1649-3",
+                            "display": "Stockbridge",
+                            "definition": "Stockbridge"
+                        },
+                        {
+                            "code": "1651-9",
+                            "display": "Susanville",
+                            "definition": "Susanville"
+                        },
+                        {
+                            "code": "1653-5",
+                            "display": "Tohono O'Odham",
+                            "definition": "Tohono O'Odham"
+                        },
+                        {
+                            "code": "1659-2",
+                            "display": "Tolowa",
+                            "definition": "Tolowa"
+                        },
+                        {
+                            "code": "1661-8",
+                            "display": "Tonkawa",
+                            "definition": "Tonkawa"
+                        },
+                        {
+                            "code": "1663-4",
+                            "display": "Tygh",
+                            "definition": "Tygh"
+                        },
+                        {
+                            "code": "1665-9",
+                            "display": "Umatilla",
+                            "definition": "Umatilla"
+                        },
+                        {
+                            "code": "1667-5",
+                            "display": "Umpqua",
+                            "definition": "Umpqua"
+                        },
+                        {
+                            "code": "1670-9",
+                            "display": "Ute",
+                            "definition": "Ute"
+                        },
+                        {
+                            "code": "1675-8",
+                            "display": "Wailaki",
+                            "definition": "Wailaki"
+                        },
+                        {
+                            "code": "1677-4",
+                            "display": "Walla-Walla",
+                            "definition": "Walla-Walla"
+                        },
+                        {
+                            "code": "1679-0",
+                            "display": "Wampanoag",
+                            "definition": "Wampanoag"
+                        },
+                        {
+                            "code": "1683-2",
+                            "display": "Warm Springs",
+                            "definition": "Warm Springs"
+                        },
+                        {
+                            "code": "1685-7",
+                            "display": "Wascopum",
+                            "definition": "Wascopum"
+                        },
+                        {
+                            "code": "1687-3",
+                            "display": "Washoe",
+                            "definition": "Washoe"
+                        },
+                        {
+                            "code": "1692-3",
+                            "display": "Wichita",
+                            "definition": "Wichita"
+                        },
+                        {
+                            "code": "1694-9",
+                            "display": "Wind River",
+                            "definition": "Wind River"
+                        },
+                        {
+                            "code": "1696-4",
+                            "display": "Winnebago",
+                            "definition": "Winnebago"
+                        },
+                        {
+                            "code": "1700-4",
+                            "display": "Winnemucca",
+                            "definition": "Winnemucca"
+                        },
+                        {
+                            "code": "1702-0",
+                            "display": "Wintun",
+                            "definition": "Wintun"
+                        },
+                        {
+                            "code": "1704-6",
+                            "display": "Wiyot",
+                            "definition": "Wiyot"
+                        },
+                        {
+                            "code": "1707-9",
+                            "display": "Yakama",
+                            "definition": "Yakama"
+                        },
+                        {
+                            "code": "1709-5",
+                            "display": "Yakama Cowlitz",
+                            "definition": "Yakama Cowlitz"
+                        },
+                        {
+                            "code": "1711-1",
+                            "display": "Yaqui",
+                            "definition": "Yaqui"
+                        },
+                        {
+                            "code": "1715-2",
+                            "display": "Yavapai Apache",
+                            "definition": "Yavapai Apache"
+                        },
+                        {
+                            "code": "1717-8",
+                            "display": "Yokuts",
+                            "definition": "Yokuts"
+                        },
+                        {
+                            "code": "1722-8",
+                            "display": "Yuchi",
+                            "definition": "Yuchi"
+                        },
+                        {
+                            "code": "1724-4",
+                            "display": "Yuman",
+                            "definition": "Yuman"
+                        },
+                        {
+                            "code": "1732-7",
+                            "display": "Yurok",
+                            "definition": "Yurok"
+                        },
+                        {
+                            "code": "1011-6",
+                            "display": "Chiricahua",
+                            "definition": "Chiricahua"
+                        },
+                        {
+                            "code": "1012-4",
+                            "display": "Fort Sill Apache",
+                            "definition": "Fort Sill Apache"
+                        },
+                        {
+                            "code": "1013-2",
+                            "display": "Jicarilla Apache",
+                            "definition": "Jicarilla Apache"
+                        },
+                        {
+                            "code": "1014-0",
+                            "display": "Lipan Apache",
+                            "definition": "Lipan Apache"
+                        },
+                        {
+                            "code": "1015-7",
+                            "display": "Mescalero Apache",
+                            "definition": "Mescalero Apache"
+                        },
+                        {
+                            "code": "1016-5",
+                            "display": "Oklahoma Apache",
+                            "definition": "Oklahoma Apache"
+                        },
+                        {
+                            "code": "1017-3",
+                            "display": "Payson Apache",
+                            "definition": "Payson Apache"
+                        },
+                        {
+                            "code": "1018-1",
+                            "display": "San Carlos Apache",
+                            "definition": "San Carlos Apache"
+                        },
+                        {
+                            "code": "1019-9",
+                            "display": "White Mountain Apache",
+                            "definition": "White Mountain Apache"
+                        },
+                        {
+                            "code": "1022-3",
+                            "display": "Northern Arapaho",
+                            "definition": "Northern Arapaho"
+                        },
+                        {
+                            "code": "1023-1",
+                            "display": "Southern Arapaho",
+                            "definition": "Southern Arapaho"
+                        },
+                        {
+                            "code": "1024-9",
+                            "display": "Wind River Arapaho",
+                            "definition": "Wind River Arapaho"
+                        },
+                        {
+                            "code": "1031-4",
+                            "display": "Fort Peck Assiniboine Sioux",
+                            "definition": "Fort Peck Assiniboine Sioux"
+                        },
+                        {
+                            "code": "1042-1",
+                            "display": "Oklahoma Cado",
+                            "definition": "Oklahoma Cado"
+                        },
+                        {
+                            "code": "1045-4",
+                            "display": "Agua Caliente Cahuilla",
+                            "definition": "Agua Caliente Cahuilla"
+                        },
+                        {
+                            "code": "1046-2",
+                            "display": "Augustine",
+                            "definition": "Augustine"
+                        },
+                        {
+                            "code": "1047-0",
+                            "display": "Cabazon",
+                            "definition": "Cabazon"
+                        },
+                        {
+                            "code": "1048-8",
+                            "display": "Los Coyotes",
+                            "definition": "Los Coyotes"
+                        },
+                        {
+                            "code": "1049-6",
+                            "display": "Morongo",
+                            "definition": "Morongo"
+                        },
+                        {
+                            "code": "1050-4",
+                            "display": "Santa Rosa Cahuilla",
+                            "definition": "Santa Rosa Cahuilla"
+                        },
+                        {
+                            "code": "1051-2",
+                            "display": "Torres-Martinez",
+                            "definition": "Torres-Martinez"
+                        },
+                        {
+                            "code": "1054-6",
+                            "display": "Cahto",
+                            "definition": "Cahto"
+                        },
+                        {
+                            "code": "1055-3",
+                            "display": "Chimariko",
+                            "definition": "Chimariko"
+                        },
+                        {
+                            "code": "1056-1",
+                            "display": "Coast Miwok",
+                            "definition": "Coast Miwok"
+                        },
+                        {
+                            "code": "1057-9",
+                            "display": "Digger",
+                            "definition": "Digger"
+                        },
+                        {
+                            "code": "1058-7",
+                            "display": "Kawaiisu",
+                            "definition": "Kawaiisu"
+                        },
+                        {
+                            "code": "1059-5",
+                            "display": "Kern River",
+                            "definition": "Kern River"
+                        },
+                        {
+                            "code": "1060-3",
+                            "display": "Mattole",
+                            "definition": "Mattole"
+                        },
+                        {
+                            "code": "1061-1",
+                            "display": "Red Wood",
+                            "definition": "Red Wood"
+                        },
+                        {
+                            "code": "1062-9",
+                            "display": "Santa Rosa",
+                            "definition": "Santa Rosa"
+                        },
+                        {
+                            "code": "1063-7",
+                            "display": "Takelma",
+                            "definition": "Takelma"
+                        },
+                        {
+                            "code": "1064-5",
+                            "display": "Wappo",
+                            "definition": "Wappo"
+                        },
+                        {
+                            "code": "1065-2",
+                            "display": "Yana",
+                            "definition": "Yana"
+                        },
+                        {
+                            "code": "1066-0",
+                            "display": "Yuki",
+                            "definition": "Yuki"
+                        },
+                        {
+                            "code": "1069-4",
+                            "display": "Canadian Indian",
+                            "definition": "Canadian Indian"
+                        },
+                        {
+                            "code": "1070-2",
+                            "display": "Central American Indian",
+                            "definition": "Central American Indian"
+                        },
+                        {
+                            "code": "1071-0",
+                            "display": "French American Indian",
+                            "definition": "French American Indian"
+                        },
+                        {
+                            "code": "1072-8",
+                            "display": "Mexican American Indian",
+                            "definition": "Mexican American Indian"
+                        },
+                        {
+                            "code": "1073-6",
+                            "display": "South American Indian",
+                            "definition": "South American Indian"
+                        },
+                        {
+                            "code": "1074-4",
+                            "display": "Spanish American Indian",
+                            "definition": "Spanish American Indian"
+                        },
+                        {
+                            "code": "1083-5",
+                            "display": "Hoh",
+                            "definition": "Hoh"
+                        },
+                        {
+                            "code": "1084-3",
+                            "display": "Quileute",
+                            "definition": "Quileute"
+                        },
+                        {
+                            "code": "1089-2",
+                            "display": "Cherokee Alabama",
+                            "definition": "Cherokee Alabama"
+                        },
+                        {
+                            "code": "1090-0",
+                            "display": "Cherokees of Northeast Alabama",
+                            "definition": "Cherokees of Northeast Alabama"
+                        },
+                        {
+                            "code": "1091-8",
+                            "display": "Cherokees of Southeast Alabama",
+                            "definition": "Cherokees of Southeast Alabama"
+                        },
+                        {
+                            "code": "1092-6",
+                            "display": "Eastern Cherokee",
+                            "definition": "Eastern Cherokee"
+                        },
+                        {
+                            "code": "1093-4",
+                            "display": "Echota Cherokee",
+                            "definition": "Echota Cherokee"
+                        },
+                        {
+                            "code": "1094-2",
+                            "display": "Etowah Cherokee",
+                            "definition": "Etowah Cherokee"
+                        },
+                        {
+                            "code": "1095-9",
+                            "display": "Northern Cherokee",
+                            "definition": "Northern Cherokee"
+                        },
+                        {
+                            "code": "1096-7",
+                            "display": "Tuscola",
+                            "definition": "Tuscola"
+                        },
+                        {
+                            "code": "1097-5",
+                            "display": "United Keetowah Band of Cherokee",
+                            "definition": "United Keetowah Band of Cherokee"
+                        },
+                        {
+                            "code": "1098-3",
+                            "display": "Western Cherokee",
+                            "definition": "Western Cherokee"
+                        },
+                        {
+                            "code": "1103-1",
+                            "display": "Northern Cheyenne",
+                            "definition": "Northern Cheyenne"
+                        },
+                        {
+                            "code": "1104-9",
+                            "display": "Southern Cheyenne",
+                            "definition": "Southern Cheyenne"
+                        },
+                        {
+                            "code": "1109-8",
+                            "display": "Eastern Chickahominy",
+                            "definition": "Eastern Chickahominy"
+                        },
+                        {
+                            "code": "1110-6",
+                            "display": "Western Chickahominy",
+                            "definition": "Western Chickahominy"
+                        },
+                        {
+                            "code": "1115-5",
+                            "display": "Clatsop",
+                            "definition": "Clatsop"
+                        },
+                        {
+                            "code": "1116-3",
+                            "display": "Columbia River Chinook",
+                            "definition": "Columbia River Chinook"
+                        },
+                        {
+                            "code": "1117-1",
+                            "display": "Kathlamet",
+                            "definition": "Kathlamet"
+                        },
+                        {
+                            "code": "1118-9",
+                            "display": "Upper Chinook",
+                            "definition": "Upper Chinook"
+                        },
+                        {
+                            "code": "1119-7",
+                            "display": "Wakiakum Chinook",
+                            "definition": "Wakiakum Chinook"
+                        },
+                        {
+                            "code": "1120-5",
+                            "display": "Willapa Chinook",
+                            "definition": "Willapa Chinook"
+                        },
+                        {
+                            "code": "1121-3",
+                            "display": "Wishram",
+                            "definition": "Wishram"
+                        },
+                        {
+                            "code": "1124-7",
+                            "display": "Bad River",
+                            "definition": "Bad River"
+                        },
+                        {
+                            "code": "1125-4",
+                            "display": "Bay Mills Chippewa",
+                            "definition": "Bay Mills Chippewa"
+                        },
+                        {
+                            "code": "1126-2",
+                            "display": "Bois Forte",
+                            "definition": "Bois Forte"
+                        },
+                        {
+                            "code": "1127-0",
+                            "display": "Burt Lake Chippewa",
+                            "definition": "Burt Lake Chippewa"
+                        },
+                        {
+                            "code": "1128-8",
+                            "display": "Fond du Lac",
+                            "definition": "Fond du Lac"
+                        },
+                        {
+                            "code": "1129-6",
+                            "display": "Grand Portage",
+                            "definition": "Grand Portage"
+                        },
+                        {
+                            "code": "1130-4",
+                            "display": "Grand Traverse Band of Ottawa/Chippewa",
+                            "definition": "Grand Traverse Band of Ottawa/Chippewa"
+                        },
+                        {
+                            "code": "1131-2",
+                            "display": "Keweenaw",
+                            "definition": "Keweenaw"
+                        },
+                        {
+                            "code": "1132-0",
+                            "display": "Lac Courte Oreilles",
+                            "definition": "Lac Courte Oreilles"
+                        },
+                        {
+                            "code": "1133-8",
+                            "display": "Lac du Flambeau",
+                            "definition": "Lac du Flambeau"
+                        },
+                        {
+                            "code": "1134-6",
+                            "display": "Lac Vieux Desert Chippewa",
+                            "definition": "Lac Vieux Desert Chippewa"
+                        },
+                        {
+                            "code": "1135-3",
+                            "display": "Lake Superior",
+                            "definition": "Lake Superior"
+                        },
+                        {
+                            "code": "1136-1",
+                            "display": "Leech Lake",
+                            "definition": "Leech Lake"
+                        },
+                        {
+                            "code": "1137-9",
+                            "display": "Little Shell Chippewa",
+                            "definition": "Little Shell Chippewa"
+                        },
+                        {
+                            "code": "1138-7",
+                            "display": "Mille Lacs",
+                            "definition": "Mille Lacs"
+                        },
+                        {
+                            "code": "1139-5",
+                            "display": "Minnesota Chippewa",
+                            "definition": "Minnesota Chippewa"
+                        },
+                        {
+                            "code": "1140-3",
+                            "display": "Ontonagon",
+                            "definition": "Ontonagon"
+                        },
+                        {
+                            "code": "1141-1",
+                            "display": "Red Cliff Chippewa",
+                            "definition": "Red Cliff Chippewa"
+                        },
+                        {
+                            "code": "1142-9",
+                            "display": "Red Lake Chippewa",
+                            "definition": "Red Lake Chippewa"
+                        },
+                        {
+                            "code": "1143-7",
+                            "display": "Saginaw Chippewa",
+                            "definition": "Saginaw Chippewa"
+                        },
+                        {
+                            "code": "1144-5",
+                            "display": "St. Croix Chippewa",
+                            "definition": "St. Croix Chippewa"
+                        },
+                        {
+                            "code": "1145-2",
+                            "display": "Sault Ste. Marie Chippewa",
+                            "definition": "Sault Ste. Marie Chippewa"
+                        },
+                        {
+                            "code": "1146-0",
+                            "display": "Sokoagon Chippewa",
+                            "definition": "Sokoagon Chippewa"
+                        },
+                        {
+                            "code": "1147-8",
+                            "display": "Turtle Mountain",
+                            "definition": "Turtle Mountain"
+                        },
+                        {
+                            "code": "1148-6",
+                            "display": "White Earth",
+                            "definition": "White Earth"
+                        },
+                        {
+                            "code": "1151-0",
+                            "display": "Rocky Boy's Chippewa Cree",
+                            "definition": "Rocky Boy's Chippewa Cree"
+                        },
+                        {
+                            "code": "1156-9",
+                            "display": "Clifton Choctaw",
+                            "definition": "Clifton Choctaw"
+                        },
+                        {
+                            "code": "1157-7",
+                            "display": "Jena Choctaw",
+                            "definition": "Jena Choctaw"
+                        },
+                        {
+                            "code": "1158-5",
+                            "display": "Mississippi Choctaw",
+                            "definition": "Mississippi Choctaw"
+                        },
+                        {
+                            "code": "1159-3",
+                            "display": "Mowa Band of Choctaw",
+                            "definition": "Mowa Band of Choctaw"
+                        },
+                        {
+                            "code": "1160-1",
+                            "display": "Oklahoma Choctaw",
+                            "definition": "Oklahoma Choctaw"
+                        },
+                        {
+                            "code": "1163-5",
+                            "display": "Santa Ynez",
+                            "definition": "Santa Ynez"
+                        },
+                        {
+                            "code": "1176-7",
+                            "display": "Oklahoma Comanche",
+                            "definition": "Oklahoma Comanche"
+                        },
+                        {
+                            "code": "1187-4",
+                            "display": "Alabama Coushatta",
+                            "definition": "Alabama Coushatta"
+                        },
+                        {
+                            "code": "1194-0",
+                            "display": "Alabama Creek",
+                            "definition": "Alabama Creek"
+                        },
+                        {
+                            "code": "1195-7",
+                            "display": "Alabama Quassarte",
+                            "definition": "Alabama Quassarte"
+                        },
+                        {
+                            "code": "1196-5",
+                            "display": "Eastern Creek",
+                            "definition": "Eastern Creek"
+                        },
+                        {
+                            "code": "1197-3",
+                            "display": "Eastern Muscogee",
+                            "definition": "Eastern Muscogee"
+                        },
+                        {
+                            "code": "1198-1",
+                            "display": "Kialegee",
+                            "definition": "Kialegee"
+                        },
+                        {
+                            "code": "1199-9",
+                            "display": "Lower Muscogee",
+                            "definition": "Lower Muscogee"
+                        },
+                        {
+                            "code": "1200-5",
+                            "display": "Machis Lower Creek Indian",
+                            "definition": "Machis Lower Creek Indian"
+                        },
+                        {
+                            "code": "1201-3",
+                            "display": "Poarch Band",
+                            "definition": "Poarch Band"
+                        },
+                        {
+                            "code": "1202-1",
+                            "display": "Principal Creek Indian Nation",
+                            "definition": "Principal Creek Indian Nation"
+                        },
+                        {
+                            "code": "1203-9",
+                            "display": "Star Clan of Muscogee Creeks",
+                            "definition": "Star Clan of Muscogee Creeks"
+                        },
+                        {
+                            "code": "1204-7",
+                            "display": "Thlopthlocco",
+                            "definition": "Thlopthlocco"
+                        },
+                        {
+                            "code": "1205-4",
+                            "display": "Tuckabachee",
+                            "definition": "Tuckabachee"
+                        },
+                        {
+                            "code": "1212-0",
+                            "display": "Agua Caliente",
+                            "definition": "Agua Caliente"
+                        },
+                        {
+                            "code": "1215-3",
+                            "display": "Eastern Delaware",
+                            "definition": "Eastern Delaware"
+                        },
+                        {
+                            "code": "1216-1",
+                            "display": "Lenni-Lenape",
+                            "definition": "Lenni-Lenape"
+                        },
+                        {
+                            "code": "1217-9",
+                            "display": "Munsee",
+                            "definition": "Munsee"
+                        },
+                        {
+                            "code": "1218-7",
+                            "display": "Oklahoma Delaware",
+                            "definition": "Oklahoma Delaware"
+                        },
+                        {
+                            "code": "1219-5",
+                            "display": "Rampough Mountain",
+                            "definition": "Rampough Mountain"
+                        },
+                        {
+                            "code": "1220-3",
+                            "display": "Sand Hill",
+                            "definition": "Sand Hill"
+                        },
+                        {
+                            "code": "1223-7",
+                            "display": "Campo",
+                            "definition": "Campo"
+                        },
+                        {
+                            "code": "1224-5",
+                            "display": "Capitan Grande",
+                            "definition": "Capitan Grande"
+                        },
+                        {
+                            "code": "1225-2",
+                            "display": "Cuyapaipe",
+                            "definition": "Cuyapaipe"
+                        },
+                        {
+                            "code": "1226-0",
+                            "display": "La Posta",
+                            "definition": "La Posta"
+                        },
+                        {
+                            "code": "1227-8",
+                            "display": "Manzanita",
+                            "definition": "Manzanita"
+                        },
+                        {
+                            "code": "1228-6",
+                            "display": "Mesa Grande",
+                            "definition": "Mesa Grande"
+                        },
+                        {
+                            "code": "1229-4",
+                            "display": "San Pasqual",
+                            "definition": "San Pasqual"
+                        },
+                        {
+                            "code": "1230-2",
+                            "display": "Santa Ysabel",
+                            "definition": "Santa Ysabel"
+                        },
+                        {
+                            "code": "1231-0",
+                            "display": "Sycuan",
+                            "definition": "Sycuan"
+                        },
+                        {
+                            "code": "1234-4",
+                            "display": "Attacapa",
+                            "definition": "Attacapa"
+                        },
+                        {
+                            "code": "1235-1",
+                            "display": "Biloxi",
+                            "definition": "Biloxi"
+                        },
+                        {
+                            "code": "1236-9",
+                            "display": "Georgetown (Eastern Tribes)",
+                            "definition": "Georgetown (Eastern Tribes)"
+                        },
+                        {
+                            "code": "1237-7",
+                            "display": "Moor",
+                            "definition": "Moor"
+                        },
+                        {
+                            "code": "1238-5",
+                            "display": "Nansemond",
+                            "definition": "Nansemond"
+                        },
+                        {
+                            "code": "1239-3",
+                            "display": "Natchez",
+                            "definition": "Natchez"
+                        },
+                        {
+                            "code": "1240-1",
+                            "display": "Nausu Waiwash",
+                            "definition": "Nausu Waiwash"
+                        },
+                        {
+                            "code": "1241-9",
+                            "display": "Nipmuc",
+                            "definition": "Nipmuc"
+                        },
+                        {
+                            "code": "1242-7",
+                            "display": "Paugussett",
+                            "definition": "Paugussett"
+                        },
+                        {
+                            "code": "1243-5",
+                            "display": "Pocomoke Acohonock",
+                            "definition": "Pocomoke Acohonock"
+                        },
+                        {
+                            "code": "1244-3",
+                            "display": "Southeastern Indians",
+                            "definition": "Southeastern Indians"
+                        },
+                        {
+                            "code": "1245-0",
+                            "display": "Susquehanock",
+                            "definition": "Susquehanock"
+                        },
+                        {
+                            "code": "1246-8",
+                            "display": "Tunica Biloxi",
+                            "definition": "Tunica Biloxi"
+                        },
+                        {
+                            "code": "1247-6",
+                            "display": "Waccamaw-Siousan",
+                            "definition": "Waccamaw-Siousan"
+                        },
+                        {
+                            "code": "1248-4",
+                            "display": "Wicomico",
+                            "definition": "Wicomico"
+                        },
+                        {
+                            "code": "1265-8",
+                            "display": "Atsina",
+                            "definition": "Atsina"
+                        },
+                        {
+                            "code": "1272-4",
+                            "display": "Trinity",
+                            "definition": "Trinity"
+                        },
+                        {
+                            "code": "1273-2",
+                            "display": "Whilkut",
+                            "definition": "Whilkut"
+                        },
+                        {
+                            "code": "1282-3",
+                            "display": "Iowa of Kansas-Nebraska",
+                            "definition": "Iowa of Kansas-Nebraska"
+                        },
+                        {
+                            "code": "1283-1",
+                            "display": "Iowa of Oklahoma",
+                            "definition": "Iowa of Oklahoma"
+                        },
+                        {
+                            "code": "1286-4",
+                            "display": "Cayuga",
+                            "definition": "Cayuga"
+                        },
+                        {
+                            "code": "1287-2",
+                            "display": "Mohawk",
+                            "definition": "Mohawk"
+                        },
+                        {
+                            "code": "1288-0",
+                            "display": "Oneida",
+                            "definition": "Oneida"
+                        },
+                        {
+                            "code": "1289-8",
+                            "display": "Onondaga",
+                            "definition": "Onondaga"
+                        },
+                        {
+                            "code": "1290-6",
+                            "display": "Seneca",
+                            "definition": "Seneca"
+                        },
+                        {
+                            "code": "1291-4",
+                            "display": "Seneca Nation",
+                            "definition": "Seneca Nation"
+                        },
+                        {
+                            "code": "1292-2",
+                            "display": "Seneca-Cayuga",
+                            "definition": "Seneca-Cayuga"
+                        },
+                        {
+                            "code": "1293-0",
+                            "display": "Tonawanda Seneca",
+                            "definition": "Tonawanda Seneca"
+                        },
+                        {
+                            "code": "1294-8",
+                            "display": "Tuscarora",
+                            "definition": "Tuscarora"
+                        },
+                        {
+                            "code": "1295-5",
+                            "display": "Wyandotte",
+                            "definition": "Wyandotte"
+                        },
+                        {
+                            "code": "1306-0",
+                            "display": "Oklahoma Kickapoo",
+                            "definition": "Oklahoma Kickapoo"
+                        },
+                        {
+                            "code": "1307-8",
+                            "display": "Texas Kickapoo",
+                            "definition": "Texas Kickapoo"
+                        },
+                        {
+                            "code": "1310-2",
+                            "display": "Oklahoma Kiowa",
+                            "definition": "Oklahoma Kiowa"
+                        },
+                        {
+                            "code": "1313-6",
+                            "display": "Jamestown",
+                            "definition": "Jamestown"
+                        },
+                        {
+                            "code": "1314-4",
+                            "display": "Lower Elwha",
+                            "definition": "Lower Elwha"
+                        },
+                        {
+                            "code": "1315-1",
+                            "display": "Port Gamble Klallam",
+                            "definition": "Port Gamble Klallam"
+                        },
+                        {
+                            "code": "1326-8",
+                            "display": "Matinecock",
+                            "definition": "Matinecock"
+                        },
+                        {
+                            "code": "1327-6",
+                            "display": "Montauk",
+                            "definition": "Montauk"
+                        },
+                        {
+                            "code": "1328-4",
+                            "display": "Poospatuck",
+                            "definition": "Poospatuck"
+                        },
+                        {
+                            "code": "1329-2",
+                            "display": "Setauket",
+                            "definition": "Setauket"
+                        },
+                        {
+                            "code": "1332-6",
+                            "display": "La Jolla",
+                            "definition": "La Jolla"
+                        },
+                        {
+                            "code": "1333-4",
+                            "display": "Pala",
+                            "definition": "Pala"
+                        },
+                        {
+                            "code": "1334-2",
+                            "display": "Pauma",
+                            "definition": "Pauma"
+                        },
+                        {
+                            "code": "1335-9",
+                            "display": "Pechanga",
+                            "definition": "Pechanga"
+                        },
+                        {
+                            "code": "1336-7",
+                            "display": "Soboba",
+                            "definition": "Soboba"
+                        },
+                        {
+                            "code": "1337-5",
+                            "display": "Twenty-Nine Palms",
+                            "definition": "Twenty-Nine Palms"
+                        },
+                        {
+                            "code": "1338-3",
+                            "display": "Temecula",
+                            "definition": "Temecula"
+                        },
+                        {
+                            "code": "1345-8",
+                            "display": "Mountain Maidu",
+                            "definition": "Mountain Maidu"
+                        },
+                        {
+                            "code": "1346-6",
+                            "display": "Nishinam",
+                            "definition": "Nishinam"
+                        },
+                        {
+                            "code": "1359-9",
+                            "display": "Illinois Miami",
+                            "definition": "Illinois Miami"
+                        },
+                        {
+                            "code": "1360-7",
+                            "display": "Indiana Miami",
+                            "definition": "Indiana Miami"
+                        },
+                        {
+                            "code": "1361-5",
+                            "display": "Oklahoma Miami",
+                            "definition": "Oklahoma Miami"
+                        },
+                        {
+                            "code": "1366-4",
+                            "display": "Aroostook",
+                            "definition": "Aroostook"
+                        },
+                        {
+                            "code": "1383-9",
+                            "display": "Alamo Navajo",
+                            "definition": "Alamo Navajo"
+                        },
+                        {
+                            "code": "1384-7",
+                            "display": "Canoncito Navajo",
+                            "definition": "Canoncito Navajo"
+                        },
+                        {
+                            "code": "1385-4",
+                            "display": "Ramah Navajo",
+                            "definition": "Ramah Navajo"
+                        },
+                        {
+                            "code": "1392-0",
+                            "display": "Alsea",
+                            "definition": "Alsea"
+                        },
+                        {
+                            "code": "1393-8",
+                            "display": "Celilo",
+                            "definition": "Celilo"
+                        },
+                        {
+                            "code": "1394-6",
+                            "display": "Columbia",
+                            "definition": "Columbia"
+                        },
+                        {
+                            "code": "1395-3",
+                            "display": "Kalapuya",
+                            "definition": "Kalapuya"
+                        },
+                        {
+                            "code": "1396-1",
+                            "display": "Molala",
+                            "definition": "Molala"
+                        },
+                        {
+                            "code": "1397-9",
+                            "display": "Talakamish",
+                            "definition": "Talakamish"
+                        },
+                        {
+                            "code": "1398-7",
+                            "display": "Tenino",
+                            "definition": "Tenino"
+                        },
+                        {
+                            "code": "1399-5",
+                            "display": "Tillamook",
+                            "definition": "Tillamook"
+                        },
+                        {
+                            "code": "1400-1",
+                            "display": "Wenatchee",
+                            "definition": "Wenatchee"
+                        },
+                        {
+                            "code": "1401-9",
+                            "display": "Yahooskin",
+                            "definition": "Yahooskin"
+                        },
+                        {
+                            "code": "1412-6",
+                            "display": "Burt Lake Ottawa",
+                            "definition": "Burt Lake Ottawa"
+                        },
+                        {
+                            "code": "1413-4",
+                            "display": "Michigan Ottawa",
+                            "definition": "Michigan Ottawa"
+                        },
+                        {
+                            "code": "1414-2",
+                            "display": "Oklahoma Ottawa",
+                            "definition": "Oklahoma Ottawa"
+                        },
+                        {
+                            "code": "1417-5",
+                            "display": "Bishop",
+                            "definition": "Bishop"
+                        },
+                        {
+                            "code": "1418-3",
+                            "display": "Bridgeport",
+                            "definition": "Bridgeport"
+                        },
+                        {
+                            "code": "1419-1",
+                            "display": "Burns Paiute",
+                            "definition": "Burns Paiute"
+                        },
+                        {
+                            "code": "1420-9",
+                            "display": "Cedarville",
+                            "definition": "Cedarville"
+                        },
+                        {
+                            "code": "1421-7",
+                            "display": "Fort Bidwell",
+                            "definition": "Fort Bidwell"
+                        },
+                        {
+                            "code": "1422-5",
+                            "display": "Fort Independence",
+                            "definition": "Fort Independence"
+                        },
+                        {
+                            "code": "1423-3",
+                            "display": "Kaibab",
+                            "definition": "Kaibab"
+                        },
+                        {
+                            "code": "1424-1",
+                            "display": "Las Vegas",
+                            "definition": "Las Vegas"
+                        },
+                        {
+                            "code": "1425-8",
+                            "display": "Lone Pine",
+                            "definition": "Lone Pine"
+                        },
+                        {
+                            "code": "1426-6",
+                            "display": "Lovelock",
+                            "definition": "Lovelock"
+                        },
+                        {
+                            "code": "1427-4",
+                            "display": "Malheur Paiute",
+                            "definition": "Malheur Paiute"
+                        },
+                        {
+                            "code": "1428-2",
+                            "display": "Moapa",
+                            "definition": "Moapa"
+                        },
+                        {
+                            "code": "1429-0",
+                            "display": "Northern Paiute",
+                            "definition": "Northern Paiute"
+                        },
+                        {
+                            "code": "1430-8",
+                            "display": "Owens Valley",
+                            "definition": "Owens Valley"
+                        },
+                        {
+                            "code": "1431-6",
+                            "display": "Pyramid Lake",
+                            "definition": "Pyramid Lake"
+                        },
+                        {
+                            "code": "1432-4",
+                            "display": "San Juan Southern Paiute",
+                            "definition": "San Juan Southern Paiute"
+                        },
+                        {
+                            "code": "1433-2",
+                            "display": "Southern Paiute",
+                            "definition": "Southern Paiute"
+                        },
+                        {
+                            "code": "1434-0",
+                            "display": "Summit Lake",
+                            "definition": "Summit Lake"
+                        },
+                        {
+                            "code": "1435-7",
+                            "display": "Utu Utu Gwaitu Paiute",
+                            "definition": "Utu Utu Gwaitu Paiute"
+                        },
+                        {
+                            "code": "1436-5",
+                            "display": "Walker River",
+                            "definition": "Walker River"
+                        },
+                        {
+                            "code": "1437-3",
+                            "display": "Yerington Paiute",
+                            "definition": "Yerington Paiute"
+                        },
+                        {
+                            "code": "1442-3",
+                            "display": "Indian Township",
+                            "definition": "Indian Township"
+                        },
+                        {
+                            "code": "1443-1",
+                            "display": "Pleasant Point Passamaquoddy",
+                            "definition": "Pleasant Point Passamaquoddy"
+                        },
+                        {
+                            "code": "1446-4",
+                            "display": "Oklahoma Pawnee",
+                            "definition": "Oklahoma Pawnee"
+                        },
+                        {
+                            "code": "1451-4",
+                            "display": "Oklahoma Peoria",
+                            "definition": "Oklahoma Peoria"
+                        },
+                        {
+                            "code": "1454-8",
+                            "display": "Marshantucket Pequot",
+                            "definition": "Marshantucket Pequot"
+                        },
+                        {
+                            "code": "1457-1",
+                            "display": "Gila River Pima-Maricopa",
+                            "definition": "Gila River Pima-Maricopa"
+                        },
+                        {
+                            "code": "1458-9",
+                            "display": "Salt River Pima-Maricopa",
+                            "definition": "Salt River Pima-Maricopa"
+                        },
+                        {
+                            "code": "1465-4",
+                            "display": "Central Pomo",
+                            "definition": "Central Pomo"
+                        },
+                        {
+                            "code": "1466-2",
+                            "display": "Dry Creek",
+                            "definition": "Dry Creek"
+                        },
+                        {
+                            "code": "1467-0",
+                            "display": "Eastern Pomo",
+                            "definition": "Eastern Pomo"
+                        },
+                        {
+                            "code": "1468-8",
+                            "display": "Kashia",
+                            "definition": "Kashia"
+                        },
+                        {
+                            "code": "1469-6",
+                            "display": "Northern Pomo",
+                            "definition": "Northern Pomo"
+                        },
+                        {
+                            "code": "1470-4",
+                            "display": "Scotts Valley",
+                            "definition": "Scotts Valley"
+                        },
+                        {
+                            "code": "1471-2",
+                            "display": "Stonyford",
+                            "definition": "Stonyford"
+                        },
+                        {
+                            "code": "1472-0",
+                            "display": "Sulphur Bank",
+                            "definition": "Sulphur Bank"
+                        },
+                        {
+                            "code": "1475-3",
+                            "display": "Nebraska Ponca",
+                            "definition": "Nebraska Ponca"
+                        },
+                        {
+                            "code": "1476-1",
+                            "display": "Oklahoma Ponca",
+                            "definition": "Oklahoma Ponca"
+                        },
+                        {
+                            "code": "1479-5",
+                            "display": "Citizen Band Potawatomi",
+                            "definition": "Citizen Band Potawatomi"
+                        },
+                        {
+                            "code": "1480-3",
+                            "display": "Forest County",
+                            "definition": "Forest County"
+                        },
+                        {
+                            "code": "1481-1",
+                            "display": "Hannahville",
+                            "definition": "Hannahville"
+                        },
+                        {
+                            "code": "1482-9",
+                            "display": "Huron Potawatomi",
+                            "definition": "Huron Potawatomi"
+                        },
+                        {
+                            "code": "1483-7",
+                            "display": "Pokagon Potawatomi",
+                            "definition": "Pokagon Potawatomi"
+                        },
+                        {
+                            "code": "1484-5",
+                            "display": "Prairie Band",
+                            "definition": "Prairie Band"
+                        },
+                        {
+                            "code": "1485-2",
+                            "display": "Wisconsin Potawatomi",
+                            "definition": "Wisconsin Potawatomi"
+                        },
+                        {
+                            "code": "1490-2",
+                            "display": "Acoma",
+                            "definition": "Acoma"
+                        },
+                        {
+                            "code": "1491-0",
+                            "display": "Arizona Tewa",
+                            "definition": "Arizona Tewa"
+                        },
+                        {
+                            "code": "1492-8",
+                            "display": "Cochiti",
+                            "definition": "Cochiti"
+                        },
+                        {
+                            "code": "1493-6",
+                            "display": "Hopi",
+                            "definition": "Hopi"
+                        },
+                        {
+                            "code": "1494-4",
+                            "display": "Isleta",
+                            "definition": "Isleta"
+                        },
+                        {
+                            "code": "1495-1",
+                            "display": "Jemez",
+                            "definition": "Jemez"
+                        },
+                        {
+                            "code": "1496-9",
+                            "display": "Keres",
+                            "definition": "Keres"
+                        },
+                        {
+                            "code": "1497-7",
+                            "display": "Laguna",
+                            "definition": "Laguna"
+                        },
+                        {
+                            "code": "1498-5",
+                            "display": "Nambe",
+                            "definition": "Nambe"
+                        },
+                        {
+                            "code": "1499-3",
+                            "display": "Picuris",
+                            "definition": "Picuris"
+                        },
+                        {
+                            "code": "1500-8",
+                            "display": "Piro",
+                            "definition": "Piro"
+                        },
+                        {
+                            "code": "1501-6",
+                            "display": "Pojoaque",
+                            "definition": "Pojoaque"
+                        },
+                        {
+                            "code": "1502-4",
+                            "display": "San Felipe",
+                            "definition": "San Felipe"
+                        },
+                        {
+                            "code": "1503-2",
+                            "display": "San Ildefonso",
+                            "definition": "San Ildefonso"
+                        },
+                        {
+                            "code": "1504-0",
+                            "display": "San Juan Pueblo",
+                            "definition": "San Juan Pueblo"
+                        },
+                        {
+                            "code": "1505-7",
+                            "display": "San Juan De",
+                            "definition": "San Juan De"
+                        },
+                        {
+                            "code": "1506-5",
+                            "display": "San Juan",
+                            "definition": "San Juan"
+                        },
+                        {
+                            "code": "1507-3",
+                            "display": "Sandia",
+                            "definition": "Sandia"
+                        },
+                        {
+                            "code": "1508-1",
+                            "display": "Santa Ana",
+                            "definition": "Santa Ana"
+                        },
+                        {
+                            "code": "1509-9",
+                            "display": "Santa Clara",
+                            "definition": "Santa Clara"
+                        },
+                        {
+                            "code": "1510-7",
+                            "display": "Santo Domingo",
+                            "definition": "Santo Domingo"
+                        },
+                        {
+                            "code": "1511-5",
+                            "display": "Taos",
+                            "definition": "Taos"
+                        },
+                        {
+                            "code": "1512-3",
+                            "display": "Tesuque",
+                            "definition": "Tesuque"
+                        },
+                        {
+                            "code": "1513-1",
+                            "display": "Tewa",
+                            "definition": "Tewa"
+                        },
+                        {
+                            "code": "1514-9",
+                            "display": "Tigua",
+                            "definition": "Tigua"
+                        },
+                        {
+                            "code": "1515-6",
+                            "display": "Zia",
+                            "definition": "Zia"
+                        },
+                        {
+                            "code": "1516-4",
+                            "display": "Zuni",
+                            "definition": "Zuni"
+                        },
+                        {
+                            "code": "1519-8",
+                            "display": "Duwamish",
+                            "definition": "Duwamish"
+                        },
+                        {
+                            "code": "1520-6",
+                            "display": "Kikiallus",
+                            "definition": "Kikiallus"
+                        },
+                        {
+                            "code": "1521-4",
+                            "display": "Lower Skagit",
+                            "definition": "Lower Skagit"
+                        },
+                        {
+                            "code": "1522-2",
+                            "display": "Muckleshoot",
+                            "definition": "Muckleshoot"
+                        },
+                        {
+                            "code": "1523-0",
+                            "display": "Nisqually",
+                            "definition": "Nisqually"
+                        },
+                        {
+                            "code": "1524-8",
+                            "display": "Nooksack",
+                            "definition": "Nooksack"
+                        },
+                        {
+                            "code": "1525-5",
+                            "display": "Port Madison",
+                            "definition": "Port Madison"
+                        },
+                        {
+                            "code": "1526-3",
+                            "display": "Puyallup",
+                            "definition": "Puyallup"
+                        },
+                        {
+                            "code": "1527-1",
+                            "display": "Samish",
+                            "definition": "Samish"
+                        },
+                        {
+                            "code": "1528-9",
+                            "display": "Sauk-Suiattle",
+                            "definition": "Sauk-Suiattle"
+                        },
+                        {
+                            "code": "1529-7",
+                            "display": "Skokomish",
+                            "definition": "Skokomish"
+                        },
+                        {
+                            "code": "1530-5",
+                            "display": "Skykomish",
+                            "definition": "Skykomish"
+                        },
+                        {
+                            "code": "1531-3",
+                            "display": "Snohomish",
+                            "definition": "Snohomish"
+                        },
+                        {
+                            "code": "1532-1",
+                            "display": "Snoqualmie",
+                            "definition": "Snoqualmie"
+                        },
+                        {
+                            "code": "1533-9",
+                            "display": "Squaxin Island",
+                            "definition": "Squaxin Island"
+                        },
+                        {
+                            "code": "1534-7",
+                            "display": "Steilacoom",
+                            "definition": "Steilacoom"
+                        },
+                        {
+                            "code": "1535-4",
+                            "display": "Stillaguamish",
+                            "definition": "Stillaguamish"
+                        },
+                        {
+                            "code": "1536-2",
+                            "display": "Suquamish",
+                            "definition": "Suquamish"
+                        },
+                        {
+                            "code": "1537-0",
+                            "display": "Swinomish",
+                            "definition": "Swinomish"
+                        },
+                        {
+                            "code": "1538-8",
+                            "display": "Tulalip",
+                            "definition": "Tulalip"
+                        },
+                        {
+                            "code": "1539-6",
+                            "display": "Upper Skagit",
+                            "definition": "Upper Skagit"
+                        },
+                        {
+                            "code": "1552-9",
+                            "display": "Iowa Sac and Fox",
+                            "definition": "Iowa Sac and Fox"
+                        },
+                        {
+                            "code": "1553-7",
+                            "display": "Missouri Sac and Fox",
+                            "definition": "Missouri Sac and Fox"
+                        },
+                        {
+                            "code": "1554-5",
+                            "display": "Oklahoma Sac and Fox",
+                            "definition": "Oklahoma Sac and Fox"
+                        },
+                        {
+                            "code": "1567-7",
+                            "display": "Big Cypress",
+                            "definition": "Big Cypress"
+                        },
+                        {
+                            "code": "1568-5",
+                            "display": "Brighton",
+                            "definition": "Brighton"
+                        },
+                        {
+                            "code": "1569-3",
+                            "display": "Florida Seminole",
+                            "definition": "Florida Seminole"
+                        },
+                        {
+                            "code": "1570-1",
+                            "display": "Hollywood Seminole",
+                            "definition": "Hollywood Seminole"
+                        },
+                        {
+                            "code": "1571-9",
+                            "display": "Oklahoma Seminole",
+                            "definition": "Oklahoma Seminole"
+                        },
+                        {
+                            "code": "1574-3",
+                            "display": "San Manual",
+                            "definition": "San Manual"
+                        },
+                        {
+                            "code": "1579-2",
+                            "display": "Absentee Shawnee",
+                            "definition": "Absentee Shawnee"
+                        },
+                        {
+                            "code": "1580-0",
+                            "display": "Eastern Shawnee",
+                            "definition": "Eastern Shawnee"
+                        },
+                        {
+                            "code": "1587-5",
+                            "display": "Battle Mountain",
+                            "definition": "Battle Mountain"
+                        },
+                        {
+                            "code": "1588-3",
+                            "display": "Duckwater",
+                            "definition": "Duckwater"
+                        },
+                        {
+                            "code": "1589-1",
+                            "display": "Elko",
+                            "definition": "Elko"
+                        },
+                        {
+                            "code": "1590-9",
+                            "display": "Ely",
+                            "definition": "Ely"
+                        },
+                        {
+                            "code": "1591-7",
+                            "display": "Goshute",
+                            "definition": "Goshute"
+                        },
+                        {
+                            "code": "1592-5",
+                            "display": "Panamint",
+                            "definition": "Panamint"
+                        },
+                        {
+                            "code": "1593-3",
+                            "display": "Ruby Valley",
+                            "definition": "Ruby Valley"
+                        },
+                        {
+                            "code": "1594-1",
+                            "display": "Skull Valley",
+                            "definition": "Skull Valley"
+                        },
+                        {
+                            "code": "1595-8",
+                            "display": "South Fork Shoshone",
+                            "definition": "South Fork Shoshone"
+                        },
+                        {
+                            "code": "1596-6",
+                            "display": "Te-Moak Western Shoshone",
+                            "definition": "Te-Moak Western Shoshone"
+                        },
+                        {
+                            "code": "1597-4",
+                            "display": "Timbi-Sha Shoshone",
+                            "definition": "Timbi-Sha Shoshone"
+                        },
+                        {
+                            "code": "1598-2",
+                            "display": "Washakie",
+                            "definition": "Washakie"
+                        },
+                        {
+                            "code": "1599-0",
+                            "display": "Wind River Shoshone",
+                            "definition": "Wind River Shoshone"
+                        },
+                        {
+                            "code": "1600-6",
+                            "display": "Yomba",
+                            "definition": "Yomba"
+                        },
+                        {
+                            "code": "1603-0",
+                            "display": "Duck Valley",
+                            "definition": "Duck Valley"
+                        },
+                        {
+                            "code": "1604-8",
+                            "display": "Fallon",
+                            "definition": "Fallon"
+                        },
+                        {
+                            "code": "1605-5",
+                            "display": "Fort McDermitt",
+                            "definition": "Fort McDermitt"
+                        },
+                        {
+                            "code": "1610-5",
+                            "display": "Blackfoot Sioux",
+                            "definition": "Blackfoot Sioux"
+                        },
+                        {
+                            "code": "1611-3",
+                            "display": "Brule Sioux",
+                            "definition": "Brule Sioux"
+                        },
+                        {
+                            "code": "1612-1",
+                            "display": "Cheyenne River Sioux",
+                            "definition": "Cheyenne River Sioux"
+                        },
+                        {
+                            "code": "1613-9",
+                            "display": "Crow Creek Sioux",
+                            "definition": "Crow Creek Sioux"
+                        },
+                        {
+                            "code": "1614-7",
+                            "display": "Dakota Sioux",
+                            "definition": "Dakota Sioux"
+                        },
+                        {
+                            "code": "1615-4",
+                            "display": "Flandreau Santee",
+                            "definition": "Flandreau Santee"
+                        },
+                        {
+                            "code": "1616-2",
+                            "display": "Fort Peck",
+                            "definition": "Fort Peck"
+                        },
+                        {
+                            "code": "1617-0",
+                            "display": "Lake Traverse Sioux",
+                            "definition": "Lake Traverse Sioux"
+                        },
+                        {
+                            "code": "1618-8",
+                            "display": "Lower Brule Sioux",
+                            "definition": "Lower Brule Sioux"
+                        },
+                        {
+                            "code": "1619-6",
+                            "display": "Lower Sioux",
+                            "definition": "Lower Sioux"
+                        },
+                        {
+                            "code": "1620-4",
+                            "display": "Mdewakanton Sioux",
+                            "definition": "Mdewakanton Sioux"
+                        },
+                        {
+                            "code": "1621-2",
+                            "display": "Miniconjou",
+                            "definition": "Miniconjou"
+                        },
+                        {
+                            "code": "1622-0",
+                            "display": "Oglala Sioux",
+                            "definition": "Oglala Sioux"
+                        },
+                        {
+                            "code": "1623-8",
+                            "display": "Pine Ridge Sioux",
+                            "definition": "Pine Ridge Sioux"
+                        },
+                        {
+                            "code": "1624-6",
+                            "display": "Pipestone Sioux",
+                            "definition": "Pipestone Sioux"
+                        },
+                        {
+                            "code": "1625-3",
+                            "display": "Prairie Island Sioux",
+                            "definition": "Prairie Island Sioux"
+                        },
+                        {
+                            "code": "1626-1",
+                            "display": "Prior Lake Sioux",
+                            "definition": "Prior Lake Sioux"
+                        },
+                        {
+                            "code": "1627-9",
+                            "display": "Rosebud Sioux",
+                            "definition": "Rosebud Sioux"
+                        },
+                        {
+                            "code": "1628-7",
+                            "display": "Sans Arc Sioux",
+                            "definition": "Sans Arc Sioux"
+                        },
+                        {
+                            "code": "1629-5",
+                            "display": "Santee Sioux",
+                            "definition": "Santee Sioux"
+                        },
+                        {
+                            "code": "1630-3",
+                            "display": "Sisseton-Wahpeton",
+                            "definition": "Sisseton-Wahpeton"
+                        },
+                        {
+                            "code": "1631-1",
+                            "display": "Sisseton Sioux",
+                            "definition": "Sisseton Sioux"
+                        },
+                        {
+                            "code": "1632-9",
+                            "display": "Spirit Lake Sioux",
+                            "definition": "Spirit Lake Sioux"
+                        },
+                        {
+                            "code": "1633-7",
+                            "display": "Standing Rock Sioux",
+                            "definition": "Standing Rock Sioux"
+                        },
+                        {
+                            "code": "1634-5",
+                            "display": "Teton Sioux",
+                            "definition": "Teton Sioux"
+                        },
+                        {
+                            "code": "1635-2",
+                            "display": "Two Kettle Sioux",
+                            "definition": "Two Kettle Sioux"
+                        },
+                        {
+                            "code": "1636-0",
+                            "display": "Upper Sioux",
+                            "definition": "Upper Sioux"
+                        },
+                        {
+                            "code": "1637-8",
+                            "display": "Wahpekute Sioux",
+                            "definition": "Wahpekute Sioux"
+                        },
+                        {
+                            "code": "1638-6",
+                            "display": "Wahpeton Sioux",
+                            "definition": "Wahpeton Sioux"
+                        },
+                        {
+                            "code": "1639-4",
+                            "display": "Wazhaza Sioux",
+                            "definition": "Wazhaza Sioux"
+                        },
+                        {
+                            "code": "1640-2",
+                            "display": "Yankton Sioux",
+                            "definition": "Yankton Sioux"
+                        },
+                        {
+                            "code": "1641-0",
+                            "display": "Yanktonai Sioux",
+                            "definition": "Yanktonai Sioux"
+                        },
+                        {
+                            "code": "1654-3",
+                            "display": "Ak-Chin",
+                            "definition": "Ak-Chin"
+                        },
+                        {
+                            "code": "1655-0",
+                            "display": "Gila Bend",
+                            "definition": "Gila Bend"
+                        },
+                        {
+                            "code": "1656-8",
+                            "display": "San Xavier",
+                            "definition": "San Xavier"
+                        },
+                        {
+                            "code": "1657-6",
+                            "display": "Sells",
+                            "definition": "Sells"
+                        },
+                        {
+                            "code": "1668-3",
+                            "display": "Cow Creek Umpqua",
+                            "definition": "Cow Creek Umpqua"
+                        },
+                        {
+                            "code": "1671-7",
+                            "display": "Allen Canyon",
+                            "definition": "Allen Canyon"
+                        },
+                        {
+                            "code": "1672-5",
+                            "display": "Uintah Ute",
+                            "definition": "Uintah Ute"
+                        },
+                        {
+                            "code": "1673-3",
+                            "display": "Ute Mountain Ute",
+                            "definition": "Ute Mountain Ute"
+                        },
+                        {
+                            "code": "1680-8",
+                            "display": "Gay Head Wampanoag",
+                            "definition": "Gay Head Wampanoag"
+                        },
+                        {
+                            "code": "1681-6",
+                            "display": "Mashpee Wampanoag",
+                            "definition": "Mashpee Wampanoag"
+                        },
+                        {
+                            "code": "1688-1",
+                            "display": "Alpine",
+                            "definition": "Alpine"
+                        },
+                        {
+                            "code": "1689-9",
+                            "display": "Carson",
+                            "definition": "Carson"
+                        },
+                        {
+                            "code": "1690-7",
+                            "display": "Dresslerville",
+                            "definition": "Dresslerville"
+                        },
+                        {
+                            "code": "1697-2",
+                            "display": "Ho-chunk",
+                            "definition": "Ho-chunk"
+                        },
+                        {
+                            "code": "1698-0",
+                            "display": "Nebraska Winnebago",
+                            "definition": "Nebraska Winnebago"
+                        },
+                        {
+                            "code": "1705-3",
+                            "display": "Table Bluff",
+                            "definition": "Table Bluff"
+                        },
+                        {
+                            "code": "1712-9",
+                            "display": "Barrio Libre",
+                            "definition": "Barrio Libre"
+                        },
+                        {
+                            "code": "1713-7",
+                            "display": "Pascua Yaqui",
+                            "definition": "Pascua Yaqui"
+                        },
+                        {
+                            "code": "1718-6",
+                            "display": "Chukchansi",
+                            "definition": "Chukchansi"
+                        },
+                        {
+                            "code": "1719-4",
+                            "display": "Tachi",
+                            "definition": "Tachi"
+                        },
+                        {
+                            "code": "1720-2",
+                            "display": "Tule River",
+                            "definition": "Tule River"
+                        },
+                        {
+                            "code": "1725-1",
+                            "display": "Cocopah",
+                            "definition": "Cocopah"
+                        },
+                        {
+                            "code": "1726-9",
+                            "display": "Havasupai",
+                            "definition": "Havasupai"
+                        },
+                        {
+                            "code": "1727-7",
+                            "display": "Hualapai",
+                            "definition": "Hualapai"
+                        },
+                        {
+                            "code": "1728-5",
+                            "display": "Maricopa",
+                            "definition": "Maricopa"
+                        },
+                        {
+                            "code": "1729-3",
+                            "display": "Mohave",
+                            "definition": "Mohave"
+                        },
+                        {
+                            "code": "1730-1",
+                            "display": "Quechan",
+                            "definition": "Quechan"
+                        },
+                        {
+                            "code": "1731-9",
+                            "display": "Yavapai",
+                            "definition": "Yavapai"
+                        },
+                        {
+                            "code": "1733-5",
+                            "display": "Coast Yurok",
+                            "definition": "Coast Yurok"
+                        },
+                        {
+                            "code": "1737-6",
+                            "display": "Alaska Indian",
+                            "definition": "Alaska Indian"
+                        },
+                        {
+                            "code": "1840-8",
+                            "display": "Eskimo",
+                            "definition": "Eskimo"
+                        },
+                        {
+                            "code": "1966-1",
+                            "display": "Aleut",
+                            "definition": "Aleut"
+                        },
+                        {
+                            "code": "1739-2",
+                            "display": "Alaskan Athabascan",
+                            "definition": "Alaskan Athabascan"
+                        },
+                        {
+                            "code": "1811-9",
+                            "display": "Southeast Alaska",
+                            "definition": "Southeast Alaska"
+                        },
+                        {
+                            "code": "1740-0",
+                            "display": "Ahtna",
+                            "definition": "Ahtna"
+                        },
+                        {
+                            "code": "1741-8",
+                            "display": "Alatna",
+                            "definition": "Alatna"
+                        },
+                        {
+                            "code": "1742-6",
+                            "display": "Alexander",
+                            "definition": "Alexander"
+                        },
+                        {
+                            "code": "1743-4",
+                            "display": "Allakaket",
+                            "definition": "Allakaket"
+                        },
+                        {
+                            "code": "1744-2",
+                            "display": "Alanvik",
+                            "definition": "Alanvik"
+                        },
+                        {
+                            "code": "1745-9",
+                            "display": "Anvik",
+                            "definition": "Anvik"
+                        },
+                        {
+                            "code": "1746-7",
+                            "display": "Arctic",
+                            "definition": "Arctic"
+                        },
+                        {
+                            "code": "1747-5",
+                            "display": "Beaver",
+                            "definition": "Beaver"
+                        },
+                        {
+                            "code": "1748-3",
+                            "display": "Birch Creek",
+                            "definition": "Birch Creek"
+                        },
+                        {
+                            "code": "1749-1",
+                            "display": "Cantwell",
+                            "definition": "Cantwell"
+                        },
+                        {
+                            "code": "1750-9",
+                            "display": "Chalkyitsik",
+                            "definition": "Chalkyitsik"
+                        },
+                        {
+                            "code": "1751-7",
+                            "display": "Chickaloon",
+                            "definition": "Chickaloon"
+                        },
+                        {
+                            "code": "1752-5",
+                            "display": "Chistochina",
+                            "definition": "Chistochina"
+                        },
+                        {
+                            "code": "1753-3",
+                            "display": "Chitina",
+                            "definition": "Chitina"
+                        },
+                        {
+                            "code": "1754-1",
+                            "display": "Circle",
+                            "definition": "Circle"
+                        },
+                        {
+                            "code": "1755-8",
+                            "display": "Cook Inlet",
+                            "definition": "Cook Inlet"
+                        },
+                        {
+                            "code": "1756-6",
+                            "display": "Copper Center",
+                            "definition": "Copper Center"
+                        },
+                        {
+                            "code": "1757-4",
+                            "display": "Copper River",
+                            "definition": "Copper River"
+                        },
+                        {
+                            "code": "1758-2",
+                            "display": "Dot Lake",
+                            "definition": "Dot Lake"
+                        },
+                        {
+                            "code": "1759-0",
+                            "display": "Doyon",
+                            "definition": "Doyon"
+                        },
+                        {
+                            "code": "1760-8",
+                            "display": "Eagle",
+                            "definition": "Eagle"
+                        },
+                        {
+                            "code": "1761-6",
+                            "display": "Eklutna",
+                            "definition": "Eklutna"
+                        },
+                        {
+                            "code": "1762-4",
+                            "display": "Evansville",
+                            "definition": "Evansville"
+                        },
+                        {
+                            "code": "1763-2",
+                            "display": "Fort Yukon",
+                            "definition": "Fort Yukon"
+                        },
+                        {
+                            "code": "1764-0",
+                            "display": "Gakona",
+                            "definition": "Gakona"
+                        },
+                        {
+                            "code": "1765-7",
+                            "display": "Galena",
+                            "definition": "Galena"
+                        },
+                        {
+                            "code": "1766-5",
+                            "display": "Grayling",
+                            "definition": "Grayling"
+                        },
+                        {
+                            "code": "1767-3",
+                            "display": "Gulkana",
+                            "definition": "Gulkana"
+                        },
+                        {
+                            "code": "1768-1",
+                            "display": "Healy Lake",
+                            "definition": "Healy Lake"
+                        },
+                        {
+                            "code": "1769-9",
+                            "display": "Holy Cross",
+                            "definition": "Holy Cross"
+                        },
+                        {
+                            "code": "1770-7",
+                            "display": "Hughes",
+                            "definition": "Hughes"
+                        },
+                        {
+                            "code": "1771-5",
+                            "display": "Huslia",
+                            "definition": "Huslia"
+                        },
+                        {
+                            "code": "1772-3",
+                            "display": "Iliamna",
+                            "definition": "Iliamna"
+                        },
+                        {
+                            "code": "1773-1",
+                            "display": "Kaltag",
+                            "definition": "Kaltag"
+                        },
+                        {
+                            "code": "1774-9",
+                            "display": "Kluti Kaah",
+                            "definition": "Kluti Kaah"
+                        },
+                        {
+                            "code": "1775-6",
+                            "display": "Knik",
+                            "definition": "Knik"
+                        },
+                        {
+                            "code": "1776-4",
+                            "display": "Koyukuk",
+                            "definition": "Koyukuk"
+                        },
+                        {
+                            "code": "1777-2",
+                            "display": "Lake Minchumina",
+                            "definition": "Lake Minchumina"
+                        },
+                        {
+                            "code": "1778-0",
+                            "display": "Lime",
+                            "definition": "Lime"
+                        },
+                        {
+                            "code": "1779-8",
+                            "display": "Mcgrath",
+                            "definition": "Mcgrath"
+                        },
+                        {
+                            "code": "1780-6",
+                            "display": "Manley Hot Springs",
+                            "definition": "Manley Hot Springs"
+                        },
+                        {
+                            "code": "1781-4",
+                            "display": "Mentasta Lake",
+                            "definition": "Mentasta Lake"
+                        },
+                        {
+                            "code": "1782-2",
+                            "display": "Minto",
+                            "definition": "Minto"
+                        },
+                        {
+                            "code": "1783-0",
+                            "display": "Nenana",
+                            "definition": "Nenana"
+                        },
+                        {
+                            "code": "1784-8",
+                            "display": "Nikolai",
+                            "definition": "Nikolai"
+                        },
+                        {
+                            "code": "1785-5",
+                            "display": "Ninilchik",
+                            "definition": "Ninilchik"
+                        },
+                        {
+                            "code": "1786-3",
+                            "display": "Nondalton",
+                            "definition": "Nondalton"
+                        },
+                        {
+                            "code": "1787-1",
+                            "display": "Northway",
+                            "definition": "Northway"
+                        },
+                        {
+                            "code": "1788-9",
+                            "display": "Nulato",
+                            "definition": "Nulato"
+                        },
+                        {
+                            "code": "1789-7",
+                            "display": "Pedro Bay",
+                            "definition": "Pedro Bay"
+                        },
+                        {
+                            "code": "1790-5",
+                            "display": "Rampart",
+                            "definition": "Rampart"
+                        },
+                        {
+                            "code": "1791-3",
+                            "display": "Ruby",
+                            "definition": "Ruby"
+                        },
+                        {
+                            "code": "1792-1",
+                            "display": "Salamatof",
+                            "definition": "Salamatof"
+                        },
+                        {
+                            "code": "1793-9",
+                            "display": "Seldovia",
+                            "definition": "Seldovia"
+                        },
+                        {
+                            "code": "1794-7",
+                            "display": "Slana",
+                            "definition": "Slana"
+                        },
+                        {
+                            "code": "1795-4",
+                            "display": "Shageluk",
+                            "definition": "Shageluk"
+                        },
+                        {
+                            "code": "1796-2",
+                            "display": "Stevens",
+                            "definition": "Stevens"
+                        },
+                        {
+                            "code": "1797-0",
+                            "display": "Stony River",
+                            "definition": "Stony River"
+                        },
+                        {
+                            "code": "1798-8",
+                            "display": "Takotna",
+                            "definition": "Takotna"
+                        },
+                        {
+                            "code": "1799-6",
+                            "display": "Tanacross",
+                            "definition": "Tanacross"
+                        },
+                        {
+                            "code": "1800-2",
+                            "display": "Tanaina",
+                            "definition": "Tanaina"
+                        },
+                        {
+                            "code": "1801-0",
+                            "display": "Tanana",
+                            "definition": "Tanana"
+                        },
+                        {
+                            "code": "1802-8",
+                            "display": "Tanana Chiefs",
+                            "definition": "Tanana Chiefs"
+                        },
+                        {
+                            "code": "1803-6",
+                            "display": "Tazlina",
+                            "definition": "Tazlina"
+                        },
+                        {
+                            "code": "1804-4",
+                            "display": "Telida",
+                            "definition": "Telida"
+                        },
+                        {
+                            "code": "1805-1",
+                            "display": "Tetlin",
+                            "definition": "Tetlin"
+                        },
+                        {
+                            "code": "1806-9",
+                            "display": "Tok",
+                            "definition": "Tok"
+                        },
+                        {
+                            "code": "1807-7",
+                            "display": "Tyonek",
+                            "definition": "Tyonek"
+                        },
+                        {
+                            "code": "1808-5",
+                            "display": "Venetie",
+                            "definition": "Venetie"
+                        },
+                        {
+                            "code": "1809-3",
+                            "display": "Wiseman",
+                            "definition": "Wiseman"
+                        },
+                        {
+                            "code": "1813-5",
+                            "display": "Tlingit-Haida",
+                            "definition": "Tlingit-Haida"
+                        },
+                        {
+                            "code": "1837-4",
+                            "display": "Tsimshian",
+                            "definition": "Tsimshian"
+                        },
+                        {
+                            "code": "1814-3",
+                            "display": "Angoon",
+                            "definition": "Angoon"
+                        },
+                        {
+                            "code": "1815-0",
+                            "display": "Central Council of Tlingit and Haida Tribes",
+                            "definition": "Central Council of Tlingit and Haida Tribes"
+                        },
+                        {
+                            "code": "1816-8",
+                            "display": "Chilkat",
+                            "definition": "Chilkat"
+                        },
+                        {
+                            "code": "1817-6",
+                            "display": "Chilkoot",
+                            "definition": "Chilkoot"
+                        },
+                        {
+                            "code": "1818-4",
+                            "display": "Craig",
+                            "definition": "Craig"
+                        },
+                        {
+                            "code": "1819-2",
+                            "display": "Douglas",
+                            "definition": "Douglas"
+                        },
+                        {
+                            "code": "1820-0",
+                            "display": "Haida",
+                            "definition": "Haida"
+                        },
+                        {
+                            "code": "1821-8",
+                            "display": "Hoonah",
+                            "definition": "Hoonah"
+                        },
+                        {
+                            "code": "1822-6",
+                            "display": "Hydaburg",
+                            "definition": "Hydaburg"
+                        },
+                        {
+                            "code": "1823-4",
+                            "display": "Kake",
+                            "definition": "Kake"
+                        },
+                        {
+                            "code": "1824-2",
+                            "display": "Kasaan",
+                            "definition": "Kasaan"
+                        },
+                        {
+                            "code": "1825-9",
+                            "display": "Kenaitze",
+                            "definition": "Kenaitze"
+                        },
+                        {
+                            "code": "1826-7",
+                            "display": "Ketchikan",
+                            "definition": "Ketchikan"
+                        },
+                        {
+                            "code": "1827-5",
+                            "display": "Klawock",
+                            "definition": "Klawock"
+                        },
+                        {
+                            "code": "1828-3",
+                            "display": "Pelican",
+                            "definition": "Pelican"
+                        },
+                        {
+                            "code": "1829-1",
+                            "display": "Petersburg",
+                            "definition": "Petersburg"
+                        },
+                        {
+                            "code": "1830-9",
+                            "display": "Saxman",
+                            "definition": "Saxman"
+                        },
+                        {
+                            "code": "1831-7",
+                            "display": "Sitka",
+                            "definition": "Sitka"
+                        },
+                        {
+                            "code": "1832-5",
+                            "display": "Tenakee Springs",
+                            "definition": "Tenakee Springs"
+                        },
+                        {
+                            "code": "1833-3",
+                            "display": "Tlingit",
+                            "definition": "Tlingit"
+                        },
+                        {
+                            "code": "1834-1",
+                            "display": "Wrangell",
+                            "definition": "Wrangell"
+                        },
+                        {
+                            "code": "1835-8",
+                            "display": "Yakutat",
+                            "definition": "Yakutat"
+                        },
+                        {
+                            "code": "1838-2",
+                            "display": "Metlakatla",
+                            "definition": "Metlakatla"
+                        },
+                        {
+                            "code": "1842-4",
+                            "display": "Greenland Eskimo",
+                            "definition": "Greenland Eskimo"
+                        },
+                        {
+                            "code": "1844-0",
+                            "display": "Inupiat Eskimo",
+                            "definition": "Inupiat Eskimo"
+                        },
+                        {
+                            "code": "1891-1",
+                            "display": "Siberian Eskimo",
+                            "definition": "Siberian Eskimo"
+                        },
+                        {
+                            "code": "1896-0",
+                            "display": "Yupik Eskimo",
+                            "definition": "Yupik Eskimo"
+                        },
+                        {
+                            "code": "1845-7",
+                            "display": "Ambler",
+                            "definition": "Ambler"
+                        },
+                        {
+                            "code": "1846-5",
+                            "display": "Anaktuvuk",
+                            "definition": "Anaktuvuk"
+                        },
+                        {
+                            "code": "1847-3",
+                            "display": "Anaktuvuk Pass",
+                            "definition": "Anaktuvuk Pass"
+                        },
+                        {
+                            "code": "1848-1",
+                            "display": "Arctic Slope Inupiat",
+                            "definition": "Arctic Slope Inupiat"
+                        },
+                        {
+                            "code": "1849-9",
+                            "display": "Arctic Slope Corporation",
+                            "definition": "Arctic Slope Corporation"
+                        },
+                        {
+                            "code": "1850-7",
+                            "display": "Atqasuk",
+                            "definition": "Atqasuk"
+                        },
+                        {
+                            "code": "1851-5",
+                            "display": "Barrow",
+                            "definition": "Barrow"
+                        },
+                        {
+                            "code": "1852-3",
+                            "display": "Bering Straits Inupiat",
+                            "definition": "Bering Straits Inupiat"
+                        },
+                        {
+                            "code": "1853-1",
+                            "display": "Brevig Mission",
+                            "definition": "Brevig Mission"
+                        },
+                        {
+                            "code": "1854-9",
+                            "display": "Buckland",
+                            "definition": "Buckland"
+                        },
+                        {
+                            "code": "1855-6",
+                            "display": "Chinik",
+                            "definition": "Chinik"
+                        },
+                        {
+                            "code": "1856-4",
+                            "display": "Council",
+                            "definition": "Council"
+                        },
+                        {
+                            "code": "1857-2",
+                            "display": "Deering",
+                            "definition": "Deering"
+                        },
+                        {
+                            "code": "1858-0",
+                            "display": "Elim",
+                            "definition": "Elim"
+                        },
+                        {
+                            "code": "1859-8",
+                            "display": "Golovin",
+                            "definition": "Golovin"
+                        },
+                        {
+                            "code": "1860-6",
+                            "display": "Inalik Diomede",
+                            "definition": "Inalik Diomede"
+                        },
+                        {
+                            "code": "1861-4",
+                            "display": "Inupiaq",
+                            "definition": "Inupiaq"
+                        },
+                        {
+                            "code": "1862-2",
+                            "display": "Kaktovik",
+                            "definition": "Kaktovik"
+                        },
+                        {
+                            "code": "1863-0",
+                            "display": "Kawerak",
+                            "definition": "Kawerak"
+                        },
+                        {
+                            "code": "1864-8",
+                            "display": "Kiana",
+                            "definition": "Kiana"
+                        },
+                        {
+                            "code": "1865-5",
+                            "display": "Kivalina",
+                            "definition": "Kivalina"
+                        },
+                        {
+                            "code": "1866-3",
+                            "display": "Kobuk",
+                            "definition": "Kobuk"
+                        },
+                        {
+                            "code": "1867-1",
+                            "display": "Kotzebue",
+                            "definition": "Kotzebue"
+                        },
+                        {
+                            "code": "1868-9",
+                            "display": "Koyuk",
+                            "definition": "Koyuk"
+                        },
+                        {
+                            "code": "1869-7",
+                            "display": "Kwiguk",
+                            "definition": "Kwiguk"
+                        },
+                        {
+                            "code": "1870-5",
+                            "display": "Mauneluk Inupiat",
+                            "definition": "Mauneluk Inupiat"
+                        },
+                        {
+                            "code": "1871-3",
+                            "display": "Nana Inupiat",
+                            "definition": "Nana Inupiat"
+                        },
+                        {
+                            "code": "1872-1",
+                            "display": "Noatak",
+                            "definition": "Noatak"
+                        },
+                        {
+                            "code": "1873-9",
+                            "display": "Nome",
+                            "definition": "Nome"
+                        },
+                        {
+                            "code": "1874-7",
+                            "display": "Noorvik",
+                            "definition": "Noorvik"
+                        },
+                        {
+                            "code": "1875-4",
+                            "display": "Nuiqsut",
+                            "definition": "Nuiqsut"
+                        },
+                        {
+                            "code": "1876-2",
+                            "display": "Point Hope",
+                            "definition": "Point Hope"
+                        },
+                        {
+                            "code": "1877-0",
+                            "display": "Point Lay",
+                            "definition": "Point Lay"
+                        },
+                        {
+                            "code": "1878-8",
+                            "display": "Selawik",
+                            "definition": "Selawik"
+                        },
+                        {
+                            "code": "1879-6",
+                            "display": "Shaktoolik",
+                            "definition": "Shaktoolik"
+                        },
+                        {
+                            "code": "1880-4",
+                            "display": "Shishmaref",
+                            "definition": "Shishmaref"
+                        },
+                        {
+                            "code": "1881-2",
+                            "display": "Shungnak",
+                            "definition": "Shungnak"
+                        },
+                        {
+                            "code": "1882-0",
+                            "display": "Solomon",
+                            "definition": "Solomon"
+                        },
+                        {
+                            "code": "1883-8",
+                            "display": "Teller",
+                            "definition": "Teller"
+                        },
+                        {
+                            "code": "1884-6",
+                            "display": "Unalakleet",
+                            "definition": "Unalakleet"
+                        },
+                        {
+                            "code": "1885-3",
+                            "display": "Wainwright",
+                            "definition": "Wainwright"
+                        },
+                        {
+                            "code": "1886-1",
+                            "display": "Wales",
+                            "definition": "Wales"
+                        },
+                        {
+                            "code": "1887-9",
+                            "display": "White Mountain",
+                            "definition": "White Mountain"
+                        },
+                        {
+                            "code": "1888-7",
+                            "display": "White Mountain Inupiat",
+                            "definition": "White Mountain Inupiat"
+                        },
+                        {
+                            "code": "1889-5",
+                            "display": "Mary's Igloo",
+                            "definition": "Mary's Igloo"
+                        },
+                        {
+                            "code": "1892-9",
+                            "display": "Gambell",
+                            "definition": "Gambell"
+                        },
+                        {
+                            "code": "1893-7",
+                            "display": "Savoonga",
+                            "definition": "Savoonga"
+                        },
+                        {
+                            "code": "1894-5",
+                            "display": "Siberian Yupik",
+                            "definition": "Siberian Yupik"
+                        },
+                        {
+                            "code": "1897-8",
+                            "display": "Akiachak",
+                            "definition": "Akiachak"
+                        },
+                        {
+                            "code": "1898-6",
+                            "display": "Akiak",
+                            "definition": "Akiak"
+                        },
+                        {
+                            "code": "1899-4",
+                            "display": "Alakanuk",
+                            "definition": "Alakanuk"
+                        },
+                        {
+                            "code": "1900-0",
+                            "display": "Aleknagik",
+                            "definition": "Aleknagik"
+                        },
+                        {
+                            "code": "1901-8",
+                            "display": "Andreafsky",
+                            "definition": "Andreafsky"
+                        },
+                        {
+                            "code": "1902-6",
+                            "display": "Aniak",
+                            "definition": "Aniak"
+                        },
+                        {
+                            "code": "1903-4",
+                            "display": "Atmautluak",
+                            "definition": "Atmautluak"
+                        },
+                        {
+                            "code": "1904-2",
+                            "display": "Bethel",
+                            "definition": "Bethel"
+                        },
+                        {
+                            "code": "1905-9",
+                            "display": "Bill Moore's Slough",
+                            "definition": "Bill Moore's Slough"
+                        },
+                        {
+                            "code": "1906-7",
+                            "display": "Bristol Bay Yupik",
+                            "definition": "Bristol Bay Yupik"
+                        },
+                        {
+                            "code": "1907-5",
+                            "display": "Calista Yupik",
+                            "definition": "Calista Yupik"
+                        },
+                        {
+                            "code": "1908-3",
+                            "display": "Chefornak",
+                            "definition": "Chefornak"
+                        },
+                        {
+                            "code": "1909-1",
+                            "display": "Chevak",
+                            "definition": "Chevak"
+                        },
+                        {
+                            "code": "1910-9",
+                            "display": "Chuathbaluk",
+                            "definition": "Chuathbaluk"
+                        },
+                        {
+                            "code": "1911-7",
+                            "display": "Clark's Point",
+                            "definition": "Clark's Point"
+                        },
+                        {
+                            "code": "1912-5",
+                            "display": "Crooked Creek",
+                            "definition": "Crooked Creek"
+                        },
+                        {
+                            "code": "1913-3",
+                            "display": "Dillingham",
+                            "definition": "Dillingham"
+                        },
+                        {
+                            "code": "1914-1",
+                            "display": "Eek",
+                            "definition": "Eek"
+                        },
+                        {
+                            "code": "1915-8",
+                            "display": "Ekuk",
+                            "definition": "Ekuk"
+                        },
+                        {
+                            "code": "1916-6",
+                            "display": "Ekwok",
+                            "definition": "Ekwok"
+                        },
+                        {
+                            "code": "1917-4",
+                            "display": "Emmonak",
+                            "definition": "Emmonak"
+                        },
+                        {
+                            "code": "1918-2",
+                            "display": "Goodnews Bay",
+                            "definition": "Goodnews Bay"
+                        },
+                        {
+                            "code": "1919-0",
+                            "display": "Hooper Bay",
+                            "definition": "Hooper Bay"
+                        },
+                        {
+                            "code": "1920-8",
+                            "display": "Iqurmuit (Russian Mission)",
+                            "definition": "Iqurmuit (Russian Mission)"
+                        },
+                        {
+                            "code": "1921-6",
+                            "display": "Kalskag",
+                            "definition": "Kalskag"
+                        },
+                        {
+                            "code": "1922-4",
+                            "display": "Kasigluk",
+                            "definition": "Kasigluk"
+                        },
+                        {
+                            "code": "1923-2",
+                            "display": "Kipnuk",
+                            "definition": "Kipnuk"
+                        },
+                        {
+                            "code": "1924-0",
+                            "display": "Koliganek",
+                            "definition": "Koliganek"
+                        },
+                        {
+                            "code": "1925-7",
+                            "display": "Kongiganak",
+                            "definition": "Kongiganak"
+                        },
+                        {
+                            "code": "1926-5",
+                            "display": "Kotlik",
+                            "definition": "Kotlik"
+                        },
+                        {
+                            "code": "1927-3",
+                            "display": "Kwethluk",
+                            "definition": "Kwethluk"
+                        },
+                        {
+                            "code": "1928-1",
+                            "display": "Kwigillingok",
+                            "definition": "Kwigillingok"
+                        },
+                        {
+                            "code": "1929-9",
+                            "display": "Levelock",
+                            "definition": "Levelock"
+                        },
+                        {
+                            "code": "1930-7",
+                            "display": "Lower Kalskag",
+                            "definition": "Lower Kalskag"
+                        },
+                        {
+                            "code": "1931-5",
+                            "display": "Manokotak",
+                            "definition": "Manokotak"
+                        },
+                        {
+                            "code": "1932-3",
+                            "display": "Marshall",
+                            "definition": "Marshall"
+                        },
+                        {
+                            "code": "1933-1",
+                            "display": "Mekoryuk",
+                            "definition": "Mekoryuk"
+                        },
+                        {
+                            "code": "1934-9",
+                            "display": "Mountain Village",
+                            "definition": "Mountain Village"
+                        },
+                        {
+                            "code": "1935-6",
+                            "display": "Naknek",
+                            "definition": "Naknek"
+                        },
+                        {
+                            "code": "1936-4",
+                            "display": "Napaumute",
+                            "definition": "Napaumute"
+                        },
+                        {
+                            "code": "1937-2",
+                            "display": "Napakiak",
+                            "definition": "Napakiak"
+                        },
+                        {
+                            "code": "1938-0",
+                            "display": "Napaskiak",
+                            "definition": "Napaskiak"
+                        },
+                        {
+                            "code": "1939-8",
+                            "display": "Newhalen",
+                            "definition": "Newhalen"
+                        },
+                        {
+                            "code": "1940-6",
+                            "display": "New Stuyahok",
+                            "definition": "New Stuyahok"
+                        },
+                        {
+                            "code": "1941-4",
+                            "display": "Newtok",
+                            "definition": "Newtok"
+                        },
+                        {
+                            "code": "1942-2",
+                            "display": "Nightmute",
+                            "definition": "Nightmute"
+                        },
+                        {
+                            "code": "1943-0",
+                            "display": "Nunapitchukv",
+                            "definition": "Nunapitchukv"
+                        },
+                        {
+                            "code": "1944-8",
+                            "display": "Oscarville",
+                            "definition": "Oscarville"
+                        },
+                        {
+                            "code": "1945-5",
+                            "display": "Pilot Station",
+                            "definition": "Pilot Station"
+                        },
+                        {
+                            "code": "1946-3",
+                            "display": "Pitkas Point",
+                            "definition": "Pitkas Point"
+                        },
+                        {
+                            "code": "1947-1",
+                            "display": "Platinum",
+                            "definition": "Platinum"
+                        },
+                        {
+                            "code": "1948-9",
+                            "display": "Portage Creek",
+                            "definition": "Portage Creek"
+                        },
+                        {
+                            "code": "1949-7",
+                            "display": "Quinhagak",
+                            "definition": "Quinhagak"
+                        },
+                        {
+                            "code": "1950-5",
+                            "display": "Red Devil",
+                            "definition": "Red Devil"
+                        },
+                        {
+                            "code": "1951-3",
+                            "display": "St. Michael",
+                            "definition": "St. Michael"
+                        },
+                        {
+                            "code": "1952-1",
+                            "display": "Scammon Bay",
+                            "definition": "Scammon Bay"
+                        },
+                        {
+                            "code": "1953-9",
+                            "display": "Sheldon's Point",
+                            "definition": "Sheldon's Point"
+                        },
+                        {
+                            "code": "1954-7",
+                            "display": "Sleetmute",
+                            "definition": "Sleetmute"
+                        },
+                        {
+                            "code": "1955-4",
+                            "display": "Stebbins",
+                            "definition": "Stebbins"
+                        },
+                        {
+                            "code": "1956-2",
+                            "display": "Togiak",
+                            "definition": "Togiak"
+                        },
+                        {
+                            "code": "1957-0",
+                            "display": "Toksook",
+                            "definition": "Toksook"
+                        },
+                        {
+                            "code": "1958-8",
+                            "display": "Tulukskak",
+                            "definition": "Tulukskak"
+                        },
+                        {
+                            "code": "1959-6",
+                            "display": "Tuntutuliak",
+                            "definition": "Tuntutuliak"
+                        },
+                        {
+                            "code": "1960-4",
+                            "display": "Tununak",
+                            "definition": "Tununak"
+                        },
+                        {
+                            "code": "1961-2",
+                            "display": "Twin Hills",
+                            "definition": "Twin Hills"
+                        },
+                        {
+                            "code": "1962-0",
+                            "display": "Georgetown (Yupik-Eskimo)",
+                            "definition": "Georgetown (Yupik-Eskimo)"
+                        },
+                        {
+                            "code": "1963-8",
+                            "display": "St. Mary's",
+                            "definition": "St. Mary's"
+                        },
+                        {
+                            "code": "1964-6",
+                            "display": "Umkumiate",
+                            "definition": "Umkumiate"
+                        },
+                        {
+                            "code": "1968-7",
+                            "display": "Alutiiq Aleut",
+                            "definition": "Alutiiq Aleut"
+                        },
+                        {
+                            "code": "1972-9",
+                            "display": "Bristol Bay Aleut",
+                            "definition": "Bristol Bay Aleut"
+                        },
+                        {
+                            "code": "1984-4",
+                            "display": "Chugach Aleut",
+                            "definition": "Chugach Aleut"
+                        },
+                        {
+                            "code": "1990-1",
+                            "display": "Eyak",
+                            "definition": "Eyak"
+                        },
+                        {
+                            "code": "1992-7",
+                            "display": "Koniag Aleut",
+                            "definition": "Koniag Aleut"
+                        },
+                        {
+                            "code": "2002-4",
+                            "display": "Sugpiaq",
+                            "definition": "Sugpiaq"
+                        },
+                        {
+                            "code": "2004-0",
+                            "display": "Suqpigaq",
+                            "definition": "Suqpigaq"
+                        },
+                        {
+                            "code": "2006-5",
+                            "display": "Unangan Aleut",
+                            "definition": "Unangan Aleut"
+                        },
+                        {
+                            "code": "1969-5",
+                            "display": "Tatitlek",
+                            "definition": "Tatitlek"
+                        },
+                        {
+                            "code": "1970-3",
+                            "display": "Ugashik",
+                            "definition": "Ugashik"
+                        },
+                        {
+                            "code": "1973-7",
+                            "display": "Chignik",
+                            "definition": "Chignik"
+                        },
+                        {
+                            "code": "1974-5",
+                            "display": "Chignik Lake",
+                            "definition": "Chignik Lake"
+                        },
+                        {
+                            "code": "1975-2",
+                            "display": "Egegik",
+                            "definition": "Egegik"
+                        },
+                        {
+                            "code": "1976-0",
+                            "display": "Igiugig",
+                            "definition": "Igiugig"
+                        },
+                        {
+                            "code": "1977-8",
+                            "display": "Ivanof Bay",
+                            "definition": "Ivanof Bay"
+                        },
+                        {
+                            "code": "1978-6",
+                            "display": "King Salmon",
+                            "definition": "King Salmon"
+                        },
+                        {
+                            "code": "1979-4",
+                            "display": "Kokhanok",
+                            "definition": "Kokhanok"
+                        },
+                        {
+                            "code": "1980-2",
+                            "display": "Perryville",
+                            "definition": "Perryville"
+                        },
+                        {
+                            "code": "1981-0",
+                            "display": "Pilot Point",
+                            "definition": "Pilot Point"
+                        },
+                        {
+                            "code": "1982-8",
+                            "display": "Port Heiden",
+                            "definition": "Port Heiden"
+                        },
+                        {
+                            "code": "1985-1",
+                            "display": "Chenega",
+                            "definition": "Chenega"
+                        },
+                        {
+                            "code": "1986-9",
+                            "display": "Chugach Corporation",
+                            "definition": "Chugach Corporation"
+                        },
+                        {
+                            "code": "1987-7",
+                            "display": "English Bay",
+                            "definition": "English Bay"
+                        },
+                        {
+                            "code": "1988-5",
+                            "display": "Port Graham",
+                            "definition": "Port Graham"
+                        },
+                        {
+                            "code": "1993-5",
+                            "display": "Akhiok",
+                            "definition": "Akhiok"
+                        },
+                        {
+                            "code": "1994-3",
+                            "display": "Agdaagux",
+                            "definition": "Agdaagux"
+                        },
+                        {
+                            "code": "1995-0",
+                            "display": "Karluk",
+                            "definition": "Karluk"
+                        },
+                        {
+                            "code": "1996-8",
+                            "display": "Kodiak",
+                            "definition": "Kodiak"
+                        },
+                        {
+                            "code": "1997-6",
+                            "display": "Larsen Bay",
+                            "definition": "Larsen Bay"
+                        },
+                        {
+                            "code": "1998-4",
+                            "display": "Old Harbor",
+                            "definition": "Old Harbor"
+                        },
+                        {
+                            "code": "1999-2",
+                            "display": "Ouzinkie",
+                            "definition": "Ouzinkie"
+                        },
+                        {
+                            "code": "2000-8",
+                            "display": "Port Lions",
+                            "definition": "Port Lions"
+                        },
+                        {
+                            "code": "2007-3",
+                            "display": "Akutan",
+                            "definition": "Akutan"
+                        },
+                        {
+                            "code": "2008-1",
+                            "display": "Aleut Corporation",
+                            "definition": "Aleut Corporation"
+                        },
+                        {
+                            "code": "2009-9",
+                            "display": "Aleutian",
+                            "definition": "Aleutian"
+                        },
+                        {
+                            "code": "2010-7",
+                            "display": "Aleutian Islander",
+                            "definition": "Aleutian Islander"
+                        },
+                        {
+                            "code": "2011-5",
+                            "display": "Atka",
+                            "definition": "Atka"
+                        },
+                        {
+                            "code": "2012-3",
+                            "display": "Belkofski",
+                            "definition": "Belkofski"
+                        },
+                        {
+                            "code": "2013-1",
+                            "display": "Chignik Lagoon",
+                            "definition": "Chignik Lagoon"
+                        },
+                        {
+                            "code": "2014-9",
+                            "display": "King Cove",
+                            "definition": "King Cove"
+                        },
+                        {
+                            "code": "2015-6",
+                            "display": "False Pass",
+                            "definition": "False Pass"
+                        },
+                        {
+                            "code": "2016-4",
+                            "display": "Nelson Lagoon",
+                            "definition": "Nelson Lagoon"
+                        },
+                        {
+                            "code": "2017-2",
+                            "display": "Nikolski",
+                            "definition": "Nikolski"
+                        },
+                        {
+                            "code": "2018-0",
+                            "display": "Pauloff Harbor",
+                            "definition": "Pauloff Harbor"
+                        },
+                        {
+                            "code": "2019-8",
+                            "display": "Qagan Toyagungin",
+                            "definition": "Qagan Toyagungin"
+                        },
+                        {
+                            "code": "2020-6",
+                            "display": "Qawalangin",
+                            "definition": "Qawalangin"
+                        },
+                        {
+                            "code": "2021-4",
+                            "display": "St. George",
+                            "definition": "St. George"
+                        },
+                        {
+                            "code": "2022-2",
+                            "display": "St. Paul",
+                            "definition": "St. Paul"
+                        },
+                        {
+                            "code": "2023-0",
+                            "display": "Sand Point",
+                            "definition": "Sand Point"
+                        },
+                        {
+                            "code": "2024-8",
+                            "display": "South Naknek",
+                            "definition": "South Naknek"
+                        },
+                        {
+                            "code": "2025-5",
+                            "display": "Unalaska",
+                            "definition": "Unalaska"
+                        },
+                        {
+                            "code": "2026-3",
+                            "display": "Unga",
+                            "definition": "Unga"
+                        }
+                    ]
+                },
+                {
+                    "code": "2028-9",
+                    "display": "Asian",
+                    "definition": "Asian",
+                    "concept": [
+                        {
+                            "code": "2029-7",
+                            "display": "Asian Indian",
+                            "definition": "Asian Indian"
+                        },
+                        {
+                            "code": "2030-5",
+                            "display": "Bangladeshi",
+                            "definition": "Bangladeshi"
+                        },
+                        {
+                            "code": "2031-3",
+                            "display": "Bhutanese",
+                            "definition": "Bhutanese"
+                        },
+                        {
+                            "code": "2032-1",
+                            "display": "Burmese",
+                            "definition": "Burmese"
+                        },
+                        {
+                            "code": "2033-9",
+                            "display": "Cambodian",
+                            "definition": "Cambodian"
+                        },
+                        {
+                            "code": "2034-7",
+                            "display": "Chinese",
+                            "definition": "Chinese"
+                        },
+                        {
+                            "code": "2035-4",
+                            "display": "Taiwanese",
+                            "definition": "Taiwanese"
+                        },
+                        {
+                            "code": "2036-2",
+                            "display": "Filipino",
+                            "definition": "Filipino"
+                        },
+                        {
+                            "code": "2037-0",
+                            "display": "Hmong",
+                            "definition": "Hmong"
+                        },
+                        {
+                            "code": "2038-8",
+                            "display": "Indonesian",
+                            "definition": "Indonesian"
+                        },
+                        {
+                            "code": "2039-6",
+                            "display": "Japanese",
+                            "definition": "Japanese"
+                        },
+                        {
+                            "code": "2040-4",
+                            "display": "Korean",
+                            "definition": "Korean"
+                        },
+                        {
+                            "code": "2041-2",
+                            "display": "Laotian",
+                            "definition": "Laotian"
+                        },
+                        {
+                            "code": "2042-0",
+                            "display": "Malaysian",
+                            "definition": "Malaysian"
+                        },
+                        {
+                            "code": "2043-8",
+                            "display": "Okinawan",
+                            "definition": "Okinawan"
+                        },
+                        {
+                            "code": "2044-6",
+                            "display": "Pakistani",
+                            "definition": "Pakistani"
+                        },
+                        {
+                            "code": "2045-3",
+                            "display": "Sri Lankan",
+                            "definition": "Sri Lankan"
+                        },
+                        {
+                            "code": "2046-1",
+                            "display": "Thai",
+                            "definition": "Thai"
+                        },
+                        {
+                            "code": "2047-9",
+                            "display": "Vietnamese",
+                            "definition": "Vietnamese"
+                        },
+                        {
+                            "code": "2048-7",
+                            "display": "Iwo Jiman",
+                            "definition": "Iwo Jiman"
+                        },
+                        {
+                            "code": "2049-5",
+                            "display": "Maldivian",
+                            "definition": "Maldivian"
+                        },
+                        {
+                            "code": "2050-3",
+                            "display": "Nepalese",
+                            "definition": "Nepalese"
+                        },
+                        {
+                            "code": "2051-1",
+                            "display": "Singaporean",
+                            "definition": "Singaporean"
+                        },
+                        {
+                            "code": "2052-9",
+                            "display": "Madagascar",
+                            "definition": "Madagascar"
+                        }
+                    ]
+                },
+                {
+                    "code": "2054-5",
+                    "display": "Black or African American",
+                    "definition": "Black or African American",
+                    "concept": [
+                        {
+                            "code": "2056-0",
+                            "display": "Black",
+                            "definition": "Black"
+                        },
+                        {
+                            "code": "2058-6",
+                            "display": "African American",
+                            "definition": "African American"
+                        },
+                        {
+                            "code": "2060-2",
+                            "display": "African",
+                            "definition": "African"
+                        },
+                        {
+                            "code": "2067-7",
+                            "display": "Bahamian",
+                            "definition": "Bahamian"
+                        },
+                        {
+                            "code": "2068-5",
+                            "display": "Barbadian",
+                            "definition": "Barbadian"
+                        },
+                        {
+                            "code": "2069-3",
+                            "display": "Dominican",
+                            "definition": "Dominican"
+                        },
+                        {
+                            "code": "2070-1",
+                            "display": "Dominica Islander",
+                            "definition": "Dominica Islander"
+                        },
+                        {
+                            "code": "2071-9",
+                            "display": "Haitian",
+                            "definition": "Haitian"
+                        },
+                        {
+                            "code": "2072-7",
+                            "display": "Jamaican",
+                            "definition": "Jamaican"
+                        },
+                        {
+                            "code": "2073-5",
+                            "display": "Tobagoan",
+                            "definition": "Tobagoan"
+                        },
+                        {
+                            "code": "2074-3",
+                            "display": "Trinidadian",
+                            "definition": "Trinidadian"
+                        },
+                        {
+                            "code": "2075-0",
+                            "display": "West Indian",
+                            "definition": "West Indian"
+                        },
+                        {
+                            "code": "2061-0",
+                            "display": "Botswanan",
+                            "definition": "Botswanan"
+                        },
+                        {
+                            "code": "2062-8",
+                            "display": "Ethiopian",
+                            "definition": "Ethiopian"
+                        },
+                        {
+                            "code": "2063-6",
+                            "display": "Liberian",
+                            "definition": "Liberian"
+                        },
+                        {
+                            "code": "2064-4",
+                            "display": "Namibian",
+                            "definition": "Namibian"
+                        },
+                        {
+                            "code": "2065-1",
+                            "display": "Nigerian",
+                            "definition": "Nigerian"
+                        },
+                        {
+                            "code": "2066-9",
+                            "display": "Zairean",
+                            "definition": "Zairean"
+                        }
+                    ]
+                },
+                {
+                    "code": "2076-8",
+                    "display": "Native Hawaiian or Other Pacific Islander",
+                    "definition": "Native Hawaiian or Other Pacific Islander",
+                    "concept": [
+                        {
+                            "code": "2078-4",
+                            "display": "Polynesian",
+                            "definition": "Polynesian"
+                        },
+                        {
+                            "code": "2085-9",
+                            "display": "Micronesian",
+                            "definition": "Micronesian"
+                        },
+                        {
+                            "code": "2100-6",
+                            "display": "Melanesian",
+                            "definition": "Melanesian"
+                        },
+                        {
+                            "code": "2500-7",
+                            "display": "Other Pacific Islander",
+                            "definition": "Other Pacific Islander"
+                        },
+                        {
+                            "code": "2079-2",
+                            "display": "Native Hawaiian",
+                            "definition": "Native Hawaiian"
+                        },
+                        {
+                            "code": "2080-0",
+                            "display": "Samoan",
+                            "definition": "Samoan"
+                        },
+                        {
+                            "code": "2081-8",
+                            "display": "Tahitian",
+                            "definition": "Tahitian"
+                        },
+                        {
+                            "code": "2082-6",
+                            "display": "Tongan",
+                            "definition": "Tongan"
+                        },
+                        {
+                            "code": "2083-4",
+                            "display": "Tokelauan",
+                            "definition": "Tokelauan"
+                        },
+                        {
+                            "code": "2086-7",
+                            "display": "Guamanian or Chamorro",
+                            "definition": "Guamanian or Chamorro"
+                        },
+                        {
+                            "code": "2087-5",
+                            "display": "Guamanian",
+                            "definition": "Guamanian"
+                        },
+                        {
+                            "code": "2088-3",
+                            "display": "Chamorro",
+                            "definition": "Chamorro"
+                        },
+                        {
+                            "code": "2089-1",
+                            "display": "Mariana Islander",
+                            "definition": "Mariana Islander"
+                        },
+                        {
+                            "code": "2090-9",
+                            "display": "Marshallese",
+                            "definition": "Marshallese"
+                        },
+                        {
+                            "code": "2091-7",
+                            "display": "Palauan",
+                            "definition": "Palauan"
+                        },
+                        {
+                            "code": "2092-5",
+                            "display": "Carolinian",
+                            "definition": "Carolinian"
+                        },
+                        {
+                            "code": "2093-3",
+                            "display": "Kosraean",
+                            "definition": "Kosraean"
+                        },
+                        {
+                            "code": "2094-1",
+                            "display": "Pohnpeian",
+                            "definition": "Pohnpeian"
+                        },
+                        {
+                            "code": "2095-8",
+                            "display": "Saipanese",
+                            "definition": "Saipanese"
+                        },
+                        {
+                            "code": "2096-6",
+                            "display": "Kiribati",
+                            "definition": "Kiribati"
+                        },
+                        {
+                            "code": "2097-4",
+                            "display": "Chuukese",
+                            "definition": "Chuukese"
+                        },
+                        {
+                            "code": "2098-2",
+                            "display": "Yapese",
+                            "definition": "Yapese"
+                        },
+                        {
+                            "code": "2101-4",
+                            "display": "Fijian",
+                            "definition": "Fijian"
+                        },
+                        {
+                            "code": "2102-2",
+                            "display": "Papua New Guinean",
+                            "definition": "Papua New Guinean"
+                        },
+                        {
+                            "code": "2103-0",
+                            "display": "Solomon Islander",
+                            "definition": "Solomon Islander"
+                        },
+                        {
+                            "code": "2104-8",
+                            "display": "New Hebrides",
+                            "definition": "New Hebrides"
+                        }
+                    ]
+                },
+                {
+                    "code": "2106-3",
+                    "display": "White",
+                    "definition": "White",
+                    "concept": [
+                        {
+                            "code": "2108-9",
+                            "display": "European",
+                            "definition": "European"
+                        },
+                        {
+                            "code": "2118-8",
+                            "display": "Middle Eastern or North African",
+                            "definition": "Middle Eastern or North African"
+                        },
+                        {
+                            "code": "2129-5",
+                            "display": "Arab",
+                            "definition": "Arab"
+                        },
+                        {
+                            "code": "2109-7",
+                            "display": "Armenian",
+                            "definition": "Armenian"
+                        },
+                        {
+                            "code": "2110-5",
+                            "display": "English",
+                            "definition": "English"
+                        },
+                        {
+                            "code": "2111-3",
+                            "display": "French",
+                            "definition": "French"
+                        },
+                        {
+                            "code": "2112-1",
+                            "display": "German",
+                            "definition": "German"
+                        },
+                        {
+                            "code": "2113-9",
+                            "display": "Irish",
+                            "definition": "Irish"
+                        },
+                        {
+                            "code": "2114-7",
+                            "display": "Italian",
+                            "definition": "Italian"
+                        },
+                        {
+                            "code": "2115-4",
+                            "display": "Polish",
+                            "definition": "Polish"
+                        },
+                        {
+                            "code": "2116-2",
+                            "display": "Scottish",
+                            "definition": "Scottish"
+                        },
+                        {
+                            "code": "2119-6",
+                            "display": "Assyrian",
+                            "definition": "Assyrian"
+                        },
+                        {
+                            "code": "2120-4",
+                            "display": "Egyptian",
+                            "definition": "Egyptian"
+                        },
+                        {
+                            "code": "2121-2",
+                            "display": "Iranian",
+                            "definition": "Iranian"
+                        },
+                        {
+                            "code": "2122-0",
+                            "display": "Iraqi",
+                            "definition": "Iraqi"
+                        },
+                        {
+                            "code": "2123-8",
+                            "display": "Lebanese",
+                            "definition": "Lebanese"
+                        },
+                        {
+                            "code": "2124-6",
+                            "display": "Palestinian",
+                            "definition": "Palestinian"
+                        },
+                        {
+                            "code": "2125-3",
+                            "display": "Syrian",
+                            "definition": "Syrian"
+                        },
+                        {
+                            "code": "2126-1",
+                            "display": "Afghanistani",
+                            "definition": "Afghanistani"
+                        },
+                        {
+                            "code": "2127-9",
+                            "display": "Israeili",
+                            "definition": "Israeili"
+                        }
+                    ]
+                },
+                {
+                    "code": "2131-1",
+                    "display": "Other Race",
+                    "definition": "Note that this term remains in the table for completeness, even though within HL7, the notion of Other code is deprecated."
+                }
+            ]
+        },
+        {
+            "code": "2133-7",
+            "display": "Ethnicity",
+            "definition": "Ethnicity Note that this is an abstract 'grouping' concept and not for use as a real concept",
+            "property": [
+                {
+                    "code": "abstract",
+                    "valueBoolean": true
+                }
+            ],
+            "concept": [
+                {
+                    "code": "2135-2",
+                    "display": "Hispanic or Latino",
+                    "definition": "Hispanic or Latino",
+                    "concept": [
+                        {
+                            "code": "2137-8",
+                            "display": "Spaniard",
+                            "definition": "Spaniard"
+                        },
+                        {
+                            "code": "2148-5",
+                            "display": "Mexican",
+                            "definition": "Mexican"
+                        },
+                        {
+                            "code": "2155-0",
+                            "display": "Central American",
+                            "definition": "Central American"
+                        },
+                        {
+                            "code": "2165-9",
+                            "display": "South American",
+                            "definition": "South American"
+                        },
+                        {
+                            "code": "2178-2",
+                            "display": "Latin American",
+                            "definition": "Latin American"
+                        },
+                        {
+                            "code": "2180-8",
+                            "display": "Puerto Rican",
+                            "definition": "Puerto Rican"
+                        },
+                        {
+                            "code": "2182-4",
+                            "display": "Cuban",
+                            "definition": "Cuban"
+                        },
+                        {
+                            "code": "2184-0",
+                            "display": "Dominican",
+                            "definition": "Dominican"
+                        },
+                        {
+                            "code": "2138-6",
+                            "display": "Andalusian",
+                            "definition": "Andalusian"
+                        },
+                        {
+                            "code": "2139-4",
+                            "display": "Asturian",
+                            "definition": "Asturian"
+                        },
+                        {
+                            "code": "2140-2",
+                            "display": "Castillian",
+                            "definition": "Castillian"
+                        },
+                        {
+                            "code": "2141-0",
+                            "display": "Catalonian",
+                            "definition": "Catalonian"
+                        },
+                        {
+                            "code": "2142-8",
+                            "display": "Belearic Islander",
+                            "definition": "Belearic Islander"
+                        },
+                        {
+                            "code": "2143-6",
+                            "display": "Gallego",
+                            "definition": "Gallego"
+                        },
+                        {
+                            "code": "2144-4",
+                            "display": "Valencian",
+                            "definition": "Valencian"
+                        },
+                        {
+                            "code": "2145-1",
+                            "display": "Canarian",
+                            "definition": "Canarian"
+                        },
+                        {
+                            "code": "2146-9",
+                            "display": "Spanish Basque",
+                            "definition": "Spanish Basque"
+                        },
+                        {
+                            "code": "2149-3",
+                            "display": "Mexican American",
+                            "definition": "Mexican American"
+                        },
+                        {
+                            "code": "2150-1",
+                            "display": "Mexicano",
+                            "definition": "Mexicano"
+                        },
+                        {
+                            "code": "2151-9",
+                            "display": "Chicano",
+                            "definition": "Chicano"
+                        },
+                        {
+                            "code": "2152-7",
+                            "display": "La Raza",
+                            "definition": "La Raza"
+                        },
+                        {
+                            "code": "2153-5",
+                            "display": "Mexican American Indian",
+                            "definition": "Mexican American Indian"
+                        },
+                        {
+                            "code": "2156-8",
+                            "display": "Costa Rican",
+                            "definition": "Costa Rican"
+                        },
+                        {
+                            "code": "2157-6",
+                            "display": "Guatemalan",
+                            "definition": "Guatemalan"
+                        },
+                        {
+                            "code": "2158-4",
+                            "display": "Honduran",
+                            "definition": "Honduran"
+                        },
+                        {
+                            "code": "2159-2",
+                            "display": "Nicaraguan",
+                            "definition": "Nicaraguan"
+                        },
+                        {
+                            "code": "2160-0",
+                            "display": "Panamanian",
+                            "definition": "Panamanian"
+                        },
+                        {
+                            "code": "2161-8",
+                            "display": "Salvadoran",
+                            "definition": "Salvadoran"
+                        },
+                        {
+                            "code": "2162-6",
+                            "display": "Central American Indian",
+                            "definition": "Central American Indian"
+                        },
+                        {
+                            "code": "2163-4",
+                            "display": "Canal Zone",
+                            "definition": "Canal Zone"
+                        },
+                        {
+                            "code": "2166-7",
+                            "display": "Argentinean",
+                            "definition": "Argentinean"
+                        },
+                        {
+                            "code": "2167-5",
+                            "display": "Bolivian",
+                            "definition": "Bolivian"
+                        },
+                        {
+                            "code": "2168-3",
+                            "display": "Chilean",
+                            "definition": "Chilean"
+                        },
+                        {
+                            "code": "2169-1",
+                            "display": "Colombian",
+                            "definition": "Colombian"
+                        },
+                        {
+                            "code": "2170-9",
+                            "display": "Ecuadorian",
+                            "definition": "Ecuadorian"
+                        },
+                        {
+                            "code": "2171-7",
+                            "display": "Paraguayan",
+                            "definition": "Paraguayan"
+                        },
+                        {
+                            "code": "2172-5",
+                            "display": "Peruvian",
+                            "definition": "Peruvian"
+                        },
+                        {
+                            "code": "2173-3",
+                            "display": "Uruguayan",
+                            "definition": "Uruguayan"
+                        },
+                        {
+                            "code": "2174-1",
+                            "display": "Venezuelan",
+                            "definition": "Venezuelan"
+                        },
+                        {
+                            "code": "2175-8",
+                            "display": "South American Indian",
+                            "definition": "South American Indian"
+                        },
+                        {
+                            "code": "2176-6",
+                            "display": "Criollo",
+                            "definition": "Criollo"
+                        }
+                    ]
+                },
+                {
+                    "code": "2186-5",
+                    "display": "Not Hispanic or Latino",
+                    "definition": "Note that this term remains in the table for completeness, even though within HL7, the notion of \"not otherwise coded\" term is deprecated."
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/CodeSystem-condition-category.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/CodeSystem-condition-category.json
@@ -1,76 +1,76 @@
 {
-	"resourceType": "CodeSystem",
-	"id": "condition-category",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Properties</b></p><table class=\"grid\"><tr><td><b>Code</b></td><td><b>URL</b></td><td><b>Description</b></td><td><b>Type</b></td></tr><tr><td>status</td><td>http://hl7.org/fhir/concept-properties#status</td><td>A property that indicates the status of the concept. One of active, experimental, deprecated,        retired</td><td>code</td></tr></table><p>This code system http://hl7.org/fhir/us/core/CodeSystem/condition-category defines the following codes:</p><table class=\"codes\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td><td><b>Definition</b></td><td><b>status</b></td></tr><tr><td style=\"white-space:nowrap\">problem<a name=\"condition-category-problem\"> </a></td><td>Problem</td><td>The patients problems as identified by the provider(s). Items on the provider’s problem list</td><td>deprecated</td></tr><tr><td style=\"white-space:nowrap\">health-concern<a name=\"condition-category-health-concern\"> </a></td><td>Health Concern</td><td>Additional health concerns from other stakeholders which are outside the provider’s problem list.</td><td/></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/CodeSystem/condition-category",
-	"version": "4.0.0",
-	"name": "USCoreConditionCategoryExtensionCodes",
-	"title": "US Core Condition Category Extension Codes",
-	"status": "active",
-	"date": "2021-06-28T19:10:06+00:00",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Set of codes that are needed for implementation of the US-Core Condition Profile. These codes are used as extensions to the FHIR and US Core value sets.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"caseSensitive": true,
-	"content": "complete",
-	"property": [
-		{
-			"code": "status",
-			"uri": "http://hl7.org/fhir/concept-properties#status",
-			"description": "A property that indicates the status of the concept. One of active, experimental, deprecated,        retired",
-			"type": "code"
-		}
-	],
-	"concept": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/codesystem-replacedby",
-					"valueCoding": {
-						"system": "http://terminology.hl7.org/CodeSystem/condition-category",
-						"code": "problem-list-item",
-						"display": "Problem List Item"
-					}
-				}
-			],
-			"code": "problem",
-			"display": "Problem",
-			"definition": "The patients problems as identified by the provider(s). Items on the provider’s problem list",
-			"property": [
-				{
-					"code": "status",
-					"valueCode": "deprecated"
-				}
-			]
-		},
-		{
-			"code": "health-concern",
-			"display": "Health Concern",
-			"definition": "Additional health concerns from other stakeholders which are outside the provider’s problem list."
-		}
-	]
+    "resourceType": "CodeSystem",
+    "id": "condition-category",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/CodeSystem/condition-category",
+    "version": "4.0.0",
+    "name": "USCoreConditionCategoryExtensionCodes",
+    "title": "US Core Condition Category Extension Codes",
+    "status": "active",
+    "date": "2021-06-28T19:10:06+00:00",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Set of codes that are needed for implementation of the US-Core Condition Profile. These codes are used as extensions to the FHIR and US Core value sets.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "caseSensitive": true,
+    "content": "complete",
+    "property": [
+        {
+            "code": "status",
+            "uri": "http://hl7.org/fhir/concept-properties#status",
+            "description": "A property that indicates the status of the concept. One of active, experimental, deprecated,        retired",
+            "type": "code"
+        }
+    ],
+    "concept": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/codesystem-replacedby",
+                    "valueCoding": {
+                        "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                        "code": "problem-list-item",
+                        "display": "Problem List Item"
+                    }
+                }
+            ],
+            "code": "problem",
+            "display": "Problem",
+            "definition": "The patients problems as identified by the provider(s). Items on the provider’s problem list",
+            "property": [
+                {
+                    "code": "status",
+                    "valueCode": "deprecated"
+                }
+            ]
+        },
+        {
+            "code": "health-concern",
+            "display": "Health Concern",
+            "definition": "Additional health concerns from other stakeholders which are outside the provider’s problem list."
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/CodeSystem-us-core-documentreference-category.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/CodeSystem-us-core-documentreference-category.json
@@ -1,49 +1,49 @@
 {
-	"resourceType": "CodeSystem",
-	"id": "us-core-documentreference-category",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This code system http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category defines the following codes:</p><table class=\"codes\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td><td><b>Definition</b></td></tr><tr><td style=\"white-space:nowrap\">clinical-note<a name=\"us-core-documentreference-category-clinical-note\"> </a></td><td>Clinical Note</td><td>Part of health record where healthcare professionals record details to document a patient's clinical status or achievements during the course of a hospitalization or over the course of outpatient care ([Wikipedia](https://en.wikipedia.org/wiki/Progress_note))</td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category",
-	"version": "4.0.0",
-	"name": "USCoreDocumentReferencesCategoryCodes",
-	"title": "US Core DocumentReferences Category Codes",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The US Core DocumentReferences Type Code System is a 'starter set' of categories supported for fetching and storing DocumentReference Resources.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"caseSensitive": true,
-	"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-category",
-	"content": "complete",
-	"count": 2,
-	"concept": [
-		{
-			"code": "clinical-note",
-			"display": "Clinical Note",
-			"definition": "Part of health record where healthcare professionals record details to document a patient's clinical status or achievements during the course of a hospitalization or over the course of outpatient care ([Wikipedia](https://en.wikipedia.org/wiki/Progress_note))"
-		}
-	]
+    "resourceType": "CodeSystem",
+    "id": "us-core-documentreference-category",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category",
+    "version": "4.0.0",
+    "name": "USCoreDocumentReferencesCategoryCodes",
+    "title": "US Core DocumentReferences Category Codes",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The US Core DocumentReferences Type Code System is a 'starter set' of categories supported for fetching and storing DocumentReference Resources.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "caseSensitive": true,
+    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-category",
+    "content": "complete",
+    "count": 2,
+    "concept": [
+        {
+            "code": "clinical-note",
+            "display": "Clinical Note",
+            "definition": "Part of health record where healthcare professionals record details to document a patient's clinical status or achievements during the course of a hospitalization or over the course of outpatient care ([Wikipedia](https://en.wikipedia.org/wiki/Progress_note))"
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/CodeSystem-us-core-provenance-participant-type.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/CodeSystem-us-core-provenance-participant-type.json
@@ -1,47 +1,47 @@
 {
-	"resourceType": "CodeSystem",
-	"id": "us-core-provenance-participant-type",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This code system http://hl7.org/fhir/us/core/CodeSystem/us-core-provenance-participant-type defines the following codes:</p><table class=\"codes\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td><td><b>Definition</b></td></tr><tr><td style=\"white-space:nowrap\">transmitter<a name=\"us-core-provenance-participant-type-transmitter\"> </a></td><td>Transmitter</td><td>The entity that provided the copy to your system.</td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/CodeSystem/us-core-provenance-participant-type",
-	"version": "4.0.0",
-	"name": "USCoreProvenancePaticipantTypeExtensionCodes",
-	"title": "US Core Provenance Participant Type Extension Codes",
-	"status": "active",
-	"date": "2021-06-28T19:10:06+00:00",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Set of codes that are needed for implementation of the US-Core Provenance Profile. These codes are used as extensions to the FHIR value sets.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"caseSensitive": true,
-	"content": "complete",
-	"concept": [
-		{
-			"code": "transmitter",
-			"display": "Transmitter",
-			"definition": "The entity that provided the copy to your system."
-		}
-	]
+    "resourceType": "CodeSystem",
+    "id": "us-core-provenance-participant-type",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/CodeSystem/us-core-provenance-participant-type",
+    "version": "4.0.0",
+    "name": "USCoreProvenancePaticipantTypeExtensionCodes",
+    "title": "US Core Provenance Participant Type Extension Codes",
+    "status": "active",
+    "date": "2021-06-28T19:10:06+00:00",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Set of codes that are needed for implementation of the US-Core Provenance Profile. These codes are used as extensions to the FHIR value sets.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "caseSensitive": true,
+    "content": "complete",
+    "concept": [
+        {
+            "code": "transmitter",
+            "display": "Transmitter",
+            "definition": "The entity that provided the copy to your system."
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ImplementationGuide-hl7.fhir.us.core.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ImplementationGuide-hl7.fhir.us.core.json
@@ -1,3832 +1,3832 @@
 {
-	"resourceType": "ImplementationGuide",
-	"id": "hl7.fhir.us.core",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>USCore</h2><p>The official URL for this implementation guide is: </p><pre>http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core</pre><div><p>The US Core Implementation Guide is based on FHIR Version R4 and defines the minimum conformance requirements for accessing patient data. The Argonaut pilot implementations, ONC 2015 Edition Common Clinical Data Set (CCDS), and ONC U.S. Core Data for Interoperability (USCDI) v1 provided the requirements for this guide. The prior Argonaut search and vocabulary requirements, based on FHIR DSTU2, are updated in this guide to support FHIR Version R4. This guide was used as the basis for further testing and guidance by the Argonaut Project Team to provide additional content and guidance specific to Data Query Access for purpose of ONC Certification testing. These profiles are the foundation for future US Realm FHIR implementation guides. In addition to Argonaut, they are used by DAF-Research, QI-Core, and CIMI. Under the guidance of HL7 and the HL7 US Realm Steering Committee, the content will expand in future versions to meet the needs specific to the US Realm.\nThese requirements were originally developed, balloted, and published in FHIR DSTU2 as part of the Office of the National Coordinator for Health Information Technology (ONC) sponsored Data Access Framework (DAF) project. For more information on how DAF became US Core see the US Core change notes.</p>\n</div></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core",
-	"version": "4.0.0",
-	"name": "USCore",
-	"title": "US Core Implementation Guide",
-	"status": "active",
-	"date": "2021-06-16",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The US Core Implementation Guide is based on FHIR Version R4 and defines the minimum conformance requirements for accessing patient data. The Argonaut pilot implementations, ONC 2015 Edition Common Clinical Data Set (CCDS), and ONC U.S. Core Data for Interoperability (USCDI) v1 provided the requirements for this guide. The prior Argonaut search and vocabulary requirements, based on FHIR DSTU2, are updated in this guide to support FHIR Version R4. This guide was used as the basis for further testing and guidance by the Argonaut Project Team to provide additional content and guidance specific to Data Query Access for purpose of ONC Certification testing. These profiles are the foundation for future US Realm FHIR implementation guides. In addition to Argonaut, they are used by DAF-Research, QI-Core, and CIMI. Under the guidance of HL7 and the HL7 US Realm Steering Committee, the content will expand in future versions to meet the needs specific to the US Realm.\nThese requirements were originally developed, balloted, and published in FHIR DSTU2 as part of the Office of the National Coordinator for Health Information Technology (ONC) sponsored Data Access Framework (DAF) project. For more information on how DAF became US Core see the US Core change notes.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"packageId": "hl7.fhir.us.core",
-	"license": "CC0-1.0",
-	"fhirVersion": [
-		"4.0.1"
-	],
-	"dependsOn": [
-		{
-			"id": "hl7_fhir_uv_bulkdata",
-			"uri": "http://hl7.org/fhir/uv/bulkdata/ImplementationGuide/hl7.fhir.uv.bulkdata",
-			"packageId": "hl7.fhir.uv.bulkdata",
-			"version": "1.0.1"
-		},
-		{
-			"id": "vsac",
-			"uri": "http://fhir.org/packages/us.nlm.vsac/ImplementationGuide/us.nlm.vsac",
-			"packageId": "us.nlm.vsac",
-			"version": "0.3.0"
-		}
-	],
-	"definition": {
-		"extension": [
-			{
-				"extension": [
-					{
-						"url": "code",
-						"valueString": "copyrightyear"
-					},
-					{
-						"url": "value",
-						"valueString": "2021+"
-					}
-				],
-				"url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
-			},
-			{
-				"extension": [
-					{
-						"url": "code",
-						"valueString": "releaselabel"
-					},
-					{
-						"url": "value",
-						"valueString": "STU4 Release"
-					}
-				],
-				"url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
-			},
-			{
-				"extension": [
-					{
-						"url": "code",
-						"valueString": "path-expansion-params"
-					},
-					{
-						"url": "value",
-						"valueString": "../../input/_resources/exp-params.json"
-					}
-				],
-				"url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
-			},
-			{
-				"extension": [
-					{
-						"url": "code",
-						"valueString": "active-tables"
-					},
-					{
-						"url": "value",
-						"valueString": "false"
-					}
-				],
-				"url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
-			},
-			{
-				"extension": [
-					{
-						"url": "code",
-						"valueString": "apply-contact"
-					},
-					{
-						"url": "value",
-						"valueString": "true"
-					}
-				],
-				"url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
-			},
-			{
-				"extension": [
-					{
-						"url": "code",
-						"valueString": "apply-jurisdiction"
-					},
-					{
-						"url": "value",
-						"valueString": "true"
-					}
-				],
-				"url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
-			},
-			{
-				"extension": [
-					{
-						"url": "code",
-						"valueString": "apply-publisher"
-					},
-					{
-						"url": "value",
-						"valueString": "true"
-					}
-				],
-				"url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
-			},
-			{
-				"extension": [
-					{
-						"url": "code",
-						"valueString": "apply-version"
-					},
-					{
-						"url": "value",
-						"valueString": "true"
-					}
-				],
-				"url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
-			},
-			{
-				"extension": [
-					{
-						"url": "code",
-						"valueString": "show-inherited-invariants"
-					},
-					{
-						"url": "value",
-						"valueString": "false"
-					}
-				],
-				"url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
-			},
-			{
-				"extension": [
-					{
-						"url": "code",
-						"valueString": "usage-stats-opt-out"
-					},
-					{
-						"url": "value",
-						"valueString": "true"
-					}
-				],
-				"url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
-			},
-			{
-				"extension": [
-					{
-						"url": "code",
-						"valueString": "excludexml"
-					},
-					{
-						"url": "value",
-						"valueString": "false"
-					}
-				],
-				"url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
-			},
-			{
-				"extension": [
-					{
-						"url": "code",
-						"valueString": "excludejsn"
-					},
-					{
-						"url": "value",
-						"valueString": "false"
-					}
-				],
-				"url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
-			},
-			{
-				"extension": [
-					{
-						"url": "code",
-						"valueString": "excludettl"
-					},
-					{
-						"url": "value",
-						"valueString": "true"
-					}
-				],
-				"url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
-			},
-			{
-				"extension": [
-					{
-						"url": "code",
-						"valueString": "excludemap"
-					},
-					{
-						"url": "value",
-						"valueString": "true"
-					}
-				],
-				"url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
-			},
-			{
-				"extension": [
-					{
-						"url": "code",
-						"valueString": "excludeexample"
-					},
-					{
-						"url": "value",
-						"valueString": "true"
-					}
-				],
-				"url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
-			},
-			{
-				"extension": [
-					{
-						"url": "code",
-						"valueString": "generate"
-					},
-					{
-						"url": "value",
-						"valueString": "xml"
-					}
-				],
-				"url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
-			},
-			{
-				"extension": [
-					{
-						"url": "code",
-						"valueString": "generate"
-					},
-					{
-						"url": "value",
-						"valueString": "json"
-					}
-				],
-				"url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
-			},
-			{
-				"extension": [
-					{
-						"url": "code",
-						"valueString": "path-history"
-					},
-					{
-						"url": "value",
-						"valueString": "http://hl7.org/fhir/us/core/history.html"
-					}
-				],
-				"url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
-			},
-			{
-				"extension": [
-					{
-						"url": "code",
-						"valueString": "autoload-resources"
-					},
-					{
-						"url": "value",
-						"valueString": "true"
-					}
-				],
-				"url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
-			},
-			{
-				"extension": [
-					{
-						"url": "code",
-						"valueString": "path-liquid"
-					},
-					{
-						"url": "value",
-						"valueString": "template/liquid"
-					}
-				],
-				"url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
-			},
-			{
-				"extension": [
-					{
-						"url": "code",
-						"valueString": "path-liquid"
-					},
-					{
-						"url": "value",
-						"valueString": "input/liquid"
-					}
-				],
-				"url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
-			},
-			{
-				"extension": [
-					{
-						"url": "code",
-						"valueString": "path-qa"
-					},
-					{
-						"url": "value",
-						"valueString": "temp/qa"
-					}
-				],
-				"url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
-			},
-			{
-				"extension": [
-					{
-						"url": "code",
-						"valueString": "path-temp"
-					},
-					{
-						"url": "value",
-						"valueString": "temp/pages"
-					}
-				],
-				"url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
-			},
-			{
-				"extension": [
-					{
-						"url": "code",
-						"valueString": "path-output"
-					},
-					{
-						"url": "value",
-						"valueString": "output"
-					}
-				],
-				"url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
-			},
-			{
-				"extension": [
-					{
-						"url": "code",
-						"valueString": "path-suppressed-warnings"
-					},
-					{
-						"url": "value",
-						"valueString": "input/ignoreWarnings.txt"
-					}
-				],
-				"url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
-			},
-			{
-				"extension": [
-					{
-						"url": "code",
-						"valueString": "template-html"
-					},
-					{
-						"url": "value",
-						"valueString": "template-page.html"
-					}
-				],
-				"url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
-			},
-			{
-				"extension": [
-					{
-						"url": "code",
-						"valueString": "template-md"
-					},
-					{
-						"url": "value",
-						"valueString": "template-page-md.html"
-					}
-				],
-				"url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
-			},
-			{
-				"extension": [
-					{
-						"url": "code",
-						"valueString": "apply-context"
-					},
-					{
-						"url": "value",
-						"valueString": "true"
-					}
-				],
-				"url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
-			},
-			{
-				"extension": [
-					{
-						"url": "code",
-						"valueString": "apply-copyright"
-					},
-					{
-						"url": "value",
-						"valueString": "true"
-					}
-				],
-				"url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
-			},
-			{
-				"extension": [
-					{
-						"url": "code",
-						"valueString": "apply-license"
-					},
-					{
-						"url": "value",
-						"valueString": "true"
-					}
-				],
-				"url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
-			}
-		],
-		"resource": [
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/head-occipital-frontal-circumference-percentile"
-				},
-				"name": "US Core Pediatric Head Occipital-frontal Circumference Percentile Profile",
-				"description": "Defines constraints on the Observation resource to represent head occipital-frontal circumference percentile for patients from birth to 36 months of age in FHIR using a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-allergyintolerance"
-				},
-				"name": "US Core AllergyIntolerance Profile",
-				"description": "Defines constraints and extensions on the AllergyIntolerance resource for the minimal set of data to query and retrieve allergy information.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:extension"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-birthsex"
-				},
-				"name": "US Core Birth Sex Extension",
-				"description": "A code classifying the person's sex assigned at birth  as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc). This extension aligns with the C-CDA Birth Sex Observation (LOINC 76689-9).",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-blood-pressure"
-				},
-				"name": "US Core Blood Pressure Profile",
-				"description": "Defines constraints on Observation to represent diastolic and systolic blood pressure observations with standard LOINC codes and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-bmi"
-				},
-				"name": "US Core BMI Profile",
-				"description": "Defines constraints on Observation to represent Body Mass Index (BMI) observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-body-height"
-				},
-				"name": "US Core Body Height Profile",
-				"description": "Defines constraints on Observation to represent body height observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-body-temperature"
-				},
-				"name": "US Core Body Temperature Profile",
-				"description": "Defines constraints on Observation to represent body temperature observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-body-weight"
-				},
-				"name": "US Core Body Weight Profile",
-				"description": "Defines constraints on Observation to represent body weight observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-careplan"
-				},
-				"name": "US Core CarePlan Profile",
-				"description": "Defines constraints and extensions on the CarePlan resource for the minimal set of data to query and retrieve a patient's Care Plan.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-careteam"
-				},
-				"name": "US Core CareTeam Profile",
-				"description": "Defines constraints and extensions on the CareTeam resource for the minimal set of data to query and retrieve a patient's Care Team.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-condition"
-				},
-				"name": "US Core Condition Profile",
-				"description": "Defines constraints and extensions on the Condition resource for the minimal set of data to query and retrieve problems and health concerns information.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-diagnosticreport-lab"
-				},
-				"name": "US Core DiagnosticReport Profile for Laboratory Results Reporting",
-				"description": "Defines constraints and extensions on the DiagnosticReport resource  for the minimal set of data to query and retrieve diagnostic reports associated with laboratory results for a patient",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-diagnosticreport-note"
-				},
-				"name": "US Core DiagnosticReport Profile for Report and Note exchange",
-				"description": "Defines constraints and extensions on the DiagnosticReport resource  for the minimal set of data to query and retrieve diagnostic reports associated with clinical notes for a patient",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:extension"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-direct"
-				},
-				"name": "US Core Direct email Extension",
-				"description": "This email address is associated with a [direct](http://wiki.directproject.org/Addressing+Specification) service.  This extension can only be used on contact points where the system = 'email'",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-documentreference"
-				},
-				"name": "US Core DocumentReference Profile",
-				"description": "The document reference profile used in US Core.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-encounter"
-				},
-				"name": "US Core Encounter Profile",
-				"description": "The Encounter referenced in the US Core profiles.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:extension"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-ethnicity"
-				},
-				"name": "US Core Ethnicity Extension",
-				"description": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-goal"
-				},
-				"name": "US Core Goal Profile",
-				"description": "Defines constraints and extensions on the Goal resource for the minimal set of data to query and retrieve a patient's goal(s).",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-head-circumference"
-				},
-				"name": "US Core Head Circumference Profile",
-				"description": "Defines constraints on Observation to represent head circumference observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-heart-rate"
-				},
-				"name": "US Core Heart Rate Profile",
-				"description": "Defines constraints on Observation to represent heart rate observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-immunization"
-				},
-				"name": "US Core Immunization Profile",
-				"description": "Defines constraints and extensions on the Immunization resource for the minimal set of data to query and retrieve  patient's immunization information.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-implantable-device"
-				},
-				"name": "US Core Implantable Device Profile",
-				"description": "Defines constraints and extensions on the Device resource for the minimal set of data to query and retrieve a patient's implantable device(s).",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-location"
-				},
-				"name": "US Core Location Profile",
-				"description": "Defines basic constraints and extensions on the Location resource for use with other US Core resources",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-medication"
-				},
-				"name": "US Core Medication Profile",
-				"description": "Defines constraints and extensions on the Medication resource for the minimal set of data to query and retrieve patient retrieving patient's medication information.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-medicationrequest"
-				},
-				"name": "US Core MedicationRequest Profile",
-				"description": "Defines constraints and extensions on the MedicationRequest resource for the minimal set of data to query and retrieve prescription information.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-observation-lab"
-				},
-				"name": "US Core Laboratory Result Observation Profile",
-				"description": "Defines constraints and extensions on the Observation resource for the minimal set of data to query and retrieve laboratory test results",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-organization"
-				},
-				"name": "US Core Organization Profile",
-				"description": "Defines basic constraints and extensions on the Organization resource for use with other US Core resources",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/pediatric-bmi-for-age"
-				},
-				"name": "US Core Pediatric BMI for Age Observation Profile",
-				"description": "Defines constraints on Observation to represent to represent BMI percentile per age and sex for youth 2-20 observations in FHIR using a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/pediatric-weight-for-height"
-				},
-				"name": "US Core Pediatric Weight for Height Observation Profile",
-				"description": "Defines constraints on the Observation resource to represent pediatric Weight-for-length per age and gender observations in FHIR with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-practitioner"
-				},
-				"name": "US Core Practitioner Profile",
-				"description": "The practitioner(s) referenced in US Core profiles.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-practitionerrole"
-				},
-				"name": "US Core PractitionerRole Profile",
-				"description": "The practitioner roles referenced in the US Core profiles.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-procedure"
-				},
-				"name": "US Core Procedure Profile",
-				"description": "Defines constraints and extensions on the Procedure resource for the minimal set of data to query and retrieve patient's procedure information.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-provenance"
-				},
-				"name": "US Core Provenance Profile",
-				"description": "Draft set of requirements to satisfy Basic Provenance Requirements.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-pulse-oximetry"
-				},
-				"name": "US Core Pulse Oximetry Profile",
-				"description": "Defines constraints on the Observation resource to represent inspired O2 by pulse oximetry and inspired oxygen concentration observations with a standard LOINC codes and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:extension"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-race"
-				},
-				"name": "US Core Race Extension",
-				"description": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\n - American Indian or Alaska Native\n - Asian\n - Black or African American\n - Native Hawaiian or Other Pacific Islander\n - White.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-respiratory-rate"
-				},
-				"name": "US Core Respiratory Rate Profile",
-				"description": "Defines constraints on Observation to represent respiratory rate observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-smokingstatus"
-				},
-				"name": "US Core Smoking Status Observation Profile",
-				"description": "Defines constraints and extensions on the Observation  resource for the minimal set of data to query and retrieve patient's Smoking Status information.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-vital-signs"
-				},
-				"name": "US Core Vital Signs Profile",
-				"description": "Defines constraints on the Observation resource to represent vital signs observations.  This profile is used as the base definition for the other US Core Vital Signs Profiles and based on the FHIR VitalSigns Profile.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CapabilityStatement"
-					}
-				],
-				"reference": {
-					"reference": "CapabilityStatement/us-core-client"
-				},
-				"name": "US Core Client CapabilityStatement",
-				"description": "This Section describes the expected capabilities of the US Core Client which is responsible for creating and initiating the queries for information about an individual patient. The complete list of FHIR profiles, RESTful operations, and search parameters supported by US Core Servers are defined in the [Conformance Requirements for Server](CapabilityStatement-us-core-server.html). US Core Clients have the option of choosing from this list to access necessary data based on their local use cases and other contextual requirements.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CapabilityStatement"
-					}
-				],
-				"reference": {
-					"reference": "CapabilityStatement/us-core-server"
-				},
-				"name": "US Core Server CapabilityStatement",
-				"description": "This Section describes the expected capabilities of the US Core Server actor which is responsible for providing responses to the queries submitted by the US Core Requestors. The complete list of FHIR profiles, RESTful operations, and search parameters supported by US Core Servers are defined. Systems implementing this capability statement should meet the ONC 2015 Common Clinical Data Set (CCDS) access requirement for Patient Selection 170.315(g)(7) and Application Access - Data Category Request 170.315(g)(8) and and the ONC [U.S. Core Data for Interoperability (USCDI)](https://www.healthit.gov/isa/sites/isa/files/2020-03/USCDI-Version1-2020-Final-Standard.pdf).  US Core Clients have the option of choosing from this list to access necessary data based on their local use cases and other contextual requirements.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CodeSystem"
-					}
-				],
-				"reference": {
-					"reference": "CodeSystem/careplan-category"
-				},
-				"name": "US Core CarePlan Category Extension Codes",
-				"description": "Set of codes that are needed for implementation of the US-Core CarePlan Profile. These codes are used as extensions to the FHIR ValueSet.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CodeSystem"
-					}
-				],
-				"reference": {
-					"reference": "CodeSystem/cdcrec"
-				},
-				"name": "Race & Ethnicity - CDC",
-				"description": "The U.S. Centers for Disease Control and Prevention (CDC) has prepared a code set for use in codingrace and ethnicity data. This code set is based on current federal standards for classifying data onrace and ethnicity, specifically the minimum race and ethnicity categories defined by the U.S. Office ofManagement and Budget (OMB) and a more detailed set of race and ethnicity categories maintainedby the U.S. Bureau of the Census (BC). The main purpose of the code set is to facilitate use of federalstandards for classifying data on race and ethnicity when these data are exchanged, stored, retrieved,or analyzed in electronic form. At the same time, the code set can be applied to paper-based recordsystems to the extent that these systems are used to collect, maintain, and report data on race andethnicity in accordance with current federal standards. Source: [Race and Ethnicity Code Set Version 1.0](https://www.cdc.gov/phin/resources/vocabulary/documents/cdc-race--ethnicity-background-and-purpose.pdf).",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CodeSystem"
-					}
-				],
-				"reference": {
-					"reference": "CodeSystem/condition-category"
-				},
-				"name": "US Core Condition Category Extension Codes",
-				"description": "Set of codes that are needed for implementation of the US-Core Condition Profile. These codes are used as extensions to the FHIR and US Core value sets.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CodeSystem"
-					}
-				],
-				"reference": {
-					"reference": "CodeSystem/us-core-documentreference-category"
-				},
-				"name": "US Core DocumentReferences Category Codes",
-				"description": "The US Core DocumentReferences Type Code System is a 'starter set' of categories supported for fetching and storing DocumentReference Resources.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CodeSystem"
-					}
-				],
-				"reference": {
-					"reference": "CodeSystem/us-core-provenance-participant-type"
-				},
-				"name": "US Core Provenance Participant Type Extension Codes",
-				"description": "Set of codes that are needed for implementation of the US-Core Provenance Profile. These codes are used as extensions to the FHIR value sets.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "OperationDefinition"
-					}
-				],
-				"reference": {
-					"reference": "OperationDefinition/docref"
-				},
-				"name": "US Core Fetch DocumentReference",
-				"description": "This operation is used to return all the references to documents related to a patient. \n\n The operation requires a patient id and takes the optional input parameters: \n  - start date\n  - end date\n  - document type \n\n and returns a [Bundle](http://hl7.org/fhir/bundle.html) of type \"searchset\" containing [DocumentReference](http://hl7.org/fhir/documentreference.html) resources for the patient. The DocumentReference resources **SHOULD** conform to the [US Core DocumentReference\n Profiles](http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference). If the server has or can create documents that are related to the patient, and that are available for the given user, the server returns the DocumentReference resources needed to support the records.  The principle intended use for this operation is to provide a provider or patient with access to their available document information. \n\n This operation is *different* from a search by patient and type and date range because: \n\n 1. It is used to request a server *generate* a document based on the specified parameters. \n\n 1. If no parameters are specified, the server SHALL return a DocumentReference to the patient's most current CCD \n\n 1. If the server cannot *generate* a document based on the specified parameters, the operation will return an empty search bundle. \n\n This operation is the *same* as a FHIR RESTful search by patient,type and date range because: \n\n 1. References for *existing* documents that meet the requirements of the request SHOULD also be returned unless the client indicates they are only interested in 'on-demand' documents using the *on-demand* parameter.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-allergyintolerance-clinical-status"
-				},
-				"name": "USCoreAllergyIntoleranceClinicalStatus",
-				"description": "**active | inactive | resolved**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-allergyintolerance-patient"
-				},
-				"name": "USCoreAllergyIntolerancePatient",
-				"description": "**Who the sensitivity is for**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-careplan-category"
-				},
-				"name": "USCoreCarePlanCategory",
-				"description": "**Type of plan**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-careplan-date"
-				},
-				"name": "USCoreCarePlanDate",
-				"description": "**Time period plan covers**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-careplan-patient"
-				},
-				"name": "USCoreCarePlanPatient",
-				"description": "**Who the care plan is for**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-careplan-status"
-				},
-				"name": "USCoreCarePlanStatus",
-				"description": "**draft | active | on-hold | revoked | completed | entered-in-error | unknown**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-careteam-patient"
-				},
-				"name": "USCoreCareTeamPatient",
-				"description": "**Who care team is for**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-careteam-status"
-				},
-				"name": "USCoreCareTeamStatus",
-				"description": "**proposed | active | suspended | inactive | entered-in-error**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-condition-category"
-				},
-				"name": "USCoreConditionCategory",
-				"description": "**The category of the condition**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-condition-clinical-status"
-				},
-				"name": "USCoreConditionClinicalStatus",
-				"description": "**The clinical status of the condition**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-condition-code"
-				},
-				"name": "USCoreConditionCode",
-				"description": "**Code for the condition**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-condition-onset-date"
-				},
-				"name": "USCoreConditionOnsetDate",
-				"description": "**Date related onsets (dateTime and Period)**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-condition-patient"
-				},
-				"name": "USCoreConditionPatient",
-				"description": "**Who has the condition?**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-device-patient"
-				},
-				"name": "USCoreDevicePatient",
-				"description": "**Patient information, if the resource is affixed to a person**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-device-type"
-				},
-				"name": "USCoreDeviceType",
-				"description": "**The type of the device**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-diagnosticreport-category"
-				},
-				"name": "USCoreDiagnosticReportCategory",
-				"description": "**Which diagnostic discipline/department created the report**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-diagnosticreport-code"
-				},
-				"name": "USCoreDiagnosticReportCode",
-				"description": "**The code for the report, as opposed to codes for the atomic results, which are the names on the observation resource referred to from the result**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-diagnosticreport-date"
-				},
-				"name": "USCoreDiagnosticReportDate",
-				"description": "**The clinically relevant time of the report**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-diagnosticreport-patient"
-				},
-				"name": "USCoreDiagnosticReportPatient",
-				"description": "**The subject of the report if a patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-diagnosticreport-status"
-				},
-				"name": "USCoreDiagnosticReportStatus",
-				"description": "**The status of the report**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-documentreference-category"
-				},
-				"name": "USCoreDocumentReferenceCategory",
-				"description": "**Categorization of document**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-documentreference-date"
-				},
-				"name": "USCoreDocumentReferenceDate",
-				"description": "**When this document reference was created**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-documentreference-id"
-				},
-				"name": "USCoreDocumentReferenceId",
-				"description": "**Logical id of this artifact**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-documentreference-patient"
-				},
-				"name": "USCoreDocumentReferencePatient",
-				"description": "**Who/what is the subject of the document**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-documentreference-period"
-				},
-				"name": "USCoreDocumentReferencePeriod",
-				"description": "**Time of service that is being documented**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-documentreference-status"
-				},
-				"name": "USCoreDocumentReferenceStatus",
-				"description": "**current | superseded | entered-in-error**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-documentreference-type"
-				},
-				"name": "USCoreDocumentReferenceType",
-				"description": "**Kind of document (LOINC if possible)**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-encounter-class"
-				},
-				"name": "USCoreEncounterClass",
-				"description": "**Classification of patient encounter**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-encounter-date"
-				},
-				"name": "USCoreEncounterDate",
-				"description": "**A date within the period the Encounter lasted**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-encounter-id"
-				},
-				"name": "USCoreEncounterId",
-				"description": "**Logical id of this artifact**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-encounter-identifier"
-				},
-				"name": "USCoreEncounterIdentifier",
-				"description": "**Identifier(s) by which this encounter is known**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-encounter-patient"
-				},
-				"name": "USCoreEncounterPatient",
-				"description": "**The patient or group present at the encounter**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-encounter-status"
-				},
-				"name": "USCoreEncounterStatus",
-				"description": "**planned | arrived | triaged | in-progress | onleave | finished | cancelled +**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-encounter-type"
-				},
-				"name": "USCoreEncounterType",
-				"description": "**Specific type of encounter**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-ethnicity"
-				},
-				"name": "USCoreEthnicity",
-				"description": "Returns patients with an ethnicity extension matching the specified code.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-goal-lifecycle-status"
-				},
-				"name": "USCoreGoalLifecycleStatus",
-				"description": "**proposed | planned | accepted | active | on-hold | completed | cancelled | entered-in-error | rejected**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-goal-patient"
-				},
-				"name": "USCoreGoalPatient",
-				"description": "**Who this goal is intended for**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-goal-target-date"
-				},
-				"name": "USCoreGoalTargetDate",
-				"description": "**Reach goal on or before**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-immunization-date"
-				},
-				"name": "USCoreImmunizationDate",
-				"description": "**Vaccination  (non)-Administration Date**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-immunization-patient"
-				},
-				"name": "USCoreImmunizationPatient",
-				"description": "**The patient for the vaccination record**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-immunization-status"
-				},
-				"name": "USCoreImmunizationStatus",
-				"description": "**Immunization event status**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-location-address-city"
-				},
-				"name": "USCoreLocationAddressCity",
-				"description": "**A city specified in an address**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-location-address-postalcode"
-				},
-				"name": "USCoreLocationAddressPostalcode",
-				"description": "**A postal code specified in an address**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-location-address-state"
-				},
-				"name": "USCoreLocationAddressState",
-				"description": "**A state specified in an address**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-location-address"
-				},
-				"name": "USCoreLocationAddress",
-				"description": "**A (part of the) address of the location**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-location-name"
-				},
-				"name": "USCoreLocationName",
-				"description": "**A portion of the location's name or alias**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-medicationrequest-authoredon"
-				},
-				"name": "USCoreMedicationRequestAuthoredon",
-				"description": "**Return prescriptions written on this date**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-medicationrequest-encounter"
-				},
-				"name": "USCoreMedicationRequestEncounter",
-				"description": "**Return prescriptions with this encounter identifier**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-medicationrequest-intent"
-				},
-				"name": "USCoreMedicationRequestIntent",
-				"description": "**Returns prescriptions with different intents**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-medicationrequest-patient"
-				},
-				"name": "USCoreMedicationRequestPatient",
-				"description": "**Returns prescriptions for a specific patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-medicationrequest-status"
-				},
-				"name": "USCoreMedicationRequestStatus",
-				"description": "**Status of the prescription**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-observation-category"
-				},
-				"name": "USCoreObservationCategory",
-				"description": "**The classification of the type of observation**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-observation-code"
-				},
-				"name": "USCoreObservationCode",
-				"description": "**The code of the observation type**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-observation-date"
-				},
-				"name": "USCoreObservationDate",
-				"description": "**Obtained date/time. If the obtained element is a period, a date that falls in the period**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-observation-patient"
-				},
-				"name": "USCoreObservationPatient",
-				"description": "**The subject that the observation is about (if patient)**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-observation-status"
-				},
-				"name": "USCoreObservationStatus",
-				"description": "**The status of the observation**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-organization-address"
-				},
-				"name": "USCoreOrganizationAddress",
-				"description": "**A server defined search that may match any of the string fields in the Address, including line, city, district, state, country, postalCode, and/or text**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-organization-name"
-				},
-				"name": "USCoreOrganizationName",
-				"description": "**A portion of the organization's name or alias**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-patient-birthdate"
-				},
-				"name": "USCorePatientBirthdate",
-				"description": "**The patient's date of birth**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-patient-family"
-				},
-				"name": "USCorePatientFamily",
-				"description": "**A portion of the family name of the patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-patient-gender"
-				},
-				"name": "USCorePatientGender",
-				"description": "**Gender of the patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-patient-given"
-				},
-				"name": "USCorePatientGiven",
-				"description": "**A portion of the given name of the patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-patient-id"
-				},
-				"name": "USCorePatientId",
-				"description": "**Logical id of this artifact**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-patient-identifier"
-				},
-				"name": "USCorePatientIdentifier",
-				"description": "**A patient identifier**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-patient-name"
-				},
-				"name": "USCorePatientName",
-				"description": "**A server defined search that may match any of the string fields in the HumanName, including family, give, prefix, suffix, suffix, and/or text**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-practitioner-identifier"
-				},
-				"name": "USCorePractitionerIdentifier",
-				"description": "**A practitioner's Identifier**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-practitioner-name"
-				},
-				"name": "USCorePractitionerName",
-				"description": "**A server defined search that may match any of the string fields in the HumanName, including family, give, prefix, suffix, suffix, and/or text**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-practitionerrole-practitioner"
-				},
-				"name": "USCorePractitionerRolePractitioner",
-				"description": "**Practitioner that is able to provide the defined services for the organization**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-practitionerrole-specialty"
-				},
-				"name": "USCorePractitionerRoleSpecialty",
-				"description": "**The practitioner has this specialty at an organization**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-procedure-code"
-				},
-				"name": "USCoreProcedureCode",
-				"description": "**A code to identify a  procedure**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-procedure-date"
-				},
-				"name": "USCoreProcedureDate",
-				"description": "**When the procedure was performed**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-procedure-patient"
-				},
-				"name": "USCoreProcedurePatient",
-				"description": "**Search by subject - a patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-procedure-status"
-				},
-				"name": "USCoreProcedureStatus",
-				"description": "**preparation | in-progress | not-done | on-hold | stopped | completed | entered-in-error | unknown**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-race"
-				},
-				"name": "USCoreRace",
-				"description": "Returns patients with a race extension matching the specified code.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-patient"
-				},
-				"name": "US Core Patient Profile",
-				"description": "Defines constraints and extensions on the patient resource for the minimal set of data to query and retrieve patient demographic information.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/detailed-ethnicity"
-				},
-				"name": "Detailed ethnicity",
-				"description": "The 41 [CDC ethnicity codes](http://www.cdc.gov/phin/resources/vocabulary/index.html) that are grouped under one of the 2 OMB ethnicity category codes.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/detailed-race"
-				},
-				"name": "Detailed Race",
-				"description": "The 900+ [CDC Race codes](http://www.cdc.gov/phin/resources/vocabulary/index.html) that are grouped under one of the 5 OMB race category codes.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/omb-ethnicity-category"
-				},
-				"name": "OMB Ethnicity Categories",
-				"description": "The codes for the ethnicity categories - 'Hispanic or Latino' and 'Non Hispanic or Latino' - as defined by the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/omb-race-category"
-				},
-				"name": "OMB Race Categories",
-				"description": "The codes for the concepts 'Unknown' and  'Asked but no answer' and the the codes for the five race categories - 'American Indian' or 'Alaska Native', 'Asian', 'Black or African American', 'Native Hawaiian or Other Pacific Islander', and 'White' - as defined by the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf) .",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/simple-language"
-				},
-				"name": "Language codes with language and optionally a region modifier",
-				"description": "This value set includes codes from [BCP-47](http://tools.ietf.org/html/bcp47). This value set matches the ONC 2015 Edition LanguageCommunication data element value set within C-CDA to use a 2 character language code if one exists,   and a 3 character code if a 2 character code does not exist. It points back to [RFC 5646](https://tools.ietf.org/html/rfc5646), however only the language codes are required, all other elements are optional.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/birthsex"
-				},
-				"name": "Birth Sex",
-				"description": "Codes for assigning sex at birth as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc)",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-clinical-note-type"
-				},
-				"name": "US Core Clinical Note Type",
-				"description": "The US Core Clinical Note Type Value Set is a 'starter set' of types supported for fetching and storing clinical notes.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-condition-category"
-				},
-				"name": "US Core Condition Category Codes",
-				"description": "The US Core Condition Category Codes support the separate concepts of problems and health concerns in Condition.category in order for API consumers to be able to separate health concerns and problems. However this is not mandatory for 2015 certification",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-condition-code"
-				},
-				"name": "US Core Condition Code",
-				"description": "This describes the problem. Diagnosis/Problem List is broadly defined as a series of brief statements that catalog a patient's medical, nursing, dental, social, preventative and psychiatric events and issues that are relevant to that patient's healthcare (e.g., signs, symptoms, and defined conditions).   ICD-10 is appropriate for Diagnosis information, and ICD-9 for historical information.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-diagnosticreport-category"
-				},
-				"name": "US Core DiagnosticReport Category",
-				"description": "The US Core Diagnostic Report Category Value Set is a 'starter set' of categories supported for fetching and Diagnostic Reports and notes.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-diagnosticreport-lab-codes"
-				},
-				"name": "US Core Diagnostic Report Laboratory Codes",
-				"description": "The Document Type value set includes all LOINC  values whose CLASSTYPE is LABORATORY in the LOINC database",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-diagnosticreport-report-and-note-codes"
-				},
-				"name": "US Core DiagnosticReport Report And Note Codes",
-				"description": "This value set currently contains all of LOINC. The codes selected should represent discrete and narrative diagnostic observations and reports",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-documentreference-category"
-				},
-				"name": "US Core DocumentReference Category",
-				"description": "The US Core DocumentReferences Category Value Set is a 'starter set' of categories supported for fetching and storing clinical notes.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-documentreference-type"
-				},
-				"name": "US Core DocumentReference Type",
-				"description": "The US Core DocumentReference Type Value Set includes all LOINC  values whose SCALE is DOC in the LOINC database and the HL7 v3 Code System NullFlavor concept 'unknown'",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-encounter-type"
-				},
-				"name": "US Core Encounter Type",
-				"description": "The type of encounter: a specific code indicating type of service provided. This value set includes codes from SNOMED CT decending from the concept 308335008 (Patient encounter procedure (procedure)) and codes from the Current Procedure and Terminology (CPT) found in the following CPT sections:\n\n\n- 99201-99499 E/M\n\n- 99500-99600 home health (mainly nonphysician, such as newborn care in home)\n\n- 99605-99607 medication management\n\n- 98966-98968 non physician telephone services\n\n\n\n(subscription to AMA Required)",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-narrative-status"
-				},
-				"name": "US Core Narrative Status",
-				"description": "The US Core Narrative Status Value Set limits the text status for the resource narrative.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-observation-smokingstatus-max"
-				},
-				"name": "US Core Smoking Status Max-Binding",
-				"description": "Representing a patient’s smoking behavior using concepts from SNOMED CT.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-observation-smoking-status-status"
-				},
-				"name": "US Core Status for Smoking Status Observation",
-				"description": "Codes providing the status of an observation for smoking status. Constrained to `final`and `entered-in-error`.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-observation-value-codes"
-				},
-				"name": "US Core Observation Value Codes (SNOMED-CT)",
-				"description": "[Snomed-CT](http://www.ihtsdo.org/) concept codes for coded results",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-procedure-code"
-				},
-				"name": "US Core Procedure Codes",
-				"description": "Concepts from CPT, SNOMED CT, HCPCS Level II Alphanumeric Codes, ICD-10-PCS,CDT and LOINC code systems that can be used to indicate the type of procedure performed.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-provenance-participant-type"
-				},
-				"name": "US Core Provenance Participant Type Codes",
-				"description": "The type of participation a provenance agent played for a given target.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-provider-role"
-				},
-				"name": "US Core Provider Role (NUCC)",
-				"description": "Provider roles codes which are composed of the NUCC Health Care Provider Taxonomy Code Set classification codes for providers. Only concepts with a classification and no specialization are included.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-smoking-status-observation-codes"
-				},
-				"name": "US Core Smoking Status Observation Codes",
-				"description": "The US Core Smoking Status Observation Codes Value Set is a 'starter set' of concepts to capture smoking status.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-usps-state"
-				},
-				"name": "USPS Two Letter Alphabetic Codes",
-				"description": "This value set defines two letter USPS alphabetic codes.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-vital-signs"
-				},
-				"name": "US Core Vital Signs ValueSet",
-				"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Device"
-					}
-				],
-				"reference": {
-					"reference": "Device/udi-2"
-				},
-				"name": "Device Defib Example",
-				"description": "This is a Device defib example for the *US Core Implantable Device Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Device"
-					}
-				],
-				"reference": {
-					"reference": "Device/udi-3"
-				},
-				"name": "Device Knee Example",
-				"description": "This is a Device knee example for the *US Core Implantable Device Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "DiagnosticReport"
-					}
-				],
-				"reference": {
-					"reference": "DiagnosticReport/cardiology-report"
-				},
-				"name": "DiagnosticReport Cardiology Report Example",
-				"description": "This is a DiagnosticReport cardiology report example for the *US Core DiagnosticReport Note Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "DiagnosticReport"
-					}
-				],
-				"reference": {
-					"reference": "DiagnosticReport/chest-xray-report"
-				},
-				"name": "DiagnosticReport Chest Xray Report Example",
-				"description": "This is a DiagnosticReport chest xray report example for the *US Core DiagnosticReport Note Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Bundle"
-					}
-				],
-				"reference": {
-					"reference": "Bundle/66c8856b-ba11-4876-8aa8-467aad8c11a2"
-				},
-				"name": "PractitionerRole_Practitioner_Endpoint_Bundle_Example Example",
-				"description": "This is a PractitionerRole_Practitioner_Endpoint_Bundle_Example example for the *Bundle Profile*.",
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Procedure"
-					}
-				],
-				"reference": {
-					"reference": "Procedure/defib-implant"
-				},
-				"name": "Procedure R4 Defib Implant Example",
-				"description": "This is a Procedure R4 defib implant example for the *US Core Procedure Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Organization"
-					}
-				],
-				"reference": {
-					"reference": "Organization/acme-lab"
-				},
-				"name": "Acme Lab Example",
-				"description": "This is a acme lab example for the *US Core Organization Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "AllergyIntolerance"
-					}
-				],
-				"reference": {
-					"reference": "AllergyIntolerance/example"
-				},
-				"name": "AllergyIntolerance Example",
-				"description": "This is a allergyintolerance example for the *US Core AllergyIntolerance Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Bundle"
-					}
-				],
-				"reference": {
-					"reference": "Bundle/c887e62f-6166-419f-8268-b5ecd6c7b901"
-				},
-				"name": "AllergyIntolerance Provenance Example",
-				"description": "This is a allergyintolerance provenance example for the *Bundle Profile*.",
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/blood-glucose"
-				},
-				"name": "Blood Glucose Example",
-				"description": "This is a blood glucose example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/blood-pressure"
-				},
-				"name": "Blood Pressure Example",
-				"description": "This is a blood pressure example for the *Vitalsigns Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/bmi"
-				},
-				"name": "BMI Example",
-				"description": "This is a BMI example for the *Vitalsigns Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-bmi"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/bp-data-absent"
-				},
-				"name": "BP Data Absent Example",
-				"description": "This is a bp data absent example for the *Vitalsigns Profile* showing how to reprsesent blood pressure with a missing diastolic measurement.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/bun"
-				},
-				"name": "BUN Example",
-				"description": "This is a BUN example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CareTeam"
-					}
-				],
-				"reference": {
-					"reference": "CareTeam/example"
-				},
-				"name": "CareTeam Example",
-				"description": "This is a careteam example for the *US Core CareTeam Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "DiagnosticReport"
-					}
-				],
-				"reference": {
-					"reference": "DiagnosticReport/cbc"
-				},
-				"name": "CBC Example",
-				"description": "This is a CBC example for the *US Core DiagnosticReport Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CarePlan"
-					}
-				],
-				"reference": {
-					"reference": "CarePlan/colonoscopy"
-				},
-				"name": "Colonoscopy Example",
-				"description": "This is a colonoscopy example for the *US Core CarePlan Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Condition"
-					}
-				],
-				"reference": {
-					"reference": "Condition/example"
-				},
-				"name": "Condition Example",
-				"description": "This is a condition example for the *US Core Condition Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Encounter"
-					}
-				],
-				"reference": {
-					"reference": "Encounter/1036"
-				},
-				"name": "Encounter 1036 Example",
-				"description": "This is a encounter 1036 example for the *Encounter Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Encounter"
-					}
-				],
-				"reference": {
-					"reference": "Encounter/example-1"
-				},
-				"name": "Encounter 1 Example",
-				"description": "This is a encounter 1 example for the *US Core Encounter Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "DocumentReference"
-					}
-				],
-				"reference": {
-					"reference": "DocumentReference/episode-summary"
-				},
-				"name": "Episode Summary Example",
-				"description": "This is a episode summary example for the *US Core DocumentReference Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/erythrocytes"
-				},
-				"name": "Erythrocytes Example",
-				"description": "This is a erythrocytes example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Organization"
-					}
-				],
-				"reference": {
-					"reference": "Organization/example-organization-2"
-				},
-				"name": "Organization 2 Example",
-				"description": "This is a organization 2 example for the *US Core Organization Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Goal"
-					}
-				],
-				"reference": {
-					"reference": "Goal/goal-1"
-				},
-				"name": "Goal 1 Example",
-				"description": "This is a goal 1 example for the *US Core Goal Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Condition"
-					}
-				],
-				"reference": {
-					"reference": "Condition/hc1"
-				},
-				"name": "HC1 Example",
-				"description": "This is a hc1 example for the *US Core Condition Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/head-circumference"
-				},
-				"name": "Head Circumference Example",
-				"description": "This is a head circumference example for the *US Core Head Circumference Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-head-circumference"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/heart-rate"
-				},
-				"name": "Heart Rate Example",
-				"description": "This is a heart rate example for the *Vitalsigns Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/height"
-				},
-				"name": "Height Example",
-				"description": "This is a height example for the *Vitalsigns Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-height"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/hemoglobin"
-				},
-				"name": "Hemoglobin Example",
-				"description": "This is a hemoglobin example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Location"
-					}
-				],
-				"reference": {
-					"reference": "Location/hl7east"
-				},
-				"name": "HL7East Example",
-				"description": "This is a HL7East example for the *US Core Location Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-location"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Immunization"
-					}
-				],
-				"reference": {
-					"reference": "Immunization/imm-1"
-				},
-				"name": "Imm 1 Example",
-				"description": "This is a imm 1 example for the *US Core Immunization Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/length"
-				},
-				"name": "Length Example",
-				"description": "This is a length example for the *Vitalsigns Profile* which shows how body length (typically used for infants) is represented using 8306-3 -*Body height - lying* as an additional observation code.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-height"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/mchc"
-				},
-				"name": "MCHC Example",
-				"description": "This is a MCHC example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "DiagnosticReport"
-					}
-				],
-				"reference": {
-					"reference": "DiagnosticReport/metabolic-panel"
-				},
-				"name": "Metabolic Panel Example",
-				"description": "This is a metabolic panel example for the *US Core DiagnosticReport Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/neutrophils"
-				},
-				"name": "Neutrophils Example",
-				"description": "This is a neutrophils example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/satO2-fiO2"
-				},
-				"name": "Observation SatO2 FiO2 Example",
-				"description": "This is a observation satO2 fiO2 example for the *US Core Pulse Oximetry Profile* representing a spO2 value with a for a patient on 6 l/min of O2 suppplemental oxygen.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/ofc-percentile"
-				},
-				"name": "OFC Percentile Example",
-				"description": "This is a OFC percentile example for the *Head Occipital Frontal Circumference Percentile Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/oxygen-saturation"
-				},
-				"name": "Oxygen Saturation Example",
-				"description": "This is a typical oxygen saturation example for the *US Core Pulse Oximetry Profile* on room air where no oxygen concentration is recorded.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Patient"
-					}
-				],
-				"reference": {
-					"reference": "Patient/child-example"
-				},
-				"name": "Patient Child Example",
-				"description": "This is a patient child example for the *US Core Patient Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Patient"
-					}
-				],
-				"reference": {
-					"reference": "Patient/example"
-				},
-				"name": "Patient Example",
-				"description": "This is a patient example for the *US Core Patient Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Patient"
-					}
-				],
-				"reference": {
-					"reference": "Patient/infant-example"
-				},
-				"name": "Patient Infant Example",
-				"description": "This is a patient infant example for the *US Core Patient Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/pediatric-bmi-example"
-				},
-				"name": "Pediatric BMI Example",
-				"description": "This is a pediatric BMI example for the *Pediatric BMI For Age Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/pediatric-wt-example"
-				},
-				"name": "Pediatric Wt Example",
-				"description": "This is a pediatric wt example for the *Pediatric Weight For Height Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Practitioner"
-					}
-				],
-				"reference": {
-					"reference": "Practitioner/practitioner-1"
-				},
-				"name": "Practitioner 1 Example",
-				"description": "This is a practitioner 1 example for the *US Core Practitioner Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Practitioner"
-					}
-				],
-				"reference": {
-					"reference": "Practitioner/practitioner-2"
-				},
-				"name": "Practitioner 2 Example",
-				"description": "This is a practitioner 2 example for the *US Core Practitioner Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Procedure"
-					}
-				],
-				"reference": {
-					"reference": "Procedure/rehab"
-				},
-				"name": "Rehab Example",
-				"description": "This is a rehab example for the *US Core Procedure Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/respiratory-rate"
-				},
-				"name": "Respiratory Rate Example",
-				"description": "This is a respiratory rate example for the *Vitalsigns Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-respiratory-rate"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Organization"
-					}
-				],
-				"reference": {
-					"reference": "Organization/saint-luke-w-endpoint"
-				},
-				"name": "Saint Luke W Endpoint Example",
-				"description": "This is a saint luke w endpoint example for the *US Core Organization Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "MedicationRequest"
-					}
-				],
-				"reference": {
-					"reference": "MedicationRequest/self-tylenol"
-				},
-				"name": "Self Tylenol Example",
-				"description": "This is a self tylenol example for the *MedicationRequest Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/serum-calcium"
-				},
-				"name": "Serum Calcium Example",
-				"description": "This is a serum calcium example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/serum-chloride"
-				},
-				"name": "Serum Chloride Example",
-				"description": "This is a serum chloride example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/serum-co2"
-				},
-				"name": "Serum CO2 Example",
-				"description": "This is a serum CO2 example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/serum-creatinine"
-				},
-				"name": "Serum Creatinine Example",
-				"description": "This is a serum creatinine example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/serum-potassium"
-				},
-				"name": "Serum Potassium Example",
-				"description": "This is a serum potassium example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/serum-sodium"
-				},
-				"name": "Serum Sodium Example",
-				"description": "This is a serum sodium example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/serum-total-bilirubin"
-				},
-				"name": "Serum Total Bilirubin Example",
-				"description": "This is a serum total bilirubin example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/some-day-smoker"
-				},
-				"name": "Some Day Smoker Example",
-				"description": "This is a some day smoker example for the *US Core Smokingstatus Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/temperature"
-				},
-				"name": "Temperature Example",
-				"description": "This is a temperature example for the *Vitalsigns Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-temperature"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Device"
-					}
-				],
-				"reference": {
-					"reference": "Device/udi-1"
-				},
-				"name": "UDI 1 Example",
-				"description": "This is a UDI 1 example for the *US Core Implantable Device Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "DiagnosticReport"
-					}
-				],
-				"reference": {
-					"reference": "DiagnosticReport/urinalysis"
-				},
-				"name": "Urinalysis Example",
-				"description": "This is a urinalysis example for the *US Core DiagnosticReport Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-bacteria"
-				},
-				"name": "Urine Bacteria Example",
-				"description": "This is a urine bacteria example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-bilirubin"
-				},
-				"name": "Urine Bilirubin Example",
-				"description": "This is a urine bilirubin example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-cells"
-				},
-				"name": "Urine Cells Example",
-				"description": "This is a urine cells example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-clarity"
-				},
-				"name": "Urine Clarity Example",
-				"description": "This is a urine clarity example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-color"
-				},
-				"name": "Urine Color Example",
-				"description": "This is a urine color example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-epi-cells"
-				},
-				"name": "Urine Epi Cells Example",
-				"description": "This is a urine epi cells example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-glucose"
-				},
-				"name": "Urine Glucose Example",
-				"description": "This is a urine glucose example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-hemoglobin"
-				},
-				"name": "Urine Hemoglobin Example",
-				"description": "This is a urine hemoglobin example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-ketone"
-				},
-				"name": "Urine Ketone Example",
-				"description": "This is a urine ketone example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-leukocyte-esterase"
-				},
-				"name": "Urine Leukocyte Esterase Example",
-				"description": "This is a urine leukocyte esterase example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-nitrite"
-				},
-				"name": "Urine Nitrite Example",
-				"description": "This is a urine nitrite example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-ph"
-				},
-				"name": "Urine pH Example",
-				"description": "This is a urine pH example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-protein"
-				},
-				"name": "Urine Protein Example",
-				"description": "This is a urine protein example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-rbcs"
-				},
-				"name": "Urine RBCsExample",
-				"description": "This is a urine RBCsexample for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-sediment"
-				},
-				"name": "Urine Sediment Example",
-				"description": "This is a urine sediment example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-wbcs"
-				},
-				"name": "Urine WBCsExample",
-				"description": "This is a urine WBCsexample for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urobilinogen"
-				},
-				"name": "Urobilinogen Example",
-				"description": "This is a urobilinogen example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Medication"
-					}
-				],
-				"reference": {
-					"reference": "Medication/uscore-med1"
-				},
-				"name": "Uscore Med1 Example",
-				"description": "This is a uscore med1 example for the *US Core Medication Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Medication"
-					}
-				],
-				"reference": {
-					"reference": "Medication/uscore-med2"
-				},
-				"name": "Uscore Med2 Example",
-				"description": "This is a uscore med2 example for the *US Core Medication Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "MedicationRequest"
-					}
-				],
-				"reference": {
-					"reference": "MedicationRequest/uscore-mo1"
-				},
-				"name": "Uscore MO1 Example",
-				"description": "This is a uscore mo1 example for the *US Core MedicationRequest Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "MedicationRequest"
-					}
-				],
-				"reference": {
-					"reference": "MedicationRequest/uscore-mo2"
-				},
-				"name": "Uscore MO2 Example",
-				"description": "This is a uscore MO2 example for the *US Core MedicationRequest Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Bundle"
-					}
-				],
-				"reference": {
-					"reference": "Bundle/uscore-mo3"
-				},
-				"name": "Uscore MO3 Example",
-				"description": "This is a uscore mo3 example for the *Bundle Profile*.",
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/usg"
-				},
-				"name": "USG Example",
-				"description": "This is a USG example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/weight"
-				},
-				"name": "Weight Example",
-				"description": "This is a weight example for the *Vitalsigns Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-weight"
-			}
-		],
-		"page": {
-			"nameUrl": "toc.html",
-			"title": "Table of Contents",
-			"generation": "html",
-			"page": [
-				{
-					"nameUrl": "index.html",
-					"title": "Index",
-					"generation": "markdown"
-				},
-				{
-					"nameUrl": "guidance.html",
-					"title": "Guidance",
-					"generation": "markdown",
-					"page": [
-						{
-							"nameUrl": "general-guidance.html",
-							"title": "General Guidance",
-							"generation": "markdown"
-						},
-						{
-							"nameUrl": "conformance-expectations.html",
-							"title": "Conformance Expectations",
-							"generation": "markdown"
-						},
-						{
-							"nameUrl": "clinical-notes-guidance.html",
-							"title": "Clinical Notes Guidance",
-							"generation": "markdown"
-						},
-						{
-							"nameUrl": "medication-list-guidance.html",
-							"title": "Medication List Guidance",
-							"generation": "markdown"
-						},
-						{
-							"nameUrl": "basic-provenance.html",
-							"title": "Basic Provenance",
-							"generation": "markdown"
-						},
-						{
-							"nameUrl": "DSTU2-to-R4-conversion.html",
-							"title": "DSTU2 to R4 Conversion",
-							"generation": "markdown"
-						},
-						{
-							"nameUrl": "future-of-US-core.html",
-							"title": "Future of US Core",
-							"generation": "markdown"
-						}
-					]
-				},
-				{
-					"nameUrl": "profiles-and-extensions.html",
-					"title": "Profiles and Extensions",
-					"generation": "markdown"
-				},
-				{
-					"nameUrl": "capability-statements.html",
-					"title": "Capability Statements",
-					"generation": "markdown"
-				},
-				{
-					"nameUrl": "search-parameters-and-operations.html",
-					"title": "Search Parameters and Operations",
-					"generation": "markdown"
-				},
-				{
-					"nameUrl": "terminology.html",
-					"title": "Terminology",
-					"generation": "markdown"
-				},
-				{
-					"nameUrl": "security.html",
-					"title": "Security",
-					"generation": "markdown"
-				},
-				{
-					"nameUrl": "examples.html",
-					"title": "Examples",
-					"generation": "markdown"
-				},
-				{
-					"nameUrl": "downloads.html",
-					"title": "Downloads",
-					"generation": "markdown"
-				}
-			]
-		},
-		"parameter": [
-			{
-				"code": "path-resource",
-				"value": "input/resources"
-			},
-			{
-				"code": "path-resource",
-				"value": "fsh-generated/resources"
-			},
-			{
-				"code": "path-pages",
-				"value": "input/pagecontent"
-			},
-			{
-				"code": "path-pages",
-				"value": "input/intro-notes"
-			},
-			{
-				"code": "path-pages",
-				"value": "fsh-generated/includes"
-			},
-			{
-				"code": "path-resource",
-				"value": "input/capabilities"
-			},
-			{
-				"code": "path-resource",
-				"value": "input/examples"
-			},
-			{
-				"code": "path-resource",
-				"value": "input/extensions"
-			},
-			{
-				"code": "path-resource",
-				"value": "input/models"
-			},
-			{
-				"code": "path-resource",
-				"value": "input/operations"
-			},
-			{
-				"code": "path-resource",
-				"value": "input/profiles"
-			},
-			{
-				"code": "path-resource",
-				"value": "input/vocabulary"
-			},
-			{
-				"code": "path-resource",
-				"value": "input/testing"
-			},
-			{
-				"code": "path-resource",
-				"value": "input/history"
-			},
-			{
-				"code": "path-pages",
-				"value": "template/config"
-			},
-			{
-				"code": "path-pages",
-				"value": "input/images"
-			},
-			{
-				"code": "path-tx-cache",
-				"value": "input-cache/txcache"
-			}
-		]
-	}
+    "resourceType": "ImplementationGuide",
+    "id": "hl7.fhir.us.core",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core",
+    "version": "4.0.0",
+    "name": "USCore",
+    "title": "US Core Implementation Guide",
+    "status": "active",
+    "date": "2021-06-16",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The US Core Implementation Guide is based on FHIR Version R4 and defines the minimum conformance requirements for accessing patient data. The Argonaut pilot implementations, ONC 2015 Edition Common Clinical Data Set (CCDS), and ONC U.S. Core Data for Interoperability (USCDI) v1 provided the requirements for this guide. The prior Argonaut search and vocabulary requirements, based on FHIR DSTU2, are updated in this guide to support FHIR Version R4. This guide was used as the basis for further testing and guidance by the Argonaut Project Team to provide additional content and guidance specific to Data Query Access for purpose of ONC Certification testing. These profiles are the foundation for future US Realm FHIR implementation guides. In addition to Argonaut, they are used by DAF-Research, QI-Core, and CIMI. Under the guidance of HL7 and the HL7 US Realm Steering Committee, the content will expand in future versions to meet the needs specific to the US Realm.\nThese requirements were originally developed, balloted, and published in FHIR DSTU2 as part of the Office of the National Coordinator for Health Information Technology (ONC) sponsored Data Access Framework (DAF) project. For more information on how DAF became US Core see the US Core change notes.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "packageId": "hl7.fhir.us.core",
+    "license": "CC0-1.0",
+    "fhirVersion": [
+        "4.0.1"
+    ],
+    "dependsOn": [
+        {
+            "id": "hl7_fhir_uv_bulkdata",
+            "uri": "http://hl7.org/fhir/uv/bulkdata/ImplementationGuide/hl7.fhir.uv.bulkdata",
+            "packageId": "hl7.fhir.uv.bulkdata",
+            "version": "1.0.1"
+        },
+        {
+            "id": "vsac",
+            "uri": "http://fhir.org/packages/us.nlm.vsac/ImplementationGuide/us.nlm.vsac",
+            "packageId": "us.nlm.vsac",
+            "version": "0.3.0"
+        }
+    ],
+    "definition": {
+        "extension": [
+            {
+                "extension": [
+                    {
+                        "url": "code",
+                        "valueString": "copyrightyear"
+                    },
+                    {
+                        "url": "value",
+                        "valueString": "2021+"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "code",
+                        "valueString": "releaselabel"
+                    },
+                    {
+                        "url": "value",
+                        "valueString": "STU4 Release"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "code",
+                        "valueString": "path-expansion-params"
+                    },
+                    {
+                        "url": "value",
+                        "valueString": "../../input/_resources/exp-params.json"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "code",
+                        "valueString": "active-tables"
+                    },
+                    {
+                        "url": "value",
+                        "valueString": "false"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "code",
+                        "valueString": "apply-contact"
+                    },
+                    {
+                        "url": "value",
+                        "valueString": "true"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "code",
+                        "valueString": "apply-jurisdiction"
+                    },
+                    {
+                        "url": "value",
+                        "valueString": "true"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "code",
+                        "valueString": "apply-publisher"
+                    },
+                    {
+                        "url": "value",
+                        "valueString": "true"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "code",
+                        "valueString": "apply-version"
+                    },
+                    {
+                        "url": "value",
+                        "valueString": "true"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "code",
+                        "valueString": "show-inherited-invariants"
+                    },
+                    {
+                        "url": "value",
+                        "valueString": "false"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "code",
+                        "valueString": "usage-stats-opt-out"
+                    },
+                    {
+                        "url": "value",
+                        "valueString": "true"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "code",
+                        "valueString": "excludexml"
+                    },
+                    {
+                        "url": "value",
+                        "valueString": "false"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "code",
+                        "valueString": "excludejsn"
+                    },
+                    {
+                        "url": "value",
+                        "valueString": "false"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "code",
+                        "valueString": "excludettl"
+                    },
+                    {
+                        "url": "value",
+                        "valueString": "true"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "code",
+                        "valueString": "excludemap"
+                    },
+                    {
+                        "url": "value",
+                        "valueString": "true"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "code",
+                        "valueString": "excludeexample"
+                    },
+                    {
+                        "url": "value",
+                        "valueString": "true"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "code",
+                        "valueString": "generate"
+                    },
+                    {
+                        "url": "value",
+                        "valueString": "xml"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "code",
+                        "valueString": "generate"
+                    },
+                    {
+                        "url": "value",
+                        "valueString": "json"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "code",
+                        "valueString": "path-history"
+                    },
+                    {
+                        "url": "value",
+                        "valueString": "http://hl7.org/fhir/us/core/history.html"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "code",
+                        "valueString": "autoload-resources"
+                    },
+                    {
+                        "url": "value",
+                        "valueString": "true"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "code",
+                        "valueString": "path-liquid"
+                    },
+                    {
+                        "url": "value",
+                        "valueString": "template/liquid"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "code",
+                        "valueString": "path-liquid"
+                    },
+                    {
+                        "url": "value",
+                        "valueString": "input/liquid"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "code",
+                        "valueString": "path-qa"
+                    },
+                    {
+                        "url": "value",
+                        "valueString": "temp/qa"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "code",
+                        "valueString": "path-temp"
+                    },
+                    {
+                        "url": "value",
+                        "valueString": "temp/pages"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "code",
+                        "valueString": "path-output"
+                    },
+                    {
+                        "url": "value",
+                        "valueString": "output"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "code",
+                        "valueString": "path-suppressed-warnings"
+                    },
+                    {
+                        "url": "value",
+                        "valueString": "input/ignoreWarnings.txt"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "code",
+                        "valueString": "template-html"
+                    },
+                    {
+                        "url": "value",
+                        "valueString": "template-page.html"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "code",
+                        "valueString": "template-md"
+                    },
+                    {
+                        "url": "value",
+                        "valueString": "template-page-md.html"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "code",
+                        "valueString": "apply-context"
+                    },
+                    {
+                        "url": "value",
+                        "valueString": "true"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "code",
+                        "valueString": "apply-copyright"
+                    },
+                    {
+                        "url": "value",
+                        "valueString": "true"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "code",
+                        "valueString": "apply-license"
+                    },
+                    {
+                        "url": "value",
+                        "valueString": "true"
+                    }
+                ],
+                "url": "http://hl7.org/fhir/tools/StructureDefinition/ig-parameter"
+            }
+        ],
+        "resource": [
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/head-occipital-frontal-circumference-percentile"
+                },
+                "name": "US Core Pediatric Head Occipital-frontal Circumference Percentile Profile",
+                "description": "Defines constraints on the Observation resource to represent head occipital-frontal circumference percentile for patients from birth to 36 months of age in FHIR using a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-allergyintolerance"
+                },
+                "name": "US Core AllergyIntolerance Profile",
+                "description": "Defines constraints and extensions on the AllergyIntolerance resource for the minimal set of data to query and retrieve allergy information.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:extension"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-birthsex"
+                },
+                "name": "US Core Birth Sex Extension",
+                "description": "A code classifying the person's sex assigned at birth  as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc). This extension aligns with the C-CDA Birth Sex Observation (LOINC 76689-9).",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-blood-pressure"
+                },
+                "name": "US Core Blood Pressure Profile",
+                "description": "Defines constraints on Observation to represent diastolic and systolic blood pressure observations with standard LOINC codes and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-bmi"
+                },
+                "name": "US Core BMI Profile",
+                "description": "Defines constraints on Observation to represent Body Mass Index (BMI) observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-body-height"
+                },
+                "name": "US Core Body Height Profile",
+                "description": "Defines constraints on Observation to represent body height observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-body-temperature"
+                },
+                "name": "US Core Body Temperature Profile",
+                "description": "Defines constraints on Observation to represent body temperature observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-body-weight"
+                },
+                "name": "US Core Body Weight Profile",
+                "description": "Defines constraints on Observation to represent body weight observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-careplan"
+                },
+                "name": "US Core CarePlan Profile",
+                "description": "Defines constraints and extensions on the CarePlan resource for the minimal set of data to query and retrieve a patient's Care Plan.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-careteam"
+                },
+                "name": "US Core CareTeam Profile",
+                "description": "Defines constraints and extensions on the CareTeam resource for the minimal set of data to query and retrieve a patient's Care Team.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-condition"
+                },
+                "name": "US Core Condition Profile",
+                "description": "Defines constraints and extensions on the Condition resource for the minimal set of data to query and retrieve problems and health concerns information.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-diagnosticreport-lab"
+                },
+                "name": "US Core DiagnosticReport Profile for Laboratory Results Reporting",
+                "description": "Defines constraints and extensions on the DiagnosticReport resource  for the minimal set of data to query and retrieve diagnostic reports associated with laboratory results for a patient",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-diagnosticreport-note"
+                },
+                "name": "US Core DiagnosticReport Profile for Report and Note exchange",
+                "description": "Defines constraints and extensions on the DiagnosticReport resource  for the minimal set of data to query and retrieve diagnostic reports associated with clinical notes for a patient",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:extension"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-direct"
+                },
+                "name": "US Core Direct email Extension",
+                "description": "This email address is associated with a [direct](http://wiki.directproject.org/Addressing+Specification) service.  This extension can only be used on contact points where the system = 'email'",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-documentreference"
+                },
+                "name": "US Core DocumentReference Profile",
+                "description": "The document reference profile used in US Core.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-encounter"
+                },
+                "name": "US Core Encounter Profile",
+                "description": "The Encounter referenced in the US Core profiles.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:extension"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-ethnicity"
+                },
+                "name": "US Core Ethnicity Extension",
+                "description": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-goal"
+                },
+                "name": "US Core Goal Profile",
+                "description": "Defines constraints and extensions on the Goal resource for the minimal set of data to query and retrieve a patient's goal(s).",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-head-circumference"
+                },
+                "name": "US Core Head Circumference Profile",
+                "description": "Defines constraints on Observation to represent head circumference observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-heart-rate"
+                },
+                "name": "US Core Heart Rate Profile",
+                "description": "Defines constraints on Observation to represent heart rate observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-immunization"
+                },
+                "name": "US Core Immunization Profile",
+                "description": "Defines constraints and extensions on the Immunization resource for the minimal set of data to query and retrieve  patient's immunization information.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-implantable-device"
+                },
+                "name": "US Core Implantable Device Profile",
+                "description": "Defines constraints and extensions on the Device resource for the minimal set of data to query and retrieve a patient's implantable device(s).",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-location"
+                },
+                "name": "US Core Location Profile",
+                "description": "Defines basic constraints and extensions on the Location resource for use with other US Core resources",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-medication"
+                },
+                "name": "US Core Medication Profile",
+                "description": "Defines constraints and extensions on the Medication resource for the minimal set of data to query and retrieve patient retrieving patient's medication information.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-medicationrequest"
+                },
+                "name": "US Core MedicationRequest Profile",
+                "description": "Defines constraints and extensions on the MedicationRequest resource for the minimal set of data to query and retrieve prescription information.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-observation-lab"
+                },
+                "name": "US Core Laboratory Result Observation Profile",
+                "description": "Defines constraints and extensions on the Observation resource for the minimal set of data to query and retrieve laboratory test results",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-organization"
+                },
+                "name": "US Core Organization Profile",
+                "description": "Defines basic constraints and extensions on the Organization resource for use with other US Core resources",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/pediatric-bmi-for-age"
+                },
+                "name": "US Core Pediatric BMI for Age Observation Profile",
+                "description": "Defines constraints on Observation to represent to represent BMI percentile per age and sex for youth 2-20 observations in FHIR using a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/pediatric-weight-for-height"
+                },
+                "name": "US Core Pediatric Weight for Height Observation Profile",
+                "description": "Defines constraints on the Observation resource to represent pediatric Weight-for-length per age and gender observations in FHIR with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-practitioner"
+                },
+                "name": "US Core Practitioner Profile",
+                "description": "The practitioner(s) referenced in US Core profiles.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-practitionerrole"
+                },
+                "name": "US Core PractitionerRole Profile",
+                "description": "The practitioner roles referenced in the US Core profiles.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-procedure"
+                },
+                "name": "US Core Procedure Profile",
+                "description": "Defines constraints and extensions on the Procedure resource for the minimal set of data to query and retrieve patient's procedure information.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-provenance"
+                },
+                "name": "US Core Provenance Profile",
+                "description": "Draft set of requirements to satisfy Basic Provenance Requirements.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-pulse-oximetry"
+                },
+                "name": "US Core Pulse Oximetry Profile",
+                "description": "Defines constraints on the Observation resource to represent inspired O2 by pulse oximetry and inspired oxygen concentration observations with a standard LOINC codes and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:extension"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-race"
+                },
+                "name": "US Core Race Extension",
+                "description": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\n - American Indian or Alaska Native\n - Asian\n - Black or African American\n - Native Hawaiian or Other Pacific Islander\n - White.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-respiratory-rate"
+                },
+                "name": "US Core Respiratory Rate Profile",
+                "description": "Defines constraints on Observation to represent respiratory rate observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-smokingstatus"
+                },
+                "name": "US Core Smoking Status Observation Profile",
+                "description": "Defines constraints and extensions on the Observation  resource for the minimal set of data to query and retrieve patient's Smoking Status information.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-vital-signs"
+                },
+                "name": "US Core Vital Signs Profile",
+                "description": "Defines constraints on the Observation resource to represent vital signs observations.  This profile is used as the base definition for the other US Core Vital Signs Profiles and based on the FHIR VitalSigns Profile.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CapabilityStatement"
+                    }
+                ],
+                "reference": {
+                    "reference": "CapabilityStatement/us-core-client"
+                },
+                "name": "US Core Client CapabilityStatement",
+                "description": "This Section describes the expected capabilities of the US Core Client which is responsible for creating and initiating the queries for information about an individual patient. The complete list of FHIR profiles, RESTful operations, and search parameters supported by US Core Servers are defined in the [Conformance Requirements for Server](CapabilityStatement-us-core-server.html). US Core Clients have the option of choosing from this list to access necessary data based on their local use cases and other contextual requirements.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CapabilityStatement"
+                    }
+                ],
+                "reference": {
+                    "reference": "CapabilityStatement/us-core-server"
+                },
+                "name": "US Core Server CapabilityStatement",
+                "description": "This Section describes the expected capabilities of the US Core Server actor which is responsible for providing responses to the queries submitted by the US Core Requestors. The complete list of FHIR profiles, RESTful operations, and search parameters supported by US Core Servers are defined. Systems implementing this capability statement should meet the ONC 2015 Common Clinical Data Set (CCDS) access requirement for Patient Selection 170.315(g)(7) and Application Access - Data Category Request 170.315(g)(8) and and the ONC [U.S. Core Data for Interoperability (USCDI)](https://www.healthit.gov/isa/sites/isa/files/2020-03/USCDI-Version1-2020-Final-Standard.pdf).  US Core Clients have the option of choosing from this list to access necessary data based on their local use cases and other contextual requirements.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CodeSystem"
+                    }
+                ],
+                "reference": {
+                    "reference": "CodeSystem/careplan-category"
+                },
+                "name": "US Core CarePlan Category Extension Codes",
+                "description": "Set of codes that are needed for implementation of the US-Core CarePlan Profile. These codes are used as extensions to the FHIR ValueSet.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CodeSystem"
+                    }
+                ],
+                "reference": {
+                    "reference": "CodeSystem/cdcrec"
+                },
+                "name": "Race & Ethnicity - CDC",
+                "description": "The U.S. Centers for Disease Control and Prevention (CDC) has prepared a code set for use in codingrace and ethnicity data. This code set is based on current federal standards for classifying data onrace and ethnicity, specifically the minimum race and ethnicity categories defined by the U.S. Office ofManagement and Budget (OMB) and a more detailed set of race and ethnicity categories maintainedby the U.S. Bureau of the Census (BC). The main purpose of the code set is to facilitate use of federalstandards for classifying data on race and ethnicity when these data are exchanged, stored, retrieved,or analyzed in electronic form. At the same time, the code set can be applied to paper-based recordsystems to the extent that these systems are used to collect, maintain, and report data on race andethnicity in accordance with current federal standards. Source: [Race and Ethnicity Code Set Version 1.0](https://www.cdc.gov/phin/resources/vocabulary/documents/cdc-race--ethnicity-background-and-purpose.pdf).",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CodeSystem"
+                    }
+                ],
+                "reference": {
+                    "reference": "CodeSystem/condition-category"
+                },
+                "name": "US Core Condition Category Extension Codes",
+                "description": "Set of codes that are needed for implementation of the US-Core Condition Profile. These codes are used as extensions to the FHIR and US Core value sets.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CodeSystem"
+                    }
+                ],
+                "reference": {
+                    "reference": "CodeSystem/us-core-documentreference-category"
+                },
+                "name": "US Core DocumentReferences Category Codes",
+                "description": "The US Core DocumentReferences Type Code System is a 'starter set' of categories supported for fetching and storing DocumentReference Resources.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CodeSystem"
+                    }
+                ],
+                "reference": {
+                    "reference": "CodeSystem/us-core-provenance-participant-type"
+                },
+                "name": "US Core Provenance Participant Type Extension Codes",
+                "description": "Set of codes that are needed for implementation of the US-Core Provenance Profile. These codes are used as extensions to the FHIR value sets.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "OperationDefinition"
+                    }
+                ],
+                "reference": {
+                    "reference": "OperationDefinition/docref"
+                },
+                "name": "US Core Fetch DocumentReference",
+                "description": "This operation is used to return all the references to documents related to a patient. \n\n The operation requires a patient id and takes the optional input parameters: \n  - start date\n  - end date\n  - document type \n\n and returns a [Bundle](http://hl7.org/fhir/bundle.html) of type \"searchset\" containing [DocumentReference](http://hl7.org/fhir/documentreference.html) resources for the patient. The DocumentReference resources **SHOULD** conform to the [US Core DocumentReference\n Profiles](http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference). If the server has or can create documents that are related to the patient, and that are available for the given user, the server returns the DocumentReference resources needed to support the records.  The principle intended use for this operation is to provide a provider or patient with access to their available document information. \n\n This operation is *different* from a search by patient and type and date range because: \n\n 1. It is used to request a server *generate* a document based on the specified parameters. \n\n 1. If no parameters are specified, the server SHALL return a DocumentReference to the patient's most current CCD \n\n 1. If the server cannot *generate* a document based on the specified parameters, the operation will return an empty search bundle. \n\n This operation is the *same* as a FHIR RESTful search by patient,type and date range because: \n\n 1. References for *existing* documents that meet the requirements of the request SHOULD also be returned unless the client indicates they are only interested in 'on-demand' documents using the *on-demand* parameter.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-allergyintolerance-clinical-status"
+                },
+                "name": "USCoreAllergyIntoleranceClinicalStatus",
+                "description": "**active | inactive | resolved**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-allergyintolerance-patient"
+                },
+                "name": "USCoreAllergyIntolerancePatient",
+                "description": "**Who the sensitivity is for**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-careplan-category"
+                },
+                "name": "USCoreCarePlanCategory",
+                "description": "**Type of plan**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-careplan-date"
+                },
+                "name": "USCoreCarePlanDate",
+                "description": "**Time period plan covers**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-careplan-patient"
+                },
+                "name": "USCoreCarePlanPatient",
+                "description": "**Who the care plan is for**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-careplan-status"
+                },
+                "name": "USCoreCarePlanStatus",
+                "description": "**draft | active | on-hold | revoked | completed | entered-in-error | unknown**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-careteam-patient"
+                },
+                "name": "USCoreCareTeamPatient",
+                "description": "**Who care team is for**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-careteam-status"
+                },
+                "name": "USCoreCareTeamStatus",
+                "description": "**proposed | active | suspended | inactive | entered-in-error**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-condition-category"
+                },
+                "name": "USCoreConditionCategory",
+                "description": "**The category of the condition**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-condition-clinical-status"
+                },
+                "name": "USCoreConditionClinicalStatus",
+                "description": "**The clinical status of the condition**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-condition-code"
+                },
+                "name": "USCoreConditionCode",
+                "description": "**Code for the condition**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-condition-onset-date"
+                },
+                "name": "USCoreConditionOnsetDate",
+                "description": "**Date related onsets (dateTime and Period)**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-condition-patient"
+                },
+                "name": "USCoreConditionPatient",
+                "description": "**Who has the condition?**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-device-patient"
+                },
+                "name": "USCoreDevicePatient",
+                "description": "**Patient information, if the resource is affixed to a person**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-device-type"
+                },
+                "name": "USCoreDeviceType",
+                "description": "**The type of the device**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-diagnosticreport-category"
+                },
+                "name": "USCoreDiagnosticReportCategory",
+                "description": "**Which diagnostic discipline/department created the report**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-diagnosticreport-code"
+                },
+                "name": "USCoreDiagnosticReportCode",
+                "description": "**The code for the report, as opposed to codes for the atomic results, which are the names on the observation resource referred to from the result**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-diagnosticreport-date"
+                },
+                "name": "USCoreDiagnosticReportDate",
+                "description": "**The clinically relevant time of the report**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-diagnosticreport-patient"
+                },
+                "name": "USCoreDiagnosticReportPatient",
+                "description": "**The subject of the report if a patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-diagnosticreport-status"
+                },
+                "name": "USCoreDiagnosticReportStatus",
+                "description": "**The status of the report**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-documentreference-category"
+                },
+                "name": "USCoreDocumentReferenceCategory",
+                "description": "**Categorization of document**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-documentreference-date"
+                },
+                "name": "USCoreDocumentReferenceDate",
+                "description": "**When this document reference was created**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-documentreference-id"
+                },
+                "name": "USCoreDocumentReferenceId",
+                "description": "**Logical id of this artifact**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-documentreference-patient"
+                },
+                "name": "USCoreDocumentReferencePatient",
+                "description": "**Who/what is the subject of the document**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-documentreference-period"
+                },
+                "name": "USCoreDocumentReferencePeriod",
+                "description": "**Time of service that is being documented**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-documentreference-status"
+                },
+                "name": "USCoreDocumentReferenceStatus",
+                "description": "**current | superseded | entered-in-error**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-documentreference-type"
+                },
+                "name": "USCoreDocumentReferenceType",
+                "description": "**Kind of document (LOINC if possible)**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-encounter-class"
+                },
+                "name": "USCoreEncounterClass",
+                "description": "**Classification of patient encounter**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-encounter-date"
+                },
+                "name": "USCoreEncounterDate",
+                "description": "**A date within the period the Encounter lasted**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-encounter-id"
+                },
+                "name": "USCoreEncounterId",
+                "description": "**Logical id of this artifact**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-encounter-identifier"
+                },
+                "name": "USCoreEncounterIdentifier",
+                "description": "**Identifier(s) by which this encounter is known**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-encounter-patient"
+                },
+                "name": "USCoreEncounterPatient",
+                "description": "**The patient or group present at the encounter**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-encounter-status"
+                },
+                "name": "USCoreEncounterStatus",
+                "description": "**planned | arrived | triaged | in-progress | onleave | finished | cancelled +**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-encounter-type"
+                },
+                "name": "USCoreEncounterType",
+                "description": "**Specific type of encounter**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-ethnicity"
+                },
+                "name": "USCoreEthnicity",
+                "description": "Returns patients with an ethnicity extension matching the specified code.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-goal-lifecycle-status"
+                },
+                "name": "USCoreGoalLifecycleStatus",
+                "description": "**proposed | planned | accepted | active | on-hold | completed | cancelled | entered-in-error | rejected**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-goal-patient"
+                },
+                "name": "USCoreGoalPatient",
+                "description": "**Who this goal is intended for**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-goal-target-date"
+                },
+                "name": "USCoreGoalTargetDate",
+                "description": "**Reach goal on or before**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-immunization-date"
+                },
+                "name": "USCoreImmunizationDate",
+                "description": "**Vaccination  (non)-Administration Date**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-immunization-patient"
+                },
+                "name": "USCoreImmunizationPatient",
+                "description": "**The patient for the vaccination record**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-immunization-status"
+                },
+                "name": "USCoreImmunizationStatus",
+                "description": "**Immunization event status**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-location-address-city"
+                },
+                "name": "USCoreLocationAddressCity",
+                "description": "**A city specified in an address**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-location-address-postalcode"
+                },
+                "name": "USCoreLocationAddressPostalcode",
+                "description": "**A postal code specified in an address**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-location-address-state"
+                },
+                "name": "USCoreLocationAddressState",
+                "description": "**A state specified in an address**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-location-address"
+                },
+                "name": "USCoreLocationAddress",
+                "description": "**A (part of the) address of the location**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-location-name"
+                },
+                "name": "USCoreLocationName",
+                "description": "**A portion of the location's name or alias**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-medicationrequest-authoredon"
+                },
+                "name": "USCoreMedicationRequestAuthoredon",
+                "description": "**Return prescriptions written on this date**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-medicationrequest-encounter"
+                },
+                "name": "USCoreMedicationRequestEncounter",
+                "description": "**Return prescriptions with this encounter identifier**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-medicationrequest-intent"
+                },
+                "name": "USCoreMedicationRequestIntent",
+                "description": "**Returns prescriptions with different intents**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-medicationrequest-patient"
+                },
+                "name": "USCoreMedicationRequestPatient",
+                "description": "**Returns prescriptions for a specific patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-medicationrequest-status"
+                },
+                "name": "USCoreMedicationRequestStatus",
+                "description": "**Status of the prescription**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-observation-category"
+                },
+                "name": "USCoreObservationCategory",
+                "description": "**The classification of the type of observation**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-observation-code"
+                },
+                "name": "USCoreObservationCode",
+                "description": "**The code of the observation type**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-observation-date"
+                },
+                "name": "USCoreObservationDate",
+                "description": "**Obtained date/time. If the obtained element is a period, a date that falls in the period**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-observation-patient"
+                },
+                "name": "USCoreObservationPatient",
+                "description": "**The subject that the observation is about (if patient)**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-observation-status"
+                },
+                "name": "USCoreObservationStatus",
+                "description": "**The status of the observation**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-organization-address"
+                },
+                "name": "USCoreOrganizationAddress",
+                "description": "**A server defined search that may match any of the string fields in the Address, including line, city, district, state, country, postalCode, and/or text**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-organization-name"
+                },
+                "name": "USCoreOrganizationName",
+                "description": "**A portion of the organization's name or alias**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-patient-birthdate"
+                },
+                "name": "USCorePatientBirthdate",
+                "description": "**The patient's date of birth**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-patient-family"
+                },
+                "name": "USCorePatientFamily",
+                "description": "**A portion of the family name of the patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-patient-gender"
+                },
+                "name": "USCorePatientGender",
+                "description": "**Gender of the patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-patient-given"
+                },
+                "name": "USCorePatientGiven",
+                "description": "**A portion of the given name of the patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-patient-id"
+                },
+                "name": "USCorePatientId",
+                "description": "**Logical id of this artifact**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-patient-identifier"
+                },
+                "name": "USCorePatientIdentifier",
+                "description": "**A patient identifier**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-patient-name"
+                },
+                "name": "USCorePatientName",
+                "description": "**A server defined search that may match any of the string fields in the HumanName, including family, give, prefix, suffix, suffix, and/or text**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-practitioner-identifier"
+                },
+                "name": "USCorePractitionerIdentifier",
+                "description": "**A practitioner's Identifier**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-practitioner-name"
+                },
+                "name": "USCorePractitionerName",
+                "description": "**A server defined search that may match any of the string fields in the HumanName, including family, give, prefix, suffix, suffix, and/or text**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-practitionerrole-practitioner"
+                },
+                "name": "USCorePractitionerRolePractitioner",
+                "description": "**Practitioner that is able to provide the defined services for the organization**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-practitionerrole-specialty"
+                },
+                "name": "USCorePractitionerRoleSpecialty",
+                "description": "**The practitioner has this specialty at an organization**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-procedure-code"
+                },
+                "name": "USCoreProcedureCode",
+                "description": "**A code to identify a  procedure**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-procedure-date"
+                },
+                "name": "USCoreProcedureDate",
+                "description": "**When the procedure was performed**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-procedure-patient"
+                },
+                "name": "USCoreProcedurePatient",
+                "description": "**Search by subject - a patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-procedure-status"
+                },
+                "name": "USCoreProcedureStatus",
+                "description": "**preparation | in-progress | not-done | on-hold | stopped | completed | entered-in-error | unknown**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-race"
+                },
+                "name": "USCoreRace",
+                "description": "Returns patients with a race extension matching the specified code.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-patient"
+                },
+                "name": "US Core Patient Profile",
+                "description": "Defines constraints and extensions on the patient resource for the minimal set of data to query and retrieve patient demographic information.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/detailed-ethnicity"
+                },
+                "name": "Detailed ethnicity",
+                "description": "The 41 [CDC ethnicity codes](http://www.cdc.gov/phin/resources/vocabulary/index.html) that are grouped under one of the 2 OMB ethnicity category codes.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/detailed-race"
+                },
+                "name": "Detailed Race",
+                "description": "The 900+ [CDC Race codes](http://www.cdc.gov/phin/resources/vocabulary/index.html) that are grouped under one of the 5 OMB race category codes.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/omb-ethnicity-category"
+                },
+                "name": "OMB Ethnicity Categories",
+                "description": "The codes for the ethnicity categories - 'Hispanic or Latino' and 'Non Hispanic or Latino' - as defined by the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/omb-race-category"
+                },
+                "name": "OMB Race Categories",
+                "description": "The codes for the concepts 'Unknown' and  'Asked but no answer' and the the codes for the five race categories - 'American Indian' or 'Alaska Native', 'Asian', 'Black or African American', 'Native Hawaiian or Other Pacific Islander', and 'White' - as defined by the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf) .",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/simple-language"
+                },
+                "name": "Language codes with language and optionally a region modifier",
+                "description": "This value set includes codes from [BCP-47](http://tools.ietf.org/html/bcp47). This value set matches the ONC 2015 Edition LanguageCommunication data element value set within C-CDA to use a 2 character language code if one exists,   and a 3 character code if a 2 character code does not exist. It points back to [RFC 5646](https://tools.ietf.org/html/rfc5646), however only the language codes are required, all other elements are optional.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/birthsex"
+                },
+                "name": "Birth Sex",
+                "description": "Codes for assigning sex at birth as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc)",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-clinical-note-type"
+                },
+                "name": "US Core Clinical Note Type",
+                "description": "The US Core Clinical Note Type Value Set is a 'starter set' of types supported for fetching and storing clinical notes.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-condition-category"
+                },
+                "name": "US Core Condition Category Codes",
+                "description": "The US Core Condition Category Codes support the separate concepts of problems and health concerns in Condition.category in order for API consumers to be able to separate health concerns and problems. However this is not mandatory for 2015 certification",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-condition-code"
+                },
+                "name": "US Core Condition Code",
+                "description": "This describes the problem. Diagnosis/Problem List is broadly defined as a series of brief statements that catalog a patient's medical, nursing, dental, social, preventative and psychiatric events and issues that are relevant to that patient's healthcare (e.g., signs, symptoms, and defined conditions).   ICD-10 is appropriate for Diagnosis information, and ICD-9 for historical information.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-diagnosticreport-category"
+                },
+                "name": "US Core DiagnosticReport Category",
+                "description": "The US Core Diagnostic Report Category Value Set is a 'starter set' of categories supported for fetching and Diagnostic Reports and notes.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-diagnosticreport-lab-codes"
+                },
+                "name": "US Core Diagnostic Report Laboratory Codes",
+                "description": "The Document Type value set includes all LOINC  values whose CLASSTYPE is LABORATORY in the LOINC database",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-diagnosticreport-report-and-note-codes"
+                },
+                "name": "US Core DiagnosticReport Report And Note Codes",
+                "description": "This value set currently contains all of LOINC. The codes selected should represent discrete and narrative diagnostic observations and reports",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-documentreference-category"
+                },
+                "name": "US Core DocumentReference Category",
+                "description": "The US Core DocumentReferences Category Value Set is a 'starter set' of categories supported for fetching and storing clinical notes.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-documentreference-type"
+                },
+                "name": "US Core DocumentReference Type",
+                "description": "The US Core DocumentReference Type Value Set includes all LOINC  values whose SCALE is DOC in the LOINC database and the HL7 v3 Code System NullFlavor concept 'unknown'",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-encounter-type"
+                },
+                "name": "US Core Encounter Type",
+                "description": "The type of encounter: a specific code indicating type of service provided. This value set includes codes from SNOMED CT decending from the concept 308335008 (Patient encounter procedure (procedure)) and codes from the Current Procedure and Terminology (CPT) found in the following CPT sections:\n\n\n- 99201-99499 E/M\n\n- 99500-99600 home health (mainly nonphysician, such as newborn care in home)\n\n- 99605-99607 medication management\n\n- 98966-98968 non physician telephone services\n\n\n\n(subscription to AMA Required)",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-narrative-status"
+                },
+                "name": "US Core Narrative Status",
+                "description": "The US Core Narrative Status Value Set limits the text status for the resource narrative.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-observation-smokingstatus-max"
+                },
+                "name": "US Core Smoking Status Max-Binding",
+                "description": "Representing a patient’s smoking behavior using concepts from SNOMED CT.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-observation-smoking-status-status"
+                },
+                "name": "US Core Status for Smoking Status Observation",
+                "description": "Codes providing the status of an observation for smoking status. Constrained to `final`and `entered-in-error`.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-observation-value-codes"
+                },
+                "name": "US Core Observation Value Codes (SNOMED-CT)",
+                "description": "[Snomed-CT](http://www.ihtsdo.org/) concept codes for coded results",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-procedure-code"
+                },
+                "name": "US Core Procedure Codes",
+                "description": "Concepts from CPT, SNOMED CT, HCPCS Level II Alphanumeric Codes, ICD-10-PCS,CDT and LOINC code systems that can be used to indicate the type of procedure performed.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-provenance-participant-type"
+                },
+                "name": "US Core Provenance Participant Type Codes",
+                "description": "The type of participation a provenance agent played for a given target.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-provider-role"
+                },
+                "name": "US Core Provider Role (NUCC)",
+                "description": "Provider roles codes which are composed of the NUCC Health Care Provider Taxonomy Code Set classification codes for providers. Only concepts with a classification and no specialization are included.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-smoking-status-observation-codes"
+                },
+                "name": "US Core Smoking Status Observation Codes",
+                "description": "The US Core Smoking Status Observation Codes Value Set is a 'starter set' of concepts to capture smoking status.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-usps-state"
+                },
+                "name": "USPS Two Letter Alphabetic Codes",
+                "description": "This value set defines two letter USPS alphabetic codes.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-vital-signs"
+                },
+                "name": "US Core Vital Signs ValueSet",
+                "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Device"
+                    }
+                ],
+                "reference": {
+                    "reference": "Device/udi-2"
+                },
+                "name": "Device Defib Example",
+                "description": "This is a Device defib example for the *US Core Implantable Device Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Device"
+                    }
+                ],
+                "reference": {
+                    "reference": "Device/udi-3"
+                },
+                "name": "Device Knee Example",
+                "description": "This is a Device knee example for the *US Core Implantable Device Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "DiagnosticReport"
+                    }
+                ],
+                "reference": {
+                    "reference": "DiagnosticReport/cardiology-report"
+                },
+                "name": "DiagnosticReport Cardiology Report Example",
+                "description": "This is a DiagnosticReport cardiology report example for the *US Core DiagnosticReport Note Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "DiagnosticReport"
+                    }
+                ],
+                "reference": {
+                    "reference": "DiagnosticReport/chest-xray-report"
+                },
+                "name": "DiagnosticReport Chest Xray Report Example",
+                "description": "This is a DiagnosticReport chest xray report example for the *US Core DiagnosticReport Note Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Bundle"
+                    }
+                ],
+                "reference": {
+                    "reference": "Bundle/66c8856b-ba11-4876-8aa8-467aad8c11a2"
+                },
+                "name": "PractitionerRole_Practitioner_Endpoint_Bundle_Example Example",
+                "description": "This is a PractitionerRole_Practitioner_Endpoint_Bundle_Example example for the *Bundle Profile*.",
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Procedure"
+                    }
+                ],
+                "reference": {
+                    "reference": "Procedure/defib-implant"
+                },
+                "name": "Procedure R4 Defib Implant Example",
+                "description": "This is a Procedure R4 defib implant example for the *US Core Procedure Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Organization"
+                    }
+                ],
+                "reference": {
+                    "reference": "Organization/acme-lab"
+                },
+                "name": "Acme Lab Example",
+                "description": "This is a acme lab example for the *US Core Organization Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "AllergyIntolerance"
+                    }
+                ],
+                "reference": {
+                    "reference": "AllergyIntolerance/example"
+                },
+                "name": "AllergyIntolerance Example",
+                "description": "This is a allergyintolerance example for the *US Core AllergyIntolerance Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Bundle"
+                    }
+                ],
+                "reference": {
+                    "reference": "Bundle/c887e62f-6166-419f-8268-b5ecd6c7b901"
+                },
+                "name": "AllergyIntolerance Provenance Example",
+                "description": "This is a allergyintolerance provenance example for the *Bundle Profile*.",
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/blood-glucose"
+                },
+                "name": "Blood Glucose Example",
+                "description": "This is a blood glucose example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/blood-pressure"
+                },
+                "name": "Blood Pressure Example",
+                "description": "This is a blood pressure example for the *Vitalsigns Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/bmi"
+                },
+                "name": "BMI Example",
+                "description": "This is a BMI example for the *Vitalsigns Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-bmi"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/bp-data-absent"
+                },
+                "name": "BP Data Absent Example",
+                "description": "This is a bp data absent example for the *Vitalsigns Profile* showing how to reprsesent blood pressure with a missing diastolic measurement.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/bun"
+                },
+                "name": "BUN Example",
+                "description": "This is a BUN example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CareTeam"
+                    }
+                ],
+                "reference": {
+                    "reference": "CareTeam/example"
+                },
+                "name": "CareTeam Example",
+                "description": "This is a careteam example for the *US Core CareTeam Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "DiagnosticReport"
+                    }
+                ],
+                "reference": {
+                    "reference": "DiagnosticReport/cbc"
+                },
+                "name": "CBC Example",
+                "description": "This is a CBC example for the *US Core DiagnosticReport Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CarePlan"
+                    }
+                ],
+                "reference": {
+                    "reference": "CarePlan/colonoscopy"
+                },
+                "name": "Colonoscopy Example",
+                "description": "This is a colonoscopy example for the *US Core CarePlan Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Condition"
+                    }
+                ],
+                "reference": {
+                    "reference": "Condition/example"
+                },
+                "name": "Condition Example",
+                "description": "This is a condition example for the *US Core Condition Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Encounter"
+                    }
+                ],
+                "reference": {
+                    "reference": "Encounter/1036"
+                },
+                "name": "Encounter 1036 Example",
+                "description": "This is a encounter 1036 example for the *Encounter Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Encounter"
+                    }
+                ],
+                "reference": {
+                    "reference": "Encounter/example-1"
+                },
+                "name": "Encounter 1 Example",
+                "description": "This is a encounter 1 example for the *US Core Encounter Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "DocumentReference"
+                    }
+                ],
+                "reference": {
+                    "reference": "DocumentReference/episode-summary"
+                },
+                "name": "Episode Summary Example",
+                "description": "This is a episode summary example for the *US Core DocumentReference Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/erythrocytes"
+                },
+                "name": "Erythrocytes Example",
+                "description": "This is a erythrocytes example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Organization"
+                    }
+                ],
+                "reference": {
+                    "reference": "Organization/example-organization-2"
+                },
+                "name": "Organization 2 Example",
+                "description": "This is a organization 2 example for the *US Core Organization Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Goal"
+                    }
+                ],
+                "reference": {
+                    "reference": "Goal/goal-1"
+                },
+                "name": "Goal 1 Example",
+                "description": "This is a goal 1 example for the *US Core Goal Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Condition"
+                    }
+                ],
+                "reference": {
+                    "reference": "Condition/hc1"
+                },
+                "name": "HC1 Example",
+                "description": "This is a hc1 example for the *US Core Condition Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/head-circumference"
+                },
+                "name": "Head Circumference Example",
+                "description": "This is a head circumference example for the *US Core Head Circumference Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-head-circumference"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/heart-rate"
+                },
+                "name": "Heart Rate Example",
+                "description": "This is a heart rate example for the *Vitalsigns Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/height"
+                },
+                "name": "Height Example",
+                "description": "This is a height example for the *Vitalsigns Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-height"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/hemoglobin"
+                },
+                "name": "Hemoglobin Example",
+                "description": "This is a hemoglobin example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Location"
+                    }
+                ],
+                "reference": {
+                    "reference": "Location/hl7east"
+                },
+                "name": "HL7East Example",
+                "description": "This is a HL7East example for the *US Core Location Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-location"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Immunization"
+                    }
+                ],
+                "reference": {
+                    "reference": "Immunization/imm-1"
+                },
+                "name": "Imm 1 Example",
+                "description": "This is a imm 1 example for the *US Core Immunization Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/length"
+                },
+                "name": "Length Example",
+                "description": "This is a length example for the *Vitalsigns Profile* which shows how body length (typically used for infants) is represented using 8306-3 -*Body height - lying* as an additional observation code.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-height"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/mchc"
+                },
+                "name": "MCHC Example",
+                "description": "This is a MCHC example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "DiagnosticReport"
+                    }
+                ],
+                "reference": {
+                    "reference": "DiagnosticReport/metabolic-panel"
+                },
+                "name": "Metabolic Panel Example",
+                "description": "This is a metabolic panel example for the *US Core DiagnosticReport Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/neutrophils"
+                },
+                "name": "Neutrophils Example",
+                "description": "This is a neutrophils example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/satO2-fiO2"
+                },
+                "name": "Observation SatO2 FiO2 Example",
+                "description": "This is a observation satO2 fiO2 example for the *US Core Pulse Oximetry Profile* representing a spO2 value with a for a patient on 6 l/min of O2 suppplemental oxygen.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/ofc-percentile"
+                },
+                "name": "OFC Percentile Example",
+                "description": "This is a OFC percentile example for the *Head Occipital Frontal Circumference Percentile Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/oxygen-saturation"
+                },
+                "name": "Oxygen Saturation Example",
+                "description": "This is a typical oxygen saturation example for the *US Core Pulse Oximetry Profile* on room air where no oxygen concentration is recorded.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Patient"
+                    }
+                ],
+                "reference": {
+                    "reference": "Patient/child-example"
+                },
+                "name": "Patient Child Example",
+                "description": "This is a patient child example for the *US Core Patient Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Patient"
+                    }
+                ],
+                "reference": {
+                    "reference": "Patient/example"
+                },
+                "name": "Patient Example",
+                "description": "This is a patient example for the *US Core Patient Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Patient"
+                    }
+                ],
+                "reference": {
+                    "reference": "Patient/infant-example"
+                },
+                "name": "Patient Infant Example",
+                "description": "This is a patient infant example for the *US Core Patient Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/pediatric-bmi-example"
+                },
+                "name": "Pediatric BMI Example",
+                "description": "This is a pediatric BMI example for the *Pediatric BMI For Age Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/pediatric-wt-example"
+                },
+                "name": "Pediatric Wt Example",
+                "description": "This is a pediatric wt example for the *Pediatric Weight For Height Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Practitioner"
+                    }
+                ],
+                "reference": {
+                    "reference": "Practitioner/practitioner-1"
+                },
+                "name": "Practitioner 1 Example",
+                "description": "This is a practitioner 1 example for the *US Core Practitioner Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Practitioner"
+                    }
+                ],
+                "reference": {
+                    "reference": "Practitioner/practitioner-2"
+                },
+                "name": "Practitioner 2 Example",
+                "description": "This is a practitioner 2 example for the *US Core Practitioner Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Procedure"
+                    }
+                ],
+                "reference": {
+                    "reference": "Procedure/rehab"
+                },
+                "name": "Rehab Example",
+                "description": "This is a rehab example for the *US Core Procedure Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/respiratory-rate"
+                },
+                "name": "Respiratory Rate Example",
+                "description": "This is a respiratory rate example for the *Vitalsigns Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-respiratory-rate"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Organization"
+                    }
+                ],
+                "reference": {
+                    "reference": "Organization/saint-luke-w-endpoint"
+                },
+                "name": "Saint Luke W Endpoint Example",
+                "description": "This is a saint luke w endpoint example for the *US Core Organization Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "MedicationRequest"
+                    }
+                ],
+                "reference": {
+                    "reference": "MedicationRequest/self-tylenol"
+                },
+                "name": "Self Tylenol Example",
+                "description": "This is a self tylenol example for the *MedicationRequest Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/serum-calcium"
+                },
+                "name": "Serum Calcium Example",
+                "description": "This is a serum calcium example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/serum-chloride"
+                },
+                "name": "Serum Chloride Example",
+                "description": "This is a serum chloride example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/serum-co2"
+                },
+                "name": "Serum CO2 Example",
+                "description": "This is a serum CO2 example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/serum-creatinine"
+                },
+                "name": "Serum Creatinine Example",
+                "description": "This is a serum creatinine example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/serum-potassium"
+                },
+                "name": "Serum Potassium Example",
+                "description": "This is a serum potassium example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/serum-sodium"
+                },
+                "name": "Serum Sodium Example",
+                "description": "This is a serum sodium example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/serum-total-bilirubin"
+                },
+                "name": "Serum Total Bilirubin Example",
+                "description": "This is a serum total bilirubin example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/some-day-smoker"
+                },
+                "name": "Some Day Smoker Example",
+                "description": "This is a some day smoker example for the *US Core Smokingstatus Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/temperature"
+                },
+                "name": "Temperature Example",
+                "description": "This is a temperature example for the *Vitalsigns Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-temperature"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Device"
+                    }
+                ],
+                "reference": {
+                    "reference": "Device/udi-1"
+                },
+                "name": "UDI 1 Example",
+                "description": "This is a UDI 1 example for the *US Core Implantable Device Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "DiagnosticReport"
+                    }
+                ],
+                "reference": {
+                    "reference": "DiagnosticReport/urinalysis"
+                },
+                "name": "Urinalysis Example",
+                "description": "This is a urinalysis example for the *US Core DiagnosticReport Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-bacteria"
+                },
+                "name": "Urine Bacteria Example",
+                "description": "This is a urine bacteria example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-bilirubin"
+                },
+                "name": "Urine Bilirubin Example",
+                "description": "This is a urine bilirubin example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-cells"
+                },
+                "name": "Urine Cells Example",
+                "description": "This is a urine cells example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-clarity"
+                },
+                "name": "Urine Clarity Example",
+                "description": "This is a urine clarity example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-color"
+                },
+                "name": "Urine Color Example",
+                "description": "This is a urine color example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-epi-cells"
+                },
+                "name": "Urine Epi Cells Example",
+                "description": "This is a urine epi cells example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-glucose"
+                },
+                "name": "Urine Glucose Example",
+                "description": "This is a urine glucose example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-hemoglobin"
+                },
+                "name": "Urine Hemoglobin Example",
+                "description": "This is a urine hemoglobin example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-ketone"
+                },
+                "name": "Urine Ketone Example",
+                "description": "This is a urine ketone example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-leukocyte-esterase"
+                },
+                "name": "Urine Leukocyte Esterase Example",
+                "description": "This is a urine leukocyte esterase example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-nitrite"
+                },
+                "name": "Urine Nitrite Example",
+                "description": "This is a urine nitrite example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-ph"
+                },
+                "name": "Urine pH Example",
+                "description": "This is a urine pH example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-protein"
+                },
+                "name": "Urine Protein Example",
+                "description": "This is a urine protein example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-rbcs"
+                },
+                "name": "Urine RBCsExample",
+                "description": "This is a urine RBCsexample for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-sediment"
+                },
+                "name": "Urine Sediment Example",
+                "description": "This is a urine sediment example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-wbcs"
+                },
+                "name": "Urine WBCsExample",
+                "description": "This is a urine WBCsexample for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urobilinogen"
+                },
+                "name": "Urobilinogen Example",
+                "description": "This is a urobilinogen example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Medication"
+                    }
+                ],
+                "reference": {
+                    "reference": "Medication/uscore-med1"
+                },
+                "name": "Uscore Med1 Example",
+                "description": "This is a uscore med1 example for the *US Core Medication Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Medication"
+                    }
+                ],
+                "reference": {
+                    "reference": "Medication/uscore-med2"
+                },
+                "name": "Uscore Med2 Example",
+                "description": "This is a uscore med2 example for the *US Core Medication Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "MedicationRequest"
+                    }
+                ],
+                "reference": {
+                    "reference": "MedicationRequest/uscore-mo1"
+                },
+                "name": "Uscore MO1 Example",
+                "description": "This is a uscore mo1 example for the *US Core MedicationRequest Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "MedicationRequest"
+                    }
+                ],
+                "reference": {
+                    "reference": "MedicationRequest/uscore-mo2"
+                },
+                "name": "Uscore MO2 Example",
+                "description": "This is a uscore MO2 example for the *US Core MedicationRequest Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Bundle"
+                    }
+                ],
+                "reference": {
+                    "reference": "Bundle/uscore-mo3"
+                },
+                "name": "Uscore MO3 Example",
+                "description": "This is a uscore mo3 example for the *Bundle Profile*.",
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/usg"
+                },
+                "name": "USG Example",
+                "description": "This is a USG example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/weight"
+                },
+                "name": "Weight Example",
+                "description": "This is a weight example for the *Vitalsigns Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-weight"
+            }
+        ],
+        "page": {
+            "nameUrl": "toc.html",
+            "title": "Table of Contents",
+            "generation": "html",
+            "page": [
+                {
+                    "nameUrl": "index.html",
+                    "title": "Index",
+                    "generation": "markdown"
+                },
+                {
+                    "nameUrl": "guidance.html",
+                    "title": "Guidance",
+                    "generation": "markdown",
+                    "page": [
+                        {
+                            "nameUrl": "general-guidance.html",
+                            "title": "General Guidance",
+                            "generation": "markdown"
+                        },
+                        {
+                            "nameUrl": "conformance-expectations.html",
+                            "title": "Conformance Expectations",
+                            "generation": "markdown"
+                        },
+                        {
+                            "nameUrl": "clinical-notes-guidance.html",
+                            "title": "Clinical Notes Guidance",
+                            "generation": "markdown"
+                        },
+                        {
+                            "nameUrl": "medication-list-guidance.html",
+                            "title": "Medication List Guidance",
+                            "generation": "markdown"
+                        },
+                        {
+                            "nameUrl": "basic-provenance.html",
+                            "title": "Basic Provenance",
+                            "generation": "markdown"
+                        },
+                        {
+                            "nameUrl": "DSTU2-to-R4-conversion.html",
+                            "title": "DSTU2 to R4 Conversion",
+                            "generation": "markdown"
+                        },
+                        {
+                            "nameUrl": "future-of-US-core.html",
+                            "title": "Future of US Core",
+                            "generation": "markdown"
+                        }
+                    ]
+                },
+                {
+                    "nameUrl": "profiles-and-extensions.html",
+                    "title": "Profiles and Extensions",
+                    "generation": "markdown"
+                },
+                {
+                    "nameUrl": "capability-statements.html",
+                    "title": "Capability Statements",
+                    "generation": "markdown"
+                },
+                {
+                    "nameUrl": "search-parameters-and-operations.html",
+                    "title": "Search Parameters and Operations",
+                    "generation": "markdown"
+                },
+                {
+                    "nameUrl": "terminology.html",
+                    "title": "Terminology",
+                    "generation": "markdown"
+                },
+                {
+                    "nameUrl": "security.html",
+                    "title": "Security",
+                    "generation": "markdown"
+                },
+                {
+                    "nameUrl": "examples.html",
+                    "title": "Examples",
+                    "generation": "markdown"
+                },
+                {
+                    "nameUrl": "downloads.html",
+                    "title": "Downloads",
+                    "generation": "markdown"
+                }
+            ]
+        },
+        "parameter": [
+            {
+                "code": "path-resource",
+                "value": "input/resources"
+            },
+            {
+                "code": "path-resource",
+                "value": "fsh-generated/resources"
+            },
+            {
+                "code": "path-pages",
+                "value": "input/pagecontent"
+            },
+            {
+                "code": "path-pages",
+                "value": "input/intro-notes"
+            },
+            {
+                "code": "path-pages",
+                "value": "fsh-generated/includes"
+            },
+            {
+                "code": "path-resource",
+                "value": "input/capabilities"
+            },
+            {
+                "code": "path-resource",
+                "value": "input/examples"
+            },
+            {
+                "code": "path-resource",
+                "value": "input/extensions"
+            },
+            {
+                "code": "path-resource",
+                "value": "input/models"
+            },
+            {
+                "code": "path-resource",
+                "value": "input/operations"
+            },
+            {
+                "code": "path-resource",
+                "value": "input/profiles"
+            },
+            {
+                "code": "path-resource",
+                "value": "input/vocabulary"
+            },
+            {
+                "code": "path-resource",
+                "value": "input/testing"
+            },
+            {
+                "code": "path-resource",
+                "value": "input/history"
+            },
+            {
+                "code": "path-pages",
+                "value": "template/config"
+            },
+            {
+                "code": "path-pages",
+                "value": "input/images"
+            },
+            {
+                "code": "path-tx-cache",
+                "value": "input-cache/txcache"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/OperationDefinition-docref.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/OperationDefinition-docref.json
@@ -1,97 +1,97 @@
 {
-	"resourceType": "OperationDefinition",
-	"id": "docref",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>USCoreFetchDocumentReference</h2><p>OPERATION: USCoreFetchDocumentReference</p><p>The official URL for this operation definition is: </p><pre>http://hl7.org/fhir/us/core/OperationDefinition/docref</pre><div><p>This operation is used to return all the references to documents related to a patient.</p>\n<p>The operation requires a patient id and takes the optional input parameters:</p>\n<ul>\n<li>start date</li>\n<li>end date</li>\n<li>document type</li>\n</ul>\n<p>and returns a <a href=\"http://hl7.org/fhir/bundle.html\">Bundle</a> of type &quot;searchset&quot; containing <a href=\"http://hl7.org/fhir/documentreference.html\">DocumentReference</a> resources for the patient. The DocumentReference resources <strong>SHOULD</strong> conform to the <a href=\"http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference\">US Core DocumentReference\nProfiles</a>. If the server has or can create documents that are related to the patient, and that are available for the given user, the server returns the DocumentReference resources needed to support the records.  The principle intended use for this operation is to provide a provider or patient with access to their available document information.</p>\n<p>This operation is <em>different</em> from a search by patient and type and date range because:</p>\n<ol>\n<li>\n<p>It is used to request a server <em>generate</em> a document based on the specified parameters.</p>\n</li>\n<li>\n<p>If no parameters are specified, the server SHALL return a DocumentReference to the patient's most current CCD</p>\n</li>\n<li>\n<p>If the server cannot <em>generate</em> a document based on the specified parameters, the operation will return an empty search bundle.</p>\n</li>\n</ol>\n<p>This operation is the <em>same</em> as a FHIR RESTful search by patient,type and date range because:</p>\n<ol>\n<li>References for <em>existing</em> documents that meet the requirements of the request SHOULD also be returned unless the client indicates they are only interested in 'on-demand' documents using the <em>on-demand</em> parameter.</li>\n</ol>\n</div><p>Parameters</p><table class=\"grid\"><tr><td><b>Use</b></td><td><b>Name</b></td><td><b>Cardinality</b></td><td><b>Type</b></td><td><b>Binding</b></td><td><b>Documentation</b></td></tr><tr><td>IN</td><td>patient</td><td>1..1</td><td><a href=\"http://hl7.org/fhir/R4/datatypes.html#id\">id</a></td><td/><td><div><p>The id of the patient resource located on the server on which this operation is executed.  If there is no match, an empty Bundle is returned</p>\n</div></td></tr><tr><td>IN</td><td>start</td><td>0..1</td><td><a href=\"http://hl7.org/fhir/R4/datatypes.html#dateTime\">dateTime</a></td><td/><td><div><p>The date range relates to care dates, not record currency dates - e.g. all records relating to care provided in a certain date range. If no start date is provided, all documents prior to the end date are in scope.  If neither a start date nor an end date is provided, the most recent or current document is in scope.  The client <strong>SHOULD</strong> provide values precise to the second + time offset.</p>\n</div></td></tr><tr><td>IN</td><td>end</td><td>0..1</td><td><a href=\"http://hl7.org/fhir/R4/datatypes.html#dateTime\">dateTime</a></td><td/><td><div><p>The date range relates to care dates, not record currency dates - e.g. all records relating to care provided in a certain date range. If no end date is provided, all documents subsequent to the start date are in scope. If neither a start date nor an end date is provided, the most recent or current document is in scope.  The client <strong>SHOULD</strong> provide values precise to the second + time offset.</p>\n</div></td></tr><tr><td>IN</td><td>type</td><td>0..1</td><td><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td><a href=\"http://hl7.org/fhir/R4/valueset-c80-doc-typecodes.html\">http://hl7.org/fhir/ValueSet/c80-doc-typecodes</a> (Required)</td><td><div><p>The type relates to document type e.g. for the LOINC code for a C-CDA Clinical Summary of Care (CCD) is 34133-9 (Summary of episode note). If no type is provided, the CCD document, if available, SHALL be in scope and all other document types MAY be in scope</p>\n</div></td></tr><tr><td>IN</td><td>on-demand</td><td>0..1</td><td><a href=\"http://hl7.org/fhir/R4/datatypes.html#boolean\">boolean</a></td><td/><td><div><p>This on-demand parameter allows client to dictate whether they are requesting only ‘on-demand’ or both ‘on-demand’ and 'stable' documents (or delayed/deferred assembly) that meet the query parameters</p>\n</div></td></tr><tr><td>OUT</td><td>return</td><td>1..1</td><td><a href=\"http://hl7.org/fhir/R4/bundle.html\">Bundle</a></td><td/><td><div><p>The bundle type is &quot;searchset&quot;containing <a href=\"http://hl7.org/fhir/documentreference.html\">DocumentReference</a> resources which <strong>SHOULD</strong> conform to the <a href=\"http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference\">US Core DocumentReference Profiles</a></p>\n</div></td></tr></table><div><ul>\n<li>\n<p>The server is responsible for determining what resources, if any, to return as <a href=\"http://hl7.org/fhir/R4/search.html#revinclude\">included</a> resources rather than the client specifying which ones. This frees the client from needing to determine what it could or should ask for. For example, the server may return the referenced document as an included FHIR Binary resource within the return bundle. The server's CapabilityStatement should document this behavior.</p>\n</li>\n<li>\n<p>The document itself can be subsequently retrieved using the link provided  in the <code>DocumentReference.content.attachment.url element</code>. The link could be a FHIR endpoint to a <a href=\"http://hl7.org/fhir/R4/binary.html\">Binary</a> Resource or some other document repository.</p>\n</li>\n<li>\n<p>It is assumed that the server has identified and secured the context appropriately, and can either associate the authorization context with a single patient, or determine whether the context has the rights to the nominated patient, if there is one. If there is no nominated patient (e.g. the operation is invoked at the system level) and the context is not associated with a single patient record, then the server should return an error. Specifying the relationship between the context, a user and patient records is outside the scope of this specification</p>\n</li>\n</ul>\n</div></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/OperationDefinition/docref",
-	"version": "4.0.0",
-	"name": "USCoreFetchDocumentReference",
-	"title": "US Core Fetch DocumentReference",
-	"status": "active",
-	"kind": "operation",
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "This operation is used to return all the references to documents related to a patient. \n\n The operation requires a patient id and takes the optional input parameters: \n  - start date\n  - end date\n  - document type \n\n and returns a [Bundle](http://hl7.org/fhir/bundle.html) of type \"searchset\" containing [DocumentReference](http://hl7.org/fhir/documentreference.html) resources for the patient. The DocumentReference resources **SHOULD** conform to the [US Core DocumentReference\n Profiles](http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference). If the server has or can create documents that are related to the patient, and that are available for the given user, the server returns the DocumentReference resources needed to support the records.  The principle intended use for this operation is to provide a provider or patient with access to their available document information. \n\n This operation is *different* from a search by patient and type and date range because: \n\n 1. It is used to request a server *generate* a document based on the specified parameters. \n\n 1. If no parameters are specified, the server SHALL return a DocumentReference to the patient's most current CCD \n\n 1. If the server cannot *generate* a document based on the specified parameters, the operation will return an empty search bundle. \n\n This operation is the *same* as a FHIR RESTful search by patient,type and date range because: \n\n 1. References for *existing* documents that meet the requirements of the request SHOULD also be returned unless the client indicates they are only interested in 'on-demand' documents using the *on-demand* parameter.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "docref",
-	"comment": " - The server is responsible for determining what resources, if any, to return as [included](http://hl7.org/fhir/R4/search.html#revinclude) resources rather than the client specifying which ones. This frees the client from needing to determine what it could or should ask for. For example, the server may return the referenced document as an included FHIR Binary resource within the return bundle. The server's CapabilityStatement should document this behavior. \n\n - The document itself can be subsequently retrieved using the link provided  in the `DocumentReference.content.attachment.url element`. The link could be a FHIR endpoint to a [Binary](http://hl7.org/fhir/R4/binary.html) Resource or some other document repository. \n\n - It is assumed that the server has identified and secured the context appropriately, and can either associate the authorization context with a single patient, or determine whether the context has the rights to the nominated patient, if there is one. If there is no nominated patient (e.g. the operation is invoked at the system level) and the context is not associated with a single patient record, then the server should return an error. Specifying the relationship between the context, a user and patient records is outside the scope of this specification",
-	"system": false,
-	"type": true,
-	"instance": false,
-	"parameter": [
-		{
-			"name": "patient",
-			"use": "in",
-			"min": 1,
-			"max": "1",
-			"documentation": "The id of the patient resource located on the server on which this operation is executed.  If there is no match, an empty Bundle is returned",
-			"type": "id"
-		},
-		{
-			"name": "start",
-			"use": "in",
-			"min": 0,
-			"max": "1",
-			"documentation": "The date range relates to care dates, not record currency dates - e.g. all records relating to care provided in a certain date range. If no start date is provided, all documents prior to the end date are in scope.  If neither a start date nor an end date is provided, the most recent or current document is in scope.  The client **SHOULD** provide values precise to the second + time offset.",
-			"type": "dateTime"
-		},
-		{
-			"name": "end",
-			"use": "in",
-			"min": 0,
-			"max": "1",
-			"documentation": "The date range relates to care dates, not record currency dates - e.g. all records relating to care provided in a certain date range. If no end date is provided, all documents subsequent to the start date are in scope. If neither a start date nor an end date is provided, the most recent or current document is in scope.  The client **SHOULD** provide values precise to the second + time offset.",
-			"type": "dateTime"
-		},
-		{
-			"name": "type",
-			"use": "in",
-			"min": 0,
-			"max": "1",
-			"documentation": "The type relates to document type e.g. for the LOINC code for a C-CDA Clinical Summary of Care (CCD) is 34133-9 (Summary of episode note). If no type is provided, the CCD document, if available, SHALL be in scope and all other document types MAY be in scope",
-			"type": "CodeableConcept",
-			"binding": {
-				"strength": "required",
-				"valueSet": "http://hl7.org/fhir/ValueSet/c80-doc-typecodes"
-			}
-		},
-		{
-			"name": "on-demand",
-			"use": "in",
-			"min": 0,
-			"max": "1",
-			"documentation": "This on-demand parameter allows client to dictate whether they are requesting only ‘on-demand’ or both ‘on-demand’ and 'stable' documents (or delayed/deferred assembly) that meet the query parameters",
-			"type": "boolean"
-		},
-		{
-			"name": "return",
-			"use": "out",
-			"min": 1,
-			"max": "1",
-			"documentation": "The bundle type is \"searchset\"containing [DocumentReference](http://hl7.org/fhir/documentreference.html) resources which **SHOULD** conform to the [US Core DocumentReference Profiles](http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference)",
-			"type": "Bundle"
-		}
-	]
+    "resourceType": "OperationDefinition",
+    "id": "docref",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/OperationDefinition/docref",
+    "version": "4.0.0",
+    "name": "USCoreFetchDocumentReference",
+    "title": "US Core Fetch DocumentReference",
+    "status": "active",
+    "kind": "operation",
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "This operation is used to return all the references to documents related to a patient. \n\n The operation requires a patient id and takes the optional input parameters: \n  - start date\n  - end date\n  - document type \n\n and returns a [Bundle](http://hl7.org/fhir/bundle.html) of type \"searchset\" containing [DocumentReference](http://hl7.org/fhir/documentreference.html) resources for the patient. The DocumentReference resources **SHOULD** conform to the [US Core DocumentReference\n Profiles](http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference). If the server has or can create documents that are related to the patient, and that are available for the given user, the server returns the DocumentReference resources needed to support the records.  The principle intended use for this operation is to provide a provider or patient with access to their available document information. \n\n This operation is *different* from a search by patient and type and date range because: \n\n 1. It is used to request a server *generate* a document based on the specified parameters. \n\n 1. If no parameters are specified, the server SHALL return a DocumentReference to the patient's most current CCD \n\n 1. If the server cannot *generate* a document based on the specified parameters, the operation will return an empty search bundle. \n\n This operation is the *same* as a FHIR RESTful search by patient,type and date range because: \n\n 1. References for *existing* documents that meet the requirements of the request SHOULD also be returned unless the client indicates they are only interested in 'on-demand' documents using the *on-demand* parameter.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "docref",
+    "comment": " - The server is responsible for determining what resources, if any, to return as [included](http://hl7.org/fhir/R4/search.html#revinclude) resources rather than the client specifying which ones. This frees the client from needing to determine what it could or should ask for. For example, the server may return the referenced document as an included FHIR Binary resource within the return bundle. The server's CapabilityStatement should document this behavior. \n\n - The document itself can be subsequently retrieved using the link provided  in the `DocumentReference.content.attachment.url element`. The link could be a FHIR endpoint to a [Binary](http://hl7.org/fhir/R4/binary.html) Resource or some other document repository. \n\n - It is assumed that the server has identified and secured the context appropriately, and can either associate the authorization context with a single patient, or determine whether the context has the rights to the nominated patient, if there is one. If there is no nominated patient (e.g. the operation is invoked at the system level) and the context is not associated with a single patient record, then the server should return an error. Specifying the relationship between the context, a user and patient records is outside the scope of this specification",
+    "system": false,
+    "type": true,
+    "instance": false,
+    "parameter": [
+        {
+            "name": "patient",
+            "use": "in",
+            "min": 1,
+            "max": "1",
+            "documentation": "The id of the patient resource located on the server on which this operation is executed.  If there is no match, an empty Bundle is returned",
+            "type": "id"
+        },
+        {
+            "name": "start",
+            "use": "in",
+            "min": 0,
+            "max": "1",
+            "documentation": "The date range relates to care dates, not record currency dates - e.g. all records relating to care provided in a certain date range. If no start date is provided, all documents prior to the end date are in scope.  If neither a start date nor an end date is provided, the most recent or current document is in scope.  The client **SHOULD** provide values precise to the second + time offset.",
+            "type": "dateTime"
+        },
+        {
+            "name": "end",
+            "use": "in",
+            "min": 0,
+            "max": "1",
+            "documentation": "The date range relates to care dates, not record currency dates - e.g. all records relating to care provided in a certain date range. If no end date is provided, all documents subsequent to the start date are in scope. If neither a start date nor an end date is provided, the most recent or current document is in scope.  The client **SHOULD** provide values precise to the second + time offset.",
+            "type": "dateTime"
+        },
+        {
+            "name": "type",
+            "use": "in",
+            "min": 0,
+            "max": "1",
+            "documentation": "The type relates to document type e.g. for the LOINC code for a C-CDA Clinical Summary of Care (CCD) is 34133-9 (Summary of episode note). If no type is provided, the CCD document, if available, SHALL be in scope and all other document types MAY be in scope",
+            "type": "CodeableConcept",
+            "binding": {
+                "strength": "required",
+                "valueSet": "http://hl7.org/fhir/ValueSet/c80-doc-typecodes"
+            }
+        },
+        {
+            "name": "on-demand",
+            "use": "in",
+            "min": 0,
+            "max": "1",
+            "documentation": "This on-demand parameter allows client to dictate whether they are requesting only ‘on-demand’ or both ‘on-demand’ and 'stable' documents (or delayed/deferred assembly) that meet the query parameters",
+            "type": "boolean"
+        },
+        {
+            "name": "return",
+            "use": "out",
+            "min": 1,
+            "max": "1",
+            "documentation": "The bundle type is \"searchset\"containing [DocumentReference](http://hl7.org/fhir/documentreference.html) resources which **SHOULD** conform to the [US Core DocumentReference Profiles](http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference)",
+            "type": "Bundle"
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-allergyintolerance-clinical-status.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-allergyintolerance-clinical-status.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-allergyintolerance-clinical-status",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreAllergyIntoleranceClinicalStatus</h2> --><b> description</b> : <p><strong>active | inactive | resolved</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-allergyintolerance-clinical-status</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-clinical-status</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreAllergyIntoleranceClinicalStatus</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/AllergyIntolerance-clinical-status\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>clinical-status</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :AllergyIntolerance</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>AllergyIntolerance.clinicalStatus</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:AllergyIntolerance/f:clinicalStatus</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-clinical-status",
-	"version": "4.0.0",
-	"name": "USCoreAllergyIntoleranceClinicalStatus",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/AllergyIntolerance-clinical-status",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:26.898912Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**active | inactive | resolved**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "clinical-status",
-	"base": [
-		"AllergyIntolerance"
-	],
-	"type": "token",
-	"expression": "AllergyIntolerance.clinicalStatus",
-	"xpath": "f:AllergyIntolerance/f:clinicalStatus",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-allergyintolerance-clinical-status",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-clinical-status",
+    "version": "4.0.0",
+    "name": "USCoreAllergyIntoleranceClinicalStatus",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/AllergyIntolerance-clinical-status",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:26.898912Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**active | inactive | resolved**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "clinical-status",
+    "base": [
+        "AllergyIntolerance"
+    ],
+    "type": "token",
+    "expression": "AllergyIntolerance.clinicalStatus",
+    "xpath": "f:AllergyIntolerance/f:clinicalStatus",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-allergyintolerance-patient.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-allergyintolerance-patient.json
@@ -1,68 +1,68 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-allergyintolerance-patient",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreAllergyIntolerancePatient</h2> --><b> description</b> : <p><strong>Who the sensitivity is for</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-allergyintolerance-patient</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-patient</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreAllergyIntolerancePatient</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-patient\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>patient</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :AllergyIntolerance</p>\n\t\t\t<p><b> type</b> : reference</p>\n\t\t\t<p><b> expression</b> : <code>AllergyIntolerance.patient</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:AllergyIntolerance/f:patient</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-patient",
-	"version": "4.0.0",
-	"name": "USCoreAllergyIntolerancePatient",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:26.966454Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Who the sensitivity is for**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "patient",
-	"base": [
-		"AllergyIntolerance"
-	],
-	"type": "reference",
-	"expression": "AllergyIntolerance.patient",
-	"xpath": "f:AllergyIntolerance/f:patient",
-	"xpathUsage": "normal",
-	"target": [
-		"Patient",
-		"Group"
-	],
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-allergyintolerance-patient",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-patient",
+    "version": "4.0.0",
+    "name": "USCoreAllergyIntolerancePatient",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:26.966454Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Who the sensitivity is for**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "patient",
+    "base": [
+        "AllergyIntolerance"
+    ],
+    "type": "reference",
+    "expression": "AllergyIntolerance.patient",
+    "xpath": "f:AllergyIntolerance/f:patient",
+    "xpathUsage": "normal",
+    "target": [
+        "Patient",
+        "Group"
+    ],
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-careplan-category.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-careplan-category.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-careplan-category",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreCarePlanCategory</h2> --><b> description</b> : <p><strong>Type of plan</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-careplan-category</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-category</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreCarePlanCategory</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/CarePlan-category\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>category</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :CarePlan</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>CarePlan.category</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:CarePlan/f:category</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-category",
-	"version": "4.0.0",
-	"name": "USCoreCarePlanCategory",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/CarePlan-category",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:29.764367Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Type of plan**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "category",
-	"base": [
-		"CarePlan"
-	],
-	"type": "token",
-	"expression": "CarePlan.category",
-	"xpath": "f:CarePlan/f:category",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-careplan-category",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-category",
+    "version": "4.0.0",
+    "name": "USCoreCarePlanCategory",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/CarePlan-category",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:29.764367Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Type of plan**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "category",
+    "base": [
+        "CarePlan"
+    ],
+    "type": "token",
+    "expression": "CarePlan.category",
+    "xpath": "f:CarePlan/f:category",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-careplan-date.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-careplan-date.json
@@ -1,149 +1,149 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-careplan-date",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreCarePlanDate</h2> --><b> description</b> : <p><strong>Time period plan covers</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-careplan-date</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-date</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreCarePlanDate</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-date\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>date</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :CarePlan</p>\n\t\t\t<p><b> type</b> : date</p>\n\t\t\t<p><b> expression</b> : <code>CarePlan.period</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:CarePlan/f:period</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = SHOULD)</p>\n    \n    \n    <p><b> comparator</b> : <code>eq</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>ne</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>gt</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>ge</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>lt</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>le</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>sa</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>eb</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>ap</code> ( Conformance Expectation = MAY)</p>\n    \n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-date",
-	"version": "4.0.0",
-	"name": "USCoreCarePlanDate",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-date",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:29.793290Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Time period plan covers**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "date",
-	"base": [
-		"CarePlan"
-	],
-	"type": "date",
-	"expression": "CarePlan.period",
-	"xpath": "f:CarePlan/f:period",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHOULD"
-			}
-		]
-	},
-	"comparator": [
-		"eq",
-		"ne",
-		"gt",
-		"ge",
-		"lt",
-		"le",
-		"sa",
-		"eb",
-		"ap"
-	],
-	"_comparator": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		}
-	]
+    "resourceType": "SearchParameter",
+    "id": "us-core-careplan-date",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-date",
+    "version": "4.0.0",
+    "name": "USCoreCarePlanDate",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-date",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:29.793290Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Time period plan covers**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "date",
+    "base": [
+        "CarePlan"
+    ],
+    "type": "date",
+    "expression": "CarePlan.period",
+    "xpath": "f:CarePlan/f:period",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHOULD"
+            }
+        ]
+    },
+    "comparator": [
+        "eq",
+        "ne",
+        "gt",
+        "ge",
+        "lt",
+        "le",
+        "sa",
+        "eb",
+        "ap"
+    ],
+    "_comparator": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-careplan-patient.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-careplan-patient.json
@@ -1,68 +1,68 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-careplan-patient",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreCarePlanPatient</h2> --><b> description</b> : <p><strong>Who the care plan is for</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-careplan-patient</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-patient</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreCarePlanPatient</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-patient\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>patient</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :CarePlan</p>\n\t\t\t<p><b> type</b> : reference</p>\n\t\t\t<p><b> expression</b> : <code>CarePlan.subject.where(resolve() is Patient)</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:CarePlan/f:subject</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-patient",
-	"version": "4.0.0",
-	"name": "USCoreCarePlanPatient",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:29.827200Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Who the care plan is for**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "patient",
-	"base": [
-		"CarePlan"
-	],
-	"type": "reference",
-	"expression": "CarePlan.subject.where(resolve() is Patient)",
-	"xpath": "f:CarePlan/f:subject",
-	"xpathUsage": "normal",
-	"target": [
-		"Patient",
-		"Group"
-	],
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-careplan-patient",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-patient",
+    "version": "4.0.0",
+    "name": "USCoreCarePlanPatient",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:29.827200Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Who the care plan is for**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "patient",
+    "base": [
+        "CarePlan"
+    ],
+    "type": "reference",
+    "expression": "CarePlan.subject.where(resolve() is Patient)",
+    "xpath": "f:CarePlan/f:subject",
+    "xpathUsage": "normal",
+    "target": [
+        "Patient",
+        "Group"
+    ],
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-careplan-status.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-careplan-status.json
@@ -1,70 +1,70 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-careplan-status",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreCarePlanStatus</h2> --><b> description</b> : <p><strong>draft | active | on-hold | revoked | completed | entered-in-error | unknown</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-careplan-status</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-status</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreCarePlanStatus</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/CarePlan-status\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>status</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :CarePlan</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>CarePlan.status</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:CarePlan/f:status</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = SHALL)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"extension": [
-		{
-			"url": "http://ibm.com/fhir/extension/implicit-system",
-			"valueUri": "http://hl7.org/fhir/request-status"
-		}
-	],
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-status",
-	"version": "4.0.0",
-	"name": "USCoreCarePlanStatus",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/CarePlan-status",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:29.875071Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**draft | active | on-hold | revoked | completed | entered-in-error | unknown**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "status",
-	"base": [
-		"CarePlan"
-	],
-	"type": "token",
-	"expression": "CarePlan.status",
-	"xpath": "f:CarePlan/f:status",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHALL"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-careplan-status",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "extension": [
+        {
+            "url": "http://ibm.com/fhir/extension/implicit-system",
+            "valueUri": "http://hl7.org/fhir/request-status"
+        }
+    ],
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-status",
+    "version": "4.0.0",
+    "name": "USCoreCarePlanStatus",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/CarePlan-status",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:29.875071Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**draft | active | on-hold | revoked | completed | entered-in-error | unknown**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "status",
+    "base": [
+        "CarePlan"
+    ],
+    "type": "token",
+    "expression": "CarePlan.status",
+    "xpath": "f:CarePlan/f:status",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHALL"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-careteam-patient.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-careteam-patient.json
@@ -1,68 +1,68 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-careteam-patient",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreCareTeamPatient</h2> --><b> description</b> : <p><strong>Who care team is for</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-careteam-patient</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-patient</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreCareTeamPatient</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-patient\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>patient</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :CareTeam</p>\n\t\t\t<p><b> type</b> : reference</p>\n\t\t\t<p><b> expression</b> : <code>CareTeam.subject.where(resolve() is Patient)</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:CareTeam/f:subject</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-patient",
-	"version": "4.0.0",
-	"name": "USCoreCareTeamPatient",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:29.906985Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Who care team is for**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "patient",
-	"base": [
-		"CareTeam"
-	],
-	"type": "reference",
-	"expression": "CareTeam.subject.where(resolve() is Patient)",
-	"xpath": "f:CareTeam/f:subject",
-	"xpathUsage": "normal",
-	"target": [
-		"Patient",
-		"Group"
-	],
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-careteam-patient",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-patient",
+    "version": "4.0.0",
+    "name": "USCoreCareTeamPatient",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:29.906985Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Who care team is for**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "patient",
+    "base": [
+        "CareTeam"
+    ],
+    "type": "reference",
+    "expression": "CareTeam.subject.where(resolve() is Patient)",
+    "xpath": "f:CareTeam/f:subject",
+    "xpathUsage": "normal",
+    "target": [
+        "Patient",
+        "Group"
+    ],
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-careteam-status.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-careteam-status.json
@@ -1,70 +1,70 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-careteam-status",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreCareTeamStatus</h2> --><b> description</b> : <p><strong>proposed | active | suspended | inactive | entered-in-error</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-careteam-status</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-status</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreCareTeamStatus</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/CareTeam-status\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2021-06-08</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>status</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :CareTeam</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>CareTeam.status</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:CareTeam/f:status</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = SHOULD)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"extension": [
-		{
-			"url": "http://ibm.com/fhir/extension/implicit-system",
-			"valueUri": "http://hl7.org/fhir/care-team-status"
-		}
-	],
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-status",
-	"version": "4.0.0",
-	"name": "USCoreCareTeamStatus",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/CareTeam-status",
-	"status": "active",
-	"experimental": false,
-	"date": "2021-06-08T02:15:48.112297Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**proposed | active | suspended | inactive | entered-in-error**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "status",
-	"base": [
-		"CareTeam"
-	],
-	"type": "token",
-	"expression": "CareTeam.status",
-	"xpath": "f:CareTeam/f:status",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHOULD"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-careteam-status",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "extension": [
+        {
+            "url": "http://ibm.com/fhir/extension/implicit-system",
+            "valueUri": "http://hl7.org/fhir/care-team-status"
+        }
+    ],
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-status",
+    "version": "4.0.0",
+    "name": "USCoreCareTeamStatus",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/CareTeam-status",
+    "status": "active",
+    "experimental": false,
+    "date": "2021-06-08T02:15:48.112297Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**proposed | active | suspended | inactive | entered-in-error**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "status",
+    "base": [
+        "CareTeam"
+    ],
+    "type": "token",
+    "expression": "CareTeam.status",
+    "xpath": "f:CareTeam/f:status",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHOULD"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-condition-category.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-condition-category.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-condition-category",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreConditionCategory</h2> --><b> description</b> : <p><strong>The category of the condition</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-condition-category</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-category</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreConditionCategory</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Condition-category\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>category</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Condition</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>Condition.category</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Condition/f:category</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-category",
-	"version": "4.0.0",
-	"name": "USCoreConditionCategory",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Condition-category",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:26.997340Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**The category of the condition**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "category",
-	"base": [
-		"Condition"
-	],
-	"type": "token",
-	"expression": "Condition.category",
-	"xpath": "f:Condition/f:category",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-condition-category",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-category",
+    "version": "4.0.0",
+    "name": "USCoreConditionCategory",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Condition-category",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:26.997340Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**The category of the condition**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "category",
+    "base": [
+        "Condition"
+    ],
+    "type": "token",
+    "expression": "Condition.category",
+    "xpath": "f:Condition/f:category",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-condition-clinical-status.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-condition-clinical-status.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-condition-clinical-status",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreConditionClinicalStatus</h2> --><b> description</b> : <p><strong>The clinical status of the condition</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-condition-clinical-status</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-clinical-status</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreConditionClinicalStatus</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Condition-clinical-status\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>clinical-status</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Condition</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>Condition.clinicalStatus</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Condition/f:clinicalStatus</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-clinical-status",
-	"version": "4.0.0",
-	"name": "USCoreConditionClinicalStatus",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Condition-clinical-status",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:27.109428Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**The clinical status of the condition**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "clinical-status",
-	"base": [
-		"Condition"
-	],
-	"type": "token",
-	"expression": "Condition.clinicalStatus",
-	"xpath": "f:Condition/f:clinicalStatus",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-condition-clinical-status",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-clinical-status",
+    "version": "4.0.0",
+    "name": "USCoreConditionClinicalStatus",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Condition-clinical-status",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:27.109428Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**The clinical status of the condition**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "clinical-status",
+    "base": [
+        "Condition"
+    ],
+    "type": "token",
+    "expression": "Condition.clinicalStatus",
+    "xpath": "f:Condition/f:clinicalStatus",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-condition-code.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-condition-code.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-condition-code",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreConditionCode</h2> --><b> description</b> : <p><strong>Code for the condition</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-condition-code</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-code</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreConditionCode</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-code\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>code</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Condition</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>Condition.code</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Condition/f:code</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-code",
-	"version": "4.0.0",
-	"name": "USCoreConditionCode",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-code",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:27.846524Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Code for the condition**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "code",
-	"base": [
-		"Condition"
-	],
-	"type": "token",
-	"expression": "Condition.code",
-	"xpath": "f:Condition/f:code",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-condition-code",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-code",
+    "version": "4.0.0",
+    "name": "USCoreConditionCode",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-code",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:27.846524Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Code for the condition**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "code",
+    "base": [
+        "Condition"
+    ],
+    "type": "token",
+    "expression": "Condition.code",
+    "xpath": "f:Condition/f:code",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-condition-onset-date.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-condition-onset-date.json
@@ -1,149 +1,149 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-condition-onset-date",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreConditionOnsetDate</h2> --><b> description</b> : <p><strong>Date related onsets (dateTime and Period)</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-condition-onset-date</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-onset-date</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreConditionOnsetDate</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Condition-onset-date\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>onset-date</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Condition</p>\n\t\t\t<p><b> type</b> : date</p>\n\t\t\t<p><b> expression</b> : <code>Condition.onset.as(dateTime)|Condition.onset.as(Period)</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Condition/f:onsetDateTime|f:Condition/f:onsetPeriod</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = SHOULD)</p>\n    \n    \n    <p><b> comparator</b> : <code>eq</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>ne</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>gt</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>ge</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>lt</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>le</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>sa</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>eb</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>ap</code> ( Conformance Expectation = MAY)</p>\n    \n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-onset-date",
-	"version": "4.0.0",
-	"name": "USCoreConditionOnsetDate",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Condition-onset-date",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:27.816607Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Date related onsets (dateTime and Period)**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "onset-date",
-	"base": [
-		"Condition"
-	],
-	"type": "date",
-	"expression": "Condition.onset.as(dateTime)|Condition.onset.as(Period)",
-	"xpath": "f:Condition/f:onsetDateTime|f:Condition/f:onsetPeriod",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHOULD"
-			}
-		]
-	},
-	"comparator": [
-		"eq",
-		"ne",
-		"gt",
-		"ge",
-		"lt",
-		"le",
-		"sa",
-		"eb",
-		"ap"
-	],
-	"_comparator": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		}
-	]
+    "resourceType": "SearchParameter",
+    "id": "us-core-condition-onset-date",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-onset-date",
+    "version": "4.0.0",
+    "name": "USCoreConditionOnsetDate",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Condition-onset-date",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:27.816607Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Date related onsets (dateTime and Period)**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "onset-date",
+    "base": [
+        "Condition"
+    ],
+    "type": "date",
+    "expression": "Condition.onset.as(dateTime)|Condition.onset.as(Period)",
+    "xpath": "f:Condition/f:onsetDateTime|f:Condition/f:onsetPeriod",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHOULD"
+            }
+        ]
+    },
+    "comparator": [
+        "eq",
+        "ne",
+        "gt",
+        "ge",
+        "lt",
+        "le",
+        "sa",
+        "eb",
+        "ap"
+    ],
+    "_comparator": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-condition-patient.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-condition-patient.json
@@ -1,68 +1,68 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-condition-patient",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreConditionPatient</h2> --><b> description</b> : <p><strong>Who has the condition?</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-condition-patient</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-patient</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreConditionPatient</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-patient\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>patient</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Condition</p>\n\t\t\t<p><b> type</b> : reference</p>\n\t\t\t<p><b> expression</b> : <code>Condition.subject.where(resolve() is Patient)</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Condition/f:subject</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-patient",
-	"version": "4.0.0",
-	"name": "USCoreConditionPatient",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:27.197003Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Who has the condition?**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "patient",
-	"base": [
-		"Condition"
-	],
-	"type": "reference",
-	"expression": "Condition.subject.where(resolve() is Patient)",
-	"xpath": "f:Condition/f:subject",
-	"xpathUsage": "normal",
-	"target": [
-		"Patient",
-		"Group"
-	],
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-condition-patient",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-patient",
+    "version": "4.0.0",
+    "name": "USCoreConditionPatient",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:27.197003Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Who has the condition?**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "patient",
+    "base": [
+        "Condition"
+    ],
+    "type": "reference",
+    "expression": "Condition.subject.where(resolve() is Patient)",
+    "xpath": "f:Condition/f:subject",
+    "xpathUsage": "normal",
+    "target": [
+        "Patient",
+        "Group"
+    ],
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-device-patient.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-device-patient.json
@@ -1,67 +1,67 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-device-patient",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreDevicePatient</h2> --><b> description</b> : <p><strong>Patient information, if the resource is affixed to a person</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-device-patient</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-device-patient</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreDevicePatient</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Device-patient\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>patient</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Device</p>\n\t\t\t<p><b> type</b> : reference</p>\n\t\t\t<p><b> expression</b> : <code>Device.patient</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Device/f:patient</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-patient",
-	"version": "4.0.0",
-	"name": "USCoreDevicePatient",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Device-patient",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:30.027004Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Patient information, if the resource is affixed to a person**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "patient",
-	"base": [
-		"Device"
-	],
-	"type": "reference",
-	"expression": "Device.patient",
-	"xpath": "f:Device/f:patient",
-	"xpathUsage": "normal",
-	"target": [
-		"Patient"
-	],
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-device-patient",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-patient",
+    "version": "4.0.0",
+    "name": "USCoreDevicePatient",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Device-patient",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:30.027004Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Patient information, if the resource is affixed to a person**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "patient",
+    "base": [
+        "Device"
+    ],
+    "type": "reference",
+    "expression": "Device.patient",
+    "xpath": "f:Device/f:patient",
+    "xpathUsage": "normal",
+    "target": [
+        "Patient"
+    ],
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-device-type.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-device-type.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-device-type",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreDeviceType</h2> --><b> description</b> : <p><strong>The type of the device</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-device-type</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-device-type</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreDeviceType</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Device-type\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>type</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Device</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>Device.type</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Device/f:type</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-type",
-	"version": "4.0.0",
-	"name": "USCoreDeviceType",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Device-type",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:30.080848Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**The type of the device**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "type",
-	"base": [
-		"Device"
-	],
-	"type": "token",
-	"expression": "Device.type",
-	"xpath": "f:Device/f:type",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-device-type",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-type",
+    "version": "4.0.0",
+    "name": "USCoreDeviceType",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Device-type",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:30.080848Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**The type of the device**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "type",
+    "base": [
+        "Device"
+    ],
+    "type": "token",
+    "expression": "Device.type",
+    "xpath": "f:Device/f:type",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-diagnosticreport-category.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-diagnosticreport-category.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-diagnosticreport-category",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreDiagnosticReportCategory</h2> --><b> description</b> : <p><strong>Which diagnostic discipline/department created the report</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-diagnosticreport-category</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-category</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreDiagnosticReportCategory</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/DiagnosticReport-category\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>category</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :DiagnosticReport</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>DiagnosticReport.category</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:DiagnosticReport/f:category</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-category",
-	"version": "4.0.0",
-	"name": "USCoreDiagnosticReportCategory",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/DiagnosticReport-category",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:28.362884Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Which diagnostic discipline/department created the report**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "category",
-	"base": [
-		"DiagnosticReport"
-	],
-	"type": "token",
-	"expression": "DiagnosticReport.category",
-	"xpath": "f:DiagnosticReport/f:category",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-diagnosticreport-category",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-category",
+    "version": "4.0.0",
+    "name": "USCoreDiagnosticReportCategory",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/DiagnosticReport-category",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:28.362884Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Which diagnostic discipline/department created the report**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "category",
+    "base": [
+        "DiagnosticReport"
+    ],
+    "type": "token",
+    "expression": "DiagnosticReport.category",
+    "xpath": "f:DiagnosticReport/f:category",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-diagnosticreport-code.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-diagnosticreport-code.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-diagnosticreport-code",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreDiagnosticReportCode</h2> --><b> description</b> : <p><strong>The code for the report, as opposed to codes for the atomic results, which are the names on the observation resource referred to from the result</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-diagnosticreport-code</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-code</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreDiagnosticReportCode</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-code\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>code</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :DiagnosticReport</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>DiagnosticReport.code</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:DiagnosticReport/f:code</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = SHOULD)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-code",
-	"version": "4.0.0",
-	"name": "USCoreDiagnosticReportCode",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-code",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:28.538956Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**The code for the report, as opposed to codes for the atomic results, which are the names on the observation resource referred to from the result**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "code",
-	"base": [
-		"DiagnosticReport"
-	],
-	"type": "token",
-	"expression": "DiagnosticReport.code",
-	"xpath": "f:DiagnosticReport/f:code",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHOULD"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-diagnosticreport-code",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-code",
+    "version": "4.0.0",
+    "name": "USCoreDiagnosticReportCode",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-code",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:28.538956Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**The code for the report, as opposed to codes for the atomic results, which are the names on the observation resource referred to from the result**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "code",
+    "base": [
+        "DiagnosticReport"
+    ],
+    "type": "token",
+    "expression": "DiagnosticReport.code",
+    "xpath": "f:DiagnosticReport/f:code",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHOULD"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-diagnosticreport-date.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-diagnosticreport-date.json
@@ -1,149 +1,149 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-diagnosticreport-date",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreDiagnosticReportDate</h2> --><b> description</b> : <p><strong>The clinically relevant time of the report</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-diagnosticreport-date</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-date</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreDiagnosticReportDate</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-date\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>date</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :DiagnosticReport</p>\n\t\t\t<p><b> type</b> : date</p>\n\t\t\t<p><b> expression</b> : <code>DiagnosticReport.effective</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:DiagnosticReport/f:effectiveDateTime|f:DiagnosticReport/f:effectivePeriod</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = SHOULD)</p>\n    \n    \n    <p><b> comparator</b> : <code>eq</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>ne</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>gt</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>ge</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>lt</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>le</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>sa</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>eb</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>ap</code> ( Conformance Expectation = MAY)</p>\n    \n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-date",
-	"version": "4.0.0",
-	"name": "USCoreDiagnosticReportDate",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-date",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:28.611972Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**The clinically relevant time of the report**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "date",
-	"base": [
-		"DiagnosticReport"
-	],
-	"type": "date",
-	"expression": "DiagnosticReport.effective",
-	"xpath": "f:DiagnosticReport/f:effectiveDateTime|f:DiagnosticReport/f:effectivePeriod",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHOULD"
-			}
-		]
-	},
-	"comparator": [
-		"eq",
-		"ne",
-		"gt",
-		"ge",
-		"lt",
-		"le",
-		"sa",
-		"eb",
-		"ap"
-	],
-	"_comparator": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		}
-	]
+    "resourceType": "SearchParameter",
+    "id": "us-core-diagnosticreport-date",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-date",
+    "version": "4.0.0",
+    "name": "USCoreDiagnosticReportDate",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-date",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:28.611972Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**The clinically relevant time of the report**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "date",
+    "base": [
+        "DiagnosticReport"
+    ],
+    "type": "date",
+    "expression": "DiagnosticReport.effective",
+    "xpath": "f:DiagnosticReport/f:effectiveDateTime|f:DiagnosticReport/f:effectivePeriod",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHOULD"
+            }
+        ]
+    },
+    "comparator": [
+        "eq",
+        "ne",
+        "gt",
+        "ge",
+        "lt",
+        "le",
+        "sa",
+        "eb",
+        "ap"
+    ],
+    "_comparator": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-diagnosticreport-patient.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-diagnosticreport-patient.json
@@ -1,68 +1,68 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-diagnosticreport-patient",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreDiagnosticReportPatient</h2> --><b> description</b> : <p><strong>The subject of the report if a patient</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-diagnosticreport-patient</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreDiagnosticReportPatient</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-patient\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>patient</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :DiagnosticReport</p>\n\t\t\t<p><b> type</b> : reference</p>\n\t\t\t<p><b> expression</b> : <code>DiagnosticReport.subject.where(resolve() is Patient)</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:DiagnosticReport/f:subject</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient",
-	"version": "4.0.0",
-	"name": "USCoreDiagnosticReportPatient",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:28.323989Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**The subject of the report if a patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "patient",
-	"base": [
-		"DiagnosticReport"
-	],
-	"type": "reference",
-	"expression": "DiagnosticReport.subject.where(resolve() is Patient)",
-	"xpath": "f:DiagnosticReport/f:subject",
-	"xpathUsage": "normal",
-	"target": [
-		"Patient",
-		"Group"
-	],
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-diagnosticreport-patient",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient",
+    "version": "4.0.0",
+    "name": "USCoreDiagnosticReportPatient",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:28.323989Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**The subject of the report if a patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "patient",
+    "base": [
+        "DiagnosticReport"
+    ],
+    "type": "reference",
+    "expression": "DiagnosticReport.subject.where(resolve() is Patient)",
+    "xpath": "f:DiagnosticReport/f:subject",
+    "xpathUsage": "normal",
+    "target": [
+        "Patient",
+        "Group"
+    ],
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-diagnosticreport-status.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-diagnosticreport-status.json
@@ -1,70 +1,70 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-diagnosticreport-status",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreDiagnosticReportStatus</h2> --><b> description</b> : <p><strong>The status of the report</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-diagnosticreport-status</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-status</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreDiagnosticReportStatus</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/DiagnosticReport-status\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>status</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :DiagnosticReport</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>DiagnosticReport.status</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:DiagnosticReport/f:status</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = SHALL)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"extension": [
-		{
-			"url": "http://ibm.com/fhir/extension/implicit-system",
-			"valueUri": "http://hl7.org/fhir/diagnostic-report-status"
-		}
-	],
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-status",
-	"version": "4.0.0",
-	"name": "USCoreDiagnosticReportStatus",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/DiagnosticReport-status",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:28.293077Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**The status of the report**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "status",
-	"base": [
-		"DiagnosticReport"
-	],
-	"type": "token",
-	"expression": "DiagnosticReport.status",
-	"xpath": "f:DiagnosticReport/f:status",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHALL"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-diagnosticreport-status",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "extension": [
+        {
+            "url": "http://ibm.com/fhir/extension/implicit-system",
+            "valueUri": "http://hl7.org/fhir/diagnostic-report-status"
+        }
+    ],
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-status",
+    "version": "4.0.0",
+    "name": "USCoreDiagnosticReportStatus",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/DiagnosticReport-status",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:28.293077Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**The status of the report**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "status",
+    "base": [
+        "DiagnosticReport"
+    ],
+    "type": "token",
+    "expression": "DiagnosticReport.status",
+    "xpath": "f:DiagnosticReport/f:status",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHALL"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-documentreference-category.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-documentreference-category.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-documentreference-category",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreDocumentReferenceCategory</h2> --><b> description</b> : <p><strong>Categorization of document</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-documentreference-category</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-category</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreDocumentReferenceCategory</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/DocumentReference-category\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>category</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :DocumentReference</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>DocumentReference.category</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:DocumentReference/f:category</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-category",
-	"version": "4.0.0",
-	"name": "USCoreDocumentReferenceCategory",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/DocumentReference-category",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:28.148458Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Categorization of document**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "category",
-	"base": [
-		"DocumentReference"
-	],
-	"type": "token",
-	"expression": "DocumentReference.category",
-	"xpath": "f:DocumentReference/f:category",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-documentreference-category",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-category",
+    "version": "4.0.0",
+    "name": "USCoreDocumentReferenceCategory",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/DocumentReference-category",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:28.148458Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Categorization of document**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "category",
+    "base": [
+        "DocumentReference"
+    ],
+    "type": "token",
+    "expression": "DocumentReference.category",
+    "xpath": "f:DocumentReference/f:category",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-documentreference-date.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-documentreference-date.json
@@ -1,149 +1,149 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-documentreference-date",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreDocumentReferenceDate</h2> --><b> description</b> : <p><strong>When this document reference was created</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-documentreference-date</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-date</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreDocumentReferenceDate</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/DocumentReference-date\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>date</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :DocumentReference</p>\n\t\t\t<p><b> type</b> : date</p>\n\t\t\t<p><b> expression</b> : <code>DocumentReference.date</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:DocumentReference/f:date</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = SHOULD)</p>\n    \n    \n    <p><b> comparator</b> : <code>eq</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>ne</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>gt</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>ge</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>lt</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>le</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>sa</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>eb</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>ap</code> ( Conformance Expectation = MAY)</p>\n    \n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-date",
-	"version": "4.0.0",
-	"name": "USCoreDocumentReferenceDate",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/DocumentReference-date",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:28.229242Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**When this document reference was created**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "date",
-	"base": [
-		"DocumentReference"
-	],
-	"type": "date",
-	"expression": "DocumentReference.date",
-	"xpath": "f:DocumentReference/f:date",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHOULD"
-			}
-		]
-	},
-	"comparator": [
-		"eq",
-		"ne",
-		"gt",
-		"ge",
-		"lt",
-		"le",
-		"sa",
-		"eb",
-		"ap"
-	],
-	"_comparator": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		}
-	]
+    "resourceType": "SearchParameter",
+    "id": "us-core-documentreference-date",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-date",
+    "version": "4.0.0",
+    "name": "USCoreDocumentReferenceDate",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/DocumentReference-date",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:28.229242Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**When this document reference was created**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "date",
+    "base": [
+        "DocumentReference"
+    ],
+    "type": "date",
+    "expression": "DocumentReference.date",
+    "xpath": "f:DocumentReference/f:date",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHOULD"
+            }
+        ]
+    },
+    "comparator": [
+        "eq",
+        "ne",
+        "gt",
+        "ge",
+        "lt",
+        "le",
+        "sa",
+        "eb",
+        "ap"
+    ],
+    "_comparator": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-documentreference-id.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-documentreference-id.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-documentreference-id",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreDocumentReferenceId</h2> --><b> description</b> : <p><strong>Logical id of this artifact</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-documentreference-id</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-id</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreDocumentReferenceId</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Resource-id\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2021-06-24</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n              <!-- <p>\n\t\t\t\t<b> useContext</b> : </p> -->\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>_id</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :DocumentReference</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>DocumentReference.id</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:DocumentReference/f:id</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-id",
-	"version": "4.0.0",
-	"name": "USCoreDocumentReferenceId",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Resource-id",
-	"status": "active",
-	"experimental": false,
-	"date": "2021-06-24T23:59:31.981452Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Logical id of this artifact**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "_id",
-	"base": [
-		"DocumentReference"
-	],
-	"type": "token",
-	"expression": "DocumentReference.id",
-	"xpath": "f:DocumentReference/f:id",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-documentreference-id",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-id",
+    "version": "4.0.0",
+    "name": "USCoreDocumentReferenceId",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Resource-id",
+    "status": "active",
+    "experimental": false,
+    "date": "2021-06-24T23:59:31.981452Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Logical id of this artifact**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "_id",
+    "base": [
+        "DocumentReference"
+    ],
+    "type": "token",
+    "expression": "DocumentReference.id",
+    "xpath": "f:DocumentReference/f:id",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-documentreference-patient.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-documentreference-patient.json
@@ -1,68 +1,68 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-documentreference-patient",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreDocumentReferencePatient</h2> --><b> description</b> : <p><strong>Who/what is the subject of the document</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-documentreference-patient</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreDocumentReferencePatient</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-patient\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>patient</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :DocumentReference</p>\n\t\t\t<p><b> type</b> : reference</p>\n\t\t\t<p><b> expression</b> : <code>DocumentReference.subject.where(resolve() is Patient)</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:DocumentReference/f:subject</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient",
-	"version": "4.0.0",
-	"name": "USCoreDocumentReferencePatient",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:28.111558Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Who/what is the subject of the document**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "patient",
-	"base": [
-		"DocumentReference"
-	],
-	"type": "reference",
-	"expression": "DocumentReference.subject.where(resolve() is Patient)",
-	"xpath": "f:DocumentReference/f:subject",
-	"xpathUsage": "normal",
-	"target": [
-		"Patient",
-		"Group"
-	],
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-documentreference-patient",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient",
+    "version": "4.0.0",
+    "name": "USCoreDocumentReferencePatient",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:28.111558Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Who/what is the subject of the document**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "patient",
+    "base": [
+        "DocumentReference"
+    ],
+    "type": "reference",
+    "expression": "DocumentReference.subject.where(resolve() is Patient)",
+    "xpath": "f:DocumentReference/f:subject",
+    "xpathUsage": "normal",
+    "target": [
+        "Patient",
+        "Group"
+    ],
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-documentreference-period.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-documentreference-period.json
@@ -1,149 +1,149 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-documentreference-period",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreDocumentReferencePeriod</h2> --><b> description</b> : <p><strong>Time of service that is being documented</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-documentreference-period</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-period</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreDocumentReferencePeriod</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/DocumentReference-period\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>period</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :DocumentReference</p>\n\t\t\t<p><b> type</b> : date</p>\n\t\t\t<p><b> expression</b> : <code>DocumentReference.context.period</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:DocumentReference/f:context/f:period</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = SHOULD)</p>\n    \n    \n    <p><b> comparator</b> : <code>eq</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>ne</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>gt</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>ge</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>lt</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>le</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>sa</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>eb</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>ap</code> ( Conformance Expectation = MAY)</p>\n    \n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-period",
-	"version": "4.0.0",
-	"name": "USCoreDocumentReferencePeriod",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/DocumentReference-period",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:28.258166Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Time of service that is being documented**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "period",
-	"base": [
-		"DocumentReference"
-	],
-	"type": "date",
-	"expression": "DocumentReference.context.period",
-	"xpath": "f:DocumentReference/f:context/f:period",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHOULD"
-			}
-		]
-	},
-	"comparator": [
-		"eq",
-		"ne",
-		"gt",
-		"ge",
-		"lt",
-		"le",
-		"sa",
-		"eb",
-		"ap"
-	],
-	"_comparator": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		}
-	]
+    "resourceType": "SearchParameter",
+    "id": "us-core-documentreference-period",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-period",
+    "version": "4.0.0",
+    "name": "USCoreDocumentReferencePeriod",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/DocumentReference-period",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:28.258166Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Time of service that is being documented**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "period",
+    "base": [
+        "DocumentReference"
+    ],
+    "type": "date",
+    "expression": "DocumentReference.context.period",
+    "xpath": "f:DocumentReference/f:context/f:period",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHOULD"
+            }
+        ]
+    },
+    "comparator": [
+        "eq",
+        "ne",
+        "gt",
+        "ge",
+        "lt",
+        "le",
+        "sa",
+        "eb",
+        "ap"
+    ],
+    "_comparator": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-documentreference-status.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-documentreference-status.json
@@ -1,70 +1,70 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-documentreference-status",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreDocumentReferenceStatus</h2> --><b> description</b> : <p><strong>current | superseded | entered-in-error</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-documentreference-status</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-status</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreDocumentReferenceStatus</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/DocumentReference-status\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>status</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :DocumentReference</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>DocumentReference.status</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:DocumentReference/f:status</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = SHALL)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"extension": [
-		{
-			"url": "http://ibm.com/fhir/extension/implicit-system",
-			"valueUri": "http://hl7.org/fhir/document-reference-status"
-		}
-	],
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-status",
-	"version": "4.0.0",
-	"name": "USCoreDocumentReferenceStatus",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/DocumentReference-status",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:28.061699Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**current | superseded | entered-in-error**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "status",
-	"base": [
-		"DocumentReference"
-	],
-	"type": "token",
-	"expression": "DocumentReference.status",
-	"xpath": "f:DocumentReference/f:status",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHALL"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-documentreference-status",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "extension": [
+        {
+            "url": "http://ibm.com/fhir/extension/implicit-system",
+            "valueUri": "http://hl7.org/fhir/document-reference-status"
+        }
+    ],
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-status",
+    "version": "4.0.0",
+    "name": "USCoreDocumentReferenceStatus",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/DocumentReference-status",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:28.061699Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**current | superseded | entered-in-error**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "status",
+    "base": [
+        "DocumentReference"
+    ],
+    "type": "token",
+    "expression": "DocumentReference.status",
+    "xpath": "f:DocumentReference/f:status",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHALL"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-documentreference-type.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-documentreference-type.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-documentreference-type",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreDocumentReferenceType</h2> --><b> description</b> : <p><strong>Kind of document (LOINC if possible)</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-documentreference-type</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-type</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreDocumentReferenceType</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-type\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>type</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :DocumentReference</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>DocumentReference.type</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:DocumentReference/f:type</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-type",
-	"version": "4.0.0",
-	"name": "USCoreDocumentReferenceType",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-type",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:28.186357Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Kind of document (LOINC if possible)**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "type",
-	"base": [
-		"DocumentReference"
-	],
-	"type": "token",
-	"expression": "DocumentReference.type",
-	"xpath": "f:DocumentReference/f:type",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-documentreference-type",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-type",
+    "version": "4.0.0",
+    "name": "USCoreDocumentReferenceType",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-type",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:28.186357Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Kind of document (LOINC if possible)**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "type",
+    "base": [
+        "DocumentReference"
+    ],
+    "type": "token",
+    "expression": "DocumentReference.type",
+    "xpath": "f:DocumentReference/f:type",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-encounter-class.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-encounter-class.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-encounter-class",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreEncounterClass</h2> --><b> description</b> : <p><strong>Classification of patient encounter</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-encounter-class</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-class</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreEncounterClass</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Encounter-class\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>class</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Encounter</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>Encounter.class</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Encounter/f:class</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-class",
-	"version": "4.0.0",
-	"name": "USCoreEncounterClass",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Encounter-class",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:27.305225Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Classification of patient encounter**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "class",
-	"base": [
-		"Encounter"
-	],
-	"type": "token",
-	"expression": "Encounter.class",
-	"xpath": "f:Encounter/f:class",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-encounter-class",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-class",
+    "version": "4.0.0",
+    "name": "USCoreEncounterClass",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Encounter-class",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:27.305225Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Classification of patient encounter**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "class",
+    "base": [
+        "Encounter"
+    ],
+    "type": "token",
+    "expression": "Encounter.class",
+    "xpath": "f:Encounter/f:class",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-encounter-date.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-encounter-date.json
@@ -1,149 +1,149 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-encounter-date",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreEncounterDate</h2> --><b> description</b> : <p><strong>A date within the period the Encounter lasted</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-encounter-date</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-date</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreEncounterDate</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-date\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>date</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Encounter</p>\n\t\t\t<p><b> type</b> : date</p>\n\t\t\t<p><b> expression</b> : <code>Encounter.period</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Encounter/f:period</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = SHOULD)</p>\n    \n    \n    <p><b> comparator</b> : <code>eq</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>ne</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>gt</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>ge</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>lt</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>le</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>sa</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>eb</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>ap</code> ( Conformance Expectation = MAY)</p>\n    \n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-date",
-	"version": "4.0.0",
-	"name": "USCoreEncounterDate",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-date",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:27.336865Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**A date within the period the Encounter lasted**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "date",
-	"base": [
-		"Encounter"
-	],
-	"type": "date",
-	"expression": "Encounter.period",
-	"xpath": "f:Encounter/f:period",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHOULD"
-			}
-		]
-	},
-	"comparator": [
-		"eq",
-		"ne",
-		"gt",
-		"ge",
-		"lt",
-		"le",
-		"sa",
-		"eb",
-		"ap"
-	],
-	"_comparator": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		}
-	]
+    "resourceType": "SearchParameter",
+    "id": "us-core-encounter-date",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-date",
+    "version": "4.0.0",
+    "name": "USCoreEncounterDate",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-date",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:27.336865Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**A date within the period the Encounter lasted**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "date",
+    "base": [
+        "Encounter"
+    ],
+    "type": "date",
+    "expression": "Encounter.period",
+    "xpath": "f:Encounter/f:period",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHOULD"
+            }
+        ]
+    },
+    "comparator": [
+        "eq",
+        "ne",
+        "gt",
+        "ge",
+        "lt",
+        "le",
+        "sa",
+        "eb",
+        "ap"
+    ],
+    "_comparator": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-encounter-id.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-encounter-id.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-encounter-id",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreEncounterId</h2> --><b> description</b> : <p><strong>Logical id of this artifact</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-encounter-id</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-id</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreEncounterId</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Resource-id\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2021-06-24</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n              <!-- <p>\n\t\t\t\t<b> useContext</b> : </p> -->\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>_id</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Encounter</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>Encounter.id</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Encounter/f:id</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-id",
-	"version": "4.0.0",
-	"name": "USCoreEncounterId",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Resource-id",
-	"status": "active",
-	"experimental": false,
-	"date": "2021-06-24T23:57:15.866673Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Logical id of this artifact**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "_id",
-	"base": [
-		"Encounter"
-	],
-	"type": "token",
-	"expression": "Encounter.id",
-	"xpath": "f:Encounter/f:id",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-encounter-id",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-id",
+    "version": "4.0.0",
+    "name": "USCoreEncounterId",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Resource-id",
+    "status": "active",
+    "experimental": false,
+    "date": "2021-06-24T23:57:15.866673Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Logical id of this artifact**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "_id",
+    "base": [
+        "Encounter"
+    ],
+    "type": "token",
+    "expression": "Encounter.id",
+    "xpath": "f:Encounter/f:id",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-encounter-identifier.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-encounter-identifier.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-encounter-identifier",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreEncounterIdentifier</h2> --><b> description</b> : <p><strong>Identifier(s) by which this encounter is known</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-encounter-identifier</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-identifier</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreEncounterIdentifier</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-identifier\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>identifier</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Encounter</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>Encounter.identifier</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Encounter/f:identifier</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-identifier",
-	"version": "4.0.0",
-	"name": "USCoreEncounterIdentifier",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-identifier",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:27.379776Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Identifier(s) by which this encounter is known**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "identifier",
-	"base": [
-		"Encounter"
-	],
-	"type": "token",
-	"expression": "Encounter.identifier",
-	"xpath": "f:Encounter/f:identifier",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-encounter-identifier",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-identifier",
+    "version": "4.0.0",
+    "name": "USCoreEncounterIdentifier",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-identifier",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:27.379776Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Identifier(s) by which this encounter is known**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "identifier",
+    "base": [
+        "Encounter"
+    ],
+    "type": "token",
+    "expression": "Encounter.identifier",
+    "xpath": "f:Encounter/f:identifier",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-encounter-patient.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-encounter-patient.json
@@ -1,68 +1,68 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-encounter-patient",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreEncounterPatient</h2> --><b> description</b> : <p><strong>The patient or group present at the encounter</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-encounter-patient</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-patient</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreEncounterPatient</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-patient\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>patient</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Encounter</p>\n\t\t\t<p><b> type</b> : reference</p>\n\t\t\t<p><b> expression</b> : <code>Encounter.subject.where(resolve() is Patient)</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Encounter/f:subject</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-patient",
-	"version": "4.0.0",
-	"name": "USCoreEncounterPatient",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:27.413685Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**The patient or group present at the encounter**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "patient",
-	"base": [
-		"Encounter"
-	],
-	"type": "reference",
-	"expression": "Encounter.subject.where(resolve() is Patient)",
-	"xpath": "f:Encounter/f:subject",
-	"xpathUsage": "normal",
-	"target": [
-		"Patient",
-		"Group"
-	],
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-encounter-patient",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-patient",
+    "version": "4.0.0",
+    "name": "USCoreEncounterPatient",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:27.413685Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**The patient or group present at the encounter**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "patient",
+    "base": [
+        "Encounter"
+    ],
+    "type": "reference",
+    "expression": "Encounter.subject.where(resolve() is Patient)",
+    "xpath": "f:Encounter/f:subject",
+    "xpathUsage": "normal",
+    "target": [
+        "Patient",
+        "Group"
+    ],
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-encounter-status.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-encounter-status.json
@@ -1,70 +1,70 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-encounter-status",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreEncounterStatus</h2> --><b> description</b> : <p><strong>planned | arrived | triaged | in-progress | onleave | finished | cancelled +</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-encounter-status</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-status</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreEncounterStatus</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Encounter-status\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>status</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Encounter</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>Encounter.status</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Encounter/f:status</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"extension": [
-		{
-			"url": "http://ibm.com/fhir/extension/implicit-system",
-			"valueUri": "http://hl7.org/fhir/encounter-status"
-		}
-	],
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-status",
-	"version": "4.0.0",
-	"name": "USCoreEncounterStatus",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Encounter-status",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:27.462552Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**planned | arrived | triaged | in-progress | onleave | finished | cancelled +**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "status",
-	"base": [
-		"Encounter"
-	],
-	"type": "token",
-	"expression": "Encounter.status",
-	"xpath": "f:Encounter/f:status",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-encounter-status",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "extension": [
+        {
+            "url": "http://ibm.com/fhir/extension/implicit-system",
+            "valueUri": "http://hl7.org/fhir/encounter-status"
+        }
+    ],
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-status",
+    "version": "4.0.0",
+    "name": "USCoreEncounterStatus",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Encounter-status",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:27.462552Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**planned | arrived | triaged | in-progress | onleave | finished | cancelled +**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "status",
+    "base": [
+        "Encounter"
+    ],
+    "type": "token",
+    "expression": "Encounter.status",
+    "xpath": "f:Encounter/f:status",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-encounter-type.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-encounter-type.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-encounter-type",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreEncounterType</h2> --><b> description</b> : <p><strong>Specific type of encounter</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-encounter-type</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-type</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreEncounterType</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-type\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>type</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Encounter</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>Encounter.type</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Encounter/f:type</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-type",
-	"version": "4.0.0",
-	"name": "USCoreEncounterType",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-type",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:27.495436Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Specific type of encounter**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "type",
-	"base": [
-		"Encounter"
-	],
-	"type": "token",
-	"expression": "Encounter.type",
-	"xpath": "f:Encounter/f:type",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-encounter-type",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-type",
+    "version": "4.0.0",
+    "name": "USCoreEncounterType",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-type",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:27.495436Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Specific type of encounter**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "type",
+    "base": [
+        "Encounter"
+    ],
+    "type": "token",
+    "expression": "Encounter.type",
+    "xpath": "f:Encounter/f:type",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-ethnicity.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-ethnicity.json
@@ -1,44 +1,44 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-ethnicity",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative</b></p><p><b>url</b>: <code>http://hl7.org/fhir/us/core/SearchParameter/us-core-ethnicity</code></p><p><b>version</b>: 4.0.0</p><p><b>name</b>: USCoreEthnicity</p><p><b>status</b>: active</p><p><b>date</b>: 2019-05-21</p><p><b>publisher</b>: HL7 International - US Realm Steering Committee</p><p><b>contact</b>: HL7 International - US Realm Steering Committee: <a href=\"http://www.hl7.org/Special/committees/usrealm/index.cfm\">http://www.hl7.org/Special/committees/usrealm/index.cfm</a></p><p><b>description</b>: Returns patients with an ethnicity extension matching the specified code.</p><p><b>jurisdiction</b>: <span title=\"Codes: {urn:iso:std:iso:3166 US}\">United States of America</span></p><p><b>code</b>: ethnicity</p><p><b>base</b>: Patient</p><p><b>type</b>: token</p><p><b>expression</b>: Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity').extension.value.code</p><p><b>xpath</b>: f:Patient/f:extension[@url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity']/f:extension/f:valueCoding/f:code/@value</p><p><b>xpathUsage</b>: normal</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-ethnicity",
-	"version": "4.0.0",
-	"name": "USCoreEthnicity",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Returns patients with an ethnicity extension matching the specified code.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "ethnicity",
-	"base": [
-		"Patient"
-	],
-	"type": "token",
-	"expression": "Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity').extension.value.code",
-	"xpath": "f:Patient/f:extension[@url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity']/f:extension/f:valueCoding/f:code/@value",
-	"xpathUsage": "normal"
+    "resourceType": "SearchParameter",
+    "id": "us-core-ethnicity",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-ethnicity",
+    "version": "4.0.0",
+    "name": "USCoreEthnicity",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Returns patients with an ethnicity extension matching the specified code.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "ethnicity",
+    "base": [
+        "Patient"
+    ],
+    "type": "token",
+    "expression": "Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity').extension.value.code",
+    "xpath": "f:Patient/f:extension[@url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity']/f:extension/f:valueCoding/f:code/@value",
+    "xpathUsage": "normal"
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-goal-lifecycle-status.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-goal-lifecycle-status.json
@@ -1,70 +1,70 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-goal-lifecycle-status",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreGoalLifecycleStatus</h2> --><b> description</b> : <p><strong>proposed | planned | accepted | active | on-hold | completed | cancelled | entered-in-error | rejected</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-goal-lifecycle-status</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-lifecycle-status</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreGoalLifecycleStatus</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Goal-lifecycle-status\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>lifecycle-status</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Goal</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>Goal.lifecycleStatus</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Goal/f:lifecycleStatus</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"extension": [
-		{
-			"url": "http://ibm.com/fhir/extension/implicit-system",
-			"valueUri": "http://hl7.org/fhir/goal-status"
-		}
-	],
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-lifecycle-status",
-	"version": "4.0.0",
-	"name": "USCoreGoalLifecycleStatus",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Goal-lifecycle-status",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:28.712988Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**proposed | planned | accepted | active | on-hold | completed | cancelled | entered-in-error | rejected**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "lifecycle-status",
-	"base": [
-		"Goal"
-	],
-	"type": "token",
-	"expression": "Goal.lifecycleStatus",
-	"xpath": "f:Goal/f:lifecycleStatus",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-goal-lifecycle-status",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "extension": [
+        {
+            "url": "http://ibm.com/fhir/extension/implicit-system",
+            "valueUri": "http://hl7.org/fhir/goal-status"
+        }
+    ],
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-lifecycle-status",
+    "version": "4.0.0",
+    "name": "USCoreGoalLifecycleStatus",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Goal-lifecycle-status",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:28.712988Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**proposed | planned | accepted | active | on-hold | completed | cancelled | entered-in-error | rejected**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "lifecycle-status",
+    "base": [
+        "Goal"
+    ],
+    "type": "token",
+    "expression": "Goal.lifecycleStatus",
+    "xpath": "f:Goal/f:lifecycleStatus",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-goal-patient.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-goal-patient.json
@@ -1,68 +1,68 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-goal-patient",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreGoalPatient</h2> --><b> description</b> : <p><strong>Who this goal is intended for</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-goal-patient</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-patient</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreGoalPatient</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-patient\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>patient</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Goal</p>\n\t\t\t<p><b> type</b> : reference</p>\n\t\t\t<p><b> expression</b> : <code>Goal.subject.where(resolve() is Patient)</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Goal/f:subject</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-patient",
-	"version": "4.0.0",
-	"name": "USCoreGoalPatient",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:28.790820Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Who this goal is intended for**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "patient",
-	"base": [
-		"Goal"
-	],
-	"type": "reference",
-	"expression": "Goal.subject.where(resolve() is Patient)",
-	"xpath": "f:Goal/f:subject",
-	"xpathUsage": "normal",
-	"target": [
-		"Patient",
-		"Group"
-	],
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-goal-patient",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-patient",
+    "version": "4.0.0",
+    "name": "USCoreGoalPatient",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:28.790820Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Who this goal is intended for**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "patient",
+    "base": [
+        "Goal"
+    ],
+    "type": "reference",
+    "expression": "Goal.subject.where(resolve() is Patient)",
+    "xpath": "f:Goal/f:subject",
+    "xpathUsage": "normal",
+    "target": [
+        "Patient",
+        "Group"
+    ],
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-goal-target-date.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-goal-target-date.json
@@ -1,149 +1,149 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-goal-target-date",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreGoalTargetDate</h2> --><b> description</b> : <p><strong>Reach goal on or before</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-goal-target-date</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-target-date</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreGoalTargetDate</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Goal-target-date\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2021-06-25</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n              <!-- <p>\n\t\t\t\t<b> useContext</b> : </p> -->\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>target-date</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Goal</p>\n\t\t\t<p><b> type</b> : date</p>\n\t\t\t<p><b> expression</b> : <code>Goal.target.due as date</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Goal/f:target/f:dueDate</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = SHOULD)</p>\n    \n    \n    <p><b> comparator</b> : <code>eq</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>ne</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>gt</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>ge</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>lt</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>le</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>sa</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>eb</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>ap</code> ( Conformance Expectation = MAY)</p>\n    \n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-target-date",
-	"version": "4.0.0",
-	"name": "USCoreGoalTargetDate",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Goal-target-date",
-	"status": "active",
-	"experimental": false,
-	"date": "2021-06-25T00:22:14.972255Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Reach goal on or before**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "target-date",
-	"base": [
-		"Goal"
-	],
-	"type": "date",
-	"expression": "(Goal.target.due as date)",
-	"xpath": "f:Goal/f:target/f:dueDate",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHOULD"
-			}
-		]
-	},
-	"comparator": [
-		"eq",
-		"ne",
-		"gt",
-		"ge",
-		"lt",
-		"le",
-		"sa",
-		"eb",
-		"ap"
-	],
-	"_comparator": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		}
-	]
+    "resourceType": "SearchParameter",
+    "id": "us-core-goal-target-date",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-target-date",
+    "version": "4.0.0",
+    "name": "USCoreGoalTargetDate",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Goal-target-date",
+    "status": "active",
+    "experimental": false,
+    "date": "2021-06-25T00:22:14.972255Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Reach goal on or before**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "target-date",
+    "base": [
+        "Goal"
+    ],
+    "type": "date",
+    "expression": "(Goal.target.due as date)",
+    "xpath": "f:Goal/f:target/f:dueDate",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHOULD"
+            }
+        ]
+    },
+    "comparator": [
+        "eq",
+        "ne",
+        "gt",
+        "ge",
+        "lt",
+        "le",
+        "sa",
+        "eb",
+        "ap"
+    ],
+    "_comparator": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-immunization-date.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-immunization-date.json
@@ -1,149 +1,149 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-immunization-date",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreImmunizationDate</h2> --><b> description</b> : <p><strong>Vaccination  (non)-Administration Date</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-immunization-date</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-date</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreImmunizationDate</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-date\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>date</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Immunization</p>\n\t\t\t<p><b> type</b> : date</p>\n\t\t\t<p><b> expression</b> : <code>Immunization.occurrence</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Immunization/f:occurrenceDateTime|f:Immunization/f:occurrenceString</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = SHOULD)</p>\n    \n    \n    <p><b> comparator</b> : <code>eq</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>ne</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>gt</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>ge</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>lt</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>le</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>sa</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>eb</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>ap</code> ( Conformance Expectation = MAY)</p>\n    \n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-date",
-	"version": "4.0.0",
-	"name": "USCoreImmunizationDate",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-date",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:27.999173Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Vaccination  (non)-Administration Date**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "date",
-	"base": [
-		"Immunization"
-	],
-	"type": "date",
-	"expression": "Immunization.occurrence",
-	"xpath": "f:Immunization/f:occurrenceDateTime|f:Immunization/f:occurrenceString",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHOULD"
-			}
-		]
-	},
-	"comparator": [
-		"eq",
-		"ne",
-		"gt",
-		"ge",
-		"lt",
-		"le",
-		"sa",
-		"eb",
-		"ap"
-	],
-	"_comparator": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		}
-	]
+    "resourceType": "SearchParameter",
+    "id": "us-core-immunization-date",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-date",
+    "version": "4.0.0",
+    "name": "USCoreImmunizationDate",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-date",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:27.999173Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Vaccination  (non)-Administration Date**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "date",
+    "base": [
+        "Immunization"
+    ],
+    "type": "date",
+    "expression": "Immunization.occurrence",
+    "xpath": "f:Immunization/f:occurrenceDateTime|f:Immunization/f:occurrenceString",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHOULD"
+            }
+        ]
+    },
+    "comparator": [
+        "eq",
+        "ne",
+        "gt",
+        "ge",
+        "lt",
+        "le",
+        "sa",
+        "eb",
+        "ap"
+    ],
+    "_comparator": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-immunization-patient.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-immunization-patient.json
@@ -1,68 +1,68 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-immunization-patient",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreImmunizationPatient</h2> --><b> description</b> : <p><strong>The patient for the vaccination record</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-immunization-patient</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-patient</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreImmunizationPatient</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-patient\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>patient</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Immunization</p>\n\t\t\t<p><b> type</b> : reference</p>\n\t\t\t<p><b> expression</b> : <code>Immunization.patient</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Immunization/f:patient</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-patient",
-	"version": "4.0.0",
-	"name": "USCoreImmunizationPatient",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:27.906368Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**The patient for the vaccination record**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "patient",
-	"base": [
-		"Immunization"
-	],
-	"type": "reference",
-	"expression": "Immunization.patient",
-	"xpath": "f:Immunization/f:patient",
-	"xpathUsage": "normal",
-	"target": [
-		"Patient",
-		"Group"
-	],
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-immunization-patient",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-patient",
+    "version": "4.0.0",
+    "name": "USCoreImmunizationPatient",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:27.906368Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**The patient for the vaccination record**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "patient",
+    "base": [
+        "Immunization"
+    ],
+    "type": "reference",
+    "expression": "Immunization.patient",
+    "xpath": "f:Immunization/f:patient",
+    "xpathUsage": "normal",
+    "target": [
+        "Patient",
+        "Group"
+    ],
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-immunization-status.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-immunization-status.json
@@ -1,70 +1,70 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-immunization-status",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreImmunizationStatus</h2> --><b> description</b> : <p><strong>Immunization event status</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-immunization-status</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-status</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreImmunizationStatus</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Immunization-status\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>status</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Immunization</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>Immunization.status</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Immunization/f:status</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"extension": [
-		{
-			"url": "http://ibm.com/fhir/extension/implicit-system",
-			"valueUri": "http://hl7.org/fhir/event-status"
-		}
-	],
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-status",
-	"version": "4.0.0",
-	"name": "USCoreImmunizationStatus",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Immunization-status",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:27.944236Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Immunization event status**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "status",
-	"base": [
-		"Immunization"
-	],
-	"type": "token",
-	"expression": "Immunization.status",
-	"xpath": "f:Immunization/f:status",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-immunization-status",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "extension": [
+        {
+            "url": "http://ibm.com/fhir/extension/implicit-system",
+            "valueUri": "http://hl7.org/fhir/event-status"
+        }
+    ],
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-status",
+    "version": "4.0.0",
+    "name": "USCoreImmunizationStatus",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Immunization-status",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:27.944236Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Immunization event status**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "status",
+    "base": [
+        "Immunization"
+    ],
+    "type": "token",
+    "expression": "Immunization.status",
+    "xpath": "f:Immunization/f:status",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-location-address-city.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-location-address-city.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-location-address-city",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreLocationAddressCity</h2> --><b> description</b> : <p><strong>A city specified in an address</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-location-address-city</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-city</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreLocationAddressCity</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Location-address-city\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>address-city</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Location</p>\n\t\t\t<p><b> type</b> : string</p>\n\t\t\t<p><b> expression</b> : <code>Location.address.city</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Location/f:address/f:city</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-city",
-	"version": "4.0.0",
-	"name": "USCoreLocationAddressCity",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Location-address-city",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:30.202495Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**A city specified in an address**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "address-city",
-	"base": [
-		"Location"
-	],
-	"type": "string",
-	"expression": "Location.address.city",
-	"xpath": "f:Location/f:address/f:city",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-location-address-city",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-city",
+    "version": "4.0.0",
+    "name": "USCoreLocationAddressCity",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Location-address-city",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:30.202495Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**A city specified in an address**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "address-city",
+    "base": [
+        "Location"
+    ],
+    "type": "string",
+    "expression": "Location.address.city",
+    "xpath": "f:Location/f:address/f:city",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-location-address-postalcode.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-location-address-postalcode.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-location-address-postalcode",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreLocationAddressPostalcode</h2> --><b> description</b> : <p><strong>A postal code specified in an address</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-location-address-postalcode</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-postalcode</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreLocationAddressPostalcode</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Location-address-postalcode\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>address-postalcode</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Location</p>\n\t\t\t<p><b> type</b> : string</p>\n\t\t\t<p><b> expression</b> : <code>Location.address.postalCode</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Location/f:address/f:postalCode</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-postalcode",
-	"version": "4.0.0",
-	"name": "USCoreLocationAddressPostalcode",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Location-address-postalcode",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:30.269318Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**A postal code specified in an address**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "address-postalcode",
-	"base": [
-		"Location"
-	],
-	"type": "string",
-	"expression": "Location.address.postalCode",
-	"xpath": "f:Location/f:address/f:postalCode",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-location-address-postalcode",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-postalcode",
+    "version": "4.0.0",
+    "name": "USCoreLocationAddressPostalcode",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Location-address-postalcode",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:30.269318Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**A postal code specified in an address**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "address-postalcode",
+    "base": [
+        "Location"
+    ],
+    "type": "string",
+    "expression": "Location.address.postalCode",
+    "xpath": "f:Location/f:address/f:postalCode",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-location-address-state.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-location-address-state.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-location-address-state",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreLocationAddressState</h2> --><b> description</b> : <p><strong>A state specified in an address</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-location-address-state</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-state</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreLocationAddressState</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Location-address-state\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>address-state</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Location</p>\n\t\t\t<p><b> type</b> : string</p>\n\t\t\t<p><b> expression</b> : <code>Location.address.state</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Location/f:address/f:state</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-state",
-	"version": "4.0.0",
-	"name": "USCoreLocationAddressState",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Location-address-state",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:30.236431Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**A state specified in an address**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "address-state",
-	"base": [
-		"Location"
-	],
-	"type": "string",
-	"expression": "Location.address.state",
-	"xpath": "f:Location/f:address/f:state",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-location-address-state",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-state",
+    "version": "4.0.0",
+    "name": "USCoreLocationAddressState",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Location-address-state",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:30.236431Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**A state specified in an address**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "address-state",
+    "base": [
+        "Location"
+    ],
+    "type": "string",
+    "expression": "Location.address.state",
+    "xpath": "f:Location/f:address/f:state",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-location-address.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-location-address.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-location-address",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreLocationAddress</h2> --><b> description</b> : <p><strong>A (part of the) address of the location</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-location-address</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreLocationAddress</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Location-address\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>address</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Location</p>\n\t\t\t<p><b> type</b> : string</p>\n\t\t\t<p><b> expression</b> : <code>Location.address</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Location/f:address</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address",
-	"version": "4.0.0",
-	"name": "USCoreLocationAddress",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Location-address",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:30.151632Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**A (part of the) address of the location**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "address",
-	"base": [
-		"Location"
-	],
-	"type": "string",
-	"expression": "Location.address",
-	"xpath": "f:Location/f:address",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-location-address",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address",
+    "version": "4.0.0",
+    "name": "USCoreLocationAddress",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Location-address",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:30.151632Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**A (part of the) address of the location**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "address",
+    "base": [
+        "Location"
+    ],
+    "type": "string",
+    "expression": "Location.address",
+    "xpath": "f:Location/f:address",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-location-name.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-location-name.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-location-name",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreLocationName</h2> --><b> description</b> : <p><strong>A portion of the location's name or alias</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-location-name</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-location-name</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreLocationName</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Location-name\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>name</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Location</p>\n\t\t\t<p><b> type</b> : string</p>\n\t\t\t<p><b> expression</b> : <code>Location.name|Location.alias</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Location/f:name|f:Location/f:alias</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-name",
-	"version": "4.0.0",
-	"name": "USCoreLocationName",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Location-name",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:30.120741Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**A portion of the location's name or alias**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "name",
-	"base": [
-		"Location"
-	],
-	"type": "string",
-	"expression": "Location.name|Location.alias",
-	"xpath": "f:Location/f:name|f:Location/f:alias",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-location-name",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-name",
+    "version": "4.0.0",
+    "name": "USCoreLocationName",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Location-name",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:30.120741Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**A portion of the location's name or alias**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "name",
+    "base": [
+        "Location"
+    ],
+    "type": "string",
+    "expression": "Location.name|Location.alias",
+    "xpath": "f:Location/f:name|f:Location/f:alias",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-medicationrequest-authoredon.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-medicationrequest-authoredon.json
@@ -1,149 +1,149 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-medicationrequest-authoredon",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreMedicationRequestAuthoredon</h2> --><b> description</b> : <p><strong>Return prescriptions written on this date</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-medicationrequest-authoredon</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-authoredon</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreMedicationRequestAuthoredon</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/MedicationRequest-authoredon\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>authoredon</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :MedicationRequest</p>\n\t\t\t<p><b> type</b> : date</p>\n\t\t\t<p><b> expression</b> : <code>MedicationRequest.authoredOn</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:MedicationRequest/f:authoredOn</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = SHOULD)</p>\n    \n    \n    <p><b> comparator</b> : <code>eq</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>ne</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>gt</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>ge</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>lt</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>le</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>sa</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>eb</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>ap</code> ( Conformance Expectation = MAY)</p>\n    \n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-authoredon",
-	"version": "4.0.0",
-	"name": "USCoreMedicationRequestAuthoredon",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/MedicationRequest-authoredon",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:29.162396Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Return prescriptions written on this date**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "authoredon",
-	"base": [
-		"MedicationRequest"
-	],
-	"type": "date",
-	"expression": "MedicationRequest.authoredOn",
-	"xpath": "f:MedicationRequest/f:authoredOn",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHOULD"
-			}
-		]
-	},
-	"comparator": [
-		"eq",
-		"ne",
-		"gt",
-		"ge",
-		"lt",
-		"le",
-		"sa",
-		"eb",
-		"ap"
-	],
-	"_comparator": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		}
-	]
+    "resourceType": "SearchParameter",
+    "id": "us-core-medicationrequest-authoredon",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-authoredon",
+    "version": "4.0.0",
+    "name": "USCoreMedicationRequestAuthoredon",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/MedicationRequest-authoredon",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:29.162396Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Return prescriptions written on this date**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "authoredon",
+    "base": [
+        "MedicationRequest"
+    ],
+    "type": "date",
+    "expression": "MedicationRequest.authoredOn",
+    "xpath": "f:MedicationRequest/f:authoredOn",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHOULD"
+            }
+        ]
+    },
+    "comparator": [
+        "eq",
+        "ne",
+        "gt",
+        "ge",
+        "lt",
+        "le",
+        "sa",
+        "eb",
+        "ap"
+    ],
+    "_comparator": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-medicationrequest-encounter.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-medicationrequest-encounter.json
@@ -1,67 +1,67 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-medicationrequest-encounter",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreMedicationRequestEncounter</h2> --><b> description</b> : <p><strong>Return prescriptions with this encounter identifier</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-medicationrequest-encounter</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-encounter</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreMedicationRequestEncounter</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/medications-encounter\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>encounter</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :MedicationRequest</p>\n\t\t\t<p><b> type</b> : reference</p>\n\t\t\t<p><b> expression</b> : <code>MedicationRequest.encounter</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:MedicationRequest/f:encounter</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-encounter",
-	"version": "4.0.0",
-	"name": "USCoreMedicationRequestEncounter",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/medications-encounter",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:29.068351Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Return prescriptions with this encounter identifier**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "encounter",
-	"base": [
-		"MedicationRequest"
-	],
-	"type": "reference",
-	"expression": "MedicationRequest.encounter",
-	"xpath": "f:MedicationRequest/f:encounter",
-	"xpathUsage": "normal",
-	"target": [
-		"Encounter"
-	],
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-medicationrequest-encounter",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-encounter",
+    "version": "4.0.0",
+    "name": "USCoreMedicationRequestEncounter",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/medications-encounter",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:29.068351Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Return prescriptions with this encounter identifier**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "encounter",
+    "base": [
+        "MedicationRequest"
+    ],
+    "type": "reference",
+    "expression": "MedicationRequest.encounter",
+    "xpath": "f:MedicationRequest/f:encounter",
+    "xpathUsage": "normal",
+    "target": [
+        "Encounter"
+    ],
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-medicationrequest-intent.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-medicationrequest-intent.json
@@ -1,70 +1,70 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-medicationrequest-intent",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreMedicationRequestIntent</h2> --><b> description</b> : <p><strong>Returns prescriptions with different intents</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-medicationrequest-intent</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-intent</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreMedicationRequestIntent</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/MedicationRequest-intent\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>intent</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :MedicationRequest</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>MedicationRequest.intent</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:MedicationRequest/f:intent</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = SHALL)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"extension": [
-		{
-			"url": "http://ibm.com/fhir/extension/implicit-system",
-			"valueUri": "http://hl7.org/fhir/CodeSystem/medicationrequest-intent"
-		}
-	],
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-intent",
-	"version": "4.0.0",
-	"name": "USCoreMedicationRequestIntent",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/MedicationRequest-intent",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:28.926435Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Returns prescriptions with different intents**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "intent",
-	"base": [
-		"MedicationRequest"
-	],
-	"type": "token",
-	"expression": "MedicationRequest.intent",
-	"xpath": "f:MedicationRequest/f:intent",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHALL"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-medicationrequest-intent",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "extension": [
+        {
+            "url": "http://ibm.com/fhir/extension/implicit-system",
+            "valueUri": "http://hl7.org/fhir/CodeSystem/medicationrequest-intent"
+        }
+    ],
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-intent",
+    "version": "4.0.0",
+    "name": "USCoreMedicationRequestIntent",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/MedicationRequest-intent",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:28.926435Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Returns prescriptions with different intents**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "intent",
+    "base": [
+        "MedicationRequest"
+    ],
+    "type": "token",
+    "expression": "MedicationRequest.intent",
+    "xpath": "f:MedicationRequest/f:intent",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHALL"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-medicationrequest-patient.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-medicationrequest-patient.json
@@ -1,68 +1,68 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-medicationrequest-patient",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreMedicationRequestPatient</h2> --><b> description</b> : <p><strong>Returns prescriptions for a specific patient</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-medicationrequest-patient</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-patient</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreMedicationRequestPatient</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-patient\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>patient</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :MedicationRequest</p>\n\t\t\t<p><b> type</b> : reference</p>\n\t\t\t<p><b> expression</b> : <code>MedicationRequest.subject.where(resolve() is Patient)</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:MedicationRequest/f:subject</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-patient",
-	"version": "4.0.0",
-	"name": "USCoreMedicationRequestPatient",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:29.028336Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Returns prescriptions for a specific patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "patient",
-	"base": [
-		"MedicationRequest"
-	],
-	"type": "reference",
-	"expression": "MedicationRequest.subject.where(resolve() is Patient)",
-	"xpath": "f:MedicationRequest/f:subject",
-	"xpathUsage": "normal",
-	"target": [
-		"Patient",
-		"Group"
-	],
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-medicationrequest-patient",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-patient",
+    "version": "4.0.0",
+    "name": "USCoreMedicationRequestPatient",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:29.028336Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Returns prescriptions for a specific patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "patient",
+    "base": [
+        "MedicationRequest"
+    ],
+    "type": "reference",
+    "expression": "MedicationRequest.subject.where(resolve() is Patient)",
+    "xpath": "f:MedicationRequest/f:subject",
+    "xpathUsage": "normal",
+    "target": [
+        "Patient",
+        "Group"
+    ],
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-medicationrequest-status.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-medicationrequest-status.json
@@ -1,70 +1,70 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-medicationrequest-status",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreMedicationRequestStatus</h2> --><b> description</b> : <p><strong>Status of the prescription</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-medicationrequest-status</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-status</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreMedicationRequestStatus</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/medications-status\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>status</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :MedicationRequest</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>MedicationRequest.status</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:MedicationRequest/f:status</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = SHALL)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"extension": [
-		{
-			"url": "http://ibm.com/fhir/extension/implicit-system",
-			"valueUri": "http://hl7.org/fhir/CodeSystem/medicationrequest-status"
-		}
-	],
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-status",
-	"version": "4.0.0",
-	"name": "USCoreMedicationRequestStatus",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/medications-status",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:28.858896Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Status of the prescription**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "status",
-	"base": [
-		"MedicationRequest"
-	],
-	"type": "token",
-	"expression": "MedicationRequest.status",
-	"xpath": "f:MedicationRequest/f:status",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHALL"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-medicationrequest-status",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "extension": [
+        {
+            "url": "http://ibm.com/fhir/extension/implicit-system",
+            "valueUri": "http://hl7.org/fhir/CodeSystem/medicationrequest-status"
+        }
+    ],
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-status",
+    "version": "4.0.0",
+    "name": "USCoreMedicationRequestStatus",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/medications-status",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:28.858896Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Status of the prescription**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "status",
+    "base": [
+        "MedicationRequest"
+    ],
+    "type": "token",
+    "expression": "MedicationRequest.status",
+    "xpath": "f:MedicationRequest/f:status",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHALL"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-observation-category.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-observation-category.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-observation-category",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreObservationCategory</h2> --><b> description</b> : <p><strong>The classification of the type of observation</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-observation-category</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-category</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreObservationCategory</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Observation-category\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>category</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Observation</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>Observation.category</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Observation/f:category</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-category",
-	"version": "4.0.0",
-	"name": "USCoreObservationCategory",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Observation-category",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:29.573477Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**The classification of the type of observation**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "category",
-	"base": [
-		"Observation"
-	],
-	"type": "token",
-	"expression": "Observation.category",
-	"xpath": "f:Observation/f:category",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-observation-category",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-category",
+    "version": "4.0.0",
+    "name": "USCoreObservationCategory",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Observation-category",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:29.573477Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**The classification of the type of observation**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "category",
+    "base": [
+        "Observation"
+    ],
+    "type": "token",
+    "expression": "Observation.category",
+    "xpath": "f:Observation/f:category",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-observation-code.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-observation-code.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-observation-code",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreObservationCode</h2> --><b> description</b> : <p><strong>The code of the observation type</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-observation-code</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-code</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreObservationCode</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-code\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>code</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Observation</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>Observation.code</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Observation/f:code</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = SHOULD)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-code",
-	"version": "4.0.0",
-	"name": "USCoreObservationCode",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-code",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:29.609416Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**The code of the observation type**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "code",
-	"base": [
-		"Observation"
-	],
-	"type": "token",
-	"expression": "Observation.code",
-	"xpath": "f:Observation/f:code",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHOULD"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-observation-code",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-code",
+    "version": "4.0.0",
+    "name": "USCoreObservationCode",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-code",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:29.609416Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**The code of the observation type**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "code",
+    "base": [
+        "Observation"
+    ],
+    "type": "token",
+    "expression": "Observation.code",
+    "xpath": "f:Observation/f:code",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHOULD"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-observation-date.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-observation-date.json
@@ -1,149 +1,149 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-observation-date",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreObservationDate</h2> --><b> description</b> : <p><strong>Obtained date/time. If the obtained element is a period, a date that falls in the period</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-observation-date</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-date</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreObservationDate</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-date\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>date</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Observation</p>\n\t\t\t<p><b> type</b> : date</p>\n\t\t\t<p><b> expression</b> : <code>Observation.effective</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Observation/f:effectiveDateTime|f:Observation/f:effectivePeriod|f:Observation/f:effectiveTiming|f:Observation/f:effectiveInstant</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = SHOULD)</p>\n    \n    \n    <p><b> comparator</b> : <code>eq</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>ne</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>gt</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>ge</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>lt</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>le</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>sa</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>eb</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>ap</code> ( Conformance Expectation = MAY)</p>\n    \n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-date",
-	"version": "4.0.0",
-	"name": "USCoreObservationDate",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-date",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:29.697843Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Obtained date/time. If the obtained element is a period, a date that falls in the period**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "date",
-	"base": [
-		"Observation"
-	],
-	"type": "date",
-	"expression": "Observation.effective",
-	"xpath": "f:Observation/f:effectiveDateTime|f:Observation/f:effectivePeriod|f:Observation/f:effectiveTiming|f:Observation/f:effectiveInstant",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHOULD"
-			}
-		]
-	},
-	"comparator": [
-		"eq",
-		"ne",
-		"gt",
-		"ge",
-		"lt",
-		"le",
-		"sa",
-		"eb",
-		"ap"
-	],
-	"_comparator": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		}
-	]
+    "resourceType": "SearchParameter",
+    "id": "us-core-observation-date",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-date",
+    "version": "4.0.0",
+    "name": "USCoreObservationDate",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-date",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:29.697843Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Obtained date/time. If the obtained element is a period, a date that falls in the period**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "date",
+    "base": [
+        "Observation"
+    ],
+    "type": "date",
+    "expression": "Observation.effective",
+    "xpath": "f:Observation/f:effectiveDateTime|f:Observation/f:effectivePeriod|f:Observation/f:effectiveTiming|f:Observation/f:effectiveInstant",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHOULD"
+            }
+        ]
+    },
+    "comparator": [
+        "eq",
+        "ne",
+        "gt",
+        "ge",
+        "lt",
+        "le",
+        "sa",
+        "eb",
+        "ap"
+    ],
+    "_comparator": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-observation-patient.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-observation-patient.json
@@ -1,68 +1,68 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-observation-patient",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreObservationPatient</h2> --><b> description</b> : <p><strong>The subject that the observation is about (if patient)</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-observation-patient</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreObservationPatient</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-patient\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>patient</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Observation</p>\n\t\t\t<p><b> type</b> : reference</p>\n\t\t\t<p><b> expression</b> : <code>Observation.subject.where(resolve() is Patient)</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Observation/f:subject</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient",
-	"version": "4.0.0",
-	"name": "USCoreObservationPatient",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:29.729464Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**The subject that the observation is about (if patient)**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "patient",
-	"base": [
-		"Observation"
-	],
-	"type": "reference",
-	"expression": "Observation.subject.where(resolve() is Patient)",
-	"xpath": "f:Observation/f:subject",
-	"xpathUsage": "normal",
-	"target": [
-		"Patient",
-		"Group"
-	],
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-observation-patient",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient",
+    "version": "4.0.0",
+    "name": "USCoreObservationPatient",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:29.729464Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**The subject that the observation is about (if patient)**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "patient",
+    "base": [
+        "Observation"
+    ],
+    "type": "reference",
+    "expression": "Observation.subject.where(resolve() is Patient)",
+    "xpath": "f:Observation/f:subject",
+    "xpathUsage": "normal",
+    "target": [
+        "Patient",
+        "Group"
+    ],
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-observation-status.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-observation-status.json
@@ -1,70 +1,70 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-observation-status",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreObservationStatus</h2> --><b> description</b> : <p><strong>The status of the observation</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-observation-status</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-status</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreObservationStatus</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Observation-status\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>status</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Observation</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>Observation.status</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Observation/f:status</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = SHALL)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"extension": [
-		{
-			"url": "http://ibm.com/fhir/extension/implicit-system",
-			"valueUri": "http://hl7.org/fhir/observation-status"
-		}
-	],
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-status",
-	"version": "4.0.0",
-	"name": "USCoreObservationStatus",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Observation-status",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:29.49649Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**The status of the observation**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "status",
-	"base": [
-		"Observation"
-	],
-	"type": "token",
-	"expression": "Observation.status",
-	"xpath": "f:Observation/f:status",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHALL"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-observation-status",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "extension": [
+        {
+            "url": "http://ibm.com/fhir/extension/implicit-system",
+            "valueUri": "http://hl7.org/fhir/observation-status"
+        }
+    ],
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-status",
+    "version": "4.0.0",
+    "name": "USCoreObservationStatus",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Observation-status",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:29.49649Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**The status of the observation**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "status",
+    "base": [
+        "Observation"
+    ],
+    "type": "token",
+    "expression": "Observation.status",
+    "xpath": "f:Observation/f:status",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHALL"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-organization-address.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-organization-address.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-organization-address",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreOrganizationAddress</h2> --><b> description</b> : <p><strong>A server defined search that may match any of the string fields in the Address, including line, city, district, state, country, postalCode, and/or text</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-organization-address</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-address</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreOrganizationAddress</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Organization-address\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>address</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Organization</p>\n\t\t\t<p><b> type</b> : string</p>\n\t\t\t<p><b> expression</b> : <code>Organization.address</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Organization/f:address</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-address",
-	"version": "4.0.0",
-	"name": "USCoreOrganizationAddress",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Organization-address",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:30.411091Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**A server defined search that may match any of the string fields in the Address, including line, city, district, state, country, postalCode, and/or text**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "address",
-	"base": [
-		"Organization"
-	],
-	"type": "string",
-	"expression": "Organization.address",
-	"xpath": "f:Organization/f:address",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-organization-address",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-address",
+    "version": "4.0.0",
+    "name": "USCoreOrganizationAddress",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Organization-address",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:30.411091Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**A server defined search that may match any of the string fields in the Address, including line, city, district, state, country, postalCode, and/or text**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "address",
+    "base": [
+        "Organization"
+    ],
+    "type": "string",
+    "expression": "Organization.address",
+    "xpath": "f:Organization/f:address",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-organization-name.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-organization-name.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-organization-name",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreOrganizationName</h2> --><b> description</b> : <p><strong>A portion of the organization's name or alias</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-organization-name</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-name</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreOrganizationName</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Organization-name\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>name</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Organization</p>\n\t\t\t<p><b> type</b> : string</p>\n\t\t\t<p><b> expression</b> : <code>Organization.name|Organization.alias</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Organization/f:name|f:Organization/f:alias</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-name",
-	"version": "4.0.0",
-	"name": "USCoreOrganizationName",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Organization-name",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:30.301231Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**A portion of the organization's name or alias**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "name",
-	"base": [
-		"Organization"
-	],
-	"type": "string",
-	"expression": "Organization.name|Organization.alias",
-	"xpath": "f:Organization/f:name|f:Organization/f:alias",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-organization-name",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-name",
+    "version": "4.0.0",
+    "name": "USCoreOrganizationName",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Organization-name",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:30.301231Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**A portion of the organization's name or alias**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "name",
+    "base": [
+        "Organization"
+    ],
+    "type": "string",
+    "expression": "Organization.name|Organization.alias",
+    "xpath": "f:Organization/f:name|f:Organization/f:alias",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-patient-birthdate.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-patient-birthdate.json
@@ -1,149 +1,149 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-patient-birthdate",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCorePatientBirthdate</h2> --><b> description</b> : <p><strong>The patient's date of birth</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-patient-birthdate</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-birthdate</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCorePatientBirthdate</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/individual-birthdate\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>birthdate</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Patient</p>\n\t\t\t<p><b> type</b> : date</p>\n\t\t\t<p><b> expression</b> : <code>Patient.birthDate</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Patient/f:birthDate</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    <p><b> comparator</b> : <code>eq</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>ne</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>gt</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>ge</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>lt</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>le</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>sa</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>eb</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>ap</code> ( Conformance Expectation = MAY)</p>\n    \n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-birthdate",
-	"version": "4.0.0",
-	"name": "USCorePatientBirthdate",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/individual-birthdate",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:27.587218Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**The patient's date of birth**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "birthdate",
-	"base": [
-		"Patient"
-	],
-	"type": "date",
-	"expression": "Patient.birthDate",
-	"xpath": "f:Patient/f:birthDate",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"comparator": [
-		"eq",
-		"ne",
-		"gt",
-		"ge",
-		"lt",
-		"le",
-		"sa",
-		"eb",
-		"ap"
-	],
-	"_comparator": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		}
-	]
+    "resourceType": "SearchParameter",
+    "id": "us-core-patient-birthdate",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-birthdate",
+    "version": "4.0.0",
+    "name": "USCorePatientBirthdate",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/individual-birthdate",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:27.587218Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**The patient's date of birth**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "birthdate",
+    "base": [
+        "Patient"
+    ],
+    "type": "date",
+    "expression": "Patient.birthDate",
+    "xpath": "f:Patient/f:birthDate",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "comparator": [
+        "eq",
+        "ne",
+        "gt",
+        "ge",
+        "lt",
+        "le",
+        "sa",
+        "eb",
+        "ap"
+    ],
+    "_comparator": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-patient-family.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-patient-family.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-patient-family",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCorePatientFamily</h2> --><b> description</b> : <p><strong>A portion of the family name of the patient</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-patient-family</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-family</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCorePatientFamily</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/individual-family\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>family</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Patient</p>\n\t\t\t<p><b> type</b> : string</p>\n\t\t\t<p><b> expression</b> : <code>Patient.name.family</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Patient/f:name/f:family</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-family",
-	"version": "4.0.0",
-	"name": "USCorePatientFamily",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/individual-family",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:27.620105Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**A portion of the family name of the patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "family",
-	"base": [
-		"Patient"
-	],
-	"type": "string",
-	"expression": "Patient.name.family",
-	"xpath": "f:Patient/f:name/f:family",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-patient-family",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-family",
+    "version": "4.0.0",
+    "name": "USCorePatientFamily",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/individual-family",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:27.620105Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**A portion of the family name of the patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "family",
+    "base": [
+        "Patient"
+    ],
+    "type": "string",
+    "expression": "Patient.name.family",
+    "xpath": "f:Patient/f:name/f:family",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-patient-gender.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-patient-gender.json
@@ -1,70 +1,70 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-patient-gender",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCorePatientGender</h2> --><b> description</b> : <p><strong>Gender of the patient</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-patient-gender</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-gender</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCorePatientGender</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/individual-gender\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>gender</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Patient</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>Patient.gender</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Patient/f:gender</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"extension": [
-		{
-			"url": "http://ibm.com/fhir/extension/implicit-system",
-			"valueUri": "http://hl7.org/fhir/administrative-gender"
-		}
-	],
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-gender",
-	"version": "4.0.0",
-	"name": "USCorePatientGender",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/individual-gender",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:27.671986Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Gender of the patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "gender",
-	"base": [
-		"Patient"
-	],
-	"type": "token",
-	"expression": "Patient.gender",
-	"xpath": "f:Patient/f:gender",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-patient-gender",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "extension": [
+        {
+            "url": "http://ibm.com/fhir/extension/implicit-system",
+            "valueUri": "http://hl7.org/fhir/administrative-gender"
+        }
+    ],
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-gender",
+    "version": "4.0.0",
+    "name": "USCorePatientGender",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/individual-gender",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:27.671986Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Gender of the patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "gender",
+    "base": [
+        "Patient"
+    ],
+    "type": "token",
+    "expression": "Patient.gender",
+    "xpath": "f:Patient/f:gender",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-patient-given.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-patient-given.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-patient-given",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCorePatientGiven</h2> --><b> description</b> : <p><strong>A portion of the given name of the patient</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-patient-given</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-given</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCorePatientGiven</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/individual-given\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>given</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Patient</p>\n\t\t\t<p><b> type</b> : string</p>\n\t\t\t<p><b> expression</b> : <code>Patient.name.given</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Patient/f:name/f:given</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-given",
-	"version": "4.0.0",
-	"name": "USCorePatientGiven",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/individual-given",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:27.703906Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**A portion of the given name of the patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "given",
-	"base": [
-		"Patient"
-	],
-	"type": "string",
-	"expression": "Patient.name.given",
-	"xpath": "f:Patient/f:name/f:given",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-patient-given",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-given",
+    "version": "4.0.0",
+    "name": "USCorePatientGiven",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/individual-given",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:27.703906Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**A portion of the given name of the patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "given",
+    "base": [
+        "Patient"
+    ],
+    "type": "string",
+    "expression": "Patient.name.given",
+    "xpath": "f:Patient/f:name/f:given",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-patient-id.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-patient-id.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-patient-id",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCorePatientId</h2> --><b> description</b> : <p><strong>Logical id of this artifact</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-patient-id</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-id</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCorePatientId</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Resource-id\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2021-06-24</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n              <!-- <p>\n\t\t\t\t<b> useContext</b> : </p> -->\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>_id</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Patient</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>Patient.id</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Patient/f:id</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-id",
-	"version": "4.0.0",
-	"name": "USCorePatientId",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Resource-id",
-	"status": "active",
-	"experimental": false,
-	"date": "2021-06-24T23:54:41.938698Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Logical id of this artifact**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "_id",
-	"base": [
-		"Patient"
-	],
-	"type": "token",
-	"expression": "Patient.id",
-	"xpath": "f:Patient/f:id",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-patient-id",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-id",
+    "version": "4.0.0",
+    "name": "USCorePatientId",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Resource-id",
+    "status": "active",
+    "experimental": false,
+    "date": "2021-06-24T23:54:41.938698Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Logical id of this artifact**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "_id",
+    "base": [
+        "Patient"
+    ],
+    "type": "token",
+    "expression": "Patient.id",
+    "xpath": "f:Patient/f:id",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-patient-identifier.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-patient-identifier.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-patient-identifier",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCorePatientIdentifier</h2> --><b> description</b> : <p><strong>A patient identifier</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-patient-identifier</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-identifier</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCorePatientIdentifier</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Patient-identifier\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>identifier</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Patient</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>Patient.identifier</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Patient/f:identifier</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-identifier",
-	"version": "4.0.0",
-	"name": "USCorePatientIdentifier",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Patient-identifier",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:27.736817Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**A patient identifier**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "identifier",
-	"base": [
-		"Patient"
-	],
-	"type": "token",
-	"expression": "Patient.identifier",
-	"xpath": "f:Patient/f:identifier",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-patient-identifier",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-identifier",
+    "version": "4.0.0",
+    "name": "USCorePatientIdentifier",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Patient-identifier",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:27.736817Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**A patient identifier**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "identifier",
+    "base": [
+        "Patient"
+    ],
+    "type": "token",
+    "expression": "Patient.identifier",
+    "xpath": "f:Patient/f:identifier",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-patient-name.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-patient-name.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-patient-name",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCorePatientName</h2> --><b> description</b> : <p><strong>A server defined search that may match any of the string fields in the HumanName, including family, give, prefix, suffix, suffix, and/or text</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-patient-name</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-name</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCorePatientName</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Patient-name\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>name</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Patient</p>\n\t\t\t<p><b> type</b> : string</p>\n\t\t\t<p><b> expression</b> : <code>Patient.name</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Patient/f:name</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-name",
-	"version": "4.0.0",
-	"name": "USCorePatientName",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Patient-name",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:27.775687Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**A server defined search that may match any of the string fields in the HumanName, including family, give, prefix, suffix, suffix, and/or text**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "name",
-	"base": [
-		"Patient"
-	],
-	"type": "string",
-	"expression": "Patient.name",
-	"xpath": "f:Patient/f:name",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-patient-name",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-name",
+    "version": "4.0.0",
+    "name": "USCorePatientName",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Patient-name",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:27.775687Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**A server defined search that may match any of the string fields in the HumanName, including family, give, prefix, suffix, suffix, and/or text**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "name",
+    "base": [
+        "Patient"
+    ],
+    "type": "string",
+    "expression": "Patient.name",
+    "xpath": "f:Patient/f:name",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-practitioner-identifier.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-practitioner-identifier.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-practitioner-identifier",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCorePractitionerIdentifier</h2> --><b> description</b> : <p><strong>A practitioner's Identifier</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-practitioner-identifier</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-identifier</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCorePractitionerIdentifier</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Practitioner-identifier\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>identifier</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Practitioner</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>Practitioner.identifier</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Practitioner/f:identifier</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-identifier",
-	"version": "4.0.0",
-	"name": "USCorePractitionerIdentifier",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Practitioner-identifier",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:30.531808Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**A practitioner's Identifier**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "identifier",
-	"base": [
-		"Practitioner"
-	],
-	"type": "token",
-	"expression": "Practitioner.identifier",
-	"xpath": "f:Practitioner/f:identifier",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-practitioner-identifier",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-identifier",
+    "version": "4.0.0",
+    "name": "USCorePractitionerIdentifier",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Practitioner-identifier",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:30.531808Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**A practitioner's Identifier**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "identifier",
+    "base": [
+        "Practitioner"
+    ],
+    "type": "token",
+    "expression": "Practitioner.identifier",
+    "xpath": "f:Practitioner/f:identifier",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-practitioner-name.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-practitioner-name.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-practitioner-name",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCorePractitionerName</h2> --><b> description</b> : <p><strong>A server defined search that may match any of the string fields in the HumanName, including family, give, prefix, suffix, suffix, and/or text</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-practitioner-name</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-name</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCorePractitionerName</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Practitioner-name\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>name</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Practitioner</p>\n\t\t\t<p><b> type</b> : string</p>\n\t\t\t<p><b> expression</b> : <code>Practitioner.name</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Practitioner/f:name</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-name",
-	"version": "4.0.0",
-	"name": "USCorePractitionerName",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Practitioner-name",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:30.450985Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**A server defined search that may match any of the string fields in the HumanName, including family, give, prefix, suffix, suffix, and/or text**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "name",
-	"base": [
-		"Practitioner"
-	],
-	"type": "string",
-	"expression": "Practitioner.name",
-	"xpath": "f:Practitioner/f:name",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-practitioner-name",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-name",
+    "version": "4.0.0",
+    "name": "USCorePractitionerName",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Practitioner-name",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:30.450985Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**A server defined search that may match any of the string fields in the HumanName, including family, give, prefix, suffix, suffix, and/or text**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "name",
+    "base": [
+        "Practitioner"
+    ],
+    "type": "string",
+    "expression": "Practitioner.name",
+    "xpath": "f:Practitioner/f:name",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-practitionerrole-practitioner.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-practitionerrole-practitioner.json
@@ -1,89 +1,89 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-practitionerrole-practitioner",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCorePractitionerRolePractitioner</h2> --><b> description</b> : <p><strong>Practitioner that is able to provide the defined services for the organization</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-practitionerrole-practitioner</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-practitioner</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCorePractitionerRolePractitioner</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/PractitionerRole-practitioner\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>practitioner</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :PractitionerRole</p>\n\t\t\t<p><b> type</b> : reference</p>\n\t\t\t<p><b> expression</b> : <code>PractitionerRole.practitioner</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:PractitionerRole/f:practitioner</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n    \n    <p><b> chain</b> : <code>identifier</code>  (Conformance Expectation = SHALL)</p>\n    \n    <p><b> chain</b> : <code>name</code>  (Conformance Expectation = SHALL)</p>\n    \n\t\t\n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-practitioner",
-	"version": "4.0.0",
-	"name": "USCorePractitionerRolePractitioner",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/PractitionerRole-practitioner",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:30.639824Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Practitioner that is able to provide the defined services for the organization**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "practitioner",
-	"base": [
-		"PractitionerRole"
-	],
-	"type": "reference",
-	"expression": "PractitionerRole.practitioner",
-	"xpath": "f:PractitionerRole/f:practitioner",
-	"xpathUsage": "normal",
-	"target": [
-		"Practitioner"
-	],
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"chain": [
-		"identifier",
-		"name"
-	],
-	"_chain": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		}
-	]
+    "resourceType": "SearchParameter",
+    "id": "us-core-practitionerrole-practitioner",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-practitioner",
+    "version": "4.0.0",
+    "name": "USCorePractitionerRolePractitioner",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/PractitionerRole-practitioner",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:30.639824Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Practitioner that is able to provide the defined services for the organization**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "practitioner",
+    "base": [
+        "PractitionerRole"
+    ],
+    "type": "reference",
+    "expression": "PractitionerRole.practitioner",
+    "xpath": "f:PractitionerRole/f:practitioner",
+    "xpathUsage": "normal",
+    "target": [
+        "Practitioner"
+    ],
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "chain": [
+        "identifier",
+        "name"
+    ],
+    "_chain": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-practitionerrole-specialty.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-practitionerrole-specialty.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-practitionerrole-specialty",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCorePractitionerRoleSpecialty</h2> --><b> description</b> : <p><strong>The practitioner has this specialty at an organization</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-practitionerrole-specialty</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-specialty</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCorePractitionerRoleSpecialty</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/PractitionerRole-specialty\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>specialty</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :PractitionerRole</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>PractitionerRole.specialty</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:PractitionerRole/f:specialty</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-specialty",
-	"version": "4.0.0",
-	"name": "USCorePractitionerRoleSpecialty",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/PractitionerRole-specialty",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:30.613929Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**The practitioner has this specialty at an organization**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "specialty",
-	"base": [
-		"PractitionerRole"
-	],
-	"type": "token",
-	"expression": "PractitionerRole.specialty",
-	"xpath": "f:PractitionerRole/f:specialty",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-practitionerrole-specialty",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-specialty",
+    "version": "4.0.0",
+    "name": "USCorePractitionerRoleSpecialty",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/PractitionerRole-specialty",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:30.613929Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**The practitioner has this specialty at an organization**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "specialty",
+    "base": [
+        "PractitionerRole"
+    ],
+    "type": "token",
+    "expression": "PractitionerRole.specialty",
+    "xpath": "f:PractitionerRole/f:specialty",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-procedure-code.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-procedure-code.json
@@ -1,64 +1,64 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-procedure-code",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreProcedureCode</h2> --><b> description</b> : <p><strong>A code to identify a  procedure</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-procedure-code</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-code</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreProcedureCode</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-code\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>code</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Procedure</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>Procedure.code</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Procedure/f:code</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = SHOULD)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-code",
-	"version": "4.0.0",
-	"name": "USCoreProcedureCode",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-code",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:29.419516Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**A code to identify a  procedure**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "code",
-	"base": [
-		"Procedure"
-	],
-	"type": "token",
-	"expression": "Procedure.code",
-	"xpath": "f:Procedure/f:code",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHOULD"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-procedure-code",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-code",
+    "version": "4.0.0",
+    "name": "USCoreProcedureCode",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-code",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:29.419516Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**A code to identify a  procedure**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "code",
+    "base": [
+        "Procedure"
+    ],
+    "type": "token",
+    "expression": "Procedure.code",
+    "xpath": "f:Procedure/f:code",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHOULD"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-procedure-date.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-procedure-date.json
@@ -1,149 +1,149 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-procedure-date",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreProcedureDate</h2> --><b> description</b> : <p><strong>When the procedure was performed</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-procedure-date</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-date</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreProcedureDate</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-date\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>date</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Procedure</p>\n\t\t\t<p><b> type</b> : date</p>\n\t\t\t<p><b> expression</b> : <code>Procedure.performed</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Procedure/f:performedDateTime|f:Procedure/f:performedPeriod|f:Procedure/f:performedString|f:Procedure/f:performedAge|f:Procedure/f:performedRange</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = SHOULD)</p>\n    \n    \n    <p><b> comparator</b> : <code>eq</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>ne</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>gt</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>ge</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>lt</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>le</code> ( Conformance Expectation = SHALL)</p>\n    \n    <p><b> comparator</b> : <code>sa</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>eb</code> ( Conformance Expectation = MAY)</p>\n    \n    <p><b> comparator</b> : <code>ap</code> ( Conformance Expectation = MAY)</p>\n    \n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-date",
-	"version": "4.0.0",
-	"name": "USCoreProcedureDate",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-date",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:29.345870Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**When the procedure was performed**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "date",
-	"base": [
-		"Procedure"
-	],
-	"type": "date",
-	"expression": "Procedure.performed",
-	"xpath": "f:Procedure/f:performedDateTime|f:Procedure/f:performedPeriod|f:Procedure/f:performedString|f:Procedure/f:performedAge|f:Procedure/f:performedRange",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHOULD"
-			}
-		]
-	},
-	"comparator": [
-		"eq",
-		"ne",
-		"gt",
-		"ge",
-		"lt",
-		"le",
-		"sa",
-		"eb",
-		"ap"
-	],
-	"_comparator": [
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "SHALL"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		},
-		{
-			"extension": [
-				{
-					"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-					"valueCode": "MAY"
-				}
-			]
-		}
-	]
+    "resourceType": "SearchParameter",
+    "id": "us-core-procedure-date",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-date",
+    "version": "4.0.0",
+    "name": "USCoreProcedureDate",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-date",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:29.345870Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**When the procedure was performed**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "date",
+    "base": [
+        "Procedure"
+    ],
+    "type": "date",
+    "expression": "Procedure.performed",
+    "xpath": "f:Procedure/f:performedDateTime|f:Procedure/f:performedPeriod|f:Procedure/f:performedString|f:Procedure/f:performedAge|f:Procedure/f:performedRange",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHOULD"
+            }
+        ]
+    },
+    "comparator": [
+        "eq",
+        "ne",
+        "gt",
+        "ge",
+        "lt",
+        "le",
+        "sa",
+        "eb",
+        "ap"
+    ],
+    "_comparator": [
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "SHALL"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        },
+        {
+            "extension": [
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                    "valueCode": "MAY"
+                }
+            ]
+        }
+    ]
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-procedure-patient.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-procedure-patient.json
@@ -1,68 +1,68 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-procedure-patient",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreProcedurePatient</h2> --><b> description</b> : <p><strong>Search by subject - a patient</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-procedure-patient</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-patient</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreProcedurePatient</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/clinical-patient\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>patient</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Procedure</p>\n\t\t\t<p><b> type</b> : reference</p>\n\t\t\t<p><b> expression</b> : <code>Procedure.subject.where(resolve() is Patient)</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Procedure/f:subject</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = MAY)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-patient",
-	"version": "4.0.0",
-	"name": "USCoreProcedurePatient",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:29.297983Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**Search by subject - a patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "patient",
-	"base": [
-		"Procedure"
-	],
-	"type": "reference",
-	"expression": "Procedure.subject.where(resolve() is Patient)",
-	"xpath": "f:Procedure/f:subject",
-	"xpathUsage": "normal",
-	"target": [
-		"Patient",
-		"Group"
-	],
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-procedure-patient",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-patient",
+    "version": "4.0.0",
+    "name": "USCoreProcedurePatient",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/clinical-patient",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:29.297983Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**Search by subject - a patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "patient",
+    "base": [
+        "Procedure"
+    ],
+    "type": "reference",
+    "expression": "Procedure.subject.where(resolve() is Patient)",
+    "xpath": "f:Procedure/f:subject",
+    "xpathUsage": "normal",
+    "target": [
+        "Patient",
+        "Group"
+    ],
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-procedure-status.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-procedure-status.json
@@ -1,70 +1,70 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-procedure-status",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">  <!-- <h2>SearchParameter: USCoreProcedureStatus</h2> --><b> description</b> : <p><strong>preparation | in-progress | not-done | on-hold | stopped | completed | entered-in-error | unknown</strong><br/><strong>NOTE</strong>: This US Core SearchParameter definition extends the usage context of the\n<a href=\"http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html\">Conformance expectation extension</a></p>\n<ul><li>multipleAnd</li><li>multipleOr</li><li>comparator</li><li>modifier</li><li>chain</li></ul>\n\n\t\t\t<br/>\n\t\t\t<p><b> id</b> us-core-procedure-status</p>\n\t\t\t<p><b> url</b> : <b> http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-status</b>\n\t\t\t</p>\n\t\t\t<p><b> version</b> : 4.0.1</p>\n\t\t\t<p><b> name</b> : USCoreProcedureStatus</p>\n\t\t\t<p><b> derivedFrom</b> : http://hl7.org/fhir/SearchParameter/Procedure-status\n\t\t\t</p>\n\t\t\t<p><b> status</b> : active</p>\n\t\t\t<p><b> experimental</b>  False</p>\n\t\t\t<p><b> date</b> : 2020-11-20</p>\n\t\t\t<p><b> publisher</b> : HL7 International - US Realm Steering Committee</p>\n\t\t\t<p><b> contact</b> : http://www.hl7.org/Special/committees/usrealm/index.cfm</p>\n\t\t\t<p><b> useContext</b> : </p>\n\t\t\t<p><b> jurisdiction</b> : United States of America (the) <span> (Details : {urn:iso:std:iso:3166 code 'US' = 'United States of America', given as 'United\n           States of America (the)'})</span>\n\t\t\t</p>\n\t\t\t  <!-- <p>\n\t\t<b> purpose</b> : Need to search by identifier for various infrastructural cases - mainly retrieving packages,\n         and matching as part of a chain</p> -->\n\t\t\t<p><b> code</b> : <code>status</code>\n\t\t\t</p>\n\t\t\t<p><b> base</b> :Procedure</p>\n\t\t\t<p><b> type</b> : token</p>\n\t\t\t<p><b> expression</b> : <code>Procedure.status</code>\n\t\t\t</p>\n\t\t\t<p><b> xpath</b> : <code>f:Procedure/f:status</code>\n\t\t\t</p>\n\t\t\t<p><b> xpathUsage</b> : normal</p>\n\t\t\t<p><b> mulitpleOr</b> : True   (Conformance Expectation = SHALL)</p>\n\t\t\t<p><b> mulitpleAnd</b> : True  ( Conformance Expectation = MAY)</p>\n    \n    \n    \n\t\t</div>"
-	},
-	"extension": [
-		{
-			"url": "http://ibm.com/fhir/extension/implicit-system",
-			"valueUri": "http://hl7.org/fhir/event-status"
-		}
-	],
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-status",
-	"version": "4.0.0",
-	"name": "USCoreProcedureStatus",
-	"derivedFrom": "http://hl7.org/fhir/SearchParameter/Procedure-status",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-20T05:19:29.196316Z",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "**preparation | in-progress | not-done | on-hold | stopped | completed | entered-in-error | unknown**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "status",
-	"base": [
-		"Procedure"
-	],
-	"type": "token",
-	"expression": "Procedure.status",
-	"xpath": "f:Procedure/f:status",
-	"xpathUsage": "normal",
-	"multipleOr": true,
-	"_multipleOr": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "SHALL"
-			}
-		]
-	},
-	"multipleAnd": true,
-	"_multipleAnd": {
-		"extension": [
-			{
-				"url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
-				"valueCode": "MAY"
-			}
-		]
-	}
+    "resourceType": "SearchParameter",
+    "id": "us-core-procedure-status",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "extension": [
+        {
+            "url": "http://ibm.com/fhir/extension/implicit-system",
+            "valueUri": "http://hl7.org/fhir/event-status"
+        }
+    ],
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-status",
+    "version": "4.0.0",
+    "name": "USCoreProcedureStatus",
+    "derivedFrom": "http://hl7.org/fhir/SearchParameter/Procedure-status",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-20T05:19:29.196316Z",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "**preparation | in-progress | not-done | on-hold | stopped | completed | entered-in-error | unknown**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "status",
+    "base": [
+        "Procedure"
+    ],
+    "type": "token",
+    "expression": "Procedure.status",
+    "xpath": "f:Procedure/f:status",
+    "xpathUsage": "normal",
+    "multipleOr": true,
+    "_multipleOr": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "SHALL"
+            }
+        ]
+    },
+    "multipleAnd": true,
+    "_multipleAnd": {
+        "extension": [
+            {
+                "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                "valueCode": "MAY"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-race.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/SearchParameter-us-core-race.json
@@ -1,44 +1,44 @@
 {
-	"resourceType": "SearchParameter",
-	"id": "us-core-race",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative</b></p><p><b>url</b>: <code>http://hl7.org/fhir/us/core/SearchParameter/us-core-race</code></p><p><b>version</b>: 4.0.0</p><p><b>name</b>: USCoreRace</p><p><b>status</b>: active</p><p><b>date</b>: 2019-05-21</p><p><b>publisher</b>: HL7 International - US Realm Steering Committee</p><p><b>contact</b>: HL7 International - US Realm Steering Committee: <a href=\"http://www.hl7.org/Special/committees/usrealm/index.cfm\">http://www.hl7.org/Special/committees/usrealm/index.cfm</a></p><p><b>description</b>: Returns patients with a race extension matching the specified code.</p><p><b>jurisdiction</b>: <span title=\"Codes: {urn:iso:std:iso:3166 US}\">United States of America</span></p><p><b>code</b>: race</p><p><b>base</b>: Patient</p><p><b>type</b>: token</p><p><b>expression</b>: Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race').extension.value.code</p><p><b>xpath</b>: f:Patient/f:extension[@url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-race']/f:extension/f:valueCoding/f:code/@value</p><p><b>xpathUsage</b>: normal</p></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-race",
-	"version": "4.0.0",
-	"name": "USCoreRace",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Returns patients with a race extension matching the specified code.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"code": "race",
-	"base": [
-		"Patient"
-	],
-	"type": "token",
-	"expression": "Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race').extension.value.code",
-	"xpath": "f:Patient/f:extension[@url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-race']/f:extension/f:valueCoding/f:code/@value",
-	"xpathUsage": "normal"
+    "resourceType": "SearchParameter",
+    "id": "us-core-race",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/SearchParameter/us-core-race",
+    "version": "4.0.0",
+    "name": "USCoreRace",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Returns patients with a race extension matching the specified code.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "code": "race",
+    "base": [
+        "Patient"
+    ],
+    "type": "token",
+    "expression": "Patient.extension.where(url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race').extension.value.code",
+    "xpath": "f:Patient/f:extension[@url='http://hl7.org/fhir/us/core/StructureDefinition/us-core-race']/f:extension/f:valueCoding/f:code/@value",
+    "xpathUsage": "normal"
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-head-occipital-frontal-circumference-percentile.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-head-occipital-frontal-circumference-percentile.json
@@ -1,3810 +1,3810 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "head-occipital-frontal-circumference-percentile",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-head-occipital-frontal-circumference-percentile-definitions.html#Observation\" title=\"Defines constraints on the Observation resource to represent head occipital-frontal circumference percentile for patients from birth to 36 months of age in FHIR using a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.\">Observation</a><a name=\"Observation\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"StructureDefinition-us-core-vital-signs.html\">USCoreVitalSignsProfile</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">US Core Pediatric Head Occipital-frontal Circumference Percentile Profile</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-head-occipital-frontal-circumference-percentile-definitions.html#Observation.code\">code</a><a name=\"Observation.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">1</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Head Occipital-frontal circumference Percentile<br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck101.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#CodeableConcept.coding\">coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Code defined by a terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">(complex)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/loinc.html\">http://loinc.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">8289-1</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-head-occipital-frontal-circumference-percentile-definitions.html#Observation.valueQuantity\">valueQuantity</a><a name=\"Observation.valueQuantity\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Quantity\">Quantity</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Vital Signs Value</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-head-occipital-frontal-circumference-percentile-definitions.html#Observation.valueQuantity.value\">value</a><a name=\"Observation.valueQuantity.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#decimal\">decimal</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Numerical value (with implicit precision)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-head-occipital-frontal-circumference-percentile-definitions.html#Observation.valueQuantity.unit\">unit</a><a name=\"Observation.valueQuantity.unit\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Unit representation</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-head-occipital-frontal-circumference-percentile-definitions.html#Observation.valueQuantity.system\">system</a><a name=\"Observation.valueQuantity.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">System that defines coded unit form</span><br/><span style=\"font-weight:bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/ucum.html\">http://unitsofmeasure.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-head-occipital-frontal-circumference-percentile-definitions.html#Observation.valueQuantity.code\">code</a><a name=\"Observation.valueQuantity.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Coded responses from the common UCUM units for vital signs value set.<br/><span style=\"font-weight:bold\">Fixed Value: </span><span style=\"color: darkgreen\">%</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile",
-	"version": "4.0.0",
-	"name": "USCorePediatricHeadOccipitalFrontalCircumferencePercentileProfile",
-	"title": "US Core Pediatric Head Occipital-frontal Circumference Percentile Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-18",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints on the Observation resource to represent head occipital-frontal circumference percentile for patients from birth to 36 months of age in FHIR using a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "sct-concept",
-			"uri": "http://snomed.info/conceptdomain",
-			"name": "SNOMED CT Concept Domain Binding"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "sct-attr",
-			"uri": "http://snomed.org/attributebinding",
-			"name": "SNOMED CT Attribute Binding"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Observation",
-	"baseDefinition": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "US Core Pediatric Head Occipital-frontal Circumference Percentile Profile",
-				"definition": "Defines constraints on the Observation resource to represent head occipital-frontal circumference percentile for patients from birth to 36 months of age in FHIR using a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
-				"alias": [
-					"Vital Signs",
-					"Measurement",
-					"Results",
-					"Tests"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "obs-6",
-						"severity": "error",
-						"human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
-						"expression": "dataAbsentReason.empty() or value.empty()",
-						"xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "obs-7",
-						"severity": "error",
-						"human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
-						"expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
-						"xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "vs-2",
-						"severity": "error",
-						"human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
-						"expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
-						"xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.id",
-				"path": "Observation.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.meta",
-				"path": "Observation.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.implicitRules",
-				"path": "Observation.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Observation.language",
-				"path": "Observation.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Observation.text",
-				"path": "Observation.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Observation.contained",
-				"path": "Observation.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.extension",
-				"path": "Observation.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.modifierExtension",
-				"path": "Observation.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.identifier",
-				"path": "Observation.identifier",
-				"short": "Business Identifier for observation",
-				"definition": "A unique identifier assigned to this observation.",
-				"requirements": "Allows observations to be distinguished and referenced.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
-					},
-					{
-						"identity": "rim",
-						"map": "id"
-					}
-				]
-			},
-			{
-				"id": "Observation.basedOn",
-				"path": "Observation.basedOn",
-				"short": "Fulfills plan, proposal or order",
-				"definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
-				"requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
-				"alias": [
-					"Fulfills"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan",
-							"http://hl7.org/fhir/StructureDefinition/DeviceRequest",
-							"http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
-							"http://hl7.org/fhir/StructureDefinition/MedicationRequest",
-							"http://hl7.org/fhir/StructureDefinition/NutritionOrder",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.basedOn"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.partOf",
-				"path": "Observation.partOf",
-				"short": "Part of referenced event",
-				"definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
-				"comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
-				"alias": [
-					"Container"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.partOf",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
-							"http://hl7.org/fhir/StructureDefinition/MedicationDispense",
-							"http://hl7.org/fhir/StructureDefinition/MedicationStatement",
-							"http://hl7.org/fhir/StructureDefinition/Procedure",
-							"http://hl7.org/fhir/StructureDefinition/Immunization",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.partOf"
-					},
-					{
-						"identity": "v2",
-						"map": "Varies by domain"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=FLFS].target"
-					}
-				]
-			},
-			{
-				"id": "Observation.status",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
-						"valueString": "default: final"
-					}
-				],
-				"path": "Observation.status",
-				"short": "registered | preliminary | final | amended +",
-				"definition": "The status of the result value.",
-				"comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
-				"requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Status"
-						}
-					],
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 445584004 |Report by finality status|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-11"
-					},
-					{
-						"identity": "rim",
-						"map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
-					}
-				]
-			},
-			{
-				"id": "Observation.category",
-				"path": "Observation.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "coding.code"
-						},
-						{
-							"type": "value",
-							"path": "coding.system"
-						}
-					],
-					"ordered": false,
-					"rules": "open"
-				},
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat",
-				"path": "Observation.category",
-				"sliceName": "VSCat",
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.id",
-				"path": "Observation.category.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.extension",
-				"path": "Observation.category.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding",
-				"path": "Observation.category.coding",
-				"short": "Code defined by a terminology system",
-				"definition": "A reference to a code defined by a terminology system.",
-				"comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
-				"requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "CodeableConcept.coding",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1-8, C*E.10-22"
-					},
-					{
-						"identity": "rim",
-						"map": "union(., ./translation)"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.id",
-				"path": "Observation.category.coding.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.extension",
-				"path": "Observation.category.coding.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.system",
-				"path": "Observation.category.coding.system",
-				"short": "Identity of the terminology system",
-				"definition": "The identification of the code system that defines the meaning of the symbol in the code.",
-				"comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
-				"requirements": "Need to be unambiguous about the source of the definition of the symbol.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.3"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystem"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.version",
-				"path": "Observation.category.coding.version",
-				"short": "Version of the system - if relevant",
-				"definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
-				"comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.version",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.7"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystemVersion"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.code",
-				"path": "Observation.category.coding.code",
-				"short": "Symbol in syntax defined by the system",
-				"definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
-				"requirements": "Need to refer to a particular code in the system.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "vital-signs",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1"
-					},
-					{
-						"identity": "rim",
-						"map": "./code"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.display",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.coding.display",
-				"short": "Representation defined by the system",
-				"definition": "A representation of the meaning of the code in the system, following the rules of the system.",
-				"requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.display",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.2 - but note this is not well followed"
-					},
-					{
-						"identity": "rim",
-						"map": "CV.displayName"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.userSelected",
-				"path": "Observation.category.coding.userSelected",
-				"short": "If this coding was chosen directly by the user",
-				"definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
-				"comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
-				"requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.userSelected",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Sometimes implied by being first"
-					},
-					{
-						"identity": "rim",
-						"map": "CD.codingRationale"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.text",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.text",
-				"short": "Plain text representation of the concept",
-				"definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
-				"comment": "Very often the text is the same as a displayName of one of the codings.",
-				"requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CodeableConcept.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.9. But note many systems use C*E.2 for this"
-					},
-					{
-						"identity": "rim",
-						"map": "./originalText[mediaType/code=\"text/plain\"]/data"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
-					}
-				]
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Head Occipital-frontal circumference Percentile",
-				"definition": "Coded Responses from C-CDA Vital Sign Results.",
-				"comment": "*All* code-value and, if present, component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
-				"alias": [
-					"Name"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "8289-1"
-						}
-					]
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "116680003 |Is a|"
-					}
-				]
-			},
-			{
-				"id": "Observation.subject",
-				"path": "Observation.subject",
-				"short": "Who and/or what the observation is about",
-				"definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
-				"comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
-				"requirements": "Observations have no value if you don't know who or what they're about.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=RTGT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.focus",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
-						"valueCode": "trial-use"
-					}
-				],
-				"path": "Observation.focus",
-				"short": "What the observation is about, when it is not about the subject of record",
-				"definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
-				"comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.focus",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SBJ]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.encounter",
-				"path": "Observation.encounter",
-				"short": "Healthcare event during which this observation is made",
-				"definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
-				"comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
-				"requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
-				"alias": [
-					"Context"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.effective[x]",
-				"path": "Observation.effective[x]",
-				"short": "Often just a dateTime for Vital Signs",
-				"definition": "Often just a dateTime for Vital Signs.",
-				"comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
-				"requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
-				"alias": [
-					"Occurrence"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.effective[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-1",
-						"severity": "error",
-						"human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
-						"expression": "($this as dateTime).toString().length() >= 8",
-						"xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "Observation.issued",
-				"path": "Observation.issued",
-				"short": "Date/Time this version was made available",
-				"definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
-				"comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.issued",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=AUT].time"
-					}
-				]
-			},
-			{
-				"id": "Observation.performer",
-				"path": "Observation.performer",
-				"short": "Who is responsible for the observation",
-				"definition": "Who was responsible for asserting the observed value as \"true\".",
-				"requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.performer",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=PRF]"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]",
-				"path": "Observation.value[x]",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "type",
-							"path": "$this"
-						}
-					],
-					"ordered": false,
-					"rules": "closed"
-				},
-				"short": "Vital Signs Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity",
-				"path": "Observation.value[x]",
-				"sliceName": "valueQuantity",
-				"short": "Vital Signs Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.id",
-				"path": "Observation.value[x].id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.extension",
-				"path": "Observation.value[x].extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.value",
-				"path": "Observation.value[x].value",
-				"short": "Numerical value (with implicit precision)",
-				"definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
-				"comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
-				"requirements": "Precision is handled implicitly in almost all cases of measurement.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.2  / CQ - N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.comparator",
-				"path": "Observation.value[x].comparator",
-				"short": "< | <= | >= | > - how to understand the value",
-				"definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
-				"requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Quantity.comparator",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "QuantityComparator"
-						}
-					],
-					"strength": "required",
-					"description": "How the Quantity should be understood and represented.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.1  / CQ.1"
-					},
-					{
-						"identity": "rim",
-						"map": "IVL properties"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.unit",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.value[x].unit",
-				"short": "Unit representation",
-				"definition": "A human-readable form of the unit.",
-				"requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.unit",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.unit"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.system",
-				"path": "Observation.value[x].system",
-				"short": "System that defines coded unit form",
-				"definition": "The identification of the system that provides the coded form of the unit.",
-				"requirements": "Need to know the system that defines the coded form of the unit.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"condition": [
-					"qty-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "CO.codeSystem, PQ.translation.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.code",
-				"path": "Observation.value[x].code",
-				"short": "Coded responses from the common UCUM units for vital signs value set.",
-				"definition": "A computer processable form of the unit in some unit representation system.",
-				"comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
-				"requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "%",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.code, MO.currency, PQ.translation.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.dataAbsentReason",
-				"path": "Observation.dataAbsentReason",
-				"short": "Why the result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
-				"comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.interpretation",
-				"path": "Observation.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.note",
-				"path": "Observation.note",
-				"short": "Comments about the observation",
-				"definition": "Comments about the observation or the results.",
-				"comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
-				"requirements": "Need to be able to provide free text additional information.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
-					},
-					{
-						"identity": "rim",
-						"map": "subjectOf.observationEvent[code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.bodySite",
-				"path": "Observation.bodySite",
-				"short": "Observed body part",
-				"definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
-				"comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.bodySite",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "BodySite"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing anatomical locations. May include laterality.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/body-site"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123037004 |Body structure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-20"
-					},
-					{
-						"identity": "rim",
-						"map": "targetSiteCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "718497002 |Inherent location|"
-					}
-				]
-			},
-			{
-				"id": "Observation.method",
-				"path": "Observation.method",
-				"short": "How it was done",
-				"definition": "Indicates the mechanism used to perform the observation.",
-				"comment": "Only used if not implicit in code for Observation.code.",
-				"requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.method",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationMethod"
-						}
-					],
-					"strength": "example",
-					"description": "Methods for simple observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-17"
-					},
-					{
-						"identity": "rim",
-						"map": "methodCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.specimen",
-				"path": "Observation.specimen",
-				"short": "Specimen used for this observation",
-				"definition": "The specimen that was used when this observation was made.",
-				"comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.specimen",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Specimen"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123038009 |Specimen|"
-					},
-					{
-						"identity": "v2",
-						"map": "SPM segment"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SPC].specimen"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "704319004 |Inherent in|"
-					}
-				]
-			},
-			{
-				"id": "Observation.device",
-				"path": "Observation.device",
-				"short": "(Measurement) Device",
-				"definition": "The device used to generate the observation data.",
-				"comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.device",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/DeviceMetric"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 49062001 |Device|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-17 / PRT -10"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=DEV]"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "424226004 |Using device|"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange",
-				"path": "Observation.referenceRange",
-				"short": "Provides guide for interpretation",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "obs-3",
-						"severity": "error",
-						"human": "Must have at least a low or a high or text",
-						"expression": "low.exists() or high.exists() or text.exists()",
-						"xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.id",
-				"path": "Observation.referenceRange.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.extension",
-				"path": "Observation.referenceRange.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.modifierExtension",
-				"path": "Observation.referenceRange.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.low",
-				"path": "Observation.referenceRange.low",
-				"short": "Low Range, if relevant",
-				"definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.low",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.low"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.high",
-				"path": "Observation.referenceRange.high",
-				"short": "High Range, if relevant",
-				"definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.high",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.high"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.type",
-				"path": "Observation.referenceRange.type",
-				"short": "Reference range qualifier",
-				"definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
-				"requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeMeaning"
-						}
-					],
-					"strength": "preferred",
-					"description": "Code for the meaning of a reference range.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.appliesTo",
-				"path": "Observation.referenceRange.appliesTo",
-				"short": "Reference range population",
-				"definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
-				"requirements": "Need to be able to identify the target population for proper interpretation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange.appliesTo",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeType"
-						}
-					],
-					"strength": "example",
-					"description": "Codes identifying the population the reference range applies to.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.age",
-				"path": "Observation.referenceRange.age",
-				"short": "Applicable age range, if relevant",
-				"definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
-				"requirements": "Some analytes vary greatly over age.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.age",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Range"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.text",
-				"path": "Observation.referenceRange.text",
-				"short": "Text based reference range in an observation",
-				"definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:ST"
-					}
-				]
-			},
-			{
-				"id": "Observation.hasMember",
-				"path": "Observation.hasMember",
-				"short": "Used when reporting vital signs panel components",
-				"definition": "Used when reporting vital signs panel components.",
-				"comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.hasMember",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship"
-					}
-				]
-			},
-			{
-				"id": "Observation.derivedFrom",
-				"path": "Observation.derivedFrom",
-				"short": "Related measurements the observation is made from",
-				"definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
-				"comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.derivedFrom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/DocumentReference",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy",
-							"http://hl7.org/fhir/StructureDefinition/Media",
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": ".targetObservation"
-					}
-				]
-			},
-			{
-				"id": "Observation.component",
-				"path": "Observation.component",
-				"short": "Component observations",
-				"definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
-				"comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-3",
-						"severity": "error",
-						"human": "If there is no a value a data absent reason must be present",
-						"expression": "value.exists() or dataAbsentReason.exists()",
-						"xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "containment by OBX-4?"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=COMP]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.id",
-				"path": "Observation.component.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.extension",
-				"path": "Observation.component.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.modifierExtension",
-				"path": "Observation.component.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.code",
-				"path": "Observation.component.code",
-				"short": "Type of component observation (code / type)",
-				"definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
-				"comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.value[x]",
-				"path": "Observation.component.value[x]",
-				"short": "Vital Sign Component Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
-				"comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "Quantity"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.dataAbsentReason",
-				"path": "Observation.component.dataAbsentReason",
-				"short": "Why the component result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
-				"comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.interpretation",
-				"path": "Observation.component.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.referenceRange",
-				"path": "Observation.component.referenceRange",
-				"short": "Provides guide for interpretation of component result",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "US Core Pediatric Head Occipital-frontal Circumference Percentile Profile",
-				"definition": "Defines constraints on the Observation resource to represent head occipital-frontal circumference percentile for patients from birth to 36 months of age in FHIR using a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"mustSupport": false
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Head Occipital-frontal circumference Percentile",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "8289-1"
-						}
-					]
-				},
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity",
-				"path": "Observation.valueQuantity",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.value",
-				"path": "Observation.valueQuantity.value",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.unit",
-				"path": "Observation.valueQuantity.unit",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.system",
-				"path": "Observation.valueQuantity.system",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.code",
-				"path": "Observation.valueQuantity.code",
-				"short": "Coded responses from the common UCUM units for vital signs value set.",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "%",
-				"mustSupport": true
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "head-occipital-frontal-circumference-percentile",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile",
+    "version": "4.0.0",
+    "name": "USCorePediatricHeadOccipitalFrontalCircumferencePercentileProfile",
+    "title": "US Core Pediatric Head Occipital-frontal Circumference Percentile Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-18",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints on the Observation resource to represent head occipital-frontal circumference percentile for patients from birth to 36 months of age in FHIR using a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "sct-concept",
+            "uri": "http://snomed.info/conceptdomain",
+            "name": "SNOMED CT Concept Domain Binding"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "sct-attr",
+            "uri": "http://snomed.org/attributebinding",
+            "name": "SNOMED CT Attribute Binding"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Observation",
+    "baseDefinition": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "US Core Pediatric Head Occipital-frontal Circumference Percentile Profile",
+                "definition": "Defines constraints on the Observation resource to represent head occipital-frontal circumference percentile for patients from birth to 36 months of age in FHIR using a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
+                "alias": [
+                    "Vital Signs",
+                    "Measurement",
+                    "Results",
+                    "Tests"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "obs-6",
+                        "severity": "error",
+                        "human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
+                        "expression": "dataAbsentReason.empty() or value.empty()",
+                        "xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "obs-7",
+                        "severity": "error",
+                        "human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
+                        "expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
+                        "xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "vs-2",
+                        "severity": "error",
+                        "human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
+                        "expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
+                        "xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.id",
+                "path": "Observation.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.meta",
+                "path": "Observation.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.implicitRules",
+                "path": "Observation.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Observation.language",
+                "path": "Observation.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Observation.text",
+                "path": "Observation.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.contained",
+                "path": "Observation.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.extension",
+                "path": "Observation.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.modifierExtension",
+                "path": "Observation.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.identifier",
+                "path": "Observation.identifier",
+                "short": "Business Identifier for observation",
+                "definition": "A unique identifier assigned to this observation.",
+                "requirements": "Allows observations to be distinguished and referenced.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "id"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.basedOn",
+                "path": "Observation.basedOn",
+                "short": "Fulfills plan, proposal or order",
+                "definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
+                "requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
+                "alias": [
+                    "Fulfills"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceRequest",
+                            "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+                            "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.basedOn"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.partOf",
+                "path": "Observation.partOf",
+                "short": "Part of referenced event",
+                "definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
+                "comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
+                "alias": [
+                    "Container"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.partOf",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationDispense",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationStatement",
+                            "http://hl7.org/fhir/StructureDefinition/Procedure",
+                            "http://hl7.org/fhir/StructureDefinition/Immunization",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.partOf"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "Varies by domain"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=FLFS].target"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.status",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
+                        "valueString": "default: final"
+                    }
+                ],
+                "path": "Observation.status",
+                "short": "registered | preliminary | final | amended +",
+                "definition": "The status of the result value.",
+                "comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
+                "requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Status"
+                        }
+                    ],
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 445584004 |Report by finality status|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-11"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category",
+                "path": "Observation.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "coding.code"
+                        },
+                        {
+                            "type": "value",
+                            "path": "coding.system"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "open"
+                },
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat",
+                "path": "Observation.category",
+                "sliceName": "VSCat",
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.id",
+                "path": "Observation.category.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.extension",
+                "path": "Observation.category.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding",
+                "path": "Observation.category.coding",
+                "short": "Code defined by a terminology system",
+                "definition": "A reference to a code defined by a terminology system.",
+                "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+                "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "CodeableConcept.coding",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1-8, C*E.10-22"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "union(., ./translation)"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.id",
+                "path": "Observation.category.coding.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.extension",
+                "path": "Observation.category.coding.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.system",
+                "path": "Observation.category.coding.system",
+                "short": "Identity of the terminology system",
+                "definition": "The identification of the code system that defines the meaning of the symbol in the code.",
+                "comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
+                "requirements": "Need to be unambiguous about the source of the definition of the symbol.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystem"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.version",
+                "path": "Observation.category.coding.version",
+                "short": "Version of the system - if relevant",
+                "definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
+                "comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.version",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystemVersion"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.code",
+                "path": "Observation.category.coding.code",
+                "short": "Symbol in syntax defined by the system",
+                "definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
+                "requirements": "Need to refer to a particular code in the system.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "vital-signs",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./code"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.display",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.coding.display",
+                "short": "Representation defined by the system",
+                "definition": "A representation of the meaning of the code in the system, following the rules of the system.",
+                "requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.display",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.2 - but note this is not well followed"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CV.displayName"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.userSelected",
+                "path": "Observation.category.coding.userSelected",
+                "short": "If this coding was chosen directly by the user",
+                "definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
+                "comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
+                "requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.userSelected",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Sometimes implied by being first"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CD.codingRationale"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.text",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.text",
+                "short": "Plain text representation of the concept",
+                "definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
+                "comment": "Very often the text is the same as a displayName of one of the codings.",
+                "requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CodeableConcept.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.9. But note many systems use C*E.2 for this"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./originalText[mediaType/code=\"text/plain\"]/data"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Head Occipital-frontal circumference Percentile",
+                "definition": "Coded Responses from C-CDA Vital Sign Results.",
+                "comment": "*All* code-value and, if present, component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
+                "alias": [
+                    "Name"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "8289-1"
+                        }
+                    ]
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "116680003 |Is a|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.subject",
+                "path": "Observation.subject",
+                "short": "Who and/or what the observation is about",
+                "definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
+                "comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
+                "requirements": "Observations have no value if you don't know who or what they're about.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=RTGT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.focus",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+                        "valueCode": "trial-use"
+                    }
+                ],
+                "path": "Observation.focus",
+                "short": "What the observation is about, when it is not about the subject of record",
+                "definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
+                "comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.focus",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SBJ]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.encounter",
+                "path": "Observation.encounter",
+                "short": "Healthcare event during which this observation is made",
+                "definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
+                "comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
+                "requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
+                "alias": [
+                    "Context"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.effective[x]",
+                "path": "Observation.effective[x]",
+                "short": "Often just a dateTime for Vital Signs",
+                "definition": "Often just a dateTime for Vital Signs.",
+                "comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
+                "requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
+                "alias": [
+                    "Occurrence"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.effective[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-1",
+                        "severity": "error",
+                        "human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
+                        "expression": "($this as dateTime).toString().length() >= 8",
+                        "xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.issued",
+                "path": "Observation.issued",
+                "short": "Date/Time this version was made available",
+                "definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
+                "comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.issued",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.performer",
+                "path": "Observation.performer",
+                "short": "Who is responsible for the observation",
+                "definition": "Who was responsible for asserting the observed value as \"true\".",
+                "requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.performer",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=PRF]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]",
+                "path": "Observation.value[x]",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "type",
+                            "path": "$this"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "closed"
+                },
+                "short": "Vital Signs Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity",
+                "path": "Observation.value[x]",
+                "sliceName": "valueQuantity",
+                "short": "Vital Signs Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.id",
+                "path": "Observation.value[x].id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.extension",
+                "path": "Observation.value[x].extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.value",
+                "path": "Observation.value[x].value",
+                "short": "Numerical value (with implicit precision)",
+                "definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
+                "comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
+                "requirements": "Precision is handled implicitly in almost all cases of measurement.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.2  / CQ - N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.comparator",
+                "path": "Observation.value[x].comparator",
+                "short": "< | <= | >= | > - how to understand the value",
+                "definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
+                "requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.comparator",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "QuantityComparator"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "How the Quantity should be understood and represented.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.1  / CQ.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "IVL properties"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.unit",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.value[x].unit",
+                "short": "Unit representation",
+                "definition": "A human-readable form of the unit.",
+                "requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.unit",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.unit"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.system",
+                "path": "Observation.value[x].system",
+                "short": "System that defines coded unit form",
+                "definition": "The identification of the system that provides the coded form of the unit.",
+                "requirements": "Need to know the system that defines the coded form of the unit.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "condition": [
+                    "qty-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CO.codeSystem, PQ.translation.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.code",
+                "path": "Observation.value[x].code",
+                "short": "Coded responses from the common UCUM units for vital signs value set.",
+                "definition": "A computer processable form of the unit in some unit representation system.",
+                "comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
+                "requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "%",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.code, MO.currency, PQ.translation.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.dataAbsentReason",
+                "path": "Observation.dataAbsentReason",
+                "short": "Why the result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
+                "comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.interpretation",
+                "path": "Observation.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.note",
+                "path": "Observation.note",
+                "short": "Comments about the observation",
+                "definition": "Comments about the observation or the results.",
+                "comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
+                "requirements": "Need to be able to provide free text additional information.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "subjectOf.observationEvent[code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.bodySite",
+                "path": "Observation.bodySite",
+                "short": "Observed body part",
+                "definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
+                "comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.bodySite",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "BodySite"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing anatomical locations. May include laterality.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/body-site"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123037004 |Body structure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-20"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "targetSiteCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "718497002 |Inherent location|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.method",
+                "path": "Observation.method",
+                "short": "How it was done",
+                "definition": "Indicates the mechanism used to perform the observation.",
+                "comment": "Only used if not implicit in code for Observation.code.",
+                "requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.method",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationMethod"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Methods for simple observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "methodCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.specimen",
+                "path": "Observation.specimen",
+                "short": "Specimen used for this observation",
+                "definition": "The specimen that was used when this observation was made.",
+                "comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.specimen",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Specimen"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123038009 |Specimen|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "SPM segment"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SPC].specimen"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "704319004 |Inherent in|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.device",
+                "path": "Observation.device",
+                "short": "(Measurement) Device",
+                "definition": "The device used to generate the observation data.",
+                "comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.device",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceMetric"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 49062001 |Device|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17 / PRT -10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=DEV]"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "424226004 |Using device|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange",
+                "path": "Observation.referenceRange",
+                "short": "Provides guide for interpretation",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "obs-3",
+                        "severity": "error",
+                        "human": "Must have at least a low or a high or text",
+                        "expression": "low.exists() or high.exists() or text.exists()",
+                        "xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.id",
+                "path": "Observation.referenceRange.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.extension",
+                "path": "Observation.referenceRange.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.modifierExtension",
+                "path": "Observation.referenceRange.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.low",
+                "path": "Observation.referenceRange.low",
+                "short": "Low Range, if relevant",
+                "definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.low",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.low"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.high",
+                "path": "Observation.referenceRange.high",
+                "short": "High Range, if relevant",
+                "definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.high",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.high"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.type",
+                "path": "Observation.referenceRange.type",
+                "short": "Reference range qualifier",
+                "definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
+                "requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeMeaning"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Code for the meaning of a reference range.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.appliesTo",
+                "path": "Observation.referenceRange.appliesTo",
+                "short": "Reference range population",
+                "definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
+                "requirements": "Need to be able to identify the target population for proper interpretation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange.appliesTo",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes identifying the population the reference range applies to.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.age",
+                "path": "Observation.referenceRange.age",
+                "short": "Applicable age range, if relevant",
+                "definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
+                "requirements": "Some analytes vary greatly over age.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.age",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Range"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.text",
+                "path": "Observation.referenceRange.text",
+                "short": "Text based reference range in an observation",
+                "definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:ST"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.hasMember",
+                "path": "Observation.hasMember",
+                "short": "Used when reporting vital signs panel components",
+                "definition": "Used when reporting vital signs panel components.",
+                "comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.hasMember",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.derivedFrom",
+                "path": "Observation.derivedFrom",
+                "short": "Related measurements the observation is made from",
+                "definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
+                "comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.derivedFrom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/DocumentReference",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy",
+                            "http://hl7.org/fhir/StructureDefinition/Media",
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".targetObservation"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component",
+                "path": "Observation.component",
+                "short": "Component observations",
+                "definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
+                "comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-3",
+                        "severity": "error",
+                        "human": "If there is no a value a data absent reason must be present",
+                        "expression": "value.exists() or dataAbsentReason.exists()",
+                        "xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "containment by OBX-4?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=COMP]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.id",
+                "path": "Observation.component.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.extension",
+                "path": "Observation.component.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.modifierExtension",
+                "path": "Observation.component.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.code",
+                "path": "Observation.component.code",
+                "short": "Type of component observation (code / type)",
+                "definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
+                "comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.value[x]",
+                "path": "Observation.component.value[x]",
+                "short": "Vital Sign Component Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
+                "comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.dataAbsentReason",
+                "path": "Observation.component.dataAbsentReason",
+                "short": "Why the component result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
+                "comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.interpretation",
+                "path": "Observation.component.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.referenceRange",
+                "path": "Observation.component.referenceRange",
+                "short": "Provides guide for interpretation of component result",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "US Core Pediatric Head Occipital-frontal Circumference Percentile Profile",
+                "definition": "Defines constraints on the Observation resource to represent head occipital-frontal circumference percentile for patients from birth to 36 months of age in FHIR using a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "mustSupport": false
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Head Occipital-frontal circumference Percentile",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "8289-1"
+                        }
+                    ]
+                },
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity",
+                "path": "Observation.valueQuantity",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.value",
+                "path": "Observation.valueQuantity.value",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.unit",
+                "path": "Observation.valueQuantity.unit",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.system",
+                "path": "Observation.valueQuantity.system",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.code",
+                "path": "Observation.valueQuantity.code",
+                "short": "Coded responses from the common UCUM units for vital signs value set.",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "%",
+                "mustSupport": true
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-pediatric-bmi-for-age.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-pediatric-bmi-for-age.json
@@ -1,3810 +1,3810 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "pediatric-bmi-for-age",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-pediatric-bmi-for-age-definitions.html#Observation\" title=\"Defines constraints on Observation to represent to represent BMI percentile per age and sex for youth 2-20 observations in FHIR using a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.\">Observation</a><a name=\"Observation\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"StructureDefinition-us-core-vital-signs.html\">USCoreVitalSignsProfile</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">US Core Pediatric BMI for Age Observation Profile</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-pediatric-bmi-for-age-definitions.html#Observation.code\">code</a><a name=\"Observation.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">1</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">BMI percentile per age and sex for youth 2-20<br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck101.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#CodeableConcept.coding\">coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Code defined by a terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">(complex)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/loinc.html\">http://loinc.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">59576-9</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-pediatric-bmi-for-age-definitions.html#Observation.valueQuantity\">valueQuantity</a><a name=\"Observation.valueQuantity\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Quantity\">Quantity</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Vital Signs Value</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-pediatric-bmi-for-age-definitions.html#Observation.valueQuantity.value\">value</a><a name=\"Observation.valueQuantity.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#decimal\">decimal</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Numerical value (with implicit precision)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-pediatric-bmi-for-age-definitions.html#Observation.valueQuantity.unit\">unit</a><a name=\"Observation.valueQuantity.unit\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Unit representation</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-pediatric-bmi-for-age-definitions.html#Observation.valueQuantity.system\">system</a><a name=\"Observation.valueQuantity.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">System that defines coded unit form</span><br/><span style=\"font-weight:bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/ucum.html\">http://unitsofmeasure.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-pediatric-bmi-for-age-definitions.html#Observation.valueQuantity.code\">code</a><a name=\"Observation.valueQuantity.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Coded responses from the common UCUM units for vital signs value set.<br/><span style=\"font-weight:bold\">Fixed Value: </span><span style=\"color: darkgreen\">%</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age",
-	"version": "4.0.0",
-	"name": "USCorePediatricBMIforAgeObservationProfile",
-	"title": "US Core Pediatric BMI for Age Observation Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-18",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints on Observation to represent to represent BMI percentile per age and sex for youth 2-20 observations in FHIR using a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "sct-concept",
-			"uri": "http://snomed.info/conceptdomain",
-			"name": "SNOMED CT Concept Domain Binding"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "sct-attr",
-			"uri": "http://snomed.org/attributebinding",
-			"name": "SNOMED CT Attribute Binding"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Observation",
-	"baseDefinition": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "US Core Pediatric BMI for Age Observation Profile",
-				"definition": "Defines constraints on Observation to represent to represent BMI percentile per age and sex for youth 2-20 observations in FHIR using a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
-				"alias": [
-					"Vital Signs",
-					"Measurement",
-					"Results",
-					"Tests"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "obs-6",
-						"severity": "error",
-						"human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
-						"expression": "dataAbsentReason.empty() or value.empty()",
-						"xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "obs-7",
-						"severity": "error",
-						"human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
-						"expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
-						"xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "vs-2",
-						"severity": "error",
-						"human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
-						"expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
-						"xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.id",
-				"path": "Observation.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.meta",
-				"path": "Observation.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.implicitRules",
-				"path": "Observation.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Observation.language",
-				"path": "Observation.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Observation.text",
-				"path": "Observation.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Observation.contained",
-				"path": "Observation.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.extension",
-				"path": "Observation.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.modifierExtension",
-				"path": "Observation.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.identifier",
-				"path": "Observation.identifier",
-				"short": "Business Identifier for observation",
-				"definition": "A unique identifier assigned to this observation.",
-				"requirements": "Allows observations to be distinguished and referenced.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
-					},
-					{
-						"identity": "rim",
-						"map": "id"
-					}
-				]
-			},
-			{
-				"id": "Observation.basedOn",
-				"path": "Observation.basedOn",
-				"short": "Fulfills plan, proposal or order",
-				"definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
-				"requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
-				"alias": [
-					"Fulfills"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan",
-							"http://hl7.org/fhir/StructureDefinition/DeviceRequest",
-							"http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
-							"http://hl7.org/fhir/StructureDefinition/MedicationRequest",
-							"http://hl7.org/fhir/StructureDefinition/NutritionOrder",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.basedOn"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.partOf",
-				"path": "Observation.partOf",
-				"short": "Part of referenced event",
-				"definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
-				"comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
-				"alias": [
-					"Container"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.partOf",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
-							"http://hl7.org/fhir/StructureDefinition/MedicationDispense",
-							"http://hl7.org/fhir/StructureDefinition/MedicationStatement",
-							"http://hl7.org/fhir/StructureDefinition/Procedure",
-							"http://hl7.org/fhir/StructureDefinition/Immunization",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.partOf"
-					},
-					{
-						"identity": "v2",
-						"map": "Varies by domain"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=FLFS].target"
-					}
-				]
-			},
-			{
-				"id": "Observation.status",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
-						"valueString": "default: final"
-					}
-				],
-				"path": "Observation.status",
-				"short": "registered | preliminary | final | amended +",
-				"definition": "The status of the result value.",
-				"comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
-				"requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Status"
-						}
-					],
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 445584004 |Report by finality status|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-11"
-					},
-					{
-						"identity": "rim",
-						"map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
-					}
-				]
-			},
-			{
-				"id": "Observation.category",
-				"path": "Observation.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "coding.code"
-						},
-						{
-							"type": "value",
-							"path": "coding.system"
-						}
-					],
-					"ordered": false,
-					"rules": "open"
-				},
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat",
-				"path": "Observation.category",
-				"sliceName": "VSCat",
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.id",
-				"path": "Observation.category.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.extension",
-				"path": "Observation.category.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding",
-				"path": "Observation.category.coding",
-				"short": "Code defined by a terminology system",
-				"definition": "A reference to a code defined by a terminology system.",
-				"comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
-				"requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "CodeableConcept.coding",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1-8, C*E.10-22"
-					},
-					{
-						"identity": "rim",
-						"map": "union(., ./translation)"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.id",
-				"path": "Observation.category.coding.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.extension",
-				"path": "Observation.category.coding.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.system",
-				"path": "Observation.category.coding.system",
-				"short": "Identity of the terminology system",
-				"definition": "The identification of the code system that defines the meaning of the symbol in the code.",
-				"comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
-				"requirements": "Need to be unambiguous about the source of the definition of the symbol.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.3"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystem"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.version",
-				"path": "Observation.category.coding.version",
-				"short": "Version of the system - if relevant",
-				"definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
-				"comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.version",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.7"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystemVersion"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.code",
-				"path": "Observation.category.coding.code",
-				"short": "Symbol in syntax defined by the system",
-				"definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
-				"requirements": "Need to refer to a particular code in the system.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "vital-signs",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1"
-					},
-					{
-						"identity": "rim",
-						"map": "./code"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.display",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.coding.display",
-				"short": "Representation defined by the system",
-				"definition": "A representation of the meaning of the code in the system, following the rules of the system.",
-				"requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.display",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.2 - but note this is not well followed"
-					},
-					{
-						"identity": "rim",
-						"map": "CV.displayName"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.userSelected",
-				"path": "Observation.category.coding.userSelected",
-				"short": "If this coding was chosen directly by the user",
-				"definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
-				"comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
-				"requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.userSelected",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Sometimes implied by being first"
-					},
-					{
-						"identity": "rim",
-						"map": "CD.codingRationale"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.text",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.text",
-				"short": "Plain text representation of the concept",
-				"definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
-				"comment": "Very often the text is the same as a displayName of one of the codings.",
-				"requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CodeableConcept.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.9. But note many systems use C*E.2 for this"
-					},
-					{
-						"identity": "rim",
-						"map": "./originalText[mediaType/code=\"text/plain\"]/data"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
-					}
-				]
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "BMI percentile per age and sex for youth 2-20",
-				"definition": "Coded Responses from C-CDA Vital Sign Results.",
-				"comment": "*All* code-value and, if present, component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
-				"alias": [
-					"Name"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "59576-9"
-						}
-					]
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "116680003 |Is a|"
-					}
-				]
-			},
-			{
-				"id": "Observation.subject",
-				"path": "Observation.subject",
-				"short": "Who and/or what the observation is about",
-				"definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
-				"comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
-				"requirements": "Observations have no value if you don't know who or what they're about.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=RTGT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.focus",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
-						"valueCode": "trial-use"
-					}
-				],
-				"path": "Observation.focus",
-				"short": "What the observation is about, when it is not about the subject of record",
-				"definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
-				"comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.focus",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SBJ]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.encounter",
-				"path": "Observation.encounter",
-				"short": "Healthcare event during which this observation is made",
-				"definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
-				"comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
-				"requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
-				"alias": [
-					"Context"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.effective[x]",
-				"path": "Observation.effective[x]",
-				"short": "Often just a dateTime for Vital Signs",
-				"definition": "Often just a dateTime for Vital Signs.",
-				"comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
-				"requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
-				"alias": [
-					"Occurrence"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.effective[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-1",
-						"severity": "error",
-						"human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
-						"expression": "($this as dateTime).toString().length() >= 8",
-						"xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "Observation.issued",
-				"path": "Observation.issued",
-				"short": "Date/Time this version was made available",
-				"definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
-				"comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.issued",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=AUT].time"
-					}
-				]
-			},
-			{
-				"id": "Observation.performer",
-				"path": "Observation.performer",
-				"short": "Who is responsible for the observation",
-				"definition": "Who was responsible for asserting the observed value as \"true\".",
-				"requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.performer",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=PRF]"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]",
-				"path": "Observation.value[x]",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "type",
-							"path": "$this"
-						}
-					],
-					"ordered": false,
-					"rules": "closed"
-				},
-				"short": "Vital Signs Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity",
-				"path": "Observation.value[x]",
-				"sliceName": "valueQuantity",
-				"short": "Vital Signs Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.id",
-				"path": "Observation.value[x].id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.extension",
-				"path": "Observation.value[x].extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.value",
-				"path": "Observation.value[x].value",
-				"short": "Numerical value (with implicit precision)",
-				"definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
-				"comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
-				"requirements": "Precision is handled implicitly in almost all cases of measurement.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.2  / CQ - N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.comparator",
-				"path": "Observation.value[x].comparator",
-				"short": "< | <= | >= | > - how to understand the value",
-				"definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
-				"requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Quantity.comparator",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "QuantityComparator"
-						}
-					],
-					"strength": "required",
-					"description": "How the Quantity should be understood and represented.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.1  / CQ.1"
-					},
-					{
-						"identity": "rim",
-						"map": "IVL properties"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.unit",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.value[x].unit",
-				"short": "Unit representation",
-				"definition": "A human-readable form of the unit.",
-				"requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.unit",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.unit"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.system",
-				"path": "Observation.value[x].system",
-				"short": "System that defines coded unit form",
-				"definition": "The identification of the system that provides the coded form of the unit.",
-				"requirements": "Need to know the system that defines the coded form of the unit.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"condition": [
-					"qty-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "CO.codeSystem, PQ.translation.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.code",
-				"path": "Observation.value[x].code",
-				"short": "Coded responses from the common UCUM units for vital signs value set.",
-				"definition": "A computer processable form of the unit in some unit representation system.",
-				"comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
-				"requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "%",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.code, MO.currency, PQ.translation.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.dataAbsentReason",
-				"path": "Observation.dataAbsentReason",
-				"short": "Why the result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
-				"comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.interpretation",
-				"path": "Observation.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.note",
-				"path": "Observation.note",
-				"short": "Comments about the observation",
-				"definition": "Comments about the observation or the results.",
-				"comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
-				"requirements": "Need to be able to provide free text additional information.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
-					},
-					{
-						"identity": "rim",
-						"map": "subjectOf.observationEvent[code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.bodySite",
-				"path": "Observation.bodySite",
-				"short": "Observed body part",
-				"definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
-				"comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.bodySite",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "BodySite"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing anatomical locations. May include laterality.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/body-site"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123037004 |Body structure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-20"
-					},
-					{
-						"identity": "rim",
-						"map": "targetSiteCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "718497002 |Inherent location|"
-					}
-				]
-			},
-			{
-				"id": "Observation.method",
-				"path": "Observation.method",
-				"short": "How it was done",
-				"definition": "Indicates the mechanism used to perform the observation.",
-				"comment": "Only used if not implicit in code for Observation.code.",
-				"requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.method",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationMethod"
-						}
-					],
-					"strength": "example",
-					"description": "Methods for simple observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-17"
-					},
-					{
-						"identity": "rim",
-						"map": "methodCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.specimen",
-				"path": "Observation.specimen",
-				"short": "Specimen used for this observation",
-				"definition": "The specimen that was used when this observation was made.",
-				"comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.specimen",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Specimen"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123038009 |Specimen|"
-					},
-					{
-						"identity": "v2",
-						"map": "SPM segment"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SPC].specimen"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "704319004 |Inherent in|"
-					}
-				]
-			},
-			{
-				"id": "Observation.device",
-				"path": "Observation.device",
-				"short": "(Measurement) Device",
-				"definition": "The device used to generate the observation data.",
-				"comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.device",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/DeviceMetric"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 49062001 |Device|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-17 / PRT -10"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=DEV]"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "424226004 |Using device|"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange",
-				"path": "Observation.referenceRange",
-				"short": "Provides guide for interpretation",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "obs-3",
-						"severity": "error",
-						"human": "Must have at least a low or a high or text",
-						"expression": "low.exists() or high.exists() or text.exists()",
-						"xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.id",
-				"path": "Observation.referenceRange.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.extension",
-				"path": "Observation.referenceRange.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.modifierExtension",
-				"path": "Observation.referenceRange.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.low",
-				"path": "Observation.referenceRange.low",
-				"short": "Low Range, if relevant",
-				"definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.low",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.low"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.high",
-				"path": "Observation.referenceRange.high",
-				"short": "High Range, if relevant",
-				"definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.high",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.high"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.type",
-				"path": "Observation.referenceRange.type",
-				"short": "Reference range qualifier",
-				"definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
-				"requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeMeaning"
-						}
-					],
-					"strength": "preferred",
-					"description": "Code for the meaning of a reference range.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.appliesTo",
-				"path": "Observation.referenceRange.appliesTo",
-				"short": "Reference range population",
-				"definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
-				"requirements": "Need to be able to identify the target population for proper interpretation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange.appliesTo",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeType"
-						}
-					],
-					"strength": "example",
-					"description": "Codes identifying the population the reference range applies to.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.age",
-				"path": "Observation.referenceRange.age",
-				"short": "Applicable age range, if relevant",
-				"definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
-				"requirements": "Some analytes vary greatly over age.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.age",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Range"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.text",
-				"path": "Observation.referenceRange.text",
-				"short": "Text based reference range in an observation",
-				"definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:ST"
-					}
-				]
-			},
-			{
-				"id": "Observation.hasMember",
-				"path": "Observation.hasMember",
-				"short": "Used when reporting vital signs panel components",
-				"definition": "Used when reporting vital signs panel components.",
-				"comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.hasMember",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship"
-					}
-				]
-			},
-			{
-				"id": "Observation.derivedFrom",
-				"path": "Observation.derivedFrom",
-				"short": "Related measurements the observation is made from",
-				"definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
-				"comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.derivedFrom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/DocumentReference",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy",
-							"http://hl7.org/fhir/StructureDefinition/Media",
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": ".targetObservation"
-					}
-				]
-			},
-			{
-				"id": "Observation.component",
-				"path": "Observation.component",
-				"short": "Component observations",
-				"definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
-				"comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-3",
-						"severity": "error",
-						"human": "If there is no a value a data absent reason must be present",
-						"expression": "value.exists() or dataAbsentReason.exists()",
-						"xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "containment by OBX-4?"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=COMP]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.id",
-				"path": "Observation.component.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.extension",
-				"path": "Observation.component.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.modifierExtension",
-				"path": "Observation.component.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.code",
-				"path": "Observation.component.code",
-				"short": "Type of component observation (code / type)",
-				"definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
-				"comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.value[x]",
-				"path": "Observation.component.value[x]",
-				"short": "Vital Sign Component Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
-				"comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "Quantity"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.dataAbsentReason",
-				"path": "Observation.component.dataAbsentReason",
-				"short": "Why the component result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
-				"comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.interpretation",
-				"path": "Observation.component.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.referenceRange",
-				"path": "Observation.component.referenceRange",
-				"short": "Provides guide for interpretation of component result",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "US Core Pediatric BMI for Age Observation Profile",
-				"definition": "Defines constraints on Observation to represent to represent BMI percentile per age and sex for youth 2-20 observations in FHIR using a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"mustSupport": false
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "BMI percentile per age and sex for youth 2-20",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "59576-9"
-						}
-					]
-				},
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity",
-				"path": "Observation.valueQuantity",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.value",
-				"path": "Observation.valueQuantity.value",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.unit",
-				"path": "Observation.valueQuantity.unit",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.system",
-				"path": "Observation.valueQuantity.system",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.code",
-				"path": "Observation.valueQuantity.code",
-				"short": "Coded responses from the common UCUM units for vital signs value set.",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "%",
-				"mustSupport": true
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "pediatric-bmi-for-age",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age",
+    "version": "4.0.0",
+    "name": "USCorePediatricBMIforAgeObservationProfile",
+    "title": "US Core Pediatric BMI for Age Observation Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-18",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints on Observation to represent to represent BMI percentile per age and sex for youth 2-20 observations in FHIR using a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "sct-concept",
+            "uri": "http://snomed.info/conceptdomain",
+            "name": "SNOMED CT Concept Domain Binding"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "sct-attr",
+            "uri": "http://snomed.org/attributebinding",
+            "name": "SNOMED CT Attribute Binding"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Observation",
+    "baseDefinition": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "US Core Pediatric BMI for Age Observation Profile",
+                "definition": "Defines constraints on Observation to represent to represent BMI percentile per age and sex for youth 2-20 observations in FHIR using a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
+                "alias": [
+                    "Vital Signs",
+                    "Measurement",
+                    "Results",
+                    "Tests"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "obs-6",
+                        "severity": "error",
+                        "human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
+                        "expression": "dataAbsentReason.empty() or value.empty()",
+                        "xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "obs-7",
+                        "severity": "error",
+                        "human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
+                        "expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
+                        "xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "vs-2",
+                        "severity": "error",
+                        "human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
+                        "expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
+                        "xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.id",
+                "path": "Observation.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.meta",
+                "path": "Observation.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.implicitRules",
+                "path": "Observation.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Observation.language",
+                "path": "Observation.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Observation.text",
+                "path": "Observation.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.contained",
+                "path": "Observation.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.extension",
+                "path": "Observation.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.modifierExtension",
+                "path": "Observation.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.identifier",
+                "path": "Observation.identifier",
+                "short": "Business Identifier for observation",
+                "definition": "A unique identifier assigned to this observation.",
+                "requirements": "Allows observations to be distinguished and referenced.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "id"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.basedOn",
+                "path": "Observation.basedOn",
+                "short": "Fulfills plan, proposal or order",
+                "definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
+                "requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
+                "alias": [
+                    "Fulfills"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceRequest",
+                            "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+                            "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.basedOn"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.partOf",
+                "path": "Observation.partOf",
+                "short": "Part of referenced event",
+                "definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
+                "comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
+                "alias": [
+                    "Container"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.partOf",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationDispense",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationStatement",
+                            "http://hl7.org/fhir/StructureDefinition/Procedure",
+                            "http://hl7.org/fhir/StructureDefinition/Immunization",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.partOf"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "Varies by domain"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=FLFS].target"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.status",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
+                        "valueString": "default: final"
+                    }
+                ],
+                "path": "Observation.status",
+                "short": "registered | preliminary | final | amended +",
+                "definition": "The status of the result value.",
+                "comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
+                "requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Status"
+                        }
+                    ],
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 445584004 |Report by finality status|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-11"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category",
+                "path": "Observation.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "coding.code"
+                        },
+                        {
+                            "type": "value",
+                            "path": "coding.system"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "open"
+                },
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat",
+                "path": "Observation.category",
+                "sliceName": "VSCat",
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.id",
+                "path": "Observation.category.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.extension",
+                "path": "Observation.category.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding",
+                "path": "Observation.category.coding",
+                "short": "Code defined by a terminology system",
+                "definition": "A reference to a code defined by a terminology system.",
+                "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+                "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "CodeableConcept.coding",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1-8, C*E.10-22"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "union(., ./translation)"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.id",
+                "path": "Observation.category.coding.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.extension",
+                "path": "Observation.category.coding.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.system",
+                "path": "Observation.category.coding.system",
+                "short": "Identity of the terminology system",
+                "definition": "The identification of the code system that defines the meaning of the symbol in the code.",
+                "comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
+                "requirements": "Need to be unambiguous about the source of the definition of the symbol.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystem"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.version",
+                "path": "Observation.category.coding.version",
+                "short": "Version of the system - if relevant",
+                "definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
+                "comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.version",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystemVersion"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.code",
+                "path": "Observation.category.coding.code",
+                "short": "Symbol in syntax defined by the system",
+                "definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
+                "requirements": "Need to refer to a particular code in the system.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "vital-signs",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./code"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.display",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.coding.display",
+                "short": "Representation defined by the system",
+                "definition": "A representation of the meaning of the code in the system, following the rules of the system.",
+                "requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.display",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.2 - but note this is not well followed"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CV.displayName"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.userSelected",
+                "path": "Observation.category.coding.userSelected",
+                "short": "If this coding was chosen directly by the user",
+                "definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
+                "comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
+                "requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.userSelected",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Sometimes implied by being first"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CD.codingRationale"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.text",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.text",
+                "short": "Plain text representation of the concept",
+                "definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
+                "comment": "Very often the text is the same as a displayName of one of the codings.",
+                "requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CodeableConcept.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.9. But note many systems use C*E.2 for this"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./originalText[mediaType/code=\"text/plain\"]/data"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "BMI percentile per age and sex for youth 2-20",
+                "definition": "Coded Responses from C-CDA Vital Sign Results.",
+                "comment": "*All* code-value and, if present, component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
+                "alias": [
+                    "Name"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "59576-9"
+                        }
+                    ]
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "116680003 |Is a|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.subject",
+                "path": "Observation.subject",
+                "short": "Who and/or what the observation is about",
+                "definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
+                "comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
+                "requirements": "Observations have no value if you don't know who or what they're about.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=RTGT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.focus",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+                        "valueCode": "trial-use"
+                    }
+                ],
+                "path": "Observation.focus",
+                "short": "What the observation is about, when it is not about the subject of record",
+                "definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
+                "comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.focus",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SBJ]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.encounter",
+                "path": "Observation.encounter",
+                "short": "Healthcare event during which this observation is made",
+                "definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
+                "comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
+                "requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
+                "alias": [
+                    "Context"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.effective[x]",
+                "path": "Observation.effective[x]",
+                "short": "Often just a dateTime for Vital Signs",
+                "definition": "Often just a dateTime for Vital Signs.",
+                "comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
+                "requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
+                "alias": [
+                    "Occurrence"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.effective[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-1",
+                        "severity": "error",
+                        "human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
+                        "expression": "($this as dateTime).toString().length() >= 8",
+                        "xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.issued",
+                "path": "Observation.issued",
+                "short": "Date/Time this version was made available",
+                "definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
+                "comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.issued",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.performer",
+                "path": "Observation.performer",
+                "short": "Who is responsible for the observation",
+                "definition": "Who was responsible for asserting the observed value as \"true\".",
+                "requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.performer",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=PRF]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]",
+                "path": "Observation.value[x]",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "type",
+                            "path": "$this"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "closed"
+                },
+                "short": "Vital Signs Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity",
+                "path": "Observation.value[x]",
+                "sliceName": "valueQuantity",
+                "short": "Vital Signs Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.id",
+                "path": "Observation.value[x].id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.extension",
+                "path": "Observation.value[x].extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.value",
+                "path": "Observation.value[x].value",
+                "short": "Numerical value (with implicit precision)",
+                "definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
+                "comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
+                "requirements": "Precision is handled implicitly in almost all cases of measurement.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.2  / CQ - N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.comparator",
+                "path": "Observation.value[x].comparator",
+                "short": "< | <= | >= | > - how to understand the value",
+                "definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
+                "requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.comparator",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "QuantityComparator"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "How the Quantity should be understood and represented.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.1  / CQ.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "IVL properties"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.unit",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.value[x].unit",
+                "short": "Unit representation",
+                "definition": "A human-readable form of the unit.",
+                "requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.unit",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.unit"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.system",
+                "path": "Observation.value[x].system",
+                "short": "System that defines coded unit form",
+                "definition": "The identification of the system that provides the coded form of the unit.",
+                "requirements": "Need to know the system that defines the coded form of the unit.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "condition": [
+                    "qty-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CO.codeSystem, PQ.translation.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.code",
+                "path": "Observation.value[x].code",
+                "short": "Coded responses from the common UCUM units for vital signs value set.",
+                "definition": "A computer processable form of the unit in some unit representation system.",
+                "comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
+                "requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "%",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.code, MO.currency, PQ.translation.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.dataAbsentReason",
+                "path": "Observation.dataAbsentReason",
+                "short": "Why the result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
+                "comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.interpretation",
+                "path": "Observation.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.note",
+                "path": "Observation.note",
+                "short": "Comments about the observation",
+                "definition": "Comments about the observation or the results.",
+                "comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
+                "requirements": "Need to be able to provide free text additional information.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "subjectOf.observationEvent[code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.bodySite",
+                "path": "Observation.bodySite",
+                "short": "Observed body part",
+                "definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
+                "comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.bodySite",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "BodySite"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing anatomical locations. May include laterality.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/body-site"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123037004 |Body structure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-20"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "targetSiteCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "718497002 |Inherent location|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.method",
+                "path": "Observation.method",
+                "short": "How it was done",
+                "definition": "Indicates the mechanism used to perform the observation.",
+                "comment": "Only used if not implicit in code for Observation.code.",
+                "requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.method",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationMethod"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Methods for simple observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "methodCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.specimen",
+                "path": "Observation.specimen",
+                "short": "Specimen used for this observation",
+                "definition": "The specimen that was used when this observation was made.",
+                "comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.specimen",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Specimen"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123038009 |Specimen|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "SPM segment"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SPC].specimen"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "704319004 |Inherent in|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.device",
+                "path": "Observation.device",
+                "short": "(Measurement) Device",
+                "definition": "The device used to generate the observation data.",
+                "comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.device",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceMetric"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 49062001 |Device|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17 / PRT -10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=DEV]"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "424226004 |Using device|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange",
+                "path": "Observation.referenceRange",
+                "short": "Provides guide for interpretation",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "obs-3",
+                        "severity": "error",
+                        "human": "Must have at least a low or a high or text",
+                        "expression": "low.exists() or high.exists() or text.exists()",
+                        "xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.id",
+                "path": "Observation.referenceRange.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.extension",
+                "path": "Observation.referenceRange.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.modifierExtension",
+                "path": "Observation.referenceRange.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.low",
+                "path": "Observation.referenceRange.low",
+                "short": "Low Range, if relevant",
+                "definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.low",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.low"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.high",
+                "path": "Observation.referenceRange.high",
+                "short": "High Range, if relevant",
+                "definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.high",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.high"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.type",
+                "path": "Observation.referenceRange.type",
+                "short": "Reference range qualifier",
+                "definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
+                "requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeMeaning"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Code for the meaning of a reference range.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.appliesTo",
+                "path": "Observation.referenceRange.appliesTo",
+                "short": "Reference range population",
+                "definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
+                "requirements": "Need to be able to identify the target population for proper interpretation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange.appliesTo",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes identifying the population the reference range applies to.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.age",
+                "path": "Observation.referenceRange.age",
+                "short": "Applicable age range, if relevant",
+                "definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
+                "requirements": "Some analytes vary greatly over age.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.age",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Range"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.text",
+                "path": "Observation.referenceRange.text",
+                "short": "Text based reference range in an observation",
+                "definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:ST"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.hasMember",
+                "path": "Observation.hasMember",
+                "short": "Used when reporting vital signs panel components",
+                "definition": "Used when reporting vital signs panel components.",
+                "comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.hasMember",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.derivedFrom",
+                "path": "Observation.derivedFrom",
+                "short": "Related measurements the observation is made from",
+                "definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
+                "comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.derivedFrom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/DocumentReference",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy",
+                            "http://hl7.org/fhir/StructureDefinition/Media",
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".targetObservation"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component",
+                "path": "Observation.component",
+                "short": "Component observations",
+                "definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
+                "comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-3",
+                        "severity": "error",
+                        "human": "If there is no a value a data absent reason must be present",
+                        "expression": "value.exists() or dataAbsentReason.exists()",
+                        "xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "containment by OBX-4?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=COMP]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.id",
+                "path": "Observation.component.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.extension",
+                "path": "Observation.component.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.modifierExtension",
+                "path": "Observation.component.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.code",
+                "path": "Observation.component.code",
+                "short": "Type of component observation (code / type)",
+                "definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
+                "comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.value[x]",
+                "path": "Observation.component.value[x]",
+                "short": "Vital Sign Component Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
+                "comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.dataAbsentReason",
+                "path": "Observation.component.dataAbsentReason",
+                "short": "Why the component result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
+                "comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.interpretation",
+                "path": "Observation.component.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.referenceRange",
+                "path": "Observation.component.referenceRange",
+                "short": "Provides guide for interpretation of component result",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "US Core Pediatric BMI for Age Observation Profile",
+                "definition": "Defines constraints on Observation to represent to represent BMI percentile per age and sex for youth 2-20 observations in FHIR using a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "mustSupport": false
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "BMI percentile per age and sex for youth 2-20",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "59576-9"
+                        }
+                    ]
+                },
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity",
+                "path": "Observation.valueQuantity",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.value",
+                "path": "Observation.valueQuantity.value",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.unit",
+                "path": "Observation.valueQuantity.unit",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.system",
+                "path": "Observation.valueQuantity.system",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.code",
+                "path": "Observation.valueQuantity.code",
+                "short": "Coded responses from the common UCUM units for vital signs value set.",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "%",
+                "mustSupport": true
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-pediatric-weight-for-height.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-pediatric-weight-for-height.json
@@ -1,3812 +1,3812 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "pediatric-weight-for-height",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-pediatric-weight-for-height-definitions.html#Observation\" title=\"Defines constraints on the Observation resource to represent pediatric Weight-for-length per age and gender observations in FHIR with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.\">Observation</a><a name=\"Observation\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"StructureDefinition-us-core-vital-signs.html\">USCoreVitalSignsProfile</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">US Core Pediatric Weight for Height Observation Profile</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-pediatric-weight-for-height-definitions.html#Observation.code\">code</a><a name=\"Observation.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Weight-for-length per age and gender<br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck101.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#CodeableConcept.coding\">coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Code defined by a terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">(complex)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/loinc.html\">http://loinc.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">77606-2</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-pediatric-weight-for-height-definitions.html#Observation.valueQuantity\">valueQuantity</a><a name=\"Observation.valueQuantity\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Quantity\">Quantity</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Vital Signs Value</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-pediatric-weight-for-height-definitions.html#Observation.valueQuantity.value\">value</a><a name=\"Observation.valueQuantity.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#decimal\">decimal</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Numerical value (with implicit precision)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-pediatric-weight-for-height-definitions.html#Observation.valueQuantity.unit\">unit</a><a name=\"Observation.valueQuantity.unit\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Unit representation</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-pediatric-weight-for-height-definitions.html#Observation.valueQuantity.system\">system</a><a name=\"Observation.valueQuantity.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">System that defines coded unit form</span><br/><span style=\"font-weight:bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/ucum.html\">http://unitsofmeasure.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-pediatric-weight-for-height-definitions.html#Observation.valueQuantity.code\">code</a><a name=\"Observation.valueQuantity.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Coded responses from the common UCUM units for vital signs value set.<br/><span style=\"font-weight:bold\">Fixed Value: </span><span style=\"color: darkgreen\">%</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height",
-	"version": "4.0.0",
-	"name": "USCorePediatricWeightForHeightObservationProfile",
-	"title": "US Core Pediatric Weight for Height Observation Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-18",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints on the Observation resource to represent pediatric Weight-for-length per age and gender observations in FHIR with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "sct-concept",
-			"uri": "http://snomed.info/conceptdomain",
-			"name": "SNOMED CT Concept Domain Binding"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "sct-attr",
-			"uri": "http://snomed.org/attributebinding",
-			"name": "SNOMED CT Attribute Binding"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Observation",
-	"baseDefinition": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "US Core Pediatric Weight for Height Observation Profile",
-				"definition": "Defines constraints on the Observation resource to represent pediatric Weight-for-length per age and gender observations in FHIR with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
-				"alias": [
-					"Vital Signs",
-					"Measurement",
-					"Results",
-					"Tests"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "obs-6",
-						"severity": "error",
-						"human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
-						"expression": "dataAbsentReason.empty() or value.empty()",
-						"xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "obs-7",
-						"severity": "error",
-						"human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
-						"expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
-						"xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "vs-2",
-						"severity": "error",
-						"human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
-						"expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
-						"xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.id",
-				"path": "Observation.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.meta",
-				"path": "Observation.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.implicitRules",
-				"path": "Observation.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Observation.language",
-				"path": "Observation.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Observation.text",
-				"path": "Observation.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Observation.contained",
-				"path": "Observation.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.extension",
-				"path": "Observation.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.modifierExtension",
-				"path": "Observation.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.identifier",
-				"path": "Observation.identifier",
-				"short": "Business Identifier for observation",
-				"definition": "A unique identifier assigned to this observation.",
-				"requirements": "Allows observations to be distinguished and referenced.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
-					},
-					{
-						"identity": "rim",
-						"map": "id"
-					}
-				]
-			},
-			{
-				"id": "Observation.basedOn",
-				"path": "Observation.basedOn",
-				"short": "Fulfills plan, proposal or order",
-				"definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
-				"requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
-				"alias": [
-					"Fulfills"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan",
-							"http://hl7.org/fhir/StructureDefinition/DeviceRequest",
-							"http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
-							"http://hl7.org/fhir/StructureDefinition/MedicationRequest",
-							"http://hl7.org/fhir/StructureDefinition/NutritionOrder",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.basedOn"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.partOf",
-				"path": "Observation.partOf",
-				"short": "Part of referenced event",
-				"definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
-				"comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
-				"alias": [
-					"Container"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.partOf",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
-							"http://hl7.org/fhir/StructureDefinition/MedicationDispense",
-							"http://hl7.org/fhir/StructureDefinition/MedicationStatement",
-							"http://hl7.org/fhir/StructureDefinition/Procedure",
-							"http://hl7.org/fhir/StructureDefinition/Immunization",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.partOf"
-					},
-					{
-						"identity": "v2",
-						"map": "Varies by domain"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=FLFS].target"
-					}
-				]
-			},
-			{
-				"id": "Observation.status",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
-						"valueString": "default: final"
-					}
-				],
-				"path": "Observation.status",
-				"short": "registered | preliminary | final | amended +",
-				"definition": "The status of the result value.",
-				"comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
-				"requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Status"
-						}
-					],
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 445584004 |Report by finality status|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-11"
-					},
-					{
-						"identity": "rim",
-						"map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
-					}
-				]
-			},
-			{
-				"id": "Observation.category",
-				"path": "Observation.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "coding.code"
-						},
-						{
-							"type": "value",
-							"path": "coding.system"
-						}
-					],
-					"ordered": false,
-					"rules": "open"
-				},
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat",
-				"path": "Observation.category",
-				"sliceName": "VSCat",
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.id",
-				"path": "Observation.category.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.extension",
-				"path": "Observation.category.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding",
-				"path": "Observation.category.coding",
-				"short": "Code defined by a terminology system",
-				"definition": "A reference to a code defined by a terminology system.",
-				"comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
-				"requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "CodeableConcept.coding",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1-8, C*E.10-22"
-					},
-					{
-						"identity": "rim",
-						"map": "union(., ./translation)"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.id",
-				"path": "Observation.category.coding.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.extension",
-				"path": "Observation.category.coding.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.system",
-				"path": "Observation.category.coding.system",
-				"short": "Identity of the terminology system",
-				"definition": "The identification of the code system that defines the meaning of the symbol in the code.",
-				"comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
-				"requirements": "Need to be unambiguous about the source of the definition of the symbol.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.3"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystem"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.version",
-				"path": "Observation.category.coding.version",
-				"short": "Version of the system - if relevant",
-				"definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
-				"comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.version",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.7"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystemVersion"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.code",
-				"path": "Observation.category.coding.code",
-				"short": "Symbol in syntax defined by the system",
-				"definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
-				"requirements": "Need to refer to a particular code in the system.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "vital-signs",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1"
-					},
-					{
-						"identity": "rim",
-						"map": "./code"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.display",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.coding.display",
-				"short": "Representation defined by the system",
-				"definition": "A representation of the meaning of the code in the system, following the rules of the system.",
-				"requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.display",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.2 - but note this is not well followed"
-					},
-					{
-						"identity": "rim",
-						"map": "CV.displayName"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.userSelected",
-				"path": "Observation.category.coding.userSelected",
-				"short": "If this coding was chosen directly by the user",
-				"definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
-				"comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
-				"requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.userSelected",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Sometimes implied by being first"
-					},
-					{
-						"identity": "rim",
-						"map": "CD.codingRationale"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.text",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.text",
-				"short": "Plain text representation of the concept",
-				"definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
-				"comment": "Very often the text is the same as a displayName of one of the codings.",
-				"requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CodeableConcept.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.9. But note many systems use C*E.2 for this"
-					},
-					{
-						"identity": "rim",
-						"map": "./originalText[mediaType/code=\"text/plain\"]/data"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
-					}
-				]
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Weight-for-length per age and gender",
-				"definition": "Coded Responses from C-CDA Vital Sign Results.",
-				"comment": "*All* code-value and, if present, component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
-				"alias": [
-					"Name"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "77606-2"
-						}
-					]
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "116680003 |Is a|"
-					}
-				]
-			},
-			{
-				"id": "Observation.subject",
-				"path": "Observation.subject",
-				"short": "Who and/or what the observation is about",
-				"definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
-				"comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
-				"requirements": "Observations have no value if you don't know who or what they're about.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=RTGT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.focus",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
-						"valueCode": "trial-use"
-					}
-				],
-				"path": "Observation.focus",
-				"short": "What the observation is about, when it is not about the subject of record",
-				"definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
-				"comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.focus",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SBJ]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.encounter",
-				"path": "Observation.encounter",
-				"short": "Healthcare event during which this observation is made",
-				"definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
-				"comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
-				"requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
-				"alias": [
-					"Context"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.effective[x]",
-				"path": "Observation.effective[x]",
-				"short": "Often just a dateTime for Vital Signs",
-				"definition": "Often just a dateTime for Vital Signs.",
-				"comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
-				"requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
-				"alias": [
-					"Occurrence"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.effective[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-1",
-						"severity": "error",
-						"human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
-						"expression": "($this as dateTime).toString().length() >= 8",
-						"xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "Observation.issued",
-				"path": "Observation.issued",
-				"short": "Date/Time this version was made available",
-				"definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
-				"comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.issued",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=AUT].time"
-					}
-				]
-			},
-			{
-				"id": "Observation.performer",
-				"path": "Observation.performer",
-				"short": "Who is responsible for the observation",
-				"definition": "Who was responsible for asserting the observed value as \"true\".",
-				"requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.performer",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=PRF]"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]",
-				"path": "Observation.value[x]",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "type",
-							"path": "$this"
-						}
-					],
-					"ordered": false,
-					"rules": "closed"
-				},
-				"short": "Vital Signs Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity",
-				"path": "Observation.value[x]",
-				"sliceName": "valueQuantity",
-				"short": "Vital Signs Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.id",
-				"path": "Observation.value[x].id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.extension",
-				"path": "Observation.value[x].extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.value",
-				"path": "Observation.value[x].value",
-				"short": "Numerical value (with implicit precision)",
-				"definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
-				"comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
-				"requirements": "Precision is handled implicitly in almost all cases of measurement.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.2  / CQ - N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.comparator",
-				"path": "Observation.value[x].comparator",
-				"short": "< | <= | >= | > - how to understand the value",
-				"definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
-				"requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Quantity.comparator",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "QuantityComparator"
-						}
-					],
-					"strength": "required",
-					"description": "How the Quantity should be understood and represented.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.1  / CQ.1"
-					},
-					{
-						"identity": "rim",
-						"map": "IVL properties"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.unit",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.value[x].unit",
-				"short": "Unit representation",
-				"definition": "A human-readable form of the unit.",
-				"requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.unit",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.unit"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.system",
-				"path": "Observation.value[x].system",
-				"short": "System that defines coded unit form",
-				"definition": "The identification of the system that provides the coded form of the unit.",
-				"requirements": "Need to know the system that defines the coded form of the unit.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"condition": [
-					"qty-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "CO.codeSystem, PQ.translation.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.code",
-				"path": "Observation.value[x].code",
-				"short": "Coded responses from the common UCUM units for vital signs value set.",
-				"definition": "A computer processable form of the unit in some unit representation system.",
-				"comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
-				"requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "%",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.code, MO.currency, PQ.translation.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.dataAbsentReason",
-				"path": "Observation.dataAbsentReason",
-				"short": "Why the result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
-				"comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.interpretation",
-				"path": "Observation.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.note",
-				"path": "Observation.note",
-				"short": "Comments about the observation",
-				"definition": "Comments about the observation or the results.",
-				"comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
-				"requirements": "Need to be able to provide free text additional information.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
-					},
-					{
-						"identity": "rim",
-						"map": "subjectOf.observationEvent[code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.bodySite",
-				"path": "Observation.bodySite",
-				"short": "Observed body part",
-				"definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
-				"comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.bodySite",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "BodySite"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing anatomical locations. May include laterality.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/body-site"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123037004 |Body structure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-20"
-					},
-					{
-						"identity": "rim",
-						"map": "targetSiteCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "718497002 |Inherent location|"
-					}
-				]
-			},
-			{
-				"id": "Observation.method",
-				"path": "Observation.method",
-				"short": "How it was done",
-				"definition": "Indicates the mechanism used to perform the observation.",
-				"comment": "Only used if not implicit in code for Observation.code.",
-				"requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.method",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationMethod"
-						}
-					],
-					"strength": "example",
-					"description": "Methods for simple observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-17"
-					},
-					{
-						"identity": "rim",
-						"map": "methodCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.specimen",
-				"path": "Observation.specimen",
-				"short": "Specimen used for this observation",
-				"definition": "The specimen that was used when this observation was made.",
-				"comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.specimen",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Specimen"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123038009 |Specimen|"
-					},
-					{
-						"identity": "v2",
-						"map": "SPM segment"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SPC].specimen"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "704319004 |Inherent in|"
-					}
-				]
-			},
-			{
-				"id": "Observation.device",
-				"path": "Observation.device",
-				"short": "(Measurement) Device",
-				"definition": "The device used to generate the observation data.",
-				"comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.device",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/DeviceMetric"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 49062001 |Device|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-17 / PRT -10"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=DEV]"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "424226004 |Using device|"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange",
-				"path": "Observation.referenceRange",
-				"short": "Provides guide for interpretation",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "obs-3",
-						"severity": "error",
-						"human": "Must have at least a low or a high or text",
-						"expression": "low.exists() or high.exists() or text.exists()",
-						"xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.id",
-				"path": "Observation.referenceRange.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.extension",
-				"path": "Observation.referenceRange.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.modifierExtension",
-				"path": "Observation.referenceRange.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.low",
-				"path": "Observation.referenceRange.low",
-				"short": "Low Range, if relevant",
-				"definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.low",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.low"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.high",
-				"path": "Observation.referenceRange.high",
-				"short": "High Range, if relevant",
-				"definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.high",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.high"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.type",
-				"path": "Observation.referenceRange.type",
-				"short": "Reference range qualifier",
-				"definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
-				"requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeMeaning"
-						}
-					],
-					"strength": "preferred",
-					"description": "Code for the meaning of a reference range.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.appliesTo",
-				"path": "Observation.referenceRange.appliesTo",
-				"short": "Reference range population",
-				"definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
-				"requirements": "Need to be able to identify the target population for proper interpretation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange.appliesTo",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeType"
-						}
-					],
-					"strength": "example",
-					"description": "Codes identifying the population the reference range applies to.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.age",
-				"path": "Observation.referenceRange.age",
-				"short": "Applicable age range, if relevant",
-				"definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
-				"requirements": "Some analytes vary greatly over age.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.age",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Range"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.text",
-				"path": "Observation.referenceRange.text",
-				"short": "Text based reference range in an observation",
-				"definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:ST"
-					}
-				]
-			},
-			{
-				"id": "Observation.hasMember",
-				"path": "Observation.hasMember",
-				"short": "Used when reporting vital signs panel components",
-				"definition": "Used when reporting vital signs panel components.",
-				"comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.hasMember",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship"
-					}
-				]
-			},
-			{
-				"id": "Observation.derivedFrom",
-				"path": "Observation.derivedFrom",
-				"short": "Related measurements the observation is made from",
-				"definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
-				"comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.derivedFrom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/DocumentReference",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy",
-							"http://hl7.org/fhir/StructureDefinition/Media",
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": ".targetObservation"
-					}
-				]
-			},
-			{
-				"id": "Observation.component",
-				"path": "Observation.component",
-				"short": "Component observations",
-				"definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
-				"comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-3",
-						"severity": "error",
-						"human": "If there is no a value a data absent reason must be present",
-						"expression": "value.exists() or dataAbsentReason.exists()",
-						"xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "containment by OBX-4?"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=COMP]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.id",
-				"path": "Observation.component.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.extension",
-				"path": "Observation.component.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.modifierExtension",
-				"path": "Observation.component.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.code",
-				"path": "Observation.component.code",
-				"short": "Type of component observation (code / type)",
-				"definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
-				"comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.value[x]",
-				"path": "Observation.component.value[x]",
-				"short": "Vital Sign Component Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
-				"comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "Quantity"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.dataAbsentReason",
-				"path": "Observation.component.dataAbsentReason",
-				"short": "Why the component result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
-				"comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.interpretation",
-				"path": "Observation.component.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.referenceRange",
-				"path": "Observation.component.referenceRange",
-				"short": "Provides guide for interpretation of component result",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "US Core Pediatric Weight for Height Observation Profile",
-				"definition": "Defines constraints on the Observation resource to represent pediatric Weight-for-length per age and gender observations in FHIR with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"mustSupport": false
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Weight-for-length per age and gender",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "77606-2"
-						}
-					]
-				},
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity",
-				"path": "Observation.valueQuantity",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.value",
-				"path": "Observation.valueQuantity.value",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.unit",
-				"path": "Observation.valueQuantity.unit",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.system",
-				"path": "Observation.valueQuantity.system",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.code",
-				"path": "Observation.valueQuantity.code",
-				"short": "Coded responses from the common UCUM units for vital signs value set.",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "%",
-				"mustSupport": true
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "pediatric-weight-for-height",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height",
+    "version": "4.0.0",
+    "name": "USCorePediatricWeightForHeightObservationProfile",
+    "title": "US Core Pediatric Weight for Height Observation Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-18",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints on the Observation resource to represent pediatric Weight-for-length per age and gender observations in FHIR with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "sct-concept",
+            "uri": "http://snomed.info/conceptdomain",
+            "name": "SNOMED CT Concept Domain Binding"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "sct-attr",
+            "uri": "http://snomed.org/attributebinding",
+            "name": "SNOMED CT Attribute Binding"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Observation",
+    "baseDefinition": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "US Core Pediatric Weight for Height Observation Profile",
+                "definition": "Defines constraints on the Observation resource to represent pediatric Weight-for-length per age and gender observations in FHIR with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
+                "alias": [
+                    "Vital Signs",
+                    "Measurement",
+                    "Results",
+                    "Tests"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "obs-6",
+                        "severity": "error",
+                        "human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
+                        "expression": "dataAbsentReason.empty() or value.empty()",
+                        "xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "obs-7",
+                        "severity": "error",
+                        "human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
+                        "expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
+                        "xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "vs-2",
+                        "severity": "error",
+                        "human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
+                        "expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
+                        "xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.id",
+                "path": "Observation.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.meta",
+                "path": "Observation.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.implicitRules",
+                "path": "Observation.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Observation.language",
+                "path": "Observation.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Observation.text",
+                "path": "Observation.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.contained",
+                "path": "Observation.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.extension",
+                "path": "Observation.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.modifierExtension",
+                "path": "Observation.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.identifier",
+                "path": "Observation.identifier",
+                "short": "Business Identifier for observation",
+                "definition": "A unique identifier assigned to this observation.",
+                "requirements": "Allows observations to be distinguished and referenced.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "id"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.basedOn",
+                "path": "Observation.basedOn",
+                "short": "Fulfills plan, proposal or order",
+                "definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
+                "requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
+                "alias": [
+                    "Fulfills"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceRequest",
+                            "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+                            "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.basedOn"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.partOf",
+                "path": "Observation.partOf",
+                "short": "Part of referenced event",
+                "definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
+                "comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
+                "alias": [
+                    "Container"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.partOf",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationDispense",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationStatement",
+                            "http://hl7.org/fhir/StructureDefinition/Procedure",
+                            "http://hl7.org/fhir/StructureDefinition/Immunization",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.partOf"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "Varies by domain"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=FLFS].target"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.status",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
+                        "valueString": "default: final"
+                    }
+                ],
+                "path": "Observation.status",
+                "short": "registered | preliminary | final | amended +",
+                "definition": "The status of the result value.",
+                "comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
+                "requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Status"
+                        }
+                    ],
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 445584004 |Report by finality status|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-11"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category",
+                "path": "Observation.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "coding.code"
+                        },
+                        {
+                            "type": "value",
+                            "path": "coding.system"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "open"
+                },
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat",
+                "path": "Observation.category",
+                "sliceName": "VSCat",
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.id",
+                "path": "Observation.category.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.extension",
+                "path": "Observation.category.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding",
+                "path": "Observation.category.coding",
+                "short": "Code defined by a terminology system",
+                "definition": "A reference to a code defined by a terminology system.",
+                "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+                "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "CodeableConcept.coding",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1-8, C*E.10-22"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "union(., ./translation)"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.id",
+                "path": "Observation.category.coding.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.extension",
+                "path": "Observation.category.coding.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.system",
+                "path": "Observation.category.coding.system",
+                "short": "Identity of the terminology system",
+                "definition": "The identification of the code system that defines the meaning of the symbol in the code.",
+                "comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
+                "requirements": "Need to be unambiguous about the source of the definition of the symbol.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystem"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.version",
+                "path": "Observation.category.coding.version",
+                "short": "Version of the system - if relevant",
+                "definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
+                "comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.version",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystemVersion"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.code",
+                "path": "Observation.category.coding.code",
+                "short": "Symbol in syntax defined by the system",
+                "definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
+                "requirements": "Need to refer to a particular code in the system.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "vital-signs",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./code"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.display",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.coding.display",
+                "short": "Representation defined by the system",
+                "definition": "A representation of the meaning of the code in the system, following the rules of the system.",
+                "requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.display",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.2 - but note this is not well followed"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CV.displayName"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.userSelected",
+                "path": "Observation.category.coding.userSelected",
+                "short": "If this coding was chosen directly by the user",
+                "definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
+                "comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
+                "requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.userSelected",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Sometimes implied by being first"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CD.codingRationale"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.text",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.text",
+                "short": "Plain text representation of the concept",
+                "definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
+                "comment": "Very often the text is the same as a displayName of one of the codings.",
+                "requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CodeableConcept.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.9. But note many systems use C*E.2 for this"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./originalText[mediaType/code=\"text/plain\"]/data"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Weight-for-length per age and gender",
+                "definition": "Coded Responses from C-CDA Vital Sign Results.",
+                "comment": "*All* code-value and, if present, component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
+                "alias": [
+                    "Name"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "77606-2"
+                        }
+                    ]
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "116680003 |Is a|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.subject",
+                "path": "Observation.subject",
+                "short": "Who and/or what the observation is about",
+                "definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
+                "comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
+                "requirements": "Observations have no value if you don't know who or what they're about.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=RTGT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.focus",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+                        "valueCode": "trial-use"
+                    }
+                ],
+                "path": "Observation.focus",
+                "short": "What the observation is about, when it is not about the subject of record",
+                "definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
+                "comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.focus",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SBJ]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.encounter",
+                "path": "Observation.encounter",
+                "short": "Healthcare event during which this observation is made",
+                "definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
+                "comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
+                "requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
+                "alias": [
+                    "Context"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.effective[x]",
+                "path": "Observation.effective[x]",
+                "short": "Often just a dateTime for Vital Signs",
+                "definition": "Often just a dateTime for Vital Signs.",
+                "comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
+                "requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
+                "alias": [
+                    "Occurrence"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.effective[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-1",
+                        "severity": "error",
+                        "human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
+                        "expression": "($this as dateTime).toString().length() >= 8",
+                        "xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.issued",
+                "path": "Observation.issued",
+                "short": "Date/Time this version was made available",
+                "definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
+                "comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.issued",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.performer",
+                "path": "Observation.performer",
+                "short": "Who is responsible for the observation",
+                "definition": "Who was responsible for asserting the observed value as \"true\".",
+                "requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.performer",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=PRF]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]",
+                "path": "Observation.value[x]",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "type",
+                            "path": "$this"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "closed"
+                },
+                "short": "Vital Signs Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity",
+                "path": "Observation.value[x]",
+                "sliceName": "valueQuantity",
+                "short": "Vital Signs Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.id",
+                "path": "Observation.value[x].id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.extension",
+                "path": "Observation.value[x].extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.value",
+                "path": "Observation.value[x].value",
+                "short": "Numerical value (with implicit precision)",
+                "definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
+                "comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
+                "requirements": "Precision is handled implicitly in almost all cases of measurement.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.2  / CQ - N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.comparator",
+                "path": "Observation.value[x].comparator",
+                "short": "< | <= | >= | > - how to understand the value",
+                "definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
+                "requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.comparator",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "QuantityComparator"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "How the Quantity should be understood and represented.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.1  / CQ.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "IVL properties"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.unit",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.value[x].unit",
+                "short": "Unit representation",
+                "definition": "A human-readable form of the unit.",
+                "requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.unit",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.unit"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.system",
+                "path": "Observation.value[x].system",
+                "short": "System that defines coded unit form",
+                "definition": "The identification of the system that provides the coded form of the unit.",
+                "requirements": "Need to know the system that defines the coded form of the unit.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "condition": [
+                    "qty-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CO.codeSystem, PQ.translation.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.code",
+                "path": "Observation.value[x].code",
+                "short": "Coded responses from the common UCUM units for vital signs value set.",
+                "definition": "A computer processable form of the unit in some unit representation system.",
+                "comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
+                "requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "%",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.code, MO.currency, PQ.translation.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.dataAbsentReason",
+                "path": "Observation.dataAbsentReason",
+                "short": "Why the result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
+                "comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.interpretation",
+                "path": "Observation.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.note",
+                "path": "Observation.note",
+                "short": "Comments about the observation",
+                "definition": "Comments about the observation or the results.",
+                "comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
+                "requirements": "Need to be able to provide free text additional information.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "subjectOf.observationEvent[code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.bodySite",
+                "path": "Observation.bodySite",
+                "short": "Observed body part",
+                "definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
+                "comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.bodySite",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "BodySite"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing anatomical locations. May include laterality.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/body-site"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123037004 |Body structure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-20"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "targetSiteCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "718497002 |Inherent location|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.method",
+                "path": "Observation.method",
+                "short": "How it was done",
+                "definition": "Indicates the mechanism used to perform the observation.",
+                "comment": "Only used if not implicit in code for Observation.code.",
+                "requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.method",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationMethod"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Methods for simple observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "methodCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.specimen",
+                "path": "Observation.specimen",
+                "short": "Specimen used for this observation",
+                "definition": "The specimen that was used when this observation was made.",
+                "comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.specimen",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Specimen"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123038009 |Specimen|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "SPM segment"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SPC].specimen"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "704319004 |Inherent in|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.device",
+                "path": "Observation.device",
+                "short": "(Measurement) Device",
+                "definition": "The device used to generate the observation data.",
+                "comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.device",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceMetric"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 49062001 |Device|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17 / PRT -10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=DEV]"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "424226004 |Using device|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange",
+                "path": "Observation.referenceRange",
+                "short": "Provides guide for interpretation",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "obs-3",
+                        "severity": "error",
+                        "human": "Must have at least a low or a high or text",
+                        "expression": "low.exists() or high.exists() or text.exists()",
+                        "xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.id",
+                "path": "Observation.referenceRange.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.extension",
+                "path": "Observation.referenceRange.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.modifierExtension",
+                "path": "Observation.referenceRange.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.low",
+                "path": "Observation.referenceRange.low",
+                "short": "Low Range, if relevant",
+                "definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.low",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.low"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.high",
+                "path": "Observation.referenceRange.high",
+                "short": "High Range, if relevant",
+                "definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.high",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.high"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.type",
+                "path": "Observation.referenceRange.type",
+                "short": "Reference range qualifier",
+                "definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
+                "requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeMeaning"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Code for the meaning of a reference range.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.appliesTo",
+                "path": "Observation.referenceRange.appliesTo",
+                "short": "Reference range population",
+                "definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
+                "requirements": "Need to be able to identify the target population for proper interpretation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange.appliesTo",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes identifying the population the reference range applies to.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.age",
+                "path": "Observation.referenceRange.age",
+                "short": "Applicable age range, if relevant",
+                "definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
+                "requirements": "Some analytes vary greatly over age.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.age",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Range"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.text",
+                "path": "Observation.referenceRange.text",
+                "short": "Text based reference range in an observation",
+                "definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:ST"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.hasMember",
+                "path": "Observation.hasMember",
+                "short": "Used when reporting vital signs panel components",
+                "definition": "Used when reporting vital signs panel components.",
+                "comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.hasMember",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.derivedFrom",
+                "path": "Observation.derivedFrom",
+                "short": "Related measurements the observation is made from",
+                "definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
+                "comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.derivedFrom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/DocumentReference",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy",
+                            "http://hl7.org/fhir/StructureDefinition/Media",
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".targetObservation"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component",
+                "path": "Observation.component",
+                "short": "Component observations",
+                "definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
+                "comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-3",
+                        "severity": "error",
+                        "human": "If there is no a value a data absent reason must be present",
+                        "expression": "value.exists() or dataAbsentReason.exists()",
+                        "xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "containment by OBX-4?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=COMP]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.id",
+                "path": "Observation.component.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.extension",
+                "path": "Observation.component.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.modifierExtension",
+                "path": "Observation.component.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.code",
+                "path": "Observation.component.code",
+                "short": "Type of component observation (code / type)",
+                "definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
+                "comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.value[x]",
+                "path": "Observation.component.value[x]",
+                "short": "Vital Sign Component Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
+                "comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.dataAbsentReason",
+                "path": "Observation.component.dataAbsentReason",
+                "short": "Why the component result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
+                "comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.interpretation",
+                "path": "Observation.component.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.referenceRange",
+                "path": "Observation.component.referenceRange",
+                "short": "Provides guide for interpretation of component result",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "US Core Pediatric Weight for Height Observation Profile",
+                "definition": "Defines constraints on the Observation resource to represent pediatric Weight-for-length per age and gender observations in FHIR with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "mustSupport": false
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Weight-for-length per age and gender",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "77606-2"
+                        }
+                    ]
+                },
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity",
+                "path": "Observation.valueQuantity",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.value",
+                "path": "Observation.valueQuantity.value",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.unit",
+                "path": "Observation.valueQuantity.unit",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.system",
+                "path": "Observation.valueQuantity.system",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.code",
+                "path": "Observation.valueQuantity.code",
+                "short": "Coded responses from the common UCUM units for vital signs value set.",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "%",
+                "mustSupport": true
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-allergyintolerance.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-allergyintolerance.json
@@ -1,1848 +1,1848 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-allergyintolerance",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-allergyintolerance-definitions.html#AllergyIntolerance\" title=\"The US Core Allergies Profile is based upon the core FHIR AllergyIntolerance Resource and created to meet the 2015 Edition Common Clinical Data Set 'Medical allergies' requirements.\">AllergyIntolerance</a><a name=\"AllergyIntolerance\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/allergyintolerance.html\">AllergyIntolerance</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Allergy or Intolerance (generally: Risk of adverse reaction to a substance)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-allergyintolerance-definitions.html#AllergyIntolerance.clinicalStatus\">clinicalStatus</a><a name=\"AllergyIntolerance.clinicalStatus\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">active | inactive | resolved</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-allergyintolerance-clinical.html\">AllergyIntoleranceClinicalStatusCodes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-allergyintolerance-definitions.html#AllergyIntolerance.verificationStatus\">verificationStatus</a><a name=\"AllergyIntolerance.verificationStatus\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">unconfirmed | confirmed | refuted | entered-in-error</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-allergyintolerance-verification.html\">AllergyIntoleranceVerificationStatusCodes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-allergyintolerance-definitions.html#AllergyIntolerance.code\">code</a><a name=\"AllergyIntolerance.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Code that identifies the allergy or intolerance</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1186.8/expansion\">Common substances for allergy and intolerance documentation including refutations</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-allergyintolerance-definitions.html#AllergyIntolerance.patient\">patient</a><a name=\"AllergyIntolerance.patient\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who the sensitivity is for</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-allergyintolerance-definitions.html#AllergyIntolerance.reaction\">reaction</a><a name=\"AllergyIntolerance.reaction\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Adverse Reaction Events linked to exposure to substance</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-allergyintolerance-definitions.html#AllergyIntolerance.reaction.manifestation\">manifestation</a><a name=\"AllergyIntolerance.reaction.manifestation\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Clinical symptoms/signs associated with the Event</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-clinical-findings.html\">SNOMEDCTClinicalFindings</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)<br/></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance",
-	"version": "4.0.0",
-	"name": "USCoreAllergyIntolerance",
-	"title": "US Core AllergyIntolerance Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-06-29",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the AllergyIntolerance resource for the minimal set of data to query and retrieve allergy information.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "AllergyIntolerance",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/AllergyIntolerance",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "AllergyIntolerance",
-				"path": "AllergyIntolerance",
-				"short": "Allergy or Intolerance (generally: Risk of adverse reaction to a substance)",
-				"definition": "The US Core Allergies Profile is based upon the core FHIR AllergyIntolerance Resource and created to meet the 2015 Edition Common Clinical Data Set 'Medical allergies' requirements.",
-				"comment": "Substances include, but are not limited to: a therapeutic substance administered correctly at an appropriate dosage for the individual; food; material derived from plants or animals; or venom from insect stings.",
-				"alias": [
-					"Allergy",
-					"Intolerance",
-					"Adverse Reaction"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "AllergyIntolerance",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "ait-1",
-						"severity": "error",
-						"human": "AllergyIntolerance.clinicalStatus SHALL be present if verificationStatus is not entered-in-error.",
-						"expression": "verificationStatus.coding.where(system = 'http://terminology.hl7.org/CodeSystem/allergyintolerance-verification' and code = 'entered-in-error').exists() or clinicalStatus.exists()",
-						"xpath": "f:verificationStatus/f:coding/f:code/@value='entered-in-error' or exists(f:clinicalStatus)",
-						"source": "http://hl7.org/fhir/StructureDefinition/AllergyIntolerance"
-					},
-					{
-						"key": "ait-2",
-						"severity": "error",
-						"human": "AllergyIntolerance.clinicalStatus SHALL NOT be present if verification Status is entered-in-error",
-						"expression": "verificationStatus.coding.where(system = 'http://terminology.hl7.org/CodeSystem/allergyintolerance-verification' and code = 'entered-in-error').empty() or clinicalStatus.empty()",
-						"xpath": "not(f:verificationStatus/f:coding/f:code/@value='entered-in-error') or not(exists(f:clinicalStatus))",
-						"source": "http://hl7.org/fhir/StructureDefinition/AllergyIntolerance"
-					},
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation[classCode=OBS, moodCode=EVN]"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "AllergyIntolerance"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.id",
-				"path": "AllergyIntolerance.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "AllergyIntolerance.meta",
-				"path": "AllergyIntolerance.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "AllergyIntolerance.implicitRules",
-				"path": "AllergyIntolerance.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "AllergyIntolerance.language",
-				"path": "AllergyIntolerance.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "AllergyIntolerance.text",
-				"path": "AllergyIntolerance.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.contained",
-				"path": "AllergyIntolerance.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.extension",
-				"path": "AllergyIntolerance.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.modifierExtension",
-				"path": "AllergyIntolerance.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.identifier",
-				"path": "AllergyIntolerance.identifier",
-				"short": "External ids for this item",
-				"definition": "Business identifiers assigned to this AllergyIntolerance by the performer or other systems which remain constant as the resource is updated and propagates from server to server.",
-				"comment": "This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.",
-				"requirements": "Allows identification of the AllergyIntolerance as it is known by various participating systems and in a way that remains consistent across servers.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "AllergyIntolerance.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "IAM-7"
-					},
-					{
-						"identity": "rim",
-						"map": "id"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.clinicalStatus",
-				"path": "AllergyIntolerance.clinicalStatus",
-				"short": "active | inactive | resolved",
-				"definition": "The clinical status of the allergy or intolerance.",
-				"comment": "Refer to [discussion](http://hl7.org/fhir/R4/extensibility.html#Special-Case) if clincalStatus is missing data.\nThe data type is CodeableConcept because clinicalStatus has some clinical judgment involved, such that there might need to be more specificity than the required FHIR value set allows. For example, a SNOMED coding might allow for additional specificity.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.clinicalStatus",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"ait-1",
-					"ait-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the status contains the codes inactive and resolved that mark the AllergyIntolerance as no longer active.",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/allergyintolerance-clinical"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation ACT .inboundRelationship[typeCode=COMP].source[classCode=OBS, code=\"clinicalStatus\", moodCode=EVN].value"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "AllergyIntolerance.status"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.verificationStatus",
-				"path": "AllergyIntolerance.verificationStatus",
-				"short": "unconfirmed | confirmed | refuted | entered-in-error",
-				"definition": "Assertion about certainty associated with the propensity, or potential risk, of a reaction to the identified substance (including pharmaceutical product).",
-				"comment": "The data type is CodeableConcept because verificationStatus has some clinical judgment involved, such that there might need to be more specificity than the required FHIR value set allows. For example, a SNOMED coding might allow for additional specificity.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.verificationStatus",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"ait-1",
-					"ait-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the status contains the codes refuted and entered-in-error that mark the AllergyIntolerance as not currently valid.",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/allergyintolerance-verification"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation ACT .inboundRelationship[typeCode=COMP].source[classCode=OBS, code=\"verificationStatus\", moodCode=EVN].value"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "AllergyIntolerance.status"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.type",
-				"path": "AllergyIntolerance.type",
-				"short": "allergy | intolerance - Underlying mechanism (if known)",
-				"definition": "Identification of the underlying physiological mechanism for the reaction risk.",
-				"comment": "Allergic (typically immune-mediated) reactions have been traditionally regarded as an indicator for potential escalation to significant future risk. Contemporary knowledge suggests that some reactions previously thought to be immune-mediated are, in fact, non-immune, but in some cases can still pose a life threatening risk. It is acknowledged that many clinicians might not be in a position to distinguish the mechanism of a particular reaction. Often the term \"allergy\" is used rather generically and may overlap with the use of \"intolerance\" - in practice the boundaries between these two concepts might not be well-defined or understood. This data element is included nevertheless, because many legacy systems have captured this attribute. Immunologic testing may provide supporting evidence for the basis of the reaction and the causative substance, but no tests are 100% sensitive or specific for sensitivity to a particular substance. If, as is commonly the case, it is unclear whether the reaction is due to an allergy or an intolerance, then the type element should be omitted from the resource.",
-				"alias": [
-					"Category",
-					"Class"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AllergyIntoleranceType"
-						}
-					],
-					"strength": "required",
-					"description": "Identification of the underlying physiological mechanism for a Reaction Risk.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/allergy-intolerance-type|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "v2",
-						"map": "IAM-9"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.category",
-				"path": "AllergyIntolerance.category",
-				"short": "food | medication | environment | biologic",
-				"definition": "Category of the identified substance.",
-				"comment": "This data element has been included because it is currently being captured in some clinical systems. This data can be derived from the substance where coding systems are used, and is effectively redundant in that situation.  When searching on category, consider the implications of AllergyIntolerance resources without a category.  For example, when searching on category = medication, medication allergies that don't have a category valued will not be returned.  Refer to [search](http://hl7.org/fhir/R4/search.html) for more information on how to search category with a :missing modifier to get allergies that don't have a category.  Additionally, category should be used with caution because category can be subjective based on the sender.",
-				"alias": [
-					"Category",
-					"Type",
-					"Reaction Type",
-					"Class"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "AllergyIntolerance.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AllergyIntoleranceCategory"
-						}
-					],
-					"strength": "required",
-					"description": "Category of an identified substance associated with allergies or intolerances.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/allergy-intolerance-category|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "v2",
-						"map": "AL1-2"
-					},
-					{
-						"identity": "rim",
-						"map": "value < IntoleranceValue (Agent)"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.criticality",
-				"path": "AllergyIntolerance.criticality",
-				"short": "low | high | unable-to-assess",
-				"definition": "Estimate of the potential clinical harm, or seriousness, of the reaction to the identified substance.",
-				"comment": "The default criticality value for any propensity to an adverse reaction should be 'Low Risk', indicating at the very least a relative contraindication to deliberate or voluntary exposure to the substance. 'High Risk' is flagged if the clinician has identified a propensity for a more serious or potentially life-threatening reaction, such as anaphylaxis, and implies an absolute contraindication to deliberate or voluntary exposure to the substance. If this element is missing, the criticality is unknown (though it may be known elsewhere).  Systems that capture a severity at the condition level are actually representing the concept of criticality whereas the severity documented at the reaction level is representing the true reaction severity.  Existing systems that are capturing both condition criticality and reaction severity may use the term \"severity\" to represent both.  Criticality is the worst it could be in the future (i.e. situation-agnostic) whereas severity is situation-dependent.",
-				"alias": [
-					"Severity",
-					"Seriousness",
-					"Contra-indication",
-					"Risk"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.criticality",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AllergyIntoleranceCriticality"
-						}
-					],
-					"strength": "required",
-					"description": "Estimate of the potential clinical harm, or seriousness, of a reaction to an identified substance.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/allergy-intolerance-criticality|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.grade"
-					},
-					{
-						"identity": "v2",
-						"map": "AL1-4"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=SEV, value <= SeverityObservation (Severity Level)]"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.code",
-				"path": "AllergyIntolerance.code",
-				"short": "Code that identifies the allergy or intolerance",
-				"definition": "Code for an allergy or intolerance statement (either a positive or a negated/excluded statement).  This may be a code for a substance or pharmaceutical product that is considered to be responsible for the adverse reaction risk (e.g., \"Latex\"), an allergy or intolerance condition (e.g., \"Latex allergy\"), or a negated/excluded code for a specific substance or class (e.g., \"No latex allergy\") or a general or categorical negated statement (e.g.,  \"No known allergy\", \"No known drug allergies\").  Note: the substance for a specific reaction may be different from the substance identified as the cause of the risk, but it must be consistent with it. For instance, it may be a more specific substance (e.g. a brand medication) or a composite product that includes the identified substance. It must be clinically safe to only process the 'code' and ignore the 'reaction.substance'.  If a receiving system is unable to confirm that AllergyIntolerance.reaction.substance falls within the semantic scope of AllergyIntolerance.code, then the receiving system should ignore AllergyIntolerance.reaction.substance.",
-				"comment": "It is strongly recommended that this element be populated using a terminology, where possible. For example, some terminologies used include RxNorm, SNOMED CT, DM+D, NDFRT, ICD-9, IDC-10, UNII, and ATC. Plain text should only be used if there is no appropriate terminology available. Additional details can be specified in the text.\r\rWhen a substance or product code is specified for the 'code' element, the \"default\" semantic context is that this is a positive statement of an allergy or intolerance (depending on the value of the 'type' element, if present) condition to the specified substance/product.  In the corresponding SNOMED CT allergy model, the specified substance/product is the target (destination) of the \"Causative agent\" relationship.\r\rThe 'substanceExposureRisk' extension is available as a structured and more flexible alternative to the 'code' element for making positive or negative allergy or intolerance statements.  This extension provides the capability to make \"no known allergy\" (or \"no risk of adverse reaction\") statements regarding any coded substance/product (including cases when a pre-coordinated \"no allergy to x\" concept for that substance/product does not exist).  If the 'substanceExposureRisk' extension is present, the AllergyIntolerance.code element SHALL be omitted.",
-				"alias": [
-					"Code"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1186.8"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "AL1-3 / IAM-3"
-					},
-					{
-						"identity": "rim",
-						"map": "substance/product:\r\r.participation[typeCode=CAGNT].role[classCode=ADMM].player[classCode=MAT, determinerCode=KIND, code <= ExposureAgentEntityType]\r\rnegated/excluded substance/product:\r\r.participation[typeCode=CAGNT, negationInd=true].role[classCode=ADMM].player[classCode=MAT, determinerCode=KIND, code <= ExposureAgentEntityType]\r\rpositive or negated/excluded condition/situation:\r\rObservation.code=ASSERTION; Observation.value"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "AllergyIntolerance.substance"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.patient",
-				"path": "AllergyIntolerance.patient",
-				"short": "Who the sensitivity is for",
-				"definition": "The patient who has the allergy or intolerance.",
-				"alias": [
-					"Patient"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.patient",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "(PID-3)"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=SBJ].role[classCode=PAT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "AllergyIntolerance.patient"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.encounter",
-				"path": "AllergyIntolerance.encounter",
-				"short": "Encounter when the allergy or intolerance was asserted",
-				"definition": "The encounter when the allergy or intolerance was asserted.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.onset[x]",
-				"path": "AllergyIntolerance.onset[x]",
-				"short": "When allergy or intolerance was identified",
-				"definition": "Estimated or actual date,  date-time, or age when allergy or intolerance was identified.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.onset[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Age"
-					},
-					{
-						"code": "Period"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.init"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime.low"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.recordedDate",
-				"path": "AllergyIntolerance.recordedDate",
-				"short": "Date first version of the resource instance was recorded",
-				"definition": "The recordedDate represents when this particular AllergyIntolerance record was created in the system, which is often a system-generated date.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.recordedDate",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "v2",
-						"map": "IAM-13"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=AUT].time"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.recorder",
-				"path": "AllergyIntolerance.recorder",
-				"short": "Who recorded the sensitivity",
-				"definition": "Individual who recorded the record and takes responsibility for its content.",
-				"alias": [
-					"Author"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.recorder",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.author"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=AUT].role"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.asserter",
-				"path": "AllergyIntolerance.asserter",
-				"short": "Source of the information about the allergy",
-				"definition": "The source of the information about the allergy that is recorded.",
-				"comment": "The recorder takes responsibility for the content, but can reference the source from where they got it.",
-				"alias": [
-					"Source",
-					"Informant"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.asserter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson",
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.source"
-					},
-					{
-						"identity": "v2",
-						"map": "IAM-14 (if patient) / IAM-18 (if practitioner)"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=INF].role"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.lastOccurrence",
-				"path": "AllergyIntolerance.lastOccurrence",
-				"short": "Date(/time) of last known occurrence of a reaction",
-				"definition": "Represents the date and/or time of the last known occurrence of a reaction event.",
-				"comment": "This date may be replicated by one of the Onset of Reaction dates. Where a textual representation of the date of last occurrence is required e.g. 'In Childhood, '10 years ago' the Comment element should be used.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.lastOccurrence",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=SUBJ].target[classCode=OBS, moodCode=EVN, code <= CommonClinicalObservationType, value <= ObservationValue (Reaction Type)].effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.note",
-				"path": "AllergyIntolerance.note",
-				"short": "Additional text not captured in other fields",
-				"definition": "Additional narrative about the propensity for the Adverse Reaction, not captured in other fields.",
-				"comment": "For example: including reason for flagging a seriousness of 'High Risk'; and instructions related to future exposure or administration of the substance, such as administration within an Intensive Care Unit or under corticosteroid cover. The notes should be related to an allergy or intolerance as a condition in general and not related to any particular episode of it. For episode notes and descriptions, use AllergyIntolerance.event.description and  AllergyIntolerance.event.notes.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "AllergyIntolerance.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "subjectOf.observationEvent[code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.reaction",
-				"path": "AllergyIntolerance.reaction",
-				"short": "Adverse Reaction Events linked to exposure to substance",
-				"definition": "Details about each adverse reaction event linked to exposure to the identified substance.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "AllergyIntolerance.reaction",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=SUBJ].target[classCode=OBS, moodCode=EVN, code <= CommonClinicalObservationType, value <= ObservationValue (Reaction Type)]"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.reaction.id",
-				"path": "AllergyIntolerance.reaction.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.reaction.extension",
-				"path": "AllergyIntolerance.reaction.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.reaction.modifierExtension",
-				"path": "AllergyIntolerance.reaction.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.reaction.substance",
-				"path": "AllergyIntolerance.reaction.substance",
-				"short": "Specific substance or pharmaceutical product considered to be responsible for event",
-				"definition": "Identification of the specific substance (or pharmaceutical product) considered to be responsible for the Adverse Reaction event. Note: the substance for a specific reaction may be different from the substance identified as the cause of the risk, but it must be consistent with it. For instance, it may be a more specific substance (e.g. a brand medication) or a composite product that includes the identified substance. It must be clinically safe to only process the 'code' and ignore the 'reaction.substance'.  If a receiving system is unable to confirm that AllergyIntolerance.reaction.substance falls within the semantic scope of AllergyIntolerance.code, then the receiving system should ignore AllergyIntolerance.reaction.substance.",
-				"comment": "Coding of the specific substance (or pharmaceutical product) with a terminology capable of triggering decision support should be used wherever possible.  The 'code' element allows for the use of a specific substance or pharmaceutical product, or a group or class of substances. In the case of an allergy or intolerance to a class of substances, (for example, \"penicillins\"), the 'reaction.substance' element could be used to code the specific substance that was identified as having caused the reaction (for example, \"amoxycillin\"). Duplication of the value in the 'code' and 'reaction.substance' elements is acceptable when a specific substance has been recorded in 'code'.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.reaction.substance",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "SubstanceCode"
-						}
-					],
-					"strength": "example",
-					"description": "Codes defining the type of the substance (including pharmaceutical products).",
-					"valueSet": "http://hl7.org/fhir/ValueSet/substance-code"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=SAS].target[classCode=SBADM, code <= ExposureCode].participation[typeCode=CSM].role[classCode=ADMM].player[classCode=MAT, determinerCode=KIND, code <= ExposureAgentEntityType]"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.reaction.manifestation",
-				"path": "AllergyIntolerance.reaction.manifestation",
-				"short": "Clinical symptoms/signs associated with the Event",
-				"definition": "Clinical symptoms and/or signs that are observed or associated with the adverse reaction event.",
-				"comment": "Manifestation can be expressed as a single word, phrase or brief description. For example: nausea, rash or no reaction. It is preferable that manifestation should be coded with a terminology, where possible. The values entered here may be used to display on an application screen as part of a list of adverse reactions, as recommended in the UK NHS CUI guidelines.  Terminologies commonly used include, but are not limited to, SNOMED CT or ICD10.",
-				"alias": [
-					"Symptoms",
-					"Signs"
-				],
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "AllergyIntolerance.reaction.manifestation",
-					"min": 1,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "AL1-5"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.reaction.description",
-				"path": "AllergyIntolerance.reaction.description",
-				"short": "Description of the event as a whole",
-				"definition": "Text description about the reaction as a whole, including details of the manifestation if required.",
-				"comment": "Use the description to provide any details of a particular event of the occurred reaction such as circumstances, reaction specifics, what happened before/after. Information, related to the event, but not describing a particular care should be captured in the comment field. For example: at the age of four, the patient was given penicillin for strep throat and subsequently developed severe hives.",
-				"alias": [
-					"Narrative",
-					"Text"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.reaction.description",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "text"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.reaction.onset",
-				"path": "AllergyIntolerance.reaction.onset",
-				"short": "Date(/time) when manifestations showed",
-				"definition": "Record of the date and/or time of the onset of the Reaction.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.reaction.onset",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "AL1-6"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime.low"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.reaction.severity",
-				"path": "AllergyIntolerance.reaction.severity",
-				"short": "mild | moderate | severe (of event as a whole)",
-				"definition": "Clinical assessment of the severity of the reaction event as a whole, potentially considering multiple different manifestations.",
-				"comment": "It is acknowledged that this assessment is very subjective. There may be some specific practice domains where objective scales have been applied. Objective scales can be included in this model as extensions.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.reaction.severity",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AllergyIntoleranceSeverity"
-						}
-					],
-					"strength": "required",
-					"description": "Clinical assessment of the severity of a reaction event as a whole, potentially considering multiple different manifestations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/reaction-event-severity|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=SEV, value <= SeverityObservation (Severity Level)]"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.reaction.exposureRoute",
-				"path": "AllergyIntolerance.reaction.exposureRoute",
-				"short": "How the subject was exposed to the substance",
-				"definition": "Identification of the route by which the subject was exposed to the substance.",
-				"comment": "Coding of the route of exposure with a terminology should be used wherever possible.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "AllergyIntolerance.reaction.exposureRoute",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "RouteOfAdministration"
-						}
-					],
-					"strength": "example",
-					"description": "A coded concept describing the route or physiological path of administration of a therapeutic agent into or onto the body of a subject.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/route-codes"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=SAS].target[classCode=SBADM, code <= ExposureCode].routeCode"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.reaction.note",
-				"path": "AllergyIntolerance.reaction.note",
-				"short": "Text about event not captured in other fields",
-				"definition": "Additional text about the adverse reaction event not captured in other fields.",
-				"comment": "Use this field to record information indirectly related to a particular event and not captured in the description. For example: Clinical records are no longer available, recorded based on information provided to the patient by her mother and her mother is deceased.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "AllergyIntolerance.reaction.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "subjectOf.observationEvent[code=\"annotation\"].value"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "AllergyIntolerance",
-				"path": "AllergyIntolerance",
-				"definition": "The US Core Allergies Profile is based upon the core FHIR AllergyIntolerance Resource and created to meet the 2015 Edition Common Clinical Data Set 'Medical allergies' requirements.",
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "AllergyIntolerance"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.clinicalStatus",
-				"path": "AllergyIntolerance.clinicalStatus",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/allergyintolerance-clinical"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "AllergyIntolerance.status"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.verificationStatus",
-				"path": "AllergyIntolerance.verificationStatus",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/allergyintolerance-verification"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "AllergyIntolerance.status"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.code",
-				"path": "AllergyIntolerance.code",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1186.8"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "AllergyIntolerance.substance"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.patient",
-				"path": "AllergyIntolerance.patient",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "AllergyIntolerance.patient"
-					}
-				]
-			},
-			{
-				"id": "AllergyIntolerance.reaction",
-				"path": "AllergyIntolerance.reaction",
-				"min": 0,
-				"max": "*",
-				"mustSupport": true
-			},
-			{
-				"id": "AllergyIntolerance.reaction.manifestation",
-				"path": "AllergyIntolerance.reaction.manifestation",
-				"min": 1,
-				"max": "*",
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
-				}
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-allergyintolerance",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance",
+    "version": "4.0.0",
+    "name": "USCoreAllergyIntolerance",
+    "title": "US Core AllergyIntolerance Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-06-29",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the AllergyIntolerance resource for the minimal set of data to query and retrieve allergy information.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "AllergyIntolerance",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/AllergyIntolerance",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "AllergyIntolerance",
+                "path": "AllergyIntolerance",
+                "short": "Allergy or Intolerance (generally: Risk of adverse reaction to a substance)",
+                "definition": "The US Core Allergies Profile is based upon the core FHIR AllergyIntolerance Resource and created to meet the 2015 Edition Common Clinical Data Set 'Medical allergies' requirements.",
+                "comment": "Substances include, but are not limited to: a therapeutic substance administered correctly at an appropriate dosage for the individual; food; material derived from plants or animals; or venom from insect stings.",
+                "alias": [
+                    "Allergy",
+                    "Intolerance",
+                    "Adverse Reaction"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "AllergyIntolerance",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "ait-1",
+                        "severity": "error",
+                        "human": "AllergyIntolerance.clinicalStatus SHALL be present if verificationStatus is not entered-in-error.",
+                        "expression": "verificationStatus.coding.where(system = 'http://terminology.hl7.org/CodeSystem/allergyintolerance-verification' and code = 'entered-in-error').exists() or clinicalStatus.exists()",
+                        "xpath": "f:verificationStatus/f:coding/f:code/@value='entered-in-error' or exists(f:clinicalStatus)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/AllergyIntolerance"
+                    },
+                    {
+                        "key": "ait-2",
+                        "severity": "error",
+                        "human": "AllergyIntolerance.clinicalStatus SHALL NOT be present if verification Status is entered-in-error",
+                        "expression": "verificationStatus.coding.where(system = 'http://terminology.hl7.org/CodeSystem/allergyintolerance-verification' and code = 'entered-in-error').empty() or clinicalStatus.empty()",
+                        "xpath": "not(f:verificationStatus/f:coding/f:code/@value='entered-in-error') or not(exists(f:clinicalStatus))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/AllergyIntolerance"
+                    },
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation[classCode=OBS, moodCode=EVN]"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "AllergyIntolerance"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.id",
+                "path": "AllergyIntolerance.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "AllergyIntolerance.meta",
+                "path": "AllergyIntolerance.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "AllergyIntolerance.implicitRules",
+                "path": "AllergyIntolerance.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "AllergyIntolerance.language",
+                "path": "AllergyIntolerance.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "AllergyIntolerance.text",
+                "path": "AllergyIntolerance.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.contained",
+                "path": "AllergyIntolerance.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.extension",
+                "path": "AllergyIntolerance.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.modifierExtension",
+                "path": "AllergyIntolerance.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.identifier",
+                "path": "AllergyIntolerance.identifier",
+                "short": "External ids for this item",
+                "definition": "Business identifiers assigned to this AllergyIntolerance by the performer or other systems which remain constant as the resource is updated and propagates from server to server.",
+                "comment": "This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.",
+                "requirements": "Allows identification of the AllergyIntolerance as it is known by various participating systems and in a way that remains consistent across servers.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "AllergyIntolerance.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "IAM-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "id"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.clinicalStatus",
+                "path": "AllergyIntolerance.clinicalStatus",
+                "short": "active | inactive | resolved",
+                "definition": "The clinical status of the allergy or intolerance.",
+                "comment": "Refer to [discussion](http://hl7.org/fhir/R4/extensibility.html#Special-Case) if clincalStatus is missing data.\nThe data type is CodeableConcept because clinicalStatus has some clinical judgment involved, such that there might need to be more specificity than the required FHIR value set allows. For example, a SNOMED coding might allow for additional specificity.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.clinicalStatus",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "ait-1",
+                    "ait-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the status contains the codes inactive and resolved that mark the AllergyIntolerance as no longer active.",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/allergyintolerance-clinical"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation ACT .inboundRelationship[typeCode=COMP].source[classCode=OBS, code=\"clinicalStatus\", moodCode=EVN].value"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "AllergyIntolerance.status"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.verificationStatus",
+                "path": "AllergyIntolerance.verificationStatus",
+                "short": "unconfirmed | confirmed | refuted | entered-in-error",
+                "definition": "Assertion about certainty associated with the propensity, or potential risk, of a reaction to the identified substance (including pharmaceutical product).",
+                "comment": "The data type is CodeableConcept because verificationStatus has some clinical judgment involved, such that there might need to be more specificity than the required FHIR value set allows. For example, a SNOMED coding might allow for additional specificity.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.verificationStatus",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "ait-1",
+                    "ait-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the status contains the codes refuted and entered-in-error that mark the AllergyIntolerance as not currently valid.",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/allergyintolerance-verification"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation ACT .inboundRelationship[typeCode=COMP].source[classCode=OBS, code=\"verificationStatus\", moodCode=EVN].value"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "AllergyIntolerance.status"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.type",
+                "path": "AllergyIntolerance.type",
+                "short": "allergy | intolerance - Underlying mechanism (if known)",
+                "definition": "Identification of the underlying physiological mechanism for the reaction risk.",
+                "comment": "Allergic (typically immune-mediated) reactions have been traditionally regarded as an indicator for potential escalation to significant future risk. Contemporary knowledge suggests that some reactions previously thought to be immune-mediated are, in fact, non-immune, but in some cases can still pose a life threatening risk. It is acknowledged that many clinicians might not be in a position to distinguish the mechanism of a particular reaction. Often the term \"allergy\" is used rather generically and may overlap with the use of \"intolerance\" - in practice the boundaries between these two concepts might not be well-defined or understood. This data element is included nevertheless, because many legacy systems have captured this attribute. Immunologic testing may provide supporting evidence for the basis of the reaction and the causative substance, but no tests are 100% sensitive or specific for sensitivity to a particular substance. If, as is commonly the case, it is unclear whether the reaction is due to an allergy or an intolerance, then the type element should be omitted from the resource.",
+                "alias": [
+                    "Category",
+                    "Class"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AllergyIntoleranceType"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Identification of the underlying physiological mechanism for a Reaction Risk.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/allergy-intolerance-type|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "IAM-9"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.category",
+                "path": "AllergyIntolerance.category",
+                "short": "food | medication | environment | biologic",
+                "definition": "Category of the identified substance.",
+                "comment": "This data element has been included because it is currently being captured in some clinical systems. This data can be derived from the substance where coding systems are used, and is effectively redundant in that situation.  When searching on category, consider the implications of AllergyIntolerance resources without a category.  For example, when searching on category = medication, medication allergies that don't have a category valued will not be returned.  Refer to [search](http://hl7.org/fhir/R4/search.html) for more information on how to search category with a :missing modifier to get allergies that don't have a category.  Additionally, category should be used with caution because category can be subjective based on the sender.",
+                "alias": [
+                    "Category",
+                    "Type",
+                    "Reaction Type",
+                    "Class"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "AllergyIntolerance.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AllergyIntoleranceCategory"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Category of an identified substance associated with allergies or intolerances.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/allergy-intolerance-category|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "AL1-2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value < IntoleranceValue (Agent)"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.criticality",
+                "path": "AllergyIntolerance.criticality",
+                "short": "low | high | unable-to-assess",
+                "definition": "Estimate of the potential clinical harm, or seriousness, of the reaction to the identified substance.",
+                "comment": "The default criticality value for any propensity to an adverse reaction should be 'Low Risk', indicating at the very least a relative contraindication to deliberate or voluntary exposure to the substance. 'High Risk' is flagged if the clinician has identified a propensity for a more serious or potentially life-threatening reaction, such as anaphylaxis, and implies an absolute contraindication to deliberate or voluntary exposure to the substance. If this element is missing, the criticality is unknown (though it may be known elsewhere).  Systems that capture a severity at the condition level are actually representing the concept of criticality whereas the severity documented at the reaction level is representing the true reaction severity.  Existing systems that are capturing both condition criticality and reaction severity may use the term \"severity\" to represent both.  Criticality is the worst it could be in the future (i.e. situation-agnostic) whereas severity is situation-dependent.",
+                "alias": [
+                    "Severity",
+                    "Seriousness",
+                    "Contra-indication",
+                    "Risk"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.criticality",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AllergyIntoleranceCriticality"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Estimate of the potential clinical harm, or seriousness, of a reaction to an identified substance.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/allergy-intolerance-criticality|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.grade"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "AL1-4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=SEV, value <= SeverityObservation (Severity Level)]"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.code",
+                "path": "AllergyIntolerance.code",
+                "short": "Code that identifies the allergy or intolerance",
+                "definition": "Code for an allergy or intolerance statement (either a positive or a negated/excluded statement).  This may be a code for a substance or pharmaceutical product that is considered to be responsible for the adverse reaction risk (e.g., \"Latex\"), an allergy or intolerance condition (e.g., \"Latex allergy\"), or a negated/excluded code for a specific substance or class (e.g., \"No latex allergy\") or a general or categorical negated statement (e.g.,  \"No known allergy\", \"No known drug allergies\").  Note: the substance for a specific reaction may be different from the substance identified as the cause of the risk, but it must be consistent with it. For instance, it may be a more specific substance (e.g. a brand medication) or a composite product that includes the identified substance. It must be clinically safe to only process the 'code' and ignore the 'reaction.substance'.  If a receiving system is unable to confirm that AllergyIntolerance.reaction.substance falls within the semantic scope of AllergyIntolerance.code, then the receiving system should ignore AllergyIntolerance.reaction.substance.",
+                "comment": "It is strongly recommended that this element be populated using a terminology, where possible. For example, some terminologies used include RxNorm, SNOMED CT, DM+D, NDFRT, ICD-9, IDC-10, UNII, and ATC. Plain text should only be used if there is no appropriate terminology available. Additional details can be specified in the text.\r\rWhen a substance or product code is specified for the 'code' element, the \"default\" semantic context is that this is a positive statement of an allergy or intolerance (depending on the value of the 'type' element, if present) condition to the specified substance/product.  In the corresponding SNOMED CT allergy model, the specified substance/product is the target (destination) of the \"Causative agent\" relationship.\r\rThe 'substanceExposureRisk' extension is available as a structured and more flexible alternative to the 'code' element for making positive or negative allergy or intolerance statements.  This extension provides the capability to make \"no known allergy\" (or \"no risk of adverse reaction\") statements regarding any coded substance/product (including cases when a pre-coordinated \"no allergy to x\" concept for that substance/product does not exist).  If the 'substanceExposureRisk' extension is present, the AllergyIntolerance.code element SHALL be omitted.",
+                "alias": [
+                    "Code"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1186.8"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "AL1-3 / IAM-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "substance/product:\r\r.participation[typeCode=CAGNT].role[classCode=ADMM].player[classCode=MAT, determinerCode=KIND, code <= ExposureAgentEntityType]\r\rnegated/excluded substance/product:\r\r.participation[typeCode=CAGNT, negationInd=true].role[classCode=ADMM].player[classCode=MAT, determinerCode=KIND, code <= ExposureAgentEntityType]\r\rpositive or negated/excluded condition/situation:\r\rObservation.code=ASSERTION; Observation.value"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "AllergyIntolerance.substance"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.patient",
+                "path": "AllergyIntolerance.patient",
+                "short": "Who the sensitivity is for",
+                "definition": "The patient who has the allergy or intolerance.",
+                "alias": [
+                    "Patient"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.patient",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "(PID-3)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=SBJ].role[classCode=PAT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "AllergyIntolerance.patient"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.encounter",
+                "path": "AllergyIntolerance.encounter",
+                "short": "Encounter when the allergy or intolerance was asserted",
+                "definition": "The encounter when the allergy or intolerance was asserted.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.onset[x]",
+                "path": "AllergyIntolerance.onset[x]",
+                "short": "When allergy or intolerance was identified",
+                "definition": "Estimated or actual date,  date-time, or age when allergy or intolerance was identified.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.onset[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Age"
+                    },
+                    {
+                        "code": "Period"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.init"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime.low"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.recordedDate",
+                "path": "AllergyIntolerance.recordedDate",
+                "short": "Date first version of the resource instance was recorded",
+                "definition": "The recordedDate represents when this particular AllergyIntolerance record was created in the system, which is often a system-generated date.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.recordedDate",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "IAM-13"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.recorder",
+                "path": "AllergyIntolerance.recorder",
+                "short": "Who recorded the sensitivity",
+                "definition": "Individual who recorded the record and takes responsibility for its content.",
+                "alias": [
+                    "Author"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.recorder",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.author"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=AUT].role"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.asserter",
+                "path": "AllergyIntolerance.asserter",
+                "short": "Source of the information about the allergy",
+                "definition": "The source of the information about the allergy that is recorded.",
+                "comment": "The recorder takes responsibility for the content, but can reference the source from where they got it.",
+                "alias": [
+                    "Source",
+                    "Informant"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.asserter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.source"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "IAM-14 (if patient) / IAM-18 (if practitioner)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=INF].role"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.lastOccurrence",
+                "path": "AllergyIntolerance.lastOccurrence",
+                "short": "Date(/time) of last known occurrence of a reaction",
+                "definition": "Represents the date and/or time of the last known occurrence of a reaction event.",
+                "comment": "This date may be replicated by one of the Onset of Reaction dates. Where a textual representation of the date of last occurrence is required e.g. 'In Childhood, '10 years ago' the Comment element should be used.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.lastOccurrence",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=SUBJ].target[classCode=OBS, moodCode=EVN, code <= CommonClinicalObservationType, value <= ObservationValue (Reaction Type)].effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.note",
+                "path": "AllergyIntolerance.note",
+                "short": "Additional text not captured in other fields",
+                "definition": "Additional narrative about the propensity for the Adverse Reaction, not captured in other fields.",
+                "comment": "For example: including reason for flagging a seriousness of 'High Risk'; and instructions related to future exposure or administration of the substance, such as administration within an Intensive Care Unit or under corticosteroid cover. The notes should be related to an allergy or intolerance as a condition in general and not related to any particular episode of it. For episode notes and descriptions, use AllergyIntolerance.event.description and  AllergyIntolerance.event.notes.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "AllergyIntolerance.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "subjectOf.observationEvent[code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.reaction",
+                "path": "AllergyIntolerance.reaction",
+                "short": "Adverse Reaction Events linked to exposure to substance",
+                "definition": "Details about each adverse reaction event linked to exposure to the identified substance.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "AllergyIntolerance.reaction",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=SUBJ].target[classCode=OBS, moodCode=EVN, code <= CommonClinicalObservationType, value <= ObservationValue (Reaction Type)]"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.reaction.id",
+                "path": "AllergyIntolerance.reaction.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.reaction.extension",
+                "path": "AllergyIntolerance.reaction.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.reaction.modifierExtension",
+                "path": "AllergyIntolerance.reaction.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.reaction.substance",
+                "path": "AllergyIntolerance.reaction.substance",
+                "short": "Specific substance or pharmaceutical product considered to be responsible for event",
+                "definition": "Identification of the specific substance (or pharmaceutical product) considered to be responsible for the Adverse Reaction event. Note: the substance for a specific reaction may be different from the substance identified as the cause of the risk, but it must be consistent with it. For instance, it may be a more specific substance (e.g. a brand medication) or a composite product that includes the identified substance. It must be clinically safe to only process the 'code' and ignore the 'reaction.substance'.  If a receiving system is unable to confirm that AllergyIntolerance.reaction.substance falls within the semantic scope of AllergyIntolerance.code, then the receiving system should ignore AllergyIntolerance.reaction.substance.",
+                "comment": "Coding of the specific substance (or pharmaceutical product) with a terminology capable of triggering decision support should be used wherever possible.  The 'code' element allows for the use of a specific substance or pharmaceutical product, or a group or class of substances. In the case of an allergy or intolerance to a class of substances, (for example, \"penicillins\"), the 'reaction.substance' element could be used to code the specific substance that was identified as having caused the reaction (for example, \"amoxycillin\"). Duplication of the value in the 'code' and 'reaction.substance' elements is acceptable when a specific substance has been recorded in 'code'.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.reaction.substance",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "SubstanceCode"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes defining the type of the substance (including pharmaceutical products).",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/substance-code"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=SAS].target[classCode=SBADM, code <= ExposureCode].participation[typeCode=CSM].role[classCode=ADMM].player[classCode=MAT, determinerCode=KIND, code <= ExposureAgentEntityType]"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.reaction.manifestation",
+                "path": "AllergyIntolerance.reaction.manifestation",
+                "short": "Clinical symptoms/signs associated with the Event",
+                "definition": "Clinical symptoms and/or signs that are observed or associated with the adverse reaction event.",
+                "comment": "Manifestation can be expressed as a single word, phrase or brief description. For example: nausea, rash or no reaction. It is preferable that manifestation should be coded with a terminology, where possible. The values entered here may be used to display on an application screen as part of a list of adverse reactions, as recommended in the UK NHS CUI guidelines.  Terminologies commonly used include, but are not limited to, SNOMED CT or ICD10.",
+                "alias": [
+                    "Symptoms",
+                    "Signs"
+                ],
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "AllergyIntolerance.reaction.manifestation",
+                    "min": 1,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "AL1-5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.reaction.description",
+                "path": "AllergyIntolerance.reaction.description",
+                "short": "Description of the event as a whole",
+                "definition": "Text description about the reaction as a whole, including details of the manifestation if required.",
+                "comment": "Use the description to provide any details of a particular event of the occurred reaction such as circumstances, reaction specifics, what happened before/after. Information, related to the event, but not describing a particular care should be captured in the comment field. For example: at the age of four, the patient was given penicillin for strep throat and subsequently developed severe hives.",
+                "alias": [
+                    "Narrative",
+                    "Text"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.reaction.description",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "text"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.reaction.onset",
+                "path": "AllergyIntolerance.reaction.onset",
+                "short": "Date(/time) when manifestations showed",
+                "definition": "Record of the date and/or time of the onset of the Reaction.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.reaction.onset",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "AL1-6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime.low"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.reaction.severity",
+                "path": "AllergyIntolerance.reaction.severity",
+                "short": "mild | moderate | severe (of event as a whole)",
+                "definition": "Clinical assessment of the severity of the reaction event as a whole, potentially considering multiple different manifestations.",
+                "comment": "It is acknowledged that this assessment is very subjective. There may be some specific practice domains where objective scales have been applied. Objective scales can be included in this model as extensions.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.reaction.severity",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AllergyIntoleranceSeverity"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Clinical assessment of the severity of a reaction event as a whole, potentially considering multiple different manifestations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/reaction-event-severity|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=SEV, value <= SeverityObservation (Severity Level)]"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.reaction.exposureRoute",
+                "path": "AllergyIntolerance.reaction.exposureRoute",
+                "short": "How the subject was exposed to the substance",
+                "definition": "Identification of the route by which the subject was exposed to the substance.",
+                "comment": "Coding of the route of exposure with a terminology should be used wherever possible.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "AllergyIntolerance.reaction.exposureRoute",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "RouteOfAdministration"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "A coded concept describing the route or physiological path of administration of a therapeutic agent into or onto the body of a subject.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/route-codes"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=SAS].target[classCode=SBADM, code <= ExposureCode].routeCode"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.reaction.note",
+                "path": "AllergyIntolerance.reaction.note",
+                "short": "Text about event not captured in other fields",
+                "definition": "Additional text about the adverse reaction event not captured in other fields.",
+                "comment": "Use this field to record information indirectly related to a particular event and not captured in the description. For example: Clinical records are no longer available, recorded based on information provided to the patient by her mother and her mother is deceased.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "AllergyIntolerance.reaction.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "subjectOf.observationEvent[code=\"annotation\"].value"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "AllergyIntolerance",
+                "path": "AllergyIntolerance",
+                "definition": "The US Core Allergies Profile is based upon the core FHIR AllergyIntolerance Resource and created to meet the 2015 Edition Common Clinical Data Set 'Medical allergies' requirements.",
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "AllergyIntolerance"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.clinicalStatus",
+                "path": "AllergyIntolerance.clinicalStatus",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/allergyintolerance-clinical"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "AllergyIntolerance.status"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.verificationStatus",
+                "path": "AllergyIntolerance.verificationStatus",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/allergyintolerance-verification"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "AllergyIntolerance.status"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.code",
+                "path": "AllergyIntolerance.code",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1186.8"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "AllergyIntolerance.substance"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.patient",
+                "path": "AllergyIntolerance.patient",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "AllergyIntolerance.patient"
+                    }
+                ]
+            },
+            {
+                "id": "AllergyIntolerance.reaction",
+                "path": "AllergyIntolerance.reaction",
+                "min": 0,
+                "max": "*",
+                "mustSupport": true
+            },
+            {
+                "id": "AllergyIntolerance.reaction.manifestation",
+                "path": "AllergyIntolerance.reaction.manifestation",
+                "min": 1,
+                "max": "*",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
+                }
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-birthsex.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-birthsex.json
@@ -1,370 +1,370 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-birthsex",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-birthsex-definitions.html#Extension\" title=\"A code classifying the person's sex assigned at birth  as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc).\">Extension</a><a name=\"Extension\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/extensibility.html#Extension\">Extension</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Extension</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-birthsex-definitions.html#Extension.url\">url</a><a name=\"Extension.url\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">1</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"color: darkgreen\">&quot;http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex&quot;</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck00.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-birthsex-definitions.html#Extension.valueCode\">valueCode</a><a name=\"Extension.valueCode\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Value of extension</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-birthsex.html\">Birth Sex</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>): Code for sex assigned at birth<br/><br/></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
-	"version": "4.0.0",
-	"name": "USCoreBirthSexExtension",
-	"title": "US Core Birth Sex Extension",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "A code classifying the person's sex assigned at birth  as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc). This extension aligns with the C-CDA Birth Sex Observation (LOINC 76689-9).",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		}
-	],
-	"kind": "complex-type",
-	"abstract": false,
-	"context": [
-		{
-			"type": "element",
-			"expression": "Patient"
-		}
-	],
-	"type": "Extension",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Extension",
-				"path": "Extension",
-				"short": "Extension",
-				"definition": "A code classifying the person's sex assigned at birth  as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc).",
-				"comment": "The codes required are intended to present birth sex (i.e., the sex recorded on the patient’s birth certificate) and not gender identity or reassigned sex.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Extension",
-					"min": 0,
-					"max": "*"
-				},
-				"condition": [
-					"ele-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender"
-					},
-					{
-						"identity": "iso11179",
-						"map": ".patient.administrativeGenderCode"
-					}
-				]
-			},
-			{
-				"id": "Extension.id",
-				"path": "Extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension",
-				"path": "Extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.url",
-				"path": "Extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "uri"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.value[x]",
-				"path": "Extension.value[x]",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "type",
-							"path": "$this"
-						}
-					],
-					"ordered": false,
-					"rules": "closed"
-				},
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.value[x]:valueCode",
-				"path": "Extension.value[x]",
-				"sliceName": "valueCode",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"strength": "required",
-					"description": "Code for sex assigned at birth",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/birthsex"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Extension",
-				"path": "Extension",
-				"definition": "A code classifying the person's sex assigned at birth  as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc).",
-				"comment": "The codes required are intended to present birth sex (i.e., the sex recorded on the patient’s birth certificate) and not gender identity or reassigned sex.",
-				"min": 0,
-				"max": "1",
-				"isModifier": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender"
-					},
-					{
-						"identity": "iso11179",
-						"map": ".patient.administrativeGenderCode"
-					}
-				]
-			},
-			{
-				"id": "Extension.url",
-				"path": "Extension.url",
-				"fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex"
-			},
-			{
-				"id": "Extension.valueCode",
-				"path": "Extension.valueCode",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"binding": {
-					"strength": "required",
-					"description": "Code for sex assigned at birth",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/birthsex"
-				}
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-birthsex",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+    "version": "4.0.0",
+    "name": "USCoreBirthSexExtension",
+    "title": "US Core Birth Sex Extension",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "A code classifying the person's sex assigned at birth  as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc). This extension aligns with the C-CDA Birth Sex Observation (LOINC 76689-9).",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        }
+    ],
+    "kind": "complex-type",
+    "abstract": false,
+    "context": [
+        {
+            "type": "element",
+            "expression": "Patient"
+        }
+    ],
+    "type": "Extension",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Extension",
+                "path": "Extension",
+                "short": "Extension",
+                "definition": "A code classifying the person's sex assigned at birth  as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc).",
+                "comment": "The codes required are intended to present birth sex (i.e., the sex recorded on the patient’s birth certificate) and not gender identity or reassigned sex.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "condition": [
+                    "ele-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender"
+                    },
+                    {
+                        "identity": "iso11179",
+                        "map": ".patient.administrativeGenderCode"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.id",
+                "path": "Extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension",
+                "path": "Extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.url",
+                "path": "Extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "uri"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.value[x]",
+                "path": "Extension.value[x]",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "type",
+                            "path": "$this"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "closed"
+                },
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.value[x]:valueCode",
+                "path": "Extension.value[x]",
+                "sliceName": "valueCode",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "strength": "required",
+                    "description": "Code for sex assigned at birth",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/birthsex"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Extension",
+                "path": "Extension",
+                "definition": "A code classifying the person's sex assigned at birth  as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc).",
+                "comment": "The codes required are intended to present birth sex (i.e., the sex recorded on the patient’s birth certificate) and not gender identity or reassigned sex.",
+                "min": 0,
+                "max": "1",
+                "isModifier": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender"
+                    },
+                    {
+                        "identity": "iso11179",
+                        "map": ".patient.administrativeGenderCode"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.url",
+                "path": "Extension.url",
+                "fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex"
+            },
+            {
+                "id": "Extension.valueCode",
+                "path": "Extension.valueCode",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "binding": {
+                    "strength": "required",
+                    "description": "Code for sex assigned at birth",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/birthsex"
+                }
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-blood-pressure.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-blood-pressure.json
@@ -1,5183 +1,5183 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-blood-pressure",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-blood-pressure-definitions.html#Observation\" title=\"Defines constraints on Observation to represent diastolic and systolic blood pressure observations with standard LOINC codes and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.\">Observation</a><a name=\"Observation\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"StructureDefinition-us-core-vital-signs.html\">USCoreVitalSignsProfile</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">US Core Blood Pressure Profile</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-blood-pressure-definitions.html#Observation.code\">code</a><a name=\"Observation.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">1</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Blood Pressure<br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck101.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#CodeableConcept.coding\">coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Code defined by a terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">(complex)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/loinc.html\">http://loinc.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">85354-9</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck03.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Definition\" class=\"hierarchy\"/> <a style=\"font-style: italic\" href=\"StructureDefinition-us-core-blood-pressure-definitions.html#Observation.component\">Slices for component</a><a name=\"Observation.component\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red; font-style: italic\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"font-style: italic\"/><span style=\"font-style: italic\">2</span><span style=\"font-style: italic\">..</span><span style=\"font-style: italic\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5; font-style: italic\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5; font-style: italic\">Component observations</span><br style=\"font-style: italic\"/><span style=\"font-weight:bold; font-style: italic\">Slice: </span><span style=\"font-style: italic\">Unordered, Open by pattern:code</span><br style=\"font-style: italic\"/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck035.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-blood-pressure-definitions.html#Observation.component:systolic\" title=\"Slice systolic\">component:systolic</a><a name=\"Observation.component\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Systolic Blood Pressure</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0351.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-blood-pressure-definitions.html#Observation.component:systolic.code\">code</a><a name=\"Observation.component.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Systolic Blood Pressure Code<br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck03501.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#CodeableConcept.coding\">coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Code defined by a terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">(complex)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck035010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/loinc.html\">http://loinc.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck035000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">8480-6</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0341.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-blood-pressure-definitions.html#Observation.component:systolic.valueQuantity\">valueQuantity</a><a name=\"Observation.component.valueQuantity\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Quantity\">Quantity</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Vital Sign Component Value</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck03410.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-blood-pressure-definitions.html#Observation.component:systolic.valueQuantity.value\">value</a><a name=\"Observation.component.valueQuantity.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#decimal\">decimal</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Numerical value (with implicit precision)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck03410.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-blood-pressure-definitions.html#Observation.component:systolic.valueQuantity.unit\">unit</a><a name=\"Observation.component.valueQuantity.unit\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Unit representation</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck03410.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-blood-pressure-definitions.html#Observation.component:systolic.valueQuantity.system\">system</a><a name=\"Observation.component.valueQuantity.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">System that defines coded unit form</span><br/><span style=\"font-weight:bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/ucum.html\">http://unitsofmeasure.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck03400.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-blood-pressure-definitions.html#Observation.component:systolic.valueQuantity.code\">code</a><a name=\"Observation.component.valueQuantity.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Coded form of the unit</span><br/><span style=\"font-weight:bold\">Fixed Value: </span><span style=\"color: darkgreen\">mm[Hg]</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck025.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-blood-pressure-definitions.html#Observation.component:diastolic\" title=\"Slice diastolic\">component:diastolic</a><a name=\"Observation.component\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Diastolic Blood Pressure</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0251.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-blood-pressure-definitions.html#Observation.component:diastolic.code\">code</a><a name=\"Observation.component.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Diastolic Blood Pressure Code<br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck02501.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#CodeableConcept.coding\">coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Code defined by a terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">(complex)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck025010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/loinc.html\">http://loinc.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck025000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">8462-4</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0241.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-blood-pressure-definitions.html#Observation.component:diastolic.valueQuantity\">valueQuantity</a><a name=\"Observation.component.valueQuantity\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Quantity\">Quantity</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Vital Sign Component Value</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck02410.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-blood-pressure-definitions.html#Observation.component:diastolic.valueQuantity.value\">value</a><a name=\"Observation.component.valueQuantity.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#decimal\">decimal</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Numerical value (with implicit precision)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck02410.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-blood-pressure-definitions.html#Observation.component:diastolic.valueQuantity.unit\">unit</a><a name=\"Observation.component.valueQuantity.unit\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Unit representation</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck02410.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-blood-pressure-definitions.html#Observation.component:diastolic.valueQuantity.system\">system</a><a name=\"Observation.component.valueQuantity.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">System that defines coded unit form</span><br/><span style=\"font-weight:bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/ucum.html\">http://unitsofmeasure.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck02400.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-blood-pressure-definitions.html#Observation.component:diastolic.valueQuantity.code\">code</a><a name=\"Observation.component.valueQuantity.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Coded form of the unit</span><br/><span style=\"font-weight:bold\">Fixed Value: </span><span style=\"color: darkgreen\">mm[Hg]</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure",
-	"version": "4.0.0",
-	"name": "USCoreBloodPressureProfile",
-	"title": "US Core Blood Pressure Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-17",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints on Observation to represent diastolic and systolic blood pressure observations with standard LOINC codes and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "sct-concept",
-			"uri": "http://snomed.info/conceptdomain",
-			"name": "SNOMED CT Concept Domain Binding"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "sct-attr",
-			"uri": "http://snomed.org/attributebinding",
-			"name": "SNOMED CT Attribute Binding"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Observation",
-	"baseDefinition": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "US Core Blood Pressure Profile",
-				"definition": "Defines constraints on Observation to represent diastolic and systolic blood pressure observations with standard LOINC codes and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
-				"alias": [
-					"Vital Signs",
-					"Measurement",
-					"Results",
-					"Tests"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "obs-6",
-						"severity": "error",
-						"human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
-						"expression": "dataAbsentReason.empty() or value.empty()",
-						"xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "obs-7",
-						"severity": "error",
-						"human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
-						"expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
-						"xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "vs-2",
-						"severity": "error",
-						"human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
-						"expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
-						"xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.id",
-				"path": "Observation.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.meta",
-				"path": "Observation.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.implicitRules",
-				"path": "Observation.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Observation.language",
-				"path": "Observation.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Observation.text",
-				"path": "Observation.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Observation.contained",
-				"path": "Observation.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.extension",
-				"path": "Observation.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.modifierExtension",
-				"path": "Observation.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.identifier",
-				"path": "Observation.identifier",
-				"short": "Business Identifier for observation",
-				"definition": "A unique identifier assigned to this observation.",
-				"requirements": "Allows observations to be distinguished and referenced.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
-					},
-					{
-						"identity": "rim",
-						"map": "id"
-					}
-				]
-			},
-			{
-				"id": "Observation.basedOn",
-				"path": "Observation.basedOn",
-				"short": "Fulfills plan, proposal or order",
-				"definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
-				"requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
-				"alias": [
-					"Fulfills"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan",
-							"http://hl7.org/fhir/StructureDefinition/DeviceRequest",
-							"http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
-							"http://hl7.org/fhir/StructureDefinition/MedicationRequest",
-							"http://hl7.org/fhir/StructureDefinition/NutritionOrder",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.basedOn"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.partOf",
-				"path": "Observation.partOf",
-				"short": "Part of referenced event",
-				"definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
-				"comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
-				"alias": [
-					"Container"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.partOf",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
-							"http://hl7.org/fhir/StructureDefinition/MedicationDispense",
-							"http://hl7.org/fhir/StructureDefinition/MedicationStatement",
-							"http://hl7.org/fhir/StructureDefinition/Procedure",
-							"http://hl7.org/fhir/StructureDefinition/Immunization",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.partOf"
-					},
-					{
-						"identity": "v2",
-						"map": "Varies by domain"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=FLFS].target"
-					}
-				]
-			},
-			{
-				"id": "Observation.status",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
-						"valueString": "default: final"
-					}
-				],
-				"path": "Observation.status",
-				"short": "registered | preliminary | final | amended +",
-				"definition": "The status of the result value.",
-				"comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
-				"requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Status"
-						}
-					],
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 445584004 |Report by finality status|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-11"
-					},
-					{
-						"identity": "rim",
-						"map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
-					}
-				]
-			},
-			{
-				"id": "Observation.category",
-				"path": "Observation.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "coding.code"
-						},
-						{
-							"type": "value",
-							"path": "coding.system"
-						}
-					],
-					"ordered": false,
-					"rules": "open"
-				},
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat",
-				"path": "Observation.category",
-				"sliceName": "VSCat",
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.id",
-				"path": "Observation.category.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.extension",
-				"path": "Observation.category.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding",
-				"path": "Observation.category.coding",
-				"short": "Code defined by a terminology system",
-				"definition": "A reference to a code defined by a terminology system.",
-				"comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
-				"requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "CodeableConcept.coding",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1-8, C*E.10-22"
-					},
-					{
-						"identity": "rim",
-						"map": "union(., ./translation)"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.id",
-				"path": "Observation.category.coding.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.extension",
-				"path": "Observation.category.coding.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.system",
-				"path": "Observation.category.coding.system",
-				"short": "Identity of the terminology system",
-				"definition": "The identification of the code system that defines the meaning of the symbol in the code.",
-				"comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
-				"requirements": "Need to be unambiguous about the source of the definition of the symbol.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.3"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystem"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.version",
-				"path": "Observation.category.coding.version",
-				"short": "Version of the system - if relevant",
-				"definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
-				"comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.version",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.7"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystemVersion"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.code",
-				"path": "Observation.category.coding.code",
-				"short": "Symbol in syntax defined by the system",
-				"definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
-				"requirements": "Need to refer to a particular code in the system.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "vital-signs",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1"
-					},
-					{
-						"identity": "rim",
-						"map": "./code"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.display",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.coding.display",
-				"short": "Representation defined by the system",
-				"definition": "A representation of the meaning of the code in the system, following the rules of the system.",
-				"requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.display",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.2 - but note this is not well followed"
-					},
-					{
-						"identity": "rim",
-						"map": "CV.displayName"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.userSelected",
-				"path": "Observation.category.coding.userSelected",
-				"short": "If this coding was chosen directly by the user",
-				"definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
-				"comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
-				"requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.userSelected",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Sometimes implied by being first"
-					},
-					{
-						"identity": "rim",
-						"map": "CD.codingRationale"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.text",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.text",
-				"short": "Plain text representation of the concept",
-				"definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
-				"comment": "Very often the text is the same as a displayName of one of the codings.",
-				"requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CodeableConcept.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.9. But note many systems use C*E.2 for this"
-					},
-					{
-						"identity": "rim",
-						"map": "./originalText[mediaType/code=\"text/plain\"]/data"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
-					}
-				]
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Blood Pressure",
-				"definition": "Coded Responses from C-CDA Vital Sign Results.",
-				"comment": "*All* code-value and, if present, component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
-				"alias": [
-					"Name"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "85354-9"
-						}
-					]
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "116680003 |Is a|"
-					}
-				]
-			},
-			{
-				"id": "Observation.subject",
-				"path": "Observation.subject",
-				"short": "Who and/or what the observation is about",
-				"definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
-				"comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
-				"requirements": "Observations have no value if you don't know who or what they're about.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=RTGT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.focus",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
-						"valueCode": "trial-use"
-					}
-				],
-				"path": "Observation.focus",
-				"short": "What the observation is about, when it is not about the subject of record",
-				"definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
-				"comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.focus",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SBJ]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.encounter",
-				"path": "Observation.encounter",
-				"short": "Healthcare event during which this observation is made",
-				"definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
-				"comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
-				"requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
-				"alias": [
-					"Context"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.effective[x]",
-				"path": "Observation.effective[x]",
-				"short": "Often just a dateTime for Vital Signs",
-				"definition": "Often just a dateTime for Vital Signs.",
-				"comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
-				"requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
-				"alias": [
-					"Occurrence"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.effective[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-1",
-						"severity": "error",
-						"human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
-						"expression": "($this as dateTime).toString().length() >= 8",
-						"xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "Observation.issued",
-				"path": "Observation.issued",
-				"short": "Date/Time this version was made available",
-				"definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
-				"comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.issued",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=AUT].time"
-					}
-				]
-			},
-			{
-				"id": "Observation.performer",
-				"path": "Observation.performer",
-				"short": "Who is responsible for the observation",
-				"definition": "Who was responsible for asserting the observed value as \"true\".",
-				"requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.performer",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=PRF]"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]",
-				"path": "Observation.value[x]",
-				"short": "Vital Signs Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "Quantity"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.dataAbsentReason",
-				"path": "Observation.dataAbsentReason",
-				"short": "Why the result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
-				"comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.interpretation",
-				"path": "Observation.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.note",
-				"path": "Observation.note",
-				"short": "Comments about the observation",
-				"definition": "Comments about the observation or the results.",
-				"comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
-				"requirements": "Need to be able to provide free text additional information.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
-					},
-					{
-						"identity": "rim",
-						"map": "subjectOf.observationEvent[code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.bodySite",
-				"path": "Observation.bodySite",
-				"short": "Observed body part",
-				"definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
-				"comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.bodySite",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "BodySite"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing anatomical locations. May include laterality.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/body-site"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123037004 |Body structure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-20"
-					},
-					{
-						"identity": "rim",
-						"map": "targetSiteCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "718497002 |Inherent location|"
-					}
-				]
-			},
-			{
-				"id": "Observation.method",
-				"path": "Observation.method",
-				"short": "How it was done",
-				"definition": "Indicates the mechanism used to perform the observation.",
-				"comment": "Only used if not implicit in code for Observation.code.",
-				"requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.method",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationMethod"
-						}
-					],
-					"strength": "example",
-					"description": "Methods for simple observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-17"
-					},
-					{
-						"identity": "rim",
-						"map": "methodCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.specimen",
-				"path": "Observation.specimen",
-				"short": "Specimen used for this observation",
-				"definition": "The specimen that was used when this observation was made.",
-				"comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.specimen",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Specimen"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123038009 |Specimen|"
-					},
-					{
-						"identity": "v2",
-						"map": "SPM segment"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SPC].specimen"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "704319004 |Inherent in|"
-					}
-				]
-			},
-			{
-				"id": "Observation.device",
-				"path": "Observation.device",
-				"short": "(Measurement) Device",
-				"definition": "The device used to generate the observation data.",
-				"comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.device",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/DeviceMetric"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 49062001 |Device|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-17 / PRT -10"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=DEV]"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "424226004 |Using device|"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange",
-				"path": "Observation.referenceRange",
-				"short": "Provides guide for interpretation",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "obs-3",
-						"severity": "error",
-						"human": "Must have at least a low or a high or text",
-						"expression": "low.exists() or high.exists() or text.exists()",
-						"xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.id",
-				"path": "Observation.referenceRange.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.extension",
-				"path": "Observation.referenceRange.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.modifierExtension",
-				"path": "Observation.referenceRange.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.low",
-				"path": "Observation.referenceRange.low",
-				"short": "Low Range, if relevant",
-				"definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.low",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.low"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.high",
-				"path": "Observation.referenceRange.high",
-				"short": "High Range, if relevant",
-				"definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.high",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.high"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.type",
-				"path": "Observation.referenceRange.type",
-				"short": "Reference range qualifier",
-				"definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
-				"requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeMeaning"
-						}
-					],
-					"strength": "preferred",
-					"description": "Code for the meaning of a reference range.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.appliesTo",
-				"path": "Observation.referenceRange.appliesTo",
-				"short": "Reference range population",
-				"definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
-				"requirements": "Need to be able to identify the target population for proper interpretation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange.appliesTo",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeType"
-						}
-					],
-					"strength": "example",
-					"description": "Codes identifying the population the reference range applies to.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.age",
-				"path": "Observation.referenceRange.age",
-				"short": "Applicable age range, if relevant",
-				"definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
-				"requirements": "Some analytes vary greatly over age.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.age",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Range"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.text",
-				"path": "Observation.referenceRange.text",
-				"short": "Text based reference range in an observation",
-				"definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:ST"
-					}
-				]
-			},
-			{
-				"id": "Observation.hasMember",
-				"path": "Observation.hasMember",
-				"short": "Used when reporting vital signs panel components",
-				"definition": "Used when reporting vital signs panel components.",
-				"comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.hasMember",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship"
-					}
-				]
-			},
-			{
-				"id": "Observation.derivedFrom",
-				"path": "Observation.derivedFrom",
-				"short": "Related measurements the observation is made from",
-				"definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
-				"comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.derivedFrom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/DocumentReference",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy",
-							"http://hl7.org/fhir/StructureDefinition/Media",
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": ".targetObservation"
-					}
-				]
-			},
-			{
-				"id": "Observation.component",
-				"path": "Observation.component",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "code"
-						}
-					],
-					"ordered": false,
-					"rules": "open"
-				},
-				"short": "Component observations",
-				"definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
-				"comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
-				"min": 2,
-				"max": "*",
-				"base": {
-					"path": "Observation.component",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-3",
-						"severity": "error",
-						"human": "If there is no a value a data absent reason must be present",
-						"expression": "value.exists() or dataAbsentReason.exists()",
-						"xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "containment by OBX-4?"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=COMP]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.id",
-				"path": "Observation.component.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.extension",
-				"path": "Observation.component.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.modifierExtension",
-				"path": "Observation.component.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.code",
-				"path": "Observation.component.code",
-				"short": "Type of component observation (code / type)",
-				"definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
-				"comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.value[x]",
-				"path": "Observation.component.value[x]",
-				"short": "Vital Sign Component Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
-				"comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "Quantity"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.dataAbsentReason",
-				"path": "Observation.component.dataAbsentReason",
-				"short": "Why the component result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
-				"comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.interpretation",
-				"path": "Observation.component.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.referenceRange",
-				"path": "Observation.component.referenceRange",
-				"short": "Provides guide for interpretation of component result",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:systolic",
-				"path": "Observation.component",
-				"sliceName": "systolic",
-				"short": "Systolic Blood Pressure",
-				"definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
-				"comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.component",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-3",
-						"severity": "error",
-						"human": "If there is no a value a data absent reason must be present",
-						"expression": "value.exists() or dataAbsentReason.exists()",
-						"xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "containment by OBX-4?"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=COMP]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:systolic.id",
-				"path": "Observation.component.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:systolic.extension",
-				"path": "Observation.component.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:systolic.modifierExtension",
-				"path": "Observation.component.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:systolic.code",
-				"path": "Observation.component.code",
-				"short": "Systolic Blood Pressure Code",
-				"definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
-				"comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "8480-6"
-						}
-					]
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:systolic.value[x]",
-				"path": "Observation.component.value[x]",
-				"short": "Vital Sign Component Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
-				"comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:systolic.value[x].id",
-				"path": "Observation.component.value[x].id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:systolic.value[x].extension",
-				"path": "Observation.component.value[x].extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:systolic.value[x].value",
-				"path": "Observation.component.value[x].value",
-				"short": "Numerical value (with implicit precision)",
-				"definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
-				"comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
-				"requirements": "Precision is handled implicitly in almost all cases of measurement.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.2  / CQ - N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:systolic.value[x].comparator",
-				"path": "Observation.component.value[x].comparator",
-				"short": "< | <= | >= | > - how to understand the value",
-				"definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
-				"requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Quantity.comparator",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "QuantityComparator"
-						}
-					],
-					"strength": "required",
-					"description": "How the Quantity should be understood and represented.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.1  / CQ.1"
-					},
-					{
-						"identity": "rim",
-						"map": "IVL properties"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:systolic.value[x].unit",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.component.value[x].unit",
-				"short": "Unit representation",
-				"definition": "A human-readable form of the unit.",
-				"requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.unit",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.unit"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:systolic.value[x].system",
-				"path": "Observation.component.value[x].system",
-				"short": "System that defines coded unit form",
-				"definition": "The identification of the system that provides the coded form of the unit.",
-				"requirements": "Need to know the system that defines the coded form of the unit.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"condition": [
-					"qty-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "CO.codeSystem, PQ.translation.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:systolic.value[x].code",
-				"path": "Observation.component.value[x].code",
-				"short": "Coded form of the unit",
-				"definition": "A computer processable form of the unit in some unit representation system.",
-				"comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
-				"requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "mm[Hg]",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.code, MO.currency, PQ.translation.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:systolic.dataAbsentReason",
-				"path": "Observation.component.dataAbsentReason",
-				"short": "Why the component result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
-				"comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:systolic.interpretation",
-				"path": "Observation.component.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:systolic.referenceRange",
-				"path": "Observation.component.referenceRange",
-				"short": "Provides guide for interpretation of component result",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:diastolic",
-				"path": "Observation.component",
-				"sliceName": "diastolic",
-				"short": "Diastolic Blood Pressure",
-				"definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
-				"comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.component",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-3",
-						"severity": "error",
-						"human": "If there is no a value a data absent reason must be present",
-						"expression": "value.exists() or dataAbsentReason.exists()",
-						"xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "containment by OBX-4?"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=COMP]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:diastolic.id",
-				"path": "Observation.component.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:diastolic.extension",
-				"path": "Observation.component.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:diastolic.modifierExtension",
-				"path": "Observation.component.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:diastolic.code",
-				"path": "Observation.component.code",
-				"short": "Diastolic Blood Pressure Code",
-				"definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
-				"comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "8462-4"
-						}
-					]
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:diastolic.value[x]",
-				"path": "Observation.component.value[x]",
-				"short": "Vital Sign Component Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
-				"comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:diastolic.value[x].id",
-				"path": "Observation.component.value[x].id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:diastolic.value[x].extension",
-				"path": "Observation.component.value[x].extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:diastolic.value[x].value",
-				"path": "Observation.component.value[x].value",
-				"short": "Numerical value (with implicit precision)",
-				"definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
-				"comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
-				"requirements": "Precision is handled implicitly in almost all cases of measurement.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.2  / CQ - N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:diastolic.value[x].comparator",
-				"path": "Observation.component.value[x].comparator",
-				"short": "< | <= | >= | > - how to understand the value",
-				"definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
-				"requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Quantity.comparator",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "QuantityComparator"
-						}
-					],
-					"strength": "required",
-					"description": "How the Quantity should be understood and represented.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.1  / CQ.1"
-					},
-					{
-						"identity": "rim",
-						"map": "IVL properties"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:diastolic.value[x].unit",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.component.value[x].unit",
-				"short": "Unit representation",
-				"definition": "A human-readable form of the unit.",
-				"requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.unit",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.unit"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:diastolic.value[x].system",
-				"path": "Observation.component.value[x].system",
-				"short": "System that defines coded unit form",
-				"definition": "The identification of the system that provides the coded form of the unit.",
-				"requirements": "Need to know the system that defines the coded form of the unit.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"condition": [
-					"qty-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "CO.codeSystem, PQ.translation.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:diastolic.value[x].code",
-				"path": "Observation.component.value[x].code",
-				"short": "Coded form of the unit",
-				"definition": "A computer processable form of the unit in some unit representation system.",
-				"comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
-				"requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "mm[Hg]",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.code, MO.currency, PQ.translation.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:diastolic.dataAbsentReason",
-				"path": "Observation.component.dataAbsentReason",
-				"short": "Why the component result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
-				"comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:diastolic.interpretation",
-				"path": "Observation.component.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:diastolic.referenceRange",
-				"path": "Observation.component.referenceRange",
-				"short": "Provides guide for interpretation of component result",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "US Core Blood Pressure Profile",
-				"definition": "Defines constraints on Observation to represent diastolic and systolic blood pressure observations with standard LOINC codes and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile."
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Blood Pressure",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "85354-9"
-						}
-					]
-				},
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component",
-				"path": "Observation.component",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "code"
-						}
-					],
-					"ordered": false,
-					"rules": "open"
-				},
-				"min": 2,
-				"max": "*",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:systolic",
-				"path": "Observation.component",
-				"sliceName": "systolic",
-				"short": "Systolic Blood Pressure",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:systolic.code",
-				"path": "Observation.component.code",
-				"short": "Systolic Blood Pressure Code",
-				"min": 1,
-				"max": "1",
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "8480-6"
-						}
-					]
-				},
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:systolic.valueQuantity",
-				"path": "Observation.component.valueQuantity",
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:systolic.valueQuantity.value",
-				"path": "Observation.component.valueQuantity.value",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:systolic.valueQuantity.unit",
-				"path": "Observation.component.valueQuantity.unit",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:systolic.valueQuantity.system",
-				"path": "Observation.component.valueQuantity.system",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:systolic.valueQuantity.code",
-				"path": "Observation.component.valueQuantity.code",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "mm[Hg]",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:diastolic",
-				"path": "Observation.component",
-				"sliceName": "diastolic",
-				"short": "Diastolic Blood Pressure",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:diastolic.code",
-				"path": "Observation.component.code",
-				"short": "Diastolic Blood Pressure Code",
-				"min": 1,
-				"max": "1",
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "8462-4"
-						}
-					]
-				},
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:diastolic.valueQuantity",
-				"path": "Observation.component.valueQuantity",
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:diastolic.valueQuantity.value",
-				"path": "Observation.component.valueQuantity.value",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:diastolic.valueQuantity.unit",
-				"path": "Observation.component.valueQuantity.unit",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:diastolic.valueQuantity.system",
-				"path": "Observation.component.valueQuantity.system",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:diastolic.valueQuantity.code",
-				"path": "Observation.component.valueQuantity.code",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "mm[Hg]",
-				"mustSupport": true
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-blood-pressure",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure",
+    "version": "4.0.0",
+    "name": "USCoreBloodPressureProfile",
+    "title": "US Core Blood Pressure Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-17",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints on Observation to represent diastolic and systolic blood pressure observations with standard LOINC codes and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "sct-concept",
+            "uri": "http://snomed.info/conceptdomain",
+            "name": "SNOMED CT Concept Domain Binding"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "sct-attr",
+            "uri": "http://snomed.org/attributebinding",
+            "name": "SNOMED CT Attribute Binding"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Observation",
+    "baseDefinition": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "US Core Blood Pressure Profile",
+                "definition": "Defines constraints on Observation to represent diastolic and systolic blood pressure observations with standard LOINC codes and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
+                "alias": [
+                    "Vital Signs",
+                    "Measurement",
+                    "Results",
+                    "Tests"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "obs-6",
+                        "severity": "error",
+                        "human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
+                        "expression": "dataAbsentReason.empty() or value.empty()",
+                        "xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "obs-7",
+                        "severity": "error",
+                        "human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
+                        "expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
+                        "xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "vs-2",
+                        "severity": "error",
+                        "human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
+                        "expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
+                        "xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.id",
+                "path": "Observation.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.meta",
+                "path": "Observation.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.implicitRules",
+                "path": "Observation.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Observation.language",
+                "path": "Observation.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Observation.text",
+                "path": "Observation.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.contained",
+                "path": "Observation.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.extension",
+                "path": "Observation.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.modifierExtension",
+                "path": "Observation.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.identifier",
+                "path": "Observation.identifier",
+                "short": "Business Identifier for observation",
+                "definition": "A unique identifier assigned to this observation.",
+                "requirements": "Allows observations to be distinguished and referenced.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "id"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.basedOn",
+                "path": "Observation.basedOn",
+                "short": "Fulfills plan, proposal or order",
+                "definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
+                "requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
+                "alias": [
+                    "Fulfills"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceRequest",
+                            "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+                            "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.basedOn"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.partOf",
+                "path": "Observation.partOf",
+                "short": "Part of referenced event",
+                "definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
+                "comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
+                "alias": [
+                    "Container"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.partOf",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationDispense",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationStatement",
+                            "http://hl7.org/fhir/StructureDefinition/Procedure",
+                            "http://hl7.org/fhir/StructureDefinition/Immunization",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.partOf"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "Varies by domain"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=FLFS].target"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.status",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
+                        "valueString": "default: final"
+                    }
+                ],
+                "path": "Observation.status",
+                "short": "registered | preliminary | final | amended +",
+                "definition": "The status of the result value.",
+                "comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
+                "requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Status"
+                        }
+                    ],
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 445584004 |Report by finality status|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-11"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category",
+                "path": "Observation.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "coding.code"
+                        },
+                        {
+                            "type": "value",
+                            "path": "coding.system"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "open"
+                },
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat",
+                "path": "Observation.category",
+                "sliceName": "VSCat",
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.id",
+                "path": "Observation.category.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.extension",
+                "path": "Observation.category.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding",
+                "path": "Observation.category.coding",
+                "short": "Code defined by a terminology system",
+                "definition": "A reference to a code defined by a terminology system.",
+                "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+                "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "CodeableConcept.coding",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1-8, C*E.10-22"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "union(., ./translation)"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.id",
+                "path": "Observation.category.coding.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.extension",
+                "path": "Observation.category.coding.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.system",
+                "path": "Observation.category.coding.system",
+                "short": "Identity of the terminology system",
+                "definition": "The identification of the code system that defines the meaning of the symbol in the code.",
+                "comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
+                "requirements": "Need to be unambiguous about the source of the definition of the symbol.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystem"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.version",
+                "path": "Observation.category.coding.version",
+                "short": "Version of the system - if relevant",
+                "definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
+                "comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.version",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystemVersion"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.code",
+                "path": "Observation.category.coding.code",
+                "short": "Symbol in syntax defined by the system",
+                "definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
+                "requirements": "Need to refer to a particular code in the system.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "vital-signs",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./code"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.display",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.coding.display",
+                "short": "Representation defined by the system",
+                "definition": "A representation of the meaning of the code in the system, following the rules of the system.",
+                "requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.display",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.2 - but note this is not well followed"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CV.displayName"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.userSelected",
+                "path": "Observation.category.coding.userSelected",
+                "short": "If this coding was chosen directly by the user",
+                "definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
+                "comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
+                "requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.userSelected",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Sometimes implied by being first"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CD.codingRationale"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.text",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.text",
+                "short": "Plain text representation of the concept",
+                "definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
+                "comment": "Very often the text is the same as a displayName of one of the codings.",
+                "requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CodeableConcept.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.9. But note many systems use C*E.2 for this"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./originalText[mediaType/code=\"text/plain\"]/data"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Blood Pressure",
+                "definition": "Coded Responses from C-CDA Vital Sign Results.",
+                "comment": "*All* code-value and, if present, component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
+                "alias": [
+                    "Name"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "85354-9"
+                        }
+                    ]
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "116680003 |Is a|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.subject",
+                "path": "Observation.subject",
+                "short": "Who and/or what the observation is about",
+                "definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
+                "comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
+                "requirements": "Observations have no value if you don't know who or what they're about.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=RTGT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.focus",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+                        "valueCode": "trial-use"
+                    }
+                ],
+                "path": "Observation.focus",
+                "short": "What the observation is about, when it is not about the subject of record",
+                "definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
+                "comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.focus",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SBJ]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.encounter",
+                "path": "Observation.encounter",
+                "short": "Healthcare event during which this observation is made",
+                "definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
+                "comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
+                "requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
+                "alias": [
+                    "Context"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.effective[x]",
+                "path": "Observation.effective[x]",
+                "short": "Often just a dateTime for Vital Signs",
+                "definition": "Often just a dateTime for Vital Signs.",
+                "comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
+                "requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
+                "alias": [
+                    "Occurrence"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.effective[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-1",
+                        "severity": "error",
+                        "human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
+                        "expression": "($this as dateTime).toString().length() >= 8",
+                        "xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.issued",
+                "path": "Observation.issued",
+                "short": "Date/Time this version was made available",
+                "definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
+                "comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.issued",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.performer",
+                "path": "Observation.performer",
+                "short": "Who is responsible for the observation",
+                "definition": "Who was responsible for asserting the observed value as \"true\".",
+                "requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.performer",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=PRF]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]",
+                "path": "Observation.value[x]",
+                "short": "Vital Signs Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.dataAbsentReason",
+                "path": "Observation.dataAbsentReason",
+                "short": "Why the result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
+                "comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.interpretation",
+                "path": "Observation.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.note",
+                "path": "Observation.note",
+                "short": "Comments about the observation",
+                "definition": "Comments about the observation or the results.",
+                "comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
+                "requirements": "Need to be able to provide free text additional information.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "subjectOf.observationEvent[code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.bodySite",
+                "path": "Observation.bodySite",
+                "short": "Observed body part",
+                "definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
+                "comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.bodySite",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "BodySite"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing anatomical locations. May include laterality.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/body-site"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123037004 |Body structure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-20"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "targetSiteCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "718497002 |Inherent location|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.method",
+                "path": "Observation.method",
+                "short": "How it was done",
+                "definition": "Indicates the mechanism used to perform the observation.",
+                "comment": "Only used if not implicit in code for Observation.code.",
+                "requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.method",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationMethod"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Methods for simple observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "methodCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.specimen",
+                "path": "Observation.specimen",
+                "short": "Specimen used for this observation",
+                "definition": "The specimen that was used when this observation was made.",
+                "comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.specimen",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Specimen"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123038009 |Specimen|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "SPM segment"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SPC].specimen"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "704319004 |Inherent in|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.device",
+                "path": "Observation.device",
+                "short": "(Measurement) Device",
+                "definition": "The device used to generate the observation data.",
+                "comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.device",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceMetric"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 49062001 |Device|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17 / PRT -10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=DEV]"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "424226004 |Using device|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange",
+                "path": "Observation.referenceRange",
+                "short": "Provides guide for interpretation",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "obs-3",
+                        "severity": "error",
+                        "human": "Must have at least a low or a high or text",
+                        "expression": "low.exists() or high.exists() or text.exists()",
+                        "xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.id",
+                "path": "Observation.referenceRange.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.extension",
+                "path": "Observation.referenceRange.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.modifierExtension",
+                "path": "Observation.referenceRange.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.low",
+                "path": "Observation.referenceRange.low",
+                "short": "Low Range, if relevant",
+                "definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.low",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.low"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.high",
+                "path": "Observation.referenceRange.high",
+                "short": "High Range, if relevant",
+                "definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.high",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.high"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.type",
+                "path": "Observation.referenceRange.type",
+                "short": "Reference range qualifier",
+                "definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
+                "requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeMeaning"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Code for the meaning of a reference range.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.appliesTo",
+                "path": "Observation.referenceRange.appliesTo",
+                "short": "Reference range population",
+                "definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
+                "requirements": "Need to be able to identify the target population for proper interpretation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange.appliesTo",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes identifying the population the reference range applies to.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.age",
+                "path": "Observation.referenceRange.age",
+                "short": "Applicable age range, if relevant",
+                "definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
+                "requirements": "Some analytes vary greatly over age.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.age",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Range"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.text",
+                "path": "Observation.referenceRange.text",
+                "short": "Text based reference range in an observation",
+                "definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:ST"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.hasMember",
+                "path": "Observation.hasMember",
+                "short": "Used when reporting vital signs panel components",
+                "definition": "Used when reporting vital signs panel components.",
+                "comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.hasMember",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.derivedFrom",
+                "path": "Observation.derivedFrom",
+                "short": "Related measurements the observation is made from",
+                "definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
+                "comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.derivedFrom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/DocumentReference",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy",
+                            "http://hl7.org/fhir/StructureDefinition/Media",
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".targetObservation"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component",
+                "path": "Observation.component",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "code"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "open"
+                },
+                "short": "Component observations",
+                "definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
+                "comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
+                "min": 2,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-3",
+                        "severity": "error",
+                        "human": "If there is no a value a data absent reason must be present",
+                        "expression": "value.exists() or dataAbsentReason.exists()",
+                        "xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "containment by OBX-4?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=COMP]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.id",
+                "path": "Observation.component.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.extension",
+                "path": "Observation.component.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.modifierExtension",
+                "path": "Observation.component.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.code",
+                "path": "Observation.component.code",
+                "short": "Type of component observation (code / type)",
+                "definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
+                "comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.value[x]",
+                "path": "Observation.component.value[x]",
+                "short": "Vital Sign Component Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
+                "comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.dataAbsentReason",
+                "path": "Observation.component.dataAbsentReason",
+                "short": "Why the component result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
+                "comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.interpretation",
+                "path": "Observation.component.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.referenceRange",
+                "path": "Observation.component.referenceRange",
+                "short": "Provides guide for interpretation of component result",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:systolic",
+                "path": "Observation.component",
+                "sliceName": "systolic",
+                "short": "Systolic Blood Pressure",
+                "definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
+                "comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-3",
+                        "severity": "error",
+                        "human": "If there is no a value a data absent reason must be present",
+                        "expression": "value.exists() or dataAbsentReason.exists()",
+                        "xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "containment by OBX-4?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=COMP]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:systolic.id",
+                "path": "Observation.component.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:systolic.extension",
+                "path": "Observation.component.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:systolic.modifierExtension",
+                "path": "Observation.component.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:systolic.code",
+                "path": "Observation.component.code",
+                "short": "Systolic Blood Pressure Code",
+                "definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
+                "comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "8480-6"
+                        }
+                    ]
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:systolic.value[x]",
+                "path": "Observation.component.value[x]",
+                "short": "Vital Sign Component Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
+                "comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:systolic.value[x].id",
+                "path": "Observation.component.value[x].id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:systolic.value[x].extension",
+                "path": "Observation.component.value[x].extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:systolic.value[x].value",
+                "path": "Observation.component.value[x].value",
+                "short": "Numerical value (with implicit precision)",
+                "definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
+                "comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
+                "requirements": "Precision is handled implicitly in almost all cases of measurement.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.2  / CQ - N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:systolic.value[x].comparator",
+                "path": "Observation.component.value[x].comparator",
+                "short": "< | <= | >= | > - how to understand the value",
+                "definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
+                "requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.comparator",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "QuantityComparator"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "How the Quantity should be understood and represented.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.1  / CQ.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "IVL properties"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:systolic.value[x].unit",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.component.value[x].unit",
+                "short": "Unit representation",
+                "definition": "A human-readable form of the unit.",
+                "requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.unit",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.unit"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:systolic.value[x].system",
+                "path": "Observation.component.value[x].system",
+                "short": "System that defines coded unit form",
+                "definition": "The identification of the system that provides the coded form of the unit.",
+                "requirements": "Need to know the system that defines the coded form of the unit.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "condition": [
+                    "qty-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CO.codeSystem, PQ.translation.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:systolic.value[x].code",
+                "path": "Observation.component.value[x].code",
+                "short": "Coded form of the unit",
+                "definition": "A computer processable form of the unit in some unit representation system.",
+                "comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
+                "requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "mm[Hg]",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.code, MO.currency, PQ.translation.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:systolic.dataAbsentReason",
+                "path": "Observation.component.dataAbsentReason",
+                "short": "Why the component result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
+                "comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:systolic.interpretation",
+                "path": "Observation.component.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:systolic.referenceRange",
+                "path": "Observation.component.referenceRange",
+                "short": "Provides guide for interpretation of component result",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:diastolic",
+                "path": "Observation.component",
+                "sliceName": "diastolic",
+                "short": "Diastolic Blood Pressure",
+                "definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
+                "comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-3",
+                        "severity": "error",
+                        "human": "If there is no a value a data absent reason must be present",
+                        "expression": "value.exists() or dataAbsentReason.exists()",
+                        "xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "containment by OBX-4?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=COMP]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:diastolic.id",
+                "path": "Observation.component.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:diastolic.extension",
+                "path": "Observation.component.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:diastolic.modifierExtension",
+                "path": "Observation.component.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:diastolic.code",
+                "path": "Observation.component.code",
+                "short": "Diastolic Blood Pressure Code",
+                "definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
+                "comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "8462-4"
+                        }
+                    ]
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:diastolic.value[x]",
+                "path": "Observation.component.value[x]",
+                "short": "Vital Sign Component Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
+                "comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:diastolic.value[x].id",
+                "path": "Observation.component.value[x].id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:diastolic.value[x].extension",
+                "path": "Observation.component.value[x].extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:diastolic.value[x].value",
+                "path": "Observation.component.value[x].value",
+                "short": "Numerical value (with implicit precision)",
+                "definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
+                "comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
+                "requirements": "Precision is handled implicitly in almost all cases of measurement.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.2  / CQ - N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:diastolic.value[x].comparator",
+                "path": "Observation.component.value[x].comparator",
+                "short": "< | <= | >= | > - how to understand the value",
+                "definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
+                "requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.comparator",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "QuantityComparator"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "How the Quantity should be understood and represented.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.1  / CQ.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "IVL properties"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:diastolic.value[x].unit",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.component.value[x].unit",
+                "short": "Unit representation",
+                "definition": "A human-readable form of the unit.",
+                "requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.unit",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.unit"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:diastolic.value[x].system",
+                "path": "Observation.component.value[x].system",
+                "short": "System that defines coded unit form",
+                "definition": "The identification of the system that provides the coded form of the unit.",
+                "requirements": "Need to know the system that defines the coded form of the unit.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "condition": [
+                    "qty-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CO.codeSystem, PQ.translation.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:diastolic.value[x].code",
+                "path": "Observation.component.value[x].code",
+                "short": "Coded form of the unit",
+                "definition": "A computer processable form of the unit in some unit representation system.",
+                "comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
+                "requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "mm[Hg]",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.code, MO.currency, PQ.translation.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:diastolic.dataAbsentReason",
+                "path": "Observation.component.dataAbsentReason",
+                "short": "Why the component result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
+                "comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:diastolic.interpretation",
+                "path": "Observation.component.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:diastolic.referenceRange",
+                "path": "Observation.component.referenceRange",
+                "short": "Provides guide for interpretation of component result",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "US Core Blood Pressure Profile",
+                "definition": "Defines constraints on Observation to represent diastolic and systolic blood pressure observations with standard LOINC codes and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile."
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Blood Pressure",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "85354-9"
+                        }
+                    ]
+                },
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component",
+                "path": "Observation.component",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "code"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "open"
+                },
+                "min": 2,
+                "max": "*",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:systolic",
+                "path": "Observation.component",
+                "sliceName": "systolic",
+                "short": "Systolic Blood Pressure",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:systolic.code",
+                "path": "Observation.component.code",
+                "short": "Systolic Blood Pressure Code",
+                "min": 1,
+                "max": "1",
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "8480-6"
+                        }
+                    ]
+                },
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:systolic.valueQuantity",
+                "path": "Observation.component.valueQuantity",
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:systolic.valueQuantity.value",
+                "path": "Observation.component.valueQuantity.value",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:systolic.valueQuantity.unit",
+                "path": "Observation.component.valueQuantity.unit",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:systolic.valueQuantity.system",
+                "path": "Observation.component.valueQuantity.system",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:systolic.valueQuantity.code",
+                "path": "Observation.component.valueQuantity.code",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "mm[Hg]",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:diastolic",
+                "path": "Observation.component",
+                "sliceName": "diastolic",
+                "short": "Diastolic Blood Pressure",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:diastolic.code",
+                "path": "Observation.component.code",
+                "short": "Diastolic Blood Pressure Code",
+                "min": 1,
+                "max": "1",
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "8462-4"
+                        }
+                    ]
+                },
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:diastolic.valueQuantity",
+                "path": "Observation.component.valueQuantity",
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:diastolic.valueQuantity.value",
+                "path": "Observation.component.valueQuantity.value",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:diastolic.valueQuantity.unit",
+                "path": "Observation.component.valueQuantity.unit",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:diastolic.valueQuantity.system",
+                "path": "Observation.component.valueQuantity.system",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:diastolic.valueQuantity.code",
+                "path": "Observation.component.valueQuantity.code",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "mm[Hg]",
+                "mustSupport": true
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-bmi.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-bmi.json
@@ -1,3807 +1,3807 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-bmi",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-bmi-definitions.html#Observation\" title=\"Defines constraints on Observation to represent Body Mass Index (BMI) observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.\">Observation</a><a name=\"Observation\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"StructureDefinition-us-core-vital-signs.html\">USCoreVitalSignsProfile</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">US Core Body Mass Index (BMI) Profile</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-bmi-definitions.html#Observation.code\">code</a><a name=\"Observation.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">1</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Coded Responses from C-CDA Vital Sign Results</span><br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck101.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#CodeableConcept.coding\">coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Code defined by a terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">(complex)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/loinc.html\">http://loinc.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">39156-5</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-bmi-definitions.html#Observation.valueQuantity\">valueQuantity</a><a name=\"Observation.valueQuantity\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Quantity\">Quantity</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Vital Signs Value</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-bmi-definitions.html#Observation.valueQuantity.value\">value</a><a name=\"Observation.valueQuantity.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#decimal\">decimal</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Numerical value (with implicit precision)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-bmi-definitions.html#Observation.valueQuantity.unit\">unit</a><a name=\"Observation.valueQuantity.unit\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Unit representation</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-bmi-definitions.html#Observation.valueQuantity.system\">system</a><a name=\"Observation.valueQuantity.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">System that defines coded unit form</span><br/><span style=\"font-weight:bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/ucum.html\">http://unitsofmeasure.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-bmi-definitions.html#Observation.valueQuantity.code\">code</a><a name=\"Observation.valueQuantity.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Coded responses from the common UCUM units for vital signs value set.<br/><span style=\"font-weight:bold\">Fixed Value: </span><span style=\"color: darkgreen\">kg/m2</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-bmi",
-	"version": "4.0.0",
-	"name": "USCoreBMIProfileProfile",
-	"title": "US Core BMI Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-17",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints on Observation to represent Body Mass Index (BMI) observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "sct-concept",
-			"uri": "http://snomed.info/conceptdomain",
-			"name": "SNOMED CT Concept Domain Binding"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "sct-attr",
-			"uri": "http://snomed.org/attributebinding",
-			"name": "SNOMED CT Attribute Binding"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Observation",
-	"baseDefinition": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "US Core Body Mass Index (BMI) Profile",
-				"definition": "Defines constraints on Observation to represent Body Mass Index (BMI) observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
-				"alias": [
-					"Vital Signs",
-					"Measurement",
-					"Results",
-					"Tests"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "obs-6",
-						"severity": "error",
-						"human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
-						"expression": "dataAbsentReason.empty() or value.empty()",
-						"xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "obs-7",
-						"severity": "error",
-						"human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
-						"expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
-						"xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "vs-2",
-						"severity": "error",
-						"human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
-						"expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
-						"xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.id",
-				"path": "Observation.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.meta",
-				"path": "Observation.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.implicitRules",
-				"path": "Observation.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Observation.language",
-				"path": "Observation.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Observation.text",
-				"path": "Observation.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Observation.contained",
-				"path": "Observation.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.extension",
-				"path": "Observation.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.modifierExtension",
-				"path": "Observation.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.identifier",
-				"path": "Observation.identifier",
-				"short": "Business Identifier for observation",
-				"definition": "A unique identifier assigned to this observation.",
-				"requirements": "Allows observations to be distinguished and referenced.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
-					},
-					{
-						"identity": "rim",
-						"map": "id"
-					}
-				]
-			},
-			{
-				"id": "Observation.basedOn",
-				"path": "Observation.basedOn",
-				"short": "Fulfills plan, proposal or order",
-				"definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
-				"requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
-				"alias": [
-					"Fulfills"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan",
-							"http://hl7.org/fhir/StructureDefinition/DeviceRequest",
-							"http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
-							"http://hl7.org/fhir/StructureDefinition/MedicationRequest",
-							"http://hl7.org/fhir/StructureDefinition/NutritionOrder",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.basedOn"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.partOf",
-				"path": "Observation.partOf",
-				"short": "Part of referenced event",
-				"definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
-				"comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
-				"alias": [
-					"Container"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.partOf",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
-							"http://hl7.org/fhir/StructureDefinition/MedicationDispense",
-							"http://hl7.org/fhir/StructureDefinition/MedicationStatement",
-							"http://hl7.org/fhir/StructureDefinition/Procedure",
-							"http://hl7.org/fhir/StructureDefinition/Immunization",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.partOf"
-					},
-					{
-						"identity": "v2",
-						"map": "Varies by domain"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=FLFS].target"
-					}
-				]
-			},
-			{
-				"id": "Observation.status",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
-						"valueString": "default: final"
-					}
-				],
-				"path": "Observation.status",
-				"short": "registered | preliminary | final | amended +",
-				"definition": "The status of the result value.",
-				"comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
-				"requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Status"
-						}
-					],
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 445584004 |Report by finality status|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-11"
-					},
-					{
-						"identity": "rim",
-						"map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
-					}
-				]
-			},
-			{
-				"id": "Observation.category",
-				"path": "Observation.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "coding.code"
-						},
-						{
-							"type": "value",
-							"path": "coding.system"
-						}
-					],
-					"ordered": false,
-					"rules": "open"
-				},
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat",
-				"path": "Observation.category",
-				"sliceName": "VSCat",
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.id",
-				"path": "Observation.category.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.extension",
-				"path": "Observation.category.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding",
-				"path": "Observation.category.coding",
-				"short": "Code defined by a terminology system",
-				"definition": "A reference to a code defined by a terminology system.",
-				"comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
-				"requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "CodeableConcept.coding",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1-8, C*E.10-22"
-					},
-					{
-						"identity": "rim",
-						"map": "union(., ./translation)"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.id",
-				"path": "Observation.category.coding.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.extension",
-				"path": "Observation.category.coding.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.system",
-				"path": "Observation.category.coding.system",
-				"short": "Identity of the terminology system",
-				"definition": "The identification of the code system that defines the meaning of the symbol in the code.",
-				"comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
-				"requirements": "Need to be unambiguous about the source of the definition of the symbol.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.3"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystem"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.version",
-				"path": "Observation.category.coding.version",
-				"short": "Version of the system - if relevant",
-				"definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
-				"comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.version",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.7"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystemVersion"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.code",
-				"path": "Observation.category.coding.code",
-				"short": "Symbol in syntax defined by the system",
-				"definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
-				"requirements": "Need to refer to a particular code in the system.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "vital-signs",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1"
-					},
-					{
-						"identity": "rim",
-						"map": "./code"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.display",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.coding.display",
-				"short": "Representation defined by the system",
-				"definition": "A representation of the meaning of the code in the system, following the rules of the system.",
-				"requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.display",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.2 - but note this is not well followed"
-					},
-					{
-						"identity": "rim",
-						"map": "CV.displayName"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.userSelected",
-				"path": "Observation.category.coding.userSelected",
-				"short": "If this coding was chosen directly by the user",
-				"definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
-				"comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
-				"requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.userSelected",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Sometimes implied by being first"
-					},
-					{
-						"identity": "rim",
-						"map": "CD.codingRationale"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.text",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.text",
-				"short": "Plain text representation of the concept",
-				"definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
-				"comment": "Very often the text is the same as a displayName of one of the codings.",
-				"requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CodeableConcept.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.9. But note many systems use C*E.2 for this"
-					},
-					{
-						"identity": "rim",
-						"map": "./originalText[mediaType/code=\"text/plain\"]/data"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
-					}
-				]
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Coded Responses from C-CDA Vital Sign Results",
-				"definition": "Coded Responses from C-CDA Vital Sign Results.",
-				"comment": "*All* code-value and, if present, component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
-				"alias": [
-					"Name"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "39156-5"
-						}
-					]
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "116680003 |Is a|"
-					}
-				]
-			},
-			{
-				"id": "Observation.subject",
-				"path": "Observation.subject",
-				"short": "Who and/or what the observation is about",
-				"definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
-				"comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
-				"requirements": "Observations have no value if you don't know who or what they're about.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=RTGT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.focus",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
-						"valueCode": "trial-use"
-					}
-				],
-				"path": "Observation.focus",
-				"short": "What the observation is about, when it is not about the subject of record",
-				"definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
-				"comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.focus",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SBJ]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.encounter",
-				"path": "Observation.encounter",
-				"short": "Healthcare event during which this observation is made",
-				"definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
-				"comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
-				"requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
-				"alias": [
-					"Context"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.effective[x]",
-				"path": "Observation.effective[x]",
-				"short": "Often just a dateTime for Vital Signs",
-				"definition": "Often just a dateTime for Vital Signs.",
-				"comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
-				"requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
-				"alias": [
-					"Occurrence"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.effective[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-1",
-						"severity": "error",
-						"human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
-						"expression": "($this as dateTime).toString().length() >= 8",
-						"xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "Observation.issued",
-				"path": "Observation.issued",
-				"short": "Date/Time this version was made available",
-				"definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
-				"comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.issued",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=AUT].time"
-					}
-				]
-			},
-			{
-				"id": "Observation.performer",
-				"path": "Observation.performer",
-				"short": "Who is responsible for the observation",
-				"definition": "Who was responsible for asserting the observed value as \"true\".",
-				"requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.performer",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=PRF]"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]",
-				"path": "Observation.value[x]",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "type",
-							"path": "$this"
-						}
-					],
-					"ordered": false,
-					"rules": "closed"
-				},
-				"short": "Vital Signs Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity",
-				"path": "Observation.value[x]",
-				"sliceName": "valueQuantity",
-				"short": "Vital Signs Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.id",
-				"path": "Observation.value[x].id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.extension",
-				"path": "Observation.value[x].extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.value",
-				"path": "Observation.value[x].value",
-				"short": "Numerical value (with implicit precision)",
-				"definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
-				"comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
-				"requirements": "Precision is handled implicitly in almost all cases of measurement.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.2  / CQ - N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.comparator",
-				"path": "Observation.value[x].comparator",
-				"short": "< | <= | >= | > - how to understand the value",
-				"definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
-				"requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Quantity.comparator",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "QuantityComparator"
-						}
-					],
-					"strength": "required",
-					"description": "How the Quantity should be understood and represented.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.1  / CQ.1"
-					},
-					{
-						"identity": "rim",
-						"map": "IVL properties"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.unit",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.value[x].unit",
-				"short": "Unit representation",
-				"definition": "A human-readable form of the unit.",
-				"requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.unit",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.unit"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.system",
-				"path": "Observation.value[x].system",
-				"short": "System that defines coded unit form",
-				"definition": "The identification of the system that provides the coded form of the unit.",
-				"requirements": "Need to know the system that defines the coded form of the unit.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"condition": [
-					"qty-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "CO.codeSystem, PQ.translation.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.code",
-				"path": "Observation.value[x].code",
-				"short": "Coded responses from the common UCUM units for vital signs value set.",
-				"definition": "A computer processable form of the unit in some unit representation system.",
-				"comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
-				"requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "kg/m2",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.code, MO.currency, PQ.translation.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.dataAbsentReason",
-				"path": "Observation.dataAbsentReason",
-				"short": "Why the result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
-				"comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.interpretation",
-				"path": "Observation.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.note",
-				"path": "Observation.note",
-				"short": "Comments about the observation",
-				"definition": "Comments about the observation or the results.",
-				"comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
-				"requirements": "Need to be able to provide free text additional information.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
-					},
-					{
-						"identity": "rim",
-						"map": "subjectOf.observationEvent[code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.bodySite",
-				"path": "Observation.bodySite",
-				"short": "Observed body part",
-				"definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
-				"comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.bodySite",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "BodySite"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing anatomical locations. May include laterality.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/body-site"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123037004 |Body structure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-20"
-					},
-					{
-						"identity": "rim",
-						"map": "targetSiteCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "718497002 |Inherent location|"
-					}
-				]
-			},
-			{
-				"id": "Observation.method",
-				"path": "Observation.method",
-				"short": "How it was done",
-				"definition": "Indicates the mechanism used to perform the observation.",
-				"comment": "Only used if not implicit in code for Observation.code.",
-				"requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.method",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationMethod"
-						}
-					],
-					"strength": "example",
-					"description": "Methods for simple observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-17"
-					},
-					{
-						"identity": "rim",
-						"map": "methodCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.specimen",
-				"path": "Observation.specimen",
-				"short": "Specimen used for this observation",
-				"definition": "The specimen that was used when this observation was made.",
-				"comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.specimen",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Specimen"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123038009 |Specimen|"
-					},
-					{
-						"identity": "v2",
-						"map": "SPM segment"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SPC].specimen"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "704319004 |Inherent in|"
-					}
-				]
-			},
-			{
-				"id": "Observation.device",
-				"path": "Observation.device",
-				"short": "(Measurement) Device",
-				"definition": "The device used to generate the observation data.",
-				"comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.device",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/DeviceMetric"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 49062001 |Device|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-17 / PRT -10"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=DEV]"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "424226004 |Using device|"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange",
-				"path": "Observation.referenceRange",
-				"short": "Provides guide for interpretation",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "obs-3",
-						"severity": "error",
-						"human": "Must have at least a low or a high or text",
-						"expression": "low.exists() or high.exists() or text.exists()",
-						"xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.id",
-				"path": "Observation.referenceRange.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.extension",
-				"path": "Observation.referenceRange.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.modifierExtension",
-				"path": "Observation.referenceRange.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.low",
-				"path": "Observation.referenceRange.low",
-				"short": "Low Range, if relevant",
-				"definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.low",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.low"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.high",
-				"path": "Observation.referenceRange.high",
-				"short": "High Range, if relevant",
-				"definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.high",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.high"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.type",
-				"path": "Observation.referenceRange.type",
-				"short": "Reference range qualifier",
-				"definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
-				"requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeMeaning"
-						}
-					],
-					"strength": "preferred",
-					"description": "Code for the meaning of a reference range.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.appliesTo",
-				"path": "Observation.referenceRange.appliesTo",
-				"short": "Reference range population",
-				"definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
-				"requirements": "Need to be able to identify the target population for proper interpretation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange.appliesTo",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeType"
-						}
-					],
-					"strength": "example",
-					"description": "Codes identifying the population the reference range applies to.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.age",
-				"path": "Observation.referenceRange.age",
-				"short": "Applicable age range, if relevant",
-				"definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
-				"requirements": "Some analytes vary greatly over age.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.age",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Range"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.text",
-				"path": "Observation.referenceRange.text",
-				"short": "Text based reference range in an observation",
-				"definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:ST"
-					}
-				]
-			},
-			{
-				"id": "Observation.hasMember",
-				"path": "Observation.hasMember",
-				"short": "Used when reporting vital signs panel components",
-				"definition": "Used when reporting vital signs panel components.",
-				"comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.hasMember",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship"
-					}
-				]
-			},
-			{
-				"id": "Observation.derivedFrom",
-				"path": "Observation.derivedFrom",
-				"short": "Related measurements the observation is made from",
-				"definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
-				"comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.derivedFrom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/DocumentReference",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy",
-							"http://hl7.org/fhir/StructureDefinition/Media",
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": ".targetObservation"
-					}
-				]
-			},
-			{
-				"id": "Observation.component",
-				"path": "Observation.component",
-				"short": "Component observations",
-				"definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
-				"comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-3",
-						"severity": "error",
-						"human": "If there is no a value a data absent reason must be present",
-						"expression": "value.exists() or dataAbsentReason.exists()",
-						"xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "containment by OBX-4?"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=COMP]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.id",
-				"path": "Observation.component.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.extension",
-				"path": "Observation.component.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.modifierExtension",
-				"path": "Observation.component.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.code",
-				"path": "Observation.component.code",
-				"short": "Type of component observation (code / type)",
-				"definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
-				"comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.value[x]",
-				"path": "Observation.component.value[x]",
-				"short": "Vital Sign Component Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
-				"comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "Quantity"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.dataAbsentReason",
-				"path": "Observation.component.dataAbsentReason",
-				"short": "Why the component result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
-				"comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.interpretation",
-				"path": "Observation.component.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.referenceRange",
-				"path": "Observation.component.referenceRange",
-				"short": "Provides guide for interpretation of component result",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "US Core Body Mass Index (BMI) Profile",
-				"definition": "Defines constraints on Observation to represent Body Mass Index (BMI) observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile."
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "39156-5"
-						}
-					]
-				},
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity",
-				"path": "Observation.valueQuantity",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.value",
-				"path": "Observation.valueQuantity.value",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.unit",
-				"path": "Observation.valueQuantity.unit",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.system",
-				"path": "Observation.valueQuantity.system",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.code",
-				"path": "Observation.valueQuantity.code",
-				"short": "Coded responses from the common UCUM units for vital signs value set.",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "kg/m2",
-				"mustSupport": true
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-bmi",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-bmi",
+    "version": "4.0.0",
+    "name": "USCoreBMIProfileProfile",
+    "title": "US Core BMI Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-17",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints on Observation to represent Body Mass Index (BMI) observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "sct-concept",
+            "uri": "http://snomed.info/conceptdomain",
+            "name": "SNOMED CT Concept Domain Binding"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "sct-attr",
+            "uri": "http://snomed.org/attributebinding",
+            "name": "SNOMED CT Attribute Binding"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Observation",
+    "baseDefinition": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "US Core Body Mass Index (BMI) Profile",
+                "definition": "Defines constraints on Observation to represent Body Mass Index (BMI) observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
+                "alias": [
+                    "Vital Signs",
+                    "Measurement",
+                    "Results",
+                    "Tests"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "obs-6",
+                        "severity": "error",
+                        "human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
+                        "expression": "dataAbsentReason.empty() or value.empty()",
+                        "xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "obs-7",
+                        "severity": "error",
+                        "human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
+                        "expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
+                        "xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "vs-2",
+                        "severity": "error",
+                        "human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
+                        "expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
+                        "xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.id",
+                "path": "Observation.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.meta",
+                "path": "Observation.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.implicitRules",
+                "path": "Observation.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Observation.language",
+                "path": "Observation.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Observation.text",
+                "path": "Observation.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.contained",
+                "path": "Observation.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.extension",
+                "path": "Observation.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.modifierExtension",
+                "path": "Observation.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.identifier",
+                "path": "Observation.identifier",
+                "short": "Business Identifier for observation",
+                "definition": "A unique identifier assigned to this observation.",
+                "requirements": "Allows observations to be distinguished and referenced.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "id"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.basedOn",
+                "path": "Observation.basedOn",
+                "short": "Fulfills plan, proposal or order",
+                "definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
+                "requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
+                "alias": [
+                    "Fulfills"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceRequest",
+                            "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+                            "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.basedOn"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.partOf",
+                "path": "Observation.partOf",
+                "short": "Part of referenced event",
+                "definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
+                "comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
+                "alias": [
+                    "Container"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.partOf",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationDispense",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationStatement",
+                            "http://hl7.org/fhir/StructureDefinition/Procedure",
+                            "http://hl7.org/fhir/StructureDefinition/Immunization",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.partOf"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "Varies by domain"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=FLFS].target"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.status",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
+                        "valueString": "default: final"
+                    }
+                ],
+                "path": "Observation.status",
+                "short": "registered | preliminary | final | amended +",
+                "definition": "The status of the result value.",
+                "comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
+                "requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Status"
+                        }
+                    ],
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 445584004 |Report by finality status|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-11"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category",
+                "path": "Observation.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "coding.code"
+                        },
+                        {
+                            "type": "value",
+                            "path": "coding.system"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "open"
+                },
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat",
+                "path": "Observation.category",
+                "sliceName": "VSCat",
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.id",
+                "path": "Observation.category.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.extension",
+                "path": "Observation.category.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding",
+                "path": "Observation.category.coding",
+                "short": "Code defined by a terminology system",
+                "definition": "A reference to a code defined by a terminology system.",
+                "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+                "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "CodeableConcept.coding",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1-8, C*E.10-22"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "union(., ./translation)"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.id",
+                "path": "Observation.category.coding.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.extension",
+                "path": "Observation.category.coding.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.system",
+                "path": "Observation.category.coding.system",
+                "short": "Identity of the terminology system",
+                "definition": "The identification of the code system that defines the meaning of the symbol in the code.",
+                "comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
+                "requirements": "Need to be unambiguous about the source of the definition of the symbol.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystem"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.version",
+                "path": "Observation.category.coding.version",
+                "short": "Version of the system - if relevant",
+                "definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
+                "comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.version",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystemVersion"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.code",
+                "path": "Observation.category.coding.code",
+                "short": "Symbol in syntax defined by the system",
+                "definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
+                "requirements": "Need to refer to a particular code in the system.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "vital-signs",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./code"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.display",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.coding.display",
+                "short": "Representation defined by the system",
+                "definition": "A representation of the meaning of the code in the system, following the rules of the system.",
+                "requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.display",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.2 - but note this is not well followed"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CV.displayName"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.userSelected",
+                "path": "Observation.category.coding.userSelected",
+                "short": "If this coding was chosen directly by the user",
+                "definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
+                "comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
+                "requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.userSelected",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Sometimes implied by being first"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CD.codingRationale"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.text",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.text",
+                "short": "Plain text representation of the concept",
+                "definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
+                "comment": "Very often the text is the same as a displayName of one of the codings.",
+                "requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CodeableConcept.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.9. But note many systems use C*E.2 for this"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./originalText[mediaType/code=\"text/plain\"]/data"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Coded Responses from C-CDA Vital Sign Results",
+                "definition": "Coded Responses from C-CDA Vital Sign Results.",
+                "comment": "*All* code-value and, if present, component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
+                "alias": [
+                    "Name"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "39156-5"
+                        }
+                    ]
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "116680003 |Is a|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.subject",
+                "path": "Observation.subject",
+                "short": "Who and/or what the observation is about",
+                "definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
+                "comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
+                "requirements": "Observations have no value if you don't know who or what they're about.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=RTGT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.focus",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+                        "valueCode": "trial-use"
+                    }
+                ],
+                "path": "Observation.focus",
+                "short": "What the observation is about, when it is not about the subject of record",
+                "definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
+                "comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.focus",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SBJ]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.encounter",
+                "path": "Observation.encounter",
+                "short": "Healthcare event during which this observation is made",
+                "definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
+                "comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
+                "requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
+                "alias": [
+                    "Context"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.effective[x]",
+                "path": "Observation.effective[x]",
+                "short": "Often just a dateTime for Vital Signs",
+                "definition": "Often just a dateTime for Vital Signs.",
+                "comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
+                "requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
+                "alias": [
+                    "Occurrence"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.effective[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-1",
+                        "severity": "error",
+                        "human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
+                        "expression": "($this as dateTime).toString().length() >= 8",
+                        "xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.issued",
+                "path": "Observation.issued",
+                "short": "Date/Time this version was made available",
+                "definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
+                "comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.issued",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.performer",
+                "path": "Observation.performer",
+                "short": "Who is responsible for the observation",
+                "definition": "Who was responsible for asserting the observed value as \"true\".",
+                "requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.performer",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=PRF]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]",
+                "path": "Observation.value[x]",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "type",
+                            "path": "$this"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "closed"
+                },
+                "short": "Vital Signs Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity",
+                "path": "Observation.value[x]",
+                "sliceName": "valueQuantity",
+                "short": "Vital Signs Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.id",
+                "path": "Observation.value[x].id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.extension",
+                "path": "Observation.value[x].extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.value",
+                "path": "Observation.value[x].value",
+                "short": "Numerical value (with implicit precision)",
+                "definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
+                "comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
+                "requirements": "Precision is handled implicitly in almost all cases of measurement.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.2  / CQ - N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.comparator",
+                "path": "Observation.value[x].comparator",
+                "short": "< | <= | >= | > - how to understand the value",
+                "definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
+                "requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.comparator",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "QuantityComparator"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "How the Quantity should be understood and represented.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.1  / CQ.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "IVL properties"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.unit",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.value[x].unit",
+                "short": "Unit representation",
+                "definition": "A human-readable form of the unit.",
+                "requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.unit",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.unit"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.system",
+                "path": "Observation.value[x].system",
+                "short": "System that defines coded unit form",
+                "definition": "The identification of the system that provides the coded form of the unit.",
+                "requirements": "Need to know the system that defines the coded form of the unit.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "condition": [
+                    "qty-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CO.codeSystem, PQ.translation.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.code",
+                "path": "Observation.value[x].code",
+                "short": "Coded responses from the common UCUM units for vital signs value set.",
+                "definition": "A computer processable form of the unit in some unit representation system.",
+                "comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
+                "requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "kg/m2",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.code, MO.currency, PQ.translation.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.dataAbsentReason",
+                "path": "Observation.dataAbsentReason",
+                "short": "Why the result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
+                "comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.interpretation",
+                "path": "Observation.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.note",
+                "path": "Observation.note",
+                "short": "Comments about the observation",
+                "definition": "Comments about the observation or the results.",
+                "comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
+                "requirements": "Need to be able to provide free text additional information.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "subjectOf.observationEvent[code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.bodySite",
+                "path": "Observation.bodySite",
+                "short": "Observed body part",
+                "definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
+                "comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.bodySite",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "BodySite"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing anatomical locations. May include laterality.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/body-site"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123037004 |Body structure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-20"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "targetSiteCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "718497002 |Inherent location|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.method",
+                "path": "Observation.method",
+                "short": "How it was done",
+                "definition": "Indicates the mechanism used to perform the observation.",
+                "comment": "Only used if not implicit in code for Observation.code.",
+                "requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.method",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationMethod"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Methods for simple observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "methodCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.specimen",
+                "path": "Observation.specimen",
+                "short": "Specimen used for this observation",
+                "definition": "The specimen that was used when this observation was made.",
+                "comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.specimen",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Specimen"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123038009 |Specimen|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "SPM segment"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SPC].specimen"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "704319004 |Inherent in|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.device",
+                "path": "Observation.device",
+                "short": "(Measurement) Device",
+                "definition": "The device used to generate the observation data.",
+                "comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.device",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceMetric"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 49062001 |Device|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17 / PRT -10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=DEV]"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "424226004 |Using device|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange",
+                "path": "Observation.referenceRange",
+                "short": "Provides guide for interpretation",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "obs-3",
+                        "severity": "error",
+                        "human": "Must have at least a low or a high or text",
+                        "expression": "low.exists() or high.exists() or text.exists()",
+                        "xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.id",
+                "path": "Observation.referenceRange.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.extension",
+                "path": "Observation.referenceRange.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.modifierExtension",
+                "path": "Observation.referenceRange.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.low",
+                "path": "Observation.referenceRange.low",
+                "short": "Low Range, if relevant",
+                "definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.low",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.low"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.high",
+                "path": "Observation.referenceRange.high",
+                "short": "High Range, if relevant",
+                "definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.high",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.high"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.type",
+                "path": "Observation.referenceRange.type",
+                "short": "Reference range qualifier",
+                "definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
+                "requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeMeaning"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Code for the meaning of a reference range.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.appliesTo",
+                "path": "Observation.referenceRange.appliesTo",
+                "short": "Reference range population",
+                "definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
+                "requirements": "Need to be able to identify the target population for proper interpretation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange.appliesTo",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes identifying the population the reference range applies to.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.age",
+                "path": "Observation.referenceRange.age",
+                "short": "Applicable age range, if relevant",
+                "definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
+                "requirements": "Some analytes vary greatly over age.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.age",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Range"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.text",
+                "path": "Observation.referenceRange.text",
+                "short": "Text based reference range in an observation",
+                "definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:ST"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.hasMember",
+                "path": "Observation.hasMember",
+                "short": "Used when reporting vital signs panel components",
+                "definition": "Used when reporting vital signs panel components.",
+                "comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.hasMember",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.derivedFrom",
+                "path": "Observation.derivedFrom",
+                "short": "Related measurements the observation is made from",
+                "definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
+                "comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.derivedFrom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/DocumentReference",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy",
+                            "http://hl7.org/fhir/StructureDefinition/Media",
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".targetObservation"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component",
+                "path": "Observation.component",
+                "short": "Component observations",
+                "definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
+                "comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-3",
+                        "severity": "error",
+                        "human": "If there is no a value a data absent reason must be present",
+                        "expression": "value.exists() or dataAbsentReason.exists()",
+                        "xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "containment by OBX-4?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=COMP]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.id",
+                "path": "Observation.component.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.extension",
+                "path": "Observation.component.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.modifierExtension",
+                "path": "Observation.component.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.code",
+                "path": "Observation.component.code",
+                "short": "Type of component observation (code / type)",
+                "definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
+                "comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.value[x]",
+                "path": "Observation.component.value[x]",
+                "short": "Vital Sign Component Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
+                "comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.dataAbsentReason",
+                "path": "Observation.component.dataAbsentReason",
+                "short": "Why the component result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
+                "comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.interpretation",
+                "path": "Observation.component.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.referenceRange",
+                "path": "Observation.component.referenceRange",
+                "short": "Provides guide for interpretation of component result",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "US Core Body Mass Index (BMI) Profile",
+                "definition": "Defines constraints on Observation to represent Body Mass Index (BMI) observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile."
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "39156-5"
+                        }
+                    ]
+                },
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity",
+                "path": "Observation.valueQuantity",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.value",
+                "path": "Observation.valueQuantity.value",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.unit",
+                "path": "Observation.valueQuantity.unit",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.system",
+                "path": "Observation.valueQuantity.system",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.code",
+                "path": "Observation.valueQuantity.code",
+                "short": "Coded responses from the common UCUM units for vital signs value set.",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "kg/m2",
+                "mustSupport": true
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-body-height.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-body-height.json
@@ -1,3814 +1,3814 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-body-height",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-body-height-definitions.html#Observation\" title=\"Defines constraints on Observation to represent body height observations with a standard LOINC code and UCUM units of measure.  This profile is derived from the US Core Vital Signs Profile.\">Observation</a><a name=\"Observation\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"StructureDefinition-us-core-vital-signs.html\">USCoreVitalSignsProfile</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">US Core Body Height Profile</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-body-height-definitions.html#Observation.code\">code</a><a name=\"Observation.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">1</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Body Height<br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck101.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#CodeableConcept.coding\">coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Code defined by a terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">(complex)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/loinc.html\">http://loinc.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">8302-2</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-body-height-definitions.html#Observation.valueQuantity\">valueQuantity</a><a name=\"Observation.valueQuantity\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Quantity\">Quantity</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Vital Signs Value</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-body-height-definitions.html#Observation.valueQuantity.value\">value</a><a name=\"Observation.valueQuantity.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#decimal\">decimal</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Numerical value (with implicit precision)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-body-height-definitions.html#Observation.valueQuantity.unit\">unit</a><a name=\"Observation.valueQuantity.unit\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Unit representation</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-body-height-definitions.html#Observation.valueQuantity.system\">system</a><a name=\"Observation.valueQuantity.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">System that defines coded unit form</span><br/><span style=\"font-weight:bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/ucum.html\">http://unitsofmeasure.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-body-height-definitions.html#Observation.valueQuantity.code\">code</a><a name=\"Observation.valueQuantity.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Coded responses from the common UCUM units for vital signs value set.<br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-ucum-bodylength.html\">BodyLengthUnits</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-height",
-	"version": "4.0.0",
-	"name": "USCoreBodyHeightProfile",
-	"title": "US Core Body Height Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-17",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints on Observation to represent body height observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "sct-concept",
-			"uri": "http://snomed.info/conceptdomain",
-			"name": "SNOMED CT Concept Domain Binding"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "sct-attr",
-			"uri": "http://snomed.org/attributebinding",
-			"name": "SNOMED CT Attribute Binding"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Observation",
-	"baseDefinition": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "US Core Body Height Profile",
-				"definition": "Defines constraints on Observation to represent body height observations with a standard LOINC code and UCUM units of measure.  This profile is derived from the US Core Vital Signs Profile.",
-				"comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
-				"alias": [
-					"Vital Signs",
-					"Measurement",
-					"Results",
-					"Tests"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "obs-6",
-						"severity": "error",
-						"human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
-						"expression": "dataAbsentReason.empty() or value.empty()",
-						"xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "obs-7",
-						"severity": "error",
-						"human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
-						"expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
-						"xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "vs-2",
-						"severity": "error",
-						"human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
-						"expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
-						"xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.id",
-				"path": "Observation.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.meta",
-				"path": "Observation.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.implicitRules",
-				"path": "Observation.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Observation.language",
-				"path": "Observation.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Observation.text",
-				"path": "Observation.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Observation.contained",
-				"path": "Observation.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.extension",
-				"path": "Observation.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.modifierExtension",
-				"path": "Observation.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.identifier",
-				"path": "Observation.identifier",
-				"short": "Business Identifier for observation",
-				"definition": "A unique identifier assigned to this observation.",
-				"requirements": "Allows observations to be distinguished and referenced.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
-					},
-					{
-						"identity": "rim",
-						"map": "id"
-					}
-				]
-			},
-			{
-				"id": "Observation.basedOn",
-				"path": "Observation.basedOn",
-				"short": "Fulfills plan, proposal or order",
-				"definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
-				"requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
-				"alias": [
-					"Fulfills"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan",
-							"http://hl7.org/fhir/StructureDefinition/DeviceRequest",
-							"http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
-							"http://hl7.org/fhir/StructureDefinition/MedicationRequest",
-							"http://hl7.org/fhir/StructureDefinition/NutritionOrder",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.basedOn"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.partOf",
-				"path": "Observation.partOf",
-				"short": "Part of referenced event",
-				"definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
-				"comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
-				"alias": [
-					"Container"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.partOf",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
-							"http://hl7.org/fhir/StructureDefinition/MedicationDispense",
-							"http://hl7.org/fhir/StructureDefinition/MedicationStatement",
-							"http://hl7.org/fhir/StructureDefinition/Procedure",
-							"http://hl7.org/fhir/StructureDefinition/Immunization",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.partOf"
-					},
-					{
-						"identity": "v2",
-						"map": "Varies by domain"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=FLFS].target"
-					}
-				]
-			},
-			{
-				"id": "Observation.status",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
-						"valueString": "default: final"
-					}
-				],
-				"path": "Observation.status",
-				"short": "registered | preliminary | final | amended +",
-				"definition": "The status of the result value.",
-				"comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
-				"requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Status"
-						}
-					],
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 445584004 |Report by finality status|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-11"
-					},
-					{
-						"identity": "rim",
-						"map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
-					}
-				]
-			},
-			{
-				"id": "Observation.category",
-				"path": "Observation.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "coding.code"
-						},
-						{
-							"type": "value",
-							"path": "coding.system"
-						}
-					],
-					"ordered": false,
-					"rules": "open"
-				},
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat",
-				"path": "Observation.category",
-				"sliceName": "VSCat",
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.id",
-				"path": "Observation.category.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.extension",
-				"path": "Observation.category.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding",
-				"path": "Observation.category.coding",
-				"short": "Code defined by a terminology system",
-				"definition": "A reference to a code defined by a terminology system.",
-				"comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
-				"requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "CodeableConcept.coding",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1-8, C*E.10-22"
-					},
-					{
-						"identity": "rim",
-						"map": "union(., ./translation)"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.id",
-				"path": "Observation.category.coding.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.extension",
-				"path": "Observation.category.coding.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.system",
-				"path": "Observation.category.coding.system",
-				"short": "Identity of the terminology system",
-				"definition": "The identification of the code system that defines the meaning of the symbol in the code.",
-				"comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
-				"requirements": "Need to be unambiguous about the source of the definition of the symbol.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.3"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystem"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.version",
-				"path": "Observation.category.coding.version",
-				"short": "Version of the system - if relevant",
-				"definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
-				"comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.version",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.7"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystemVersion"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.code",
-				"path": "Observation.category.coding.code",
-				"short": "Symbol in syntax defined by the system",
-				"definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
-				"requirements": "Need to refer to a particular code in the system.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "vital-signs",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1"
-					},
-					{
-						"identity": "rim",
-						"map": "./code"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.display",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.coding.display",
-				"short": "Representation defined by the system",
-				"definition": "A representation of the meaning of the code in the system, following the rules of the system.",
-				"requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.display",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.2 - but note this is not well followed"
-					},
-					{
-						"identity": "rim",
-						"map": "CV.displayName"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.userSelected",
-				"path": "Observation.category.coding.userSelected",
-				"short": "If this coding was chosen directly by the user",
-				"definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
-				"comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
-				"requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.userSelected",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Sometimes implied by being first"
-					},
-					{
-						"identity": "rim",
-						"map": "CD.codingRationale"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.text",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.text",
-				"short": "Plain text representation of the concept",
-				"definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
-				"comment": "Very often the text is the same as a displayName of one of the codings.",
-				"requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CodeableConcept.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.9. But note many systems use C*E.2 for this"
-					},
-					{
-						"identity": "rim",
-						"map": "./originalText[mediaType/code=\"text/plain\"]/data"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
-					}
-				]
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Body Height",
-				"definition": "Coded Responses from C-CDA Vital Sign Results.",
-				"comment": "*All* code-value and, if present, component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
-				"alias": [
-					"Name"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "8302-2"
-						}
-					]
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "116680003 |Is a|"
-					}
-				]
-			},
-			{
-				"id": "Observation.subject",
-				"path": "Observation.subject",
-				"short": "Who and/or what the observation is about",
-				"definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
-				"comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
-				"requirements": "Observations have no value if you don't know who or what they're about.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=RTGT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.focus",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
-						"valueCode": "trial-use"
-					}
-				],
-				"path": "Observation.focus",
-				"short": "What the observation is about, when it is not about the subject of record",
-				"definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
-				"comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.focus",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SBJ]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.encounter",
-				"path": "Observation.encounter",
-				"short": "Healthcare event during which this observation is made",
-				"definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
-				"comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
-				"requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
-				"alias": [
-					"Context"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.effective[x]",
-				"path": "Observation.effective[x]",
-				"short": "Often just a dateTime for Vital Signs",
-				"definition": "Often just a dateTime for Vital Signs.",
-				"comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
-				"requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
-				"alias": [
-					"Occurrence"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.effective[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-1",
-						"severity": "error",
-						"human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
-						"expression": "($this as dateTime).toString().length() >= 8",
-						"xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "Observation.issued",
-				"path": "Observation.issued",
-				"short": "Date/Time this version was made available",
-				"definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
-				"comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.issued",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=AUT].time"
-					}
-				]
-			},
-			{
-				"id": "Observation.performer",
-				"path": "Observation.performer",
-				"short": "Who is responsible for the observation",
-				"definition": "Who was responsible for asserting the observed value as \"true\".",
-				"requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.performer",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=PRF]"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]",
-				"path": "Observation.value[x]",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "type",
-							"path": "$this"
-						}
-					],
-					"ordered": false,
-					"rules": "closed"
-				},
-				"short": "Vital Signs Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity",
-				"path": "Observation.value[x]",
-				"sliceName": "valueQuantity",
-				"short": "Vital Signs Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.id",
-				"path": "Observation.value[x].id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.extension",
-				"path": "Observation.value[x].extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.value",
-				"path": "Observation.value[x].value",
-				"short": "Numerical value (with implicit precision)",
-				"definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
-				"comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
-				"requirements": "Precision is handled implicitly in almost all cases of measurement.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.2  / CQ - N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.comparator",
-				"path": "Observation.value[x].comparator",
-				"short": "< | <= | >= | > - how to understand the value",
-				"definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
-				"requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Quantity.comparator",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "QuantityComparator"
-						}
-					],
-					"strength": "required",
-					"description": "How the Quantity should be understood and represented.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.1  / CQ.1"
-					},
-					{
-						"identity": "rim",
-						"map": "IVL properties"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.unit",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.value[x].unit",
-				"short": "Unit representation",
-				"definition": "A human-readable form of the unit.",
-				"requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.unit",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.unit"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.system",
-				"path": "Observation.value[x].system",
-				"short": "System that defines coded unit form",
-				"definition": "The identification of the system that provides the coded form of the unit.",
-				"requirements": "Need to know the system that defines the coded form of the unit.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"condition": [
-					"qty-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "CO.codeSystem, PQ.translation.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.code",
-				"path": "Observation.value[x].code",
-				"short": "Coded responses from the common UCUM units for vital signs value set.",
-				"definition": "A computer processable form of the unit in some unit representation system.",
-				"comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
-				"requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-bodylength|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.code, MO.currency, PQ.translation.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.dataAbsentReason",
-				"path": "Observation.dataAbsentReason",
-				"short": "Why the result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
-				"comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.interpretation",
-				"path": "Observation.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.note",
-				"path": "Observation.note",
-				"short": "Comments about the observation",
-				"definition": "Comments about the observation or the results.",
-				"comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
-				"requirements": "Need to be able to provide free text additional information.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
-					},
-					{
-						"identity": "rim",
-						"map": "subjectOf.observationEvent[code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.bodySite",
-				"path": "Observation.bodySite",
-				"short": "Observed body part",
-				"definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
-				"comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.bodySite",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "BodySite"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing anatomical locations. May include laterality.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/body-site"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123037004 |Body structure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-20"
-					},
-					{
-						"identity": "rim",
-						"map": "targetSiteCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "718497002 |Inherent location|"
-					}
-				]
-			},
-			{
-				"id": "Observation.method",
-				"path": "Observation.method",
-				"short": "How it was done",
-				"definition": "Indicates the mechanism used to perform the observation.",
-				"comment": "Only used if not implicit in code for Observation.code.",
-				"requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.method",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationMethod"
-						}
-					],
-					"strength": "example",
-					"description": "Methods for simple observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-17"
-					},
-					{
-						"identity": "rim",
-						"map": "methodCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.specimen",
-				"path": "Observation.specimen",
-				"short": "Specimen used for this observation",
-				"definition": "The specimen that was used when this observation was made.",
-				"comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.specimen",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Specimen"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123038009 |Specimen|"
-					},
-					{
-						"identity": "v2",
-						"map": "SPM segment"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SPC].specimen"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "704319004 |Inherent in|"
-					}
-				]
-			},
-			{
-				"id": "Observation.device",
-				"path": "Observation.device",
-				"short": "(Measurement) Device",
-				"definition": "The device used to generate the observation data.",
-				"comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.device",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/DeviceMetric"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 49062001 |Device|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-17 / PRT -10"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=DEV]"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "424226004 |Using device|"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange",
-				"path": "Observation.referenceRange",
-				"short": "Provides guide for interpretation",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "obs-3",
-						"severity": "error",
-						"human": "Must have at least a low or a high or text",
-						"expression": "low.exists() or high.exists() or text.exists()",
-						"xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.id",
-				"path": "Observation.referenceRange.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.extension",
-				"path": "Observation.referenceRange.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.modifierExtension",
-				"path": "Observation.referenceRange.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.low",
-				"path": "Observation.referenceRange.low",
-				"short": "Low Range, if relevant",
-				"definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.low",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.low"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.high",
-				"path": "Observation.referenceRange.high",
-				"short": "High Range, if relevant",
-				"definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.high",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.high"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.type",
-				"path": "Observation.referenceRange.type",
-				"short": "Reference range qualifier",
-				"definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
-				"requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeMeaning"
-						}
-					],
-					"strength": "preferred",
-					"description": "Code for the meaning of a reference range.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.appliesTo",
-				"path": "Observation.referenceRange.appliesTo",
-				"short": "Reference range population",
-				"definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
-				"requirements": "Need to be able to identify the target population for proper interpretation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange.appliesTo",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeType"
-						}
-					],
-					"strength": "example",
-					"description": "Codes identifying the population the reference range applies to.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.age",
-				"path": "Observation.referenceRange.age",
-				"short": "Applicable age range, if relevant",
-				"definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
-				"requirements": "Some analytes vary greatly over age.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.age",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Range"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.text",
-				"path": "Observation.referenceRange.text",
-				"short": "Text based reference range in an observation",
-				"definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:ST"
-					}
-				]
-			},
-			{
-				"id": "Observation.hasMember",
-				"path": "Observation.hasMember",
-				"short": "Used when reporting vital signs panel components",
-				"definition": "Used when reporting vital signs panel components.",
-				"comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.hasMember",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship"
-					}
-				]
-			},
-			{
-				"id": "Observation.derivedFrom",
-				"path": "Observation.derivedFrom",
-				"short": "Related measurements the observation is made from",
-				"definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
-				"comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.derivedFrom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/DocumentReference",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy",
-							"http://hl7.org/fhir/StructureDefinition/Media",
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": ".targetObservation"
-					}
-				]
-			},
-			{
-				"id": "Observation.component",
-				"path": "Observation.component",
-				"short": "Component observations",
-				"definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
-				"comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-3",
-						"severity": "error",
-						"human": "If there is no a value a data absent reason must be present",
-						"expression": "value.exists() or dataAbsentReason.exists()",
-						"xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "containment by OBX-4?"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=COMP]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.id",
-				"path": "Observation.component.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.extension",
-				"path": "Observation.component.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.modifierExtension",
-				"path": "Observation.component.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.code",
-				"path": "Observation.component.code",
-				"short": "Type of component observation (code / type)",
-				"definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
-				"comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.value[x]",
-				"path": "Observation.component.value[x]",
-				"short": "Vital Sign Component Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
-				"comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "Quantity"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.dataAbsentReason",
-				"path": "Observation.component.dataAbsentReason",
-				"short": "Why the component result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
-				"comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.interpretation",
-				"path": "Observation.component.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.referenceRange",
-				"path": "Observation.component.referenceRange",
-				"short": "Provides guide for interpretation of component result",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "US Core Body Height Profile",
-				"definition": "Defines constraints on Observation to represent body height observations with a standard LOINC code and UCUM units of measure.  This profile is derived from the US Core Vital Signs Profile."
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Body Height",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "8302-2"
-						}
-					]
-				},
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity",
-				"path": "Observation.valueQuantity",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.value",
-				"path": "Observation.valueQuantity.value",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.unit",
-				"path": "Observation.valueQuantity.unit",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.system",
-				"path": "Observation.valueQuantity.system",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.code",
-				"path": "Observation.valueQuantity.code",
-				"short": "Coded responses from the common UCUM units for vital signs value set.",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-bodylength|4.0.1"
-				}
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-body-height",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-height",
+    "version": "4.0.0",
+    "name": "USCoreBodyHeightProfile",
+    "title": "US Core Body Height Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-17",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints on Observation to represent body height observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "sct-concept",
+            "uri": "http://snomed.info/conceptdomain",
+            "name": "SNOMED CT Concept Domain Binding"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "sct-attr",
+            "uri": "http://snomed.org/attributebinding",
+            "name": "SNOMED CT Attribute Binding"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Observation",
+    "baseDefinition": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "US Core Body Height Profile",
+                "definition": "Defines constraints on Observation to represent body height observations with a standard LOINC code and UCUM units of measure.  This profile is derived from the US Core Vital Signs Profile.",
+                "comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
+                "alias": [
+                    "Vital Signs",
+                    "Measurement",
+                    "Results",
+                    "Tests"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "obs-6",
+                        "severity": "error",
+                        "human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
+                        "expression": "dataAbsentReason.empty() or value.empty()",
+                        "xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "obs-7",
+                        "severity": "error",
+                        "human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
+                        "expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
+                        "xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "vs-2",
+                        "severity": "error",
+                        "human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
+                        "expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
+                        "xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.id",
+                "path": "Observation.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.meta",
+                "path": "Observation.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.implicitRules",
+                "path": "Observation.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Observation.language",
+                "path": "Observation.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Observation.text",
+                "path": "Observation.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.contained",
+                "path": "Observation.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.extension",
+                "path": "Observation.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.modifierExtension",
+                "path": "Observation.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.identifier",
+                "path": "Observation.identifier",
+                "short": "Business Identifier for observation",
+                "definition": "A unique identifier assigned to this observation.",
+                "requirements": "Allows observations to be distinguished and referenced.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "id"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.basedOn",
+                "path": "Observation.basedOn",
+                "short": "Fulfills plan, proposal or order",
+                "definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
+                "requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
+                "alias": [
+                    "Fulfills"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceRequest",
+                            "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+                            "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.basedOn"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.partOf",
+                "path": "Observation.partOf",
+                "short": "Part of referenced event",
+                "definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
+                "comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
+                "alias": [
+                    "Container"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.partOf",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationDispense",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationStatement",
+                            "http://hl7.org/fhir/StructureDefinition/Procedure",
+                            "http://hl7.org/fhir/StructureDefinition/Immunization",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.partOf"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "Varies by domain"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=FLFS].target"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.status",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
+                        "valueString": "default: final"
+                    }
+                ],
+                "path": "Observation.status",
+                "short": "registered | preliminary | final | amended +",
+                "definition": "The status of the result value.",
+                "comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
+                "requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Status"
+                        }
+                    ],
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 445584004 |Report by finality status|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-11"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category",
+                "path": "Observation.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "coding.code"
+                        },
+                        {
+                            "type": "value",
+                            "path": "coding.system"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "open"
+                },
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat",
+                "path": "Observation.category",
+                "sliceName": "VSCat",
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.id",
+                "path": "Observation.category.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.extension",
+                "path": "Observation.category.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding",
+                "path": "Observation.category.coding",
+                "short": "Code defined by a terminology system",
+                "definition": "A reference to a code defined by a terminology system.",
+                "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+                "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "CodeableConcept.coding",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1-8, C*E.10-22"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "union(., ./translation)"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.id",
+                "path": "Observation.category.coding.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.extension",
+                "path": "Observation.category.coding.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.system",
+                "path": "Observation.category.coding.system",
+                "short": "Identity of the terminology system",
+                "definition": "The identification of the code system that defines the meaning of the symbol in the code.",
+                "comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
+                "requirements": "Need to be unambiguous about the source of the definition of the symbol.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystem"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.version",
+                "path": "Observation.category.coding.version",
+                "short": "Version of the system - if relevant",
+                "definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
+                "comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.version",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystemVersion"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.code",
+                "path": "Observation.category.coding.code",
+                "short": "Symbol in syntax defined by the system",
+                "definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
+                "requirements": "Need to refer to a particular code in the system.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "vital-signs",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./code"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.display",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.coding.display",
+                "short": "Representation defined by the system",
+                "definition": "A representation of the meaning of the code in the system, following the rules of the system.",
+                "requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.display",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.2 - but note this is not well followed"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CV.displayName"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.userSelected",
+                "path": "Observation.category.coding.userSelected",
+                "short": "If this coding was chosen directly by the user",
+                "definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
+                "comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
+                "requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.userSelected",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Sometimes implied by being first"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CD.codingRationale"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.text",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.text",
+                "short": "Plain text representation of the concept",
+                "definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
+                "comment": "Very often the text is the same as a displayName of one of the codings.",
+                "requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CodeableConcept.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.9. But note many systems use C*E.2 for this"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./originalText[mediaType/code=\"text/plain\"]/data"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Body Height",
+                "definition": "Coded Responses from C-CDA Vital Sign Results.",
+                "comment": "*All* code-value and, if present, component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
+                "alias": [
+                    "Name"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "8302-2"
+                        }
+                    ]
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "116680003 |Is a|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.subject",
+                "path": "Observation.subject",
+                "short": "Who and/or what the observation is about",
+                "definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
+                "comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
+                "requirements": "Observations have no value if you don't know who or what they're about.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=RTGT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.focus",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+                        "valueCode": "trial-use"
+                    }
+                ],
+                "path": "Observation.focus",
+                "short": "What the observation is about, when it is not about the subject of record",
+                "definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
+                "comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.focus",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SBJ]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.encounter",
+                "path": "Observation.encounter",
+                "short": "Healthcare event during which this observation is made",
+                "definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
+                "comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
+                "requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
+                "alias": [
+                    "Context"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.effective[x]",
+                "path": "Observation.effective[x]",
+                "short": "Often just a dateTime for Vital Signs",
+                "definition": "Often just a dateTime for Vital Signs.",
+                "comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
+                "requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
+                "alias": [
+                    "Occurrence"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.effective[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-1",
+                        "severity": "error",
+                        "human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
+                        "expression": "($this as dateTime).toString().length() >= 8",
+                        "xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.issued",
+                "path": "Observation.issued",
+                "short": "Date/Time this version was made available",
+                "definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
+                "comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.issued",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.performer",
+                "path": "Observation.performer",
+                "short": "Who is responsible for the observation",
+                "definition": "Who was responsible for asserting the observed value as \"true\".",
+                "requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.performer",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=PRF]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]",
+                "path": "Observation.value[x]",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "type",
+                            "path": "$this"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "closed"
+                },
+                "short": "Vital Signs Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity",
+                "path": "Observation.value[x]",
+                "sliceName": "valueQuantity",
+                "short": "Vital Signs Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.id",
+                "path": "Observation.value[x].id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.extension",
+                "path": "Observation.value[x].extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.value",
+                "path": "Observation.value[x].value",
+                "short": "Numerical value (with implicit precision)",
+                "definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
+                "comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
+                "requirements": "Precision is handled implicitly in almost all cases of measurement.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.2  / CQ - N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.comparator",
+                "path": "Observation.value[x].comparator",
+                "short": "< | <= | >= | > - how to understand the value",
+                "definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
+                "requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.comparator",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "QuantityComparator"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "How the Quantity should be understood and represented.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.1  / CQ.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "IVL properties"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.unit",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.value[x].unit",
+                "short": "Unit representation",
+                "definition": "A human-readable form of the unit.",
+                "requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.unit",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.unit"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.system",
+                "path": "Observation.value[x].system",
+                "short": "System that defines coded unit form",
+                "definition": "The identification of the system that provides the coded form of the unit.",
+                "requirements": "Need to know the system that defines the coded form of the unit.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "condition": [
+                    "qty-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CO.codeSystem, PQ.translation.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.code",
+                "path": "Observation.value[x].code",
+                "short": "Coded responses from the common UCUM units for vital signs value set.",
+                "definition": "A computer processable form of the unit in some unit representation system.",
+                "comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
+                "requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-bodylength|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.code, MO.currency, PQ.translation.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.dataAbsentReason",
+                "path": "Observation.dataAbsentReason",
+                "short": "Why the result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
+                "comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.interpretation",
+                "path": "Observation.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.note",
+                "path": "Observation.note",
+                "short": "Comments about the observation",
+                "definition": "Comments about the observation or the results.",
+                "comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
+                "requirements": "Need to be able to provide free text additional information.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "subjectOf.observationEvent[code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.bodySite",
+                "path": "Observation.bodySite",
+                "short": "Observed body part",
+                "definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
+                "comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.bodySite",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "BodySite"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing anatomical locations. May include laterality.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/body-site"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123037004 |Body structure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-20"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "targetSiteCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "718497002 |Inherent location|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.method",
+                "path": "Observation.method",
+                "short": "How it was done",
+                "definition": "Indicates the mechanism used to perform the observation.",
+                "comment": "Only used if not implicit in code for Observation.code.",
+                "requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.method",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationMethod"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Methods for simple observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "methodCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.specimen",
+                "path": "Observation.specimen",
+                "short": "Specimen used for this observation",
+                "definition": "The specimen that was used when this observation was made.",
+                "comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.specimen",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Specimen"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123038009 |Specimen|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "SPM segment"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SPC].specimen"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "704319004 |Inherent in|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.device",
+                "path": "Observation.device",
+                "short": "(Measurement) Device",
+                "definition": "The device used to generate the observation data.",
+                "comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.device",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceMetric"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 49062001 |Device|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17 / PRT -10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=DEV]"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "424226004 |Using device|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange",
+                "path": "Observation.referenceRange",
+                "short": "Provides guide for interpretation",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "obs-3",
+                        "severity": "error",
+                        "human": "Must have at least a low or a high or text",
+                        "expression": "low.exists() or high.exists() or text.exists()",
+                        "xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.id",
+                "path": "Observation.referenceRange.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.extension",
+                "path": "Observation.referenceRange.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.modifierExtension",
+                "path": "Observation.referenceRange.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.low",
+                "path": "Observation.referenceRange.low",
+                "short": "Low Range, if relevant",
+                "definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.low",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.low"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.high",
+                "path": "Observation.referenceRange.high",
+                "short": "High Range, if relevant",
+                "definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.high",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.high"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.type",
+                "path": "Observation.referenceRange.type",
+                "short": "Reference range qualifier",
+                "definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
+                "requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeMeaning"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Code for the meaning of a reference range.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.appliesTo",
+                "path": "Observation.referenceRange.appliesTo",
+                "short": "Reference range population",
+                "definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
+                "requirements": "Need to be able to identify the target population for proper interpretation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange.appliesTo",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes identifying the population the reference range applies to.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.age",
+                "path": "Observation.referenceRange.age",
+                "short": "Applicable age range, if relevant",
+                "definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
+                "requirements": "Some analytes vary greatly over age.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.age",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Range"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.text",
+                "path": "Observation.referenceRange.text",
+                "short": "Text based reference range in an observation",
+                "definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:ST"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.hasMember",
+                "path": "Observation.hasMember",
+                "short": "Used when reporting vital signs panel components",
+                "definition": "Used when reporting vital signs panel components.",
+                "comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.hasMember",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.derivedFrom",
+                "path": "Observation.derivedFrom",
+                "short": "Related measurements the observation is made from",
+                "definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
+                "comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.derivedFrom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/DocumentReference",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy",
+                            "http://hl7.org/fhir/StructureDefinition/Media",
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".targetObservation"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component",
+                "path": "Observation.component",
+                "short": "Component observations",
+                "definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
+                "comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-3",
+                        "severity": "error",
+                        "human": "If there is no a value a data absent reason must be present",
+                        "expression": "value.exists() or dataAbsentReason.exists()",
+                        "xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "containment by OBX-4?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=COMP]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.id",
+                "path": "Observation.component.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.extension",
+                "path": "Observation.component.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.modifierExtension",
+                "path": "Observation.component.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.code",
+                "path": "Observation.component.code",
+                "short": "Type of component observation (code / type)",
+                "definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
+                "comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.value[x]",
+                "path": "Observation.component.value[x]",
+                "short": "Vital Sign Component Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
+                "comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.dataAbsentReason",
+                "path": "Observation.component.dataAbsentReason",
+                "short": "Why the component result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
+                "comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.interpretation",
+                "path": "Observation.component.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.referenceRange",
+                "path": "Observation.component.referenceRange",
+                "short": "Provides guide for interpretation of component result",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "US Core Body Height Profile",
+                "definition": "Defines constraints on Observation to represent body height observations with a standard LOINC code and UCUM units of measure.  This profile is derived from the US Core Vital Signs Profile."
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Body Height",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "8302-2"
+                        }
+                    ]
+                },
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity",
+                "path": "Observation.valueQuantity",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.value",
+                "path": "Observation.valueQuantity.value",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.unit",
+                "path": "Observation.valueQuantity.unit",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.system",
+                "path": "Observation.valueQuantity.system",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.code",
+                "path": "Observation.valueQuantity.code",
+                "short": "Coded responses from the common UCUM units for vital signs value set.",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-bodylength|4.0.1"
+                }
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-body-temperature.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-body-temperature.json
@@ -1,3814 +1,3814 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-body-temperature",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-body-temperature-definitions.html#Observation\" title=\"Defines constraints on Observation to represent body temperature observations with a standard LOINC code and UCUM units of measure.  This profile is derived from the US Core Vital Signs Profile.\">Observation</a><a name=\"Observation\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"StructureDefinition-us-core-vital-signs.html\">USCoreVitalSignsProfile</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">US Core Body Temperature Profile</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-body-temperature-definitions.html#Observation.code\">code</a><a name=\"Observation.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">1</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Body Temperature<br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck101.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#CodeableConcept.coding\">coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Code defined by a terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">(complex)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/loinc.html\">http://loinc.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">8310-5</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-body-temperature-definitions.html#Observation.valueQuantity\">valueQuantity</a><a name=\"Observation.valueQuantity\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Quantity\">Quantity</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Vital Signs Value</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-body-temperature-definitions.html#Observation.valueQuantity.value\">value</a><a name=\"Observation.valueQuantity.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#decimal\">decimal</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Numerical value (with implicit precision)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-body-temperature-definitions.html#Observation.valueQuantity.unit\">unit</a><a name=\"Observation.valueQuantity.unit\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Unit representation</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-body-temperature-definitions.html#Observation.valueQuantity.system\">system</a><a name=\"Observation.valueQuantity.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">System that defines coded unit form</span><br/><span style=\"font-weight:bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/ucum.html\">http://unitsofmeasure.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-body-temperature-definitions.html#Observation.valueQuantity.code\">code</a><a name=\"Observation.valueQuantity.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Coded responses from the common UCUM units for vital signs value set.<br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-ucum-bodytemp.html\">BodyTemperatureUnits</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-temperature",
-	"version": "4.0.0",
-	"name": "USCoreBodyTemperatureProfile",
-	"title": "US Core Body Temperature Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-17",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints on Observation to represent body temperature observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "sct-concept",
-			"uri": "http://snomed.info/conceptdomain",
-			"name": "SNOMED CT Concept Domain Binding"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "sct-attr",
-			"uri": "http://snomed.org/attributebinding",
-			"name": "SNOMED CT Attribute Binding"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Observation",
-	"baseDefinition": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "US Core Body Temperature Profile",
-				"definition": "Defines constraints on Observation to represent body temperature observations with a standard LOINC code and UCUM units of measure.  This profile is derived from the US Core Vital Signs Profile.",
-				"comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
-				"alias": [
-					"Vital Signs",
-					"Measurement",
-					"Results",
-					"Tests"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "obs-6",
-						"severity": "error",
-						"human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
-						"expression": "dataAbsentReason.empty() or value.empty()",
-						"xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "obs-7",
-						"severity": "error",
-						"human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
-						"expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
-						"xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "vs-2",
-						"severity": "error",
-						"human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
-						"expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
-						"xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.id",
-				"path": "Observation.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.meta",
-				"path": "Observation.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.implicitRules",
-				"path": "Observation.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Observation.language",
-				"path": "Observation.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Observation.text",
-				"path": "Observation.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Observation.contained",
-				"path": "Observation.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.extension",
-				"path": "Observation.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.modifierExtension",
-				"path": "Observation.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.identifier",
-				"path": "Observation.identifier",
-				"short": "Business Identifier for observation",
-				"definition": "A unique identifier assigned to this observation.",
-				"requirements": "Allows observations to be distinguished and referenced.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
-					},
-					{
-						"identity": "rim",
-						"map": "id"
-					}
-				]
-			},
-			{
-				"id": "Observation.basedOn",
-				"path": "Observation.basedOn",
-				"short": "Fulfills plan, proposal or order",
-				"definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
-				"requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
-				"alias": [
-					"Fulfills"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan",
-							"http://hl7.org/fhir/StructureDefinition/DeviceRequest",
-							"http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
-							"http://hl7.org/fhir/StructureDefinition/MedicationRequest",
-							"http://hl7.org/fhir/StructureDefinition/NutritionOrder",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.basedOn"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.partOf",
-				"path": "Observation.partOf",
-				"short": "Part of referenced event",
-				"definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
-				"comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
-				"alias": [
-					"Container"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.partOf",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
-							"http://hl7.org/fhir/StructureDefinition/MedicationDispense",
-							"http://hl7.org/fhir/StructureDefinition/MedicationStatement",
-							"http://hl7.org/fhir/StructureDefinition/Procedure",
-							"http://hl7.org/fhir/StructureDefinition/Immunization",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.partOf"
-					},
-					{
-						"identity": "v2",
-						"map": "Varies by domain"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=FLFS].target"
-					}
-				]
-			},
-			{
-				"id": "Observation.status",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
-						"valueString": "default: final"
-					}
-				],
-				"path": "Observation.status",
-				"short": "registered | preliminary | final | amended +",
-				"definition": "The status of the result value.",
-				"comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
-				"requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Status"
-						}
-					],
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 445584004 |Report by finality status|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-11"
-					},
-					{
-						"identity": "rim",
-						"map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
-					}
-				]
-			},
-			{
-				"id": "Observation.category",
-				"path": "Observation.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "coding.code"
-						},
-						{
-							"type": "value",
-							"path": "coding.system"
-						}
-					],
-					"ordered": false,
-					"rules": "open"
-				},
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat",
-				"path": "Observation.category",
-				"sliceName": "VSCat",
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.id",
-				"path": "Observation.category.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.extension",
-				"path": "Observation.category.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding",
-				"path": "Observation.category.coding",
-				"short": "Code defined by a terminology system",
-				"definition": "A reference to a code defined by a terminology system.",
-				"comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
-				"requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "CodeableConcept.coding",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1-8, C*E.10-22"
-					},
-					{
-						"identity": "rim",
-						"map": "union(., ./translation)"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.id",
-				"path": "Observation.category.coding.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.extension",
-				"path": "Observation.category.coding.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.system",
-				"path": "Observation.category.coding.system",
-				"short": "Identity of the terminology system",
-				"definition": "The identification of the code system that defines the meaning of the symbol in the code.",
-				"comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
-				"requirements": "Need to be unambiguous about the source of the definition of the symbol.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.3"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystem"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.version",
-				"path": "Observation.category.coding.version",
-				"short": "Version of the system - if relevant",
-				"definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
-				"comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.version",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.7"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystemVersion"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.code",
-				"path": "Observation.category.coding.code",
-				"short": "Symbol in syntax defined by the system",
-				"definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
-				"requirements": "Need to refer to a particular code in the system.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "vital-signs",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1"
-					},
-					{
-						"identity": "rim",
-						"map": "./code"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.display",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.coding.display",
-				"short": "Representation defined by the system",
-				"definition": "A representation of the meaning of the code in the system, following the rules of the system.",
-				"requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.display",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.2 - but note this is not well followed"
-					},
-					{
-						"identity": "rim",
-						"map": "CV.displayName"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.userSelected",
-				"path": "Observation.category.coding.userSelected",
-				"short": "If this coding was chosen directly by the user",
-				"definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
-				"comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
-				"requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.userSelected",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Sometimes implied by being first"
-					},
-					{
-						"identity": "rim",
-						"map": "CD.codingRationale"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.text",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.text",
-				"short": "Plain text representation of the concept",
-				"definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
-				"comment": "Very often the text is the same as a displayName of one of the codings.",
-				"requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CodeableConcept.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.9. But note many systems use C*E.2 for this"
-					},
-					{
-						"identity": "rim",
-						"map": "./originalText[mediaType/code=\"text/plain\"]/data"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
-					}
-				]
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Body Temperature",
-				"definition": "Coded Responses from C-CDA Vital Sign Results.",
-				"comment": "*All* code-value and, if present, component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
-				"alias": [
-					"Name"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "8310-5"
-						}
-					]
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "116680003 |Is a|"
-					}
-				]
-			},
-			{
-				"id": "Observation.subject",
-				"path": "Observation.subject",
-				"short": "Who and/or what the observation is about",
-				"definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
-				"comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
-				"requirements": "Observations have no value if you don't know who or what they're about.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=RTGT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.focus",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
-						"valueCode": "trial-use"
-					}
-				],
-				"path": "Observation.focus",
-				"short": "What the observation is about, when it is not about the subject of record",
-				"definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
-				"comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.focus",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SBJ]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.encounter",
-				"path": "Observation.encounter",
-				"short": "Healthcare event during which this observation is made",
-				"definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
-				"comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
-				"requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
-				"alias": [
-					"Context"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.effective[x]",
-				"path": "Observation.effective[x]",
-				"short": "Often just a dateTime for Vital Signs",
-				"definition": "Often just a dateTime for Vital Signs.",
-				"comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
-				"requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
-				"alias": [
-					"Occurrence"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.effective[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-1",
-						"severity": "error",
-						"human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
-						"expression": "($this as dateTime).toString().length() >= 8",
-						"xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "Observation.issued",
-				"path": "Observation.issued",
-				"short": "Date/Time this version was made available",
-				"definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
-				"comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.issued",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=AUT].time"
-					}
-				]
-			},
-			{
-				"id": "Observation.performer",
-				"path": "Observation.performer",
-				"short": "Who is responsible for the observation",
-				"definition": "Who was responsible for asserting the observed value as \"true\".",
-				"requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.performer",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=PRF]"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]",
-				"path": "Observation.value[x]",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "type",
-							"path": "$this"
-						}
-					],
-					"ordered": false,
-					"rules": "closed"
-				},
-				"short": "Vital Signs Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity",
-				"path": "Observation.value[x]",
-				"sliceName": "valueQuantity",
-				"short": "Vital Signs Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.id",
-				"path": "Observation.value[x].id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.extension",
-				"path": "Observation.value[x].extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.value",
-				"path": "Observation.value[x].value",
-				"short": "Numerical value (with implicit precision)",
-				"definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
-				"comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
-				"requirements": "Precision is handled implicitly in almost all cases of measurement.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.2  / CQ - N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.comparator",
-				"path": "Observation.value[x].comparator",
-				"short": "< | <= | >= | > - how to understand the value",
-				"definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
-				"requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Quantity.comparator",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "QuantityComparator"
-						}
-					],
-					"strength": "required",
-					"description": "How the Quantity should be understood and represented.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.1  / CQ.1"
-					},
-					{
-						"identity": "rim",
-						"map": "IVL properties"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.unit",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.value[x].unit",
-				"short": "Unit representation",
-				"definition": "A human-readable form of the unit.",
-				"requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.unit",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.unit"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.system",
-				"path": "Observation.value[x].system",
-				"short": "System that defines coded unit form",
-				"definition": "The identification of the system that provides the coded form of the unit.",
-				"requirements": "Need to know the system that defines the coded form of the unit.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"condition": [
-					"qty-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "CO.codeSystem, PQ.translation.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.code",
-				"path": "Observation.value[x].code",
-				"short": "Coded responses from the common UCUM units for vital signs value set.",
-				"definition": "A computer processable form of the unit in some unit representation system.",
-				"comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
-				"requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-bodytemp|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.code, MO.currency, PQ.translation.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.dataAbsentReason",
-				"path": "Observation.dataAbsentReason",
-				"short": "Why the result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
-				"comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.interpretation",
-				"path": "Observation.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.note",
-				"path": "Observation.note",
-				"short": "Comments about the observation",
-				"definition": "Comments about the observation or the results.",
-				"comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
-				"requirements": "Need to be able to provide free text additional information.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
-					},
-					{
-						"identity": "rim",
-						"map": "subjectOf.observationEvent[code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.bodySite",
-				"path": "Observation.bodySite",
-				"short": "Observed body part",
-				"definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
-				"comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.bodySite",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "BodySite"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing anatomical locations. May include laterality.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/body-site"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123037004 |Body structure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-20"
-					},
-					{
-						"identity": "rim",
-						"map": "targetSiteCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "718497002 |Inherent location|"
-					}
-				]
-			},
-			{
-				"id": "Observation.method",
-				"path": "Observation.method",
-				"short": "How it was done",
-				"definition": "Indicates the mechanism used to perform the observation.",
-				"comment": "Only used if not implicit in code for Observation.code.",
-				"requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.method",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationMethod"
-						}
-					],
-					"strength": "example",
-					"description": "Methods for simple observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-17"
-					},
-					{
-						"identity": "rim",
-						"map": "methodCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.specimen",
-				"path": "Observation.specimen",
-				"short": "Specimen used for this observation",
-				"definition": "The specimen that was used when this observation was made.",
-				"comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.specimen",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Specimen"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123038009 |Specimen|"
-					},
-					{
-						"identity": "v2",
-						"map": "SPM segment"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SPC].specimen"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "704319004 |Inherent in|"
-					}
-				]
-			},
-			{
-				"id": "Observation.device",
-				"path": "Observation.device",
-				"short": "(Measurement) Device",
-				"definition": "The device used to generate the observation data.",
-				"comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.device",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/DeviceMetric"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 49062001 |Device|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-17 / PRT -10"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=DEV]"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "424226004 |Using device|"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange",
-				"path": "Observation.referenceRange",
-				"short": "Provides guide for interpretation",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "obs-3",
-						"severity": "error",
-						"human": "Must have at least a low or a high or text",
-						"expression": "low.exists() or high.exists() or text.exists()",
-						"xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.id",
-				"path": "Observation.referenceRange.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.extension",
-				"path": "Observation.referenceRange.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.modifierExtension",
-				"path": "Observation.referenceRange.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.low",
-				"path": "Observation.referenceRange.low",
-				"short": "Low Range, if relevant",
-				"definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.low",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.low"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.high",
-				"path": "Observation.referenceRange.high",
-				"short": "High Range, if relevant",
-				"definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.high",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.high"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.type",
-				"path": "Observation.referenceRange.type",
-				"short": "Reference range qualifier",
-				"definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
-				"requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeMeaning"
-						}
-					],
-					"strength": "preferred",
-					"description": "Code for the meaning of a reference range.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.appliesTo",
-				"path": "Observation.referenceRange.appliesTo",
-				"short": "Reference range population",
-				"definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
-				"requirements": "Need to be able to identify the target population for proper interpretation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange.appliesTo",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeType"
-						}
-					],
-					"strength": "example",
-					"description": "Codes identifying the population the reference range applies to.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.age",
-				"path": "Observation.referenceRange.age",
-				"short": "Applicable age range, if relevant",
-				"definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
-				"requirements": "Some analytes vary greatly over age.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.age",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Range"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.text",
-				"path": "Observation.referenceRange.text",
-				"short": "Text based reference range in an observation",
-				"definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:ST"
-					}
-				]
-			},
-			{
-				"id": "Observation.hasMember",
-				"path": "Observation.hasMember",
-				"short": "Used when reporting vital signs panel components",
-				"definition": "Used when reporting vital signs panel components.",
-				"comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.hasMember",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship"
-					}
-				]
-			},
-			{
-				"id": "Observation.derivedFrom",
-				"path": "Observation.derivedFrom",
-				"short": "Related measurements the observation is made from",
-				"definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
-				"comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.derivedFrom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/DocumentReference",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy",
-							"http://hl7.org/fhir/StructureDefinition/Media",
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": ".targetObservation"
-					}
-				]
-			},
-			{
-				"id": "Observation.component",
-				"path": "Observation.component",
-				"short": "Component observations",
-				"definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
-				"comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-3",
-						"severity": "error",
-						"human": "If there is no a value a data absent reason must be present",
-						"expression": "value.exists() or dataAbsentReason.exists()",
-						"xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "containment by OBX-4?"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=COMP]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.id",
-				"path": "Observation.component.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.extension",
-				"path": "Observation.component.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.modifierExtension",
-				"path": "Observation.component.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.code",
-				"path": "Observation.component.code",
-				"short": "Type of component observation (code / type)",
-				"definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
-				"comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.value[x]",
-				"path": "Observation.component.value[x]",
-				"short": "Vital Sign Component Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
-				"comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "Quantity"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.dataAbsentReason",
-				"path": "Observation.component.dataAbsentReason",
-				"short": "Why the component result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
-				"comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.interpretation",
-				"path": "Observation.component.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.referenceRange",
-				"path": "Observation.component.referenceRange",
-				"short": "Provides guide for interpretation of component result",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "US Core Body Temperature Profile",
-				"definition": "Defines constraints on Observation to represent body temperature observations with a standard LOINC code and UCUM units of measure.  This profile is derived from the US Core Vital Signs Profile."
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Body Temperature",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "8310-5"
-						}
-					]
-				},
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity",
-				"path": "Observation.valueQuantity",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.value",
-				"path": "Observation.valueQuantity.value",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.unit",
-				"path": "Observation.valueQuantity.unit",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.system",
-				"path": "Observation.valueQuantity.system",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.code",
-				"path": "Observation.valueQuantity.code",
-				"short": "Coded responses from the common UCUM units for vital signs value set.",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-bodytemp|4.0.1"
-				}
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-body-temperature",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-temperature",
+    "version": "4.0.0",
+    "name": "USCoreBodyTemperatureProfile",
+    "title": "US Core Body Temperature Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-17",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints on Observation to represent body temperature observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "sct-concept",
+            "uri": "http://snomed.info/conceptdomain",
+            "name": "SNOMED CT Concept Domain Binding"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "sct-attr",
+            "uri": "http://snomed.org/attributebinding",
+            "name": "SNOMED CT Attribute Binding"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Observation",
+    "baseDefinition": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "US Core Body Temperature Profile",
+                "definition": "Defines constraints on Observation to represent body temperature observations with a standard LOINC code and UCUM units of measure.  This profile is derived from the US Core Vital Signs Profile.",
+                "comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
+                "alias": [
+                    "Vital Signs",
+                    "Measurement",
+                    "Results",
+                    "Tests"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "obs-6",
+                        "severity": "error",
+                        "human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
+                        "expression": "dataAbsentReason.empty() or value.empty()",
+                        "xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "obs-7",
+                        "severity": "error",
+                        "human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
+                        "expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
+                        "xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "vs-2",
+                        "severity": "error",
+                        "human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
+                        "expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
+                        "xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.id",
+                "path": "Observation.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.meta",
+                "path": "Observation.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.implicitRules",
+                "path": "Observation.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Observation.language",
+                "path": "Observation.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Observation.text",
+                "path": "Observation.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.contained",
+                "path": "Observation.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.extension",
+                "path": "Observation.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.modifierExtension",
+                "path": "Observation.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.identifier",
+                "path": "Observation.identifier",
+                "short": "Business Identifier for observation",
+                "definition": "A unique identifier assigned to this observation.",
+                "requirements": "Allows observations to be distinguished and referenced.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "id"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.basedOn",
+                "path": "Observation.basedOn",
+                "short": "Fulfills plan, proposal or order",
+                "definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
+                "requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
+                "alias": [
+                    "Fulfills"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceRequest",
+                            "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+                            "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.basedOn"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.partOf",
+                "path": "Observation.partOf",
+                "short": "Part of referenced event",
+                "definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
+                "comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
+                "alias": [
+                    "Container"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.partOf",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationDispense",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationStatement",
+                            "http://hl7.org/fhir/StructureDefinition/Procedure",
+                            "http://hl7.org/fhir/StructureDefinition/Immunization",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.partOf"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "Varies by domain"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=FLFS].target"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.status",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
+                        "valueString": "default: final"
+                    }
+                ],
+                "path": "Observation.status",
+                "short": "registered | preliminary | final | amended +",
+                "definition": "The status of the result value.",
+                "comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
+                "requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Status"
+                        }
+                    ],
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 445584004 |Report by finality status|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-11"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category",
+                "path": "Observation.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "coding.code"
+                        },
+                        {
+                            "type": "value",
+                            "path": "coding.system"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "open"
+                },
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat",
+                "path": "Observation.category",
+                "sliceName": "VSCat",
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.id",
+                "path": "Observation.category.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.extension",
+                "path": "Observation.category.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding",
+                "path": "Observation.category.coding",
+                "short": "Code defined by a terminology system",
+                "definition": "A reference to a code defined by a terminology system.",
+                "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+                "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "CodeableConcept.coding",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1-8, C*E.10-22"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "union(., ./translation)"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.id",
+                "path": "Observation.category.coding.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.extension",
+                "path": "Observation.category.coding.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.system",
+                "path": "Observation.category.coding.system",
+                "short": "Identity of the terminology system",
+                "definition": "The identification of the code system that defines the meaning of the symbol in the code.",
+                "comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
+                "requirements": "Need to be unambiguous about the source of the definition of the symbol.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystem"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.version",
+                "path": "Observation.category.coding.version",
+                "short": "Version of the system - if relevant",
+                "definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
+                "comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.version",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystemVersion"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.code",
+                "path": "Observation.category.coding.code",
+                "short": "Symbol in syntax defined by the system",
+                "definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
+                "requirements": "Need to refer to a particular code in the system.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "vital-signs",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./code"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.display",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.coding.display",
+                "short": "Representation defined by the system",
+                "definition": "A representation of the meaning of the code in the system, following the rules of the system.",
+                "requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.display",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.2 - but note this is not well followed"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CV.displayName"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.userSelected",
+                "path": "Observation.category.coding.userSelected",
+                "short": "If this coding was chosen directly by the user",
+                "definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
+                "comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
+                "requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.userSelected",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Sometimes implied by being first"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CD.codingRationale"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.text",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.text",
+                "short": "Plain text representation of the concept",
+                "definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
+                "comment": "Very often the text is the same as a displayName of one of the codings.",
+                "requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CodeableConcept.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.9. But note many systems use C*E.2 for this"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./originalText[mediaType/code=\"text/plain\"]/data"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Body Temperature",
+                "definition": "Coded Responses from C-CDA Vital Sign Results.",
+                "comment": "*All* code-value and, if present, component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
+                "alias": [
+                    "Name"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "8310-5"
+                        }
+                    ]
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "116680003 |Is a|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.subject",
+                "path": "Observation.subject",
+                "short": "Who and/or what the observation is about",
+                "definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
+                "comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
+                "requirements": "Observations have no value if you don't know who or what they're about.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=RTGT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.focus",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+                        "valueCode": "trial-use"
+                    }
+                ],
+                "path": "Observation.focus",
+                "short": "What the observation is about, when it is not about the subject of record",
+                "definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
+                "comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.focus",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SBJ]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.encounter",
+                "path": "Observation.encounter",
+                "short": "Healthcare event during which this observation is made",
+                "definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
+                "comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
+                "requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
+                "alias": [
+                    "Context"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.effective[x]",
+                "path": "Observation.effective[x]",
+                "short": "Often just a dateTime for Vital Signs",
+                "definition": "Often just a dateTime for Vital Signs.",
+                "comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
+                "requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
+                "alias": [
+                    "Occurrence"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.effective[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-1",
+                        "severity": "error",
+                        "human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
+                        "expression": "($this as dateTime).toString().length() >= 8",
+                        "xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.issued",
+                "path": "Observation.issued",
+                "short": "Date/Time this version was made available",
+                "definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
+                "comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.issued",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.performer",
+                "path": "Observation.performer",
+                "short": "Who is responsible for the observation",
+                "definition": "Who was responsible for asserting the observed value as \"true\".",
+                "requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.performer",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=PRF]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]",
+                "path": "Observation.value[x]",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "type",
+                            "path": "$this"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "closed"
+                },
+                "short": "Vital Signs Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity",
+                "path": "Observation.value[x]",
+                "sliceName": "valueQuantity",
+                "short": "Vital Signs Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.id",
+                "path": "Observation.value[x].id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.extension",
+                "path": "Observation.value[x].extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.value",
+                "path": "Observation.value[x].value",
+                "short": "Numerical value (with implicit precision)",
+                "definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
+                "comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
+                "requirements": "Precision is handled implicitly in almost all cases of measurement.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.2  / CQ - N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.comparator",
+                "path": "Observation.value[x].comparator",
+                "short": "< | <= | >= | > - how to understand the value",
+                "definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
+                "requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.comparator",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "QuantityComparator"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "How the Quantity should be understood and represented.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.1  / CQ.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "IVL properties"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.unit",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.value[x].unit",
+                "short": "Unit representation",
+                "definition": "A human-readable form of the unit.",
+                "requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.unit",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.unit"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.system",
+                "path": "Observation.value[x].system",
+                "short": "System that defines coded unit form",
+                "definition": "The identification of the system that provides the coded form of the unit.",
+                "requirements": "Need to know the system that defines the coded form of the unit.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "condition": [
+                    "qty-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CO.codeSystem, PQ.translation.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.code",
+                "path": "Observation.value[x].code",
+                "short": "Coded responses from the common UCUM units for vital signs value set.",
+                "definition": "A computer processable form of the unit in some unit representation system.",
+                "comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
+                "requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-bodytemp|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.code, MO.currency, PQ.translation.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.dataAbsentReason",
+                "path": "Observation.dataAbsentReason",
+                "short": "Why the result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
+                "comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.interpretation",
+                "path": "Observation.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.note",
+                "path": "Observation.note",
+                "short": "Comments about the observation",
+                "definition": "Comments about the observation or the results.",
+                "comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
+                "requirements": "Need to be able to provide free text additional information.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "subjectOf.observationEvent[code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.bodySite",
+                "path": "Observation.bodySite",
+                "short": "Observed body part",
+                "definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
+                "comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.bodySite",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "BodySite"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing anatomical locations. May include laterality.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/body-site"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123037004 |Body structure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-20"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "targetSiteCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "718497002 |Inherent location|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.method",
+                "path": "Observation.method",
+                "short": "How it was done",
+                "definition": "Indicates the mechanism used to perform the observation.",
+                "comment": "Only used if not implicit in code for Observation.code.",
+                "requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.method",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationMethod"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Methods for simple observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "methodCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.specimen",
+                "path": "Observation.specimen",
+                "short": "Specimen used for this observation",
+                "definition": "The specimen that was used when this observation was made.",
+                "comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.specimen",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Specimen"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123038009 |Specimen|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "SPM segment"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SPC].specimen"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "704319004 |Inherent in|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.device",
+                "path": "Observation.device",
+                "short": "(Measurement) Device",
+                "definition": "The device used to generate the observation data.",
+                "comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.device",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceMetric"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 49062001 |Device|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17 / PRT -10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=DEV]"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "424226004 |Using device|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange",
+                "path": "Observation.referenceRange",
+                "short": "Provides guide for interpretation",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "obs-3",
+                        "severity": "error",
+                        "human": "Must have at least a low or a high or text",
+                        "expression": "low.exists() or high.exists() or text.exists()",
+                        "xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.id",
+                "path": "Observation.referenceRange.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.extension",
+                "path": "Observation.referenceRange.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.modifierExtension",
+                "path": "Observation.referenceRange.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.low",
+                "path": "Observation.referenceRange.low",
+                "short": "Low Range, if relevant",
+                "definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.low",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.low"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.high",
+                "path": "Observation.referenceRange.high",
+                "short": "High Range, if relevant",
+                "definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.high",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.high"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.type",
+                "path": "Observation.referenceRange.type",
+                "short": "Reference range qualifier",
+                "definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
+                "requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeMeaning"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Code for the meaning of a reference range.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.appliesTo",
+                "path": "Observation.referenceRange.appliesTo",
+                "short": "Reference range population",
+                "definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
+                "requirements": "Need to be able to identify the target population for proper interpretation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange.appliesTo",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes identifying the population the reference range applies to.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.age",
+                "path": "Observation.referenceRange.age",
+                "short": "Applicable age range, if relevant",
+                "definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
+                "requirements": "Some analytes vary greatly over age.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.age",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Range"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.text",
+                "path": "Observation.referenceRange.text",
+                "short": "Text based reference range in an observation",
+                "definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:ST"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.hasMember",
+                "path": "Observation.hasMember",
+                "short": "Used when reporting vital signs panel components",
+                "definition": "Used when reporting vital signs panel components.",
+                "comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.hasMember",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.derivedFrom",
+                "path": "Observation.derivedFrom",
+                "short": "Related measurements the observation is made from",
+                "definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
+                "comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.derivedFrom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/DocumentReference",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy",
+                            "http://hl7.org/fhir/StructureDefinition/Media",
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".targetObservation"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component",
+                "path": "Observation.component",
+                "short": "Component observations",
+                "definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
+                "comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-3",
+                        "severity": "error",
+                        "human": "If there is no a value a data absent reason must be present",
+                        "expression": "value.exists() or dataAbsentReason.exists()",
+                        "xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "containment by OBX-4?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=COMP]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.id",
+                "path": "Observation.component.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.extension",
+                "path": "Observation.component.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.modifierExtension",
+                "path": "Observation.component.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.code",
+                "path": "Observation.component.code",
+                "short": "Type of component observation (code / type)",
+                "definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
+                "comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.value[x]",
+                "path": "Observation.component.value[x]",
+                "short": "Vital Sign Component Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
+                "comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.dataAbsentReason",
+                "path": "Observation.component.dataAbsentReason",
+                "short": "Why the component result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
+                "comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.interpretation",
+                "path": "Observation.component.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.referenceRange",
+                "path": "Observation.component.referenceRange",
+                "short": "Provides guide for interpretation of component result",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "US Core Body Temperature Profile",
+                "definition": "Defines constraints on Observation to represent body temperature observations with a standard LOINC code and UCUM units of measure.  This profile is derived from the US Core Vital Signs Profile."
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Body Temperature",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "8310-5"
+                        }
+                    ]
+                },
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity",
+                "path": "Observation.valueQuantity",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.value",
+                "path": "Observation.valueQuantity.value",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.unit",
+                "path": "Observation.valueQuantity.unit",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.system",
+                "path": "Observation.valueQuantity.system",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.code",
+                "path": "Observation.valueQuantity.code",
+                "short": "Coded responses from the common UCUM units for vital signs value set.",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-bodytemp|4.0.1"
+                }
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-body-weight.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-body-weight.json
@@ -1,3814 +1,3814 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-body-weight",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-body-weight-definitions.html#Observation\" title=\"Defines constraints on Observation to represent body weight observations with a standard LOINC code and UCUM units of measure.  This profile is derived from the US Core Vital Signs Profile.\">Observation</a><a name=\"Observation\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"StructureDefinition-us-core-vital-signs.html\">USCoreVitalSignsProfile</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">US Core Body Weight Profile</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-body-weight-definitions.html#Observation.code\">code</a><a name=\"Observation.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">1</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Body Weight<br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck101.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#CodeableConcept.coding\">coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Code defined by a terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">(complex)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/loinc.html\">http://loinc.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">29463-7</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-body-weight-definitions.html#Observation.valueQuantity\">valueQuantity</a><a name=\"Observation.valueQuantity\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Quantity\">Quantity</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Vital Signs Value</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-body-weight-definitions.html#Observation.valueQuantity.value\">value</a><a name=\"Observation.valueQuantity.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#decimal\">decimal</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Numerical value (with implicit precision)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-body-weight-definitions.html#Observation.valueQuantity.unit\">unit</a><a name=\"Observation.valueQuantity.unit\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Unit representation</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-body-weight-definitions.html#Observation.valueQuantity.system\">system</a><a name=\"Observation.valueQuantity.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">System that defines coded unit form</span><br/><span style=\"font-weight:bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/ucum.html\">http://unitsofmeasure.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-body-weight-definitions.html#Observation.valueQuantity.code\">code</a><a name=\"Observation.valueQuantity.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Coded responses from the common UCUM units for vital signs value set.<br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-ucum-bodyweight.html\">BodyWeightUnits</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-weight",
-	"version": "4.0.0",
-	"name": "USCoreBodyWeightProfile",
-	"title": "US Core Body Weight Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-17",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints on Observation to represent body weight observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "sct-concept",
-			"uri": "http://snomed.info/conceptdomain",
-			"name": "SNOMED CT Concept Domain Binding"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "sct-attr",
-			"uri": "http://snomed.org/attributebinding",
-			"name": "SNOMED CT Attribute Binding"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Observation",
-	"baseDefinition": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "US Core Body Weight Profile",
-				"definition": "Defines constraints on Observation to represent body weight observations with a standard LOINC code and UCUM units of measure.  This profile is derived from the US Core Vital Signs Profile.",
-				"comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
-				"alias": [
-					"Vital Signs",
-					"Measurement",
-					"Results",
-					"Tests"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "obs-6",
-						"severity": "error",
-						"human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
-						"expression": "dataAbsentReason.empty() or value.empty()",
-						"xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "obs-7",
-						"severity": "error",
-						"human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
-						"expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
-						"xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "vs-2",
-						"severity": "error",
-						"human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
-						"expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
-						"xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.id",
-				"path": "Observation.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.meta",
-				"path": "Observation.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.implicitRules",
-				"path": "Observation.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Observation.language",
-				"path": "Observation.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Observation.text",
-				"path": "Observation.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Observation.contained",
-				"path": "Observation.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.extension",
-				"path": "Observation.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.modifierExtension",
-				"path": "Observation.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.identifier",
-				"path": "Observation.identifier",
-				"short": "Business Identifier for observation",
-				"definition": "A unique identifier assigned to this observation.",
-				"requirements": "Allows observations to be distinguished and referenced.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
-					},
-					{
-						"identity": "rim",
-						"map": "id"
-					}
-				]
-			},
-			{
-				"id": "Observation.basedOn",
-				"path": "Observation.basedOn",
-				"short": "Fulfills plan, proposal or order",
-				"definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
-				"requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
-				"alias": [
-					"Fulfills"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan",
-							"http://hl7.org/fhir/StructureDefinition/DeviceRequest",
-							"http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
-							"http://hl7.org/fhir/StructureDefinition/MedicationRequest",
-							"http://hl7.org/fhir/StructureDefinition/NutritionOrder",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.basedOn"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.partOf",
-				"path": "Observation.partOf",
-				"short": "Part of referenced event",
-				"definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
-				"comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
-				"alias": [
-					"Container"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.partOf",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
-							"http://hl7.org/fhir/StructureDefinition/MedicationDispense",
-							"http://hl7.org/fhir/StructureDefinition/MedicationStatement",
-							"http://hl7.org/fhir/StructureDefinition/Procedure",
-							"http://hl7.org/fhir/StructureDefinition/Immunization",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.partOf"
-					},
-					{
-						"identity": "v2",
-						"map": "Varies by domain"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=FLFS].target"
-					}
-				]
-			},
-			{
-				"id": "Observation.status",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
-						"valueString": "default: final"
-					}
-				],
-				"path": "Observation.status",
-				"short": "registered | preliminary | final | amended +",
-				"definition": "The status of the result value.",
-				"comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
-				"requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Status"
-						}
-					],
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 445584004 |Report by finality status|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-11"
-					},
-					{
-						"identity": "rim",
-						"map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
-					}
-				]
-			},
-			{
-				"id": "Observation.category",
-				"path": "Observation.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "coding.code"
-						},
-						{
-							"type": "value",
-							"path": "coding.system"
-						}
-					],
-					"ordered": false,
-					"rules": "open"
-				},
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat",
-				"path": "Observation.category",
-				"sliceName": "VSCat",
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.id",
-				"path": "Observation.category.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.extension",
-				"path": "Observation.category.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding",
-				"path": "Observation.category.coding",
-				"short": "Code defined by a terminology system",
-				"definition": "A reference to a code defined by a terminology system.",
-				"comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
-				"requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "CodeableConcept.coding",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1-8, C*E.10-22"
-					},
-					{
-						"identity": "rim",
-						"map": "union(., ./translation)"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.id",
-				"path": "Observation.category.coding.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.extension",
-				"path": "Observation.category.coding.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.system",
-				"path": "Observation.category.coding.system",
-				"short": "Identity of the terminology system",
-				"definition": "The identification of the code system that defines the meaning of the symbol in the code.",
-				"comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
-				"requirements": "Need to be unambiguous about the source of the definition of the symbol.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.3"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystem"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.version",
-				"path": "Observation.category.coding.version",
-				"short": "Version of the system - if relevant",
-				"definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
-				"comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.version",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.7"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystemVersion"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.code",
-				"path": "Observation.category.coding.code",
-				"short": "Symbol in syntax defined by the system",
-				"definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
-				"requirements": "Need to refer to a particular code in the system.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "vital-signs",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1"
-					},
-					{
-						"identity": "rim",
-						"map": "./code"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.display",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.coding.display",
-				"short": "Representation defined by the system",
-				"definition": "A representation of the meaning of the code in the system, following the rules of the system.",
-				"requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.display",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.2 - but note this is not well followed"
-					},
-					{
-						"identity": "rim",
-						"map": "CV.displayName"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.userSelected",
-				"path": "Observation.category.coding.userSelected",
-				"short": "If this coding was chosen directly by the user",
-				"definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
-				"comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
-				"requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.userSelected",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Sometimes implied by being first"
-					},
-					{
-						"identity": "rim",
-						"map": "CD.codingRationale"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.text",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.text",
-				"short": "Plain text representation of the concept",
-				"definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
-				"comment": "Very often the text is the same as a displayName of one of the codings.",
-				"requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CodeableConcept.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.9. But note many systems use C*E.2 for this"
-					},
-					{
-						"identity": "rim",
-						"map": "./originalText[mediaType/code=\"text/plain\"]/data"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
-					}
-				]
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Body Weight",
-				"definition": "Coded Responses from C-CDA Vital Sign Results.",
-				"comment": "*All* code-value and, if present, component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
-				"alias": [
-					"Name"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "29463-7"
-						}
-					]
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "116680003 |Is a|"
-					}
-				]
-			},
-			{
-				"id": "Observation.subject",
-				"path": "Observation.subject",
-				"short": "Who and/or what the observation is about",
-				"definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
-				"comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
-				"requirements": "Observations have no value if you don't know who or what they're about.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=RTGT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.focus",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
-						"valueCode": "trial-use"
-					}
-				],
-				"path": "Observation.focus",
-				"short": "What the observation is about, when it is not about the subject of record",
-				"definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
-				"comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.focus",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SBJ]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.encounter",
-				"path": "Observation.encounter",
-				"short": "Healthcare event during which this observation is made",
-				"definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
-				"comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
-				"requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
-				"alias": [
-					"Context"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.effective[x]",
-				"path": "Observation.effective[x]",
-				"short": "Often just a dateTime for Vital Signs",
-				"definition": "Often just a dateTime for Vital Signs.",
-				"comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
-				"requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
-				"alias": [
-					"Occurrence"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.effective[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-1",
-						"severity": "error",
-						"human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
-						"expression": "($this as dateTime).toString().length() >= 8",
-						"xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "Observation.issued",
-				"path": "Observation.issued",
-				"short": "Date/Time this version was made available",
-				"definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
-				"comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.issued",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=AUT].time"
-					}
-				]
-			},
-			{
-				"id": "Observation.performer",
-				"path": "Observation.performer",
-				"short": "Who is responsible for the observation",
-				"definition": "Who was responsible for asserting the observed value as \"true\".",
-				"requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.performer",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=PRF]"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]",
-				"path": "Observation.value[x]",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "type",
-							"path": "$this"
-						}
-					],
-					"ordered": false,
-					"rules": "closed"
-				},
-				"short": "Vital Signs Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity",
-				"path": "Observation.value[x]",
-				"sliceName": "valueQuantity",
-				"short": "Vital Signs Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.id",
-				"path": "Observation.value[x].id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.extension",
-				"path": "Observation.value[x].extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.value",
-				"path": "Observation.value[x].value",
-				"short": "Numerical value (with implicit precision)",
-				"definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
-				"comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
-				"requirements": "Precision is handled implicitly in almost all cases of measurement.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.2  / CQ - N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.comparator",
-				"path": "Observation.value[x].comparator",
-				"short": "< | <= | >= | > - how to understand the value",
-				"definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
-				"requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Quantity.comparator",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "QuantityComparator"
-						}
-					],
-					"strength": "required",
-					"description": "How the Quantity should be understood and represented.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.1  / CQ.1"
-					},
-					{
-						"identity": "rim",
-						"map": "IVL properties"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.unit",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.value[x].unit",
-				"short": "Unit representation",
-				"definition": "A human-readable form of the unit.",
-				"requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.unit",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.unit"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.system",
-				"path": "Observation.value[x].system",
-				"short": "System that defines coded unit form",
-				"definition": "The identification of the system that provides the coded form of the unit.",
-				"requirements": "Need to know the system that defines the coded form of the unit.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"condition": [
-					"qty-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "CO.codeSystem, PQ.translation.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.code",
-				"path": "Observation.value[x].code",
-				"short": "Coded responses from the common UCUM units for vital signs value set.",
-				"definition": "A computer processable form of the unit in some unit representation system.",
-				"comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
-				"requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-bodyweight|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.code, MO.currency, PQ.translation.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.dataAbsentReason",
-				"path": "Observation.dataAbsentReason",
-				"short": "Why the result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
-				"comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.interpretation",
-				"path": "Observation.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.note",
-				"path": "Observation.note",
-				"short": "Comments about the observation",
-				"definition": "Comments about the observation or the results.",
-				"comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
-				"requirements": "Need to be able to provide free text additional information.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
-					},
-					{
-						"identity": "rim",
-						"map": "subjectOf.observationEvent[code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.bodySite",
-				"path": "Observation.bodySite",
-				"short": "Observed body part",
-				"definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
-				"comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.bodySite",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "BodySite"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing anatomical locations. May include laterality.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/body-site"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123037004 |Body structure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-20"
-					},
-					{
-						"identity": "rim",
-						"map": "targetSiteCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "718497002 |Inherent location|"
-					}
-				]
-			},
-			{
-				"id": "Observation.method",
-				"path": "Observation.method",
-				"short": "How it was done",
-				"definition": "Indicates the mechanism used to perform the observation.",
-				"comment": "Only used if not implicit in code for Observation.code.",
-				"requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.method",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationMethod"
-						}
-					],
-					"strength": "example",
-					"description": "Methods for simple observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-17"
-					},
-					{
-						"identity": "rim",
-						"map": "methodCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.specimen",
-				"path": "Observation.specimen",
-				"short": "Specimen used for this observation",
-				"definition": "The specimen that was used when this observation was made.",
-				"comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.specimen",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Specimen"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123038009 |Specimen|"
-					},
-					{
-						"identity": "v2",
-						"map": "SPM segment"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SPC].specimen"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "704319004 |Inherent in|"
-					}
-				]
-			},
-			{
-				"id": "Observation.device",
-				"path": "Observation.device",
-				"short": "(Measurement) Device",
-				"definition": "The device used to generate the observation data.",
-				"comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.device",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/DeviceMetric"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 49062001 |Device|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-17 / PRT -10"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=DEV]"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "424226004 |Using device|"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange",
-				"path": "Observation.referenceRange",
-				"short": "Provides guide for interpretation",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "obs-3",
-						"severity": "error",
-						"human": "Must have at least a low or a high or text",
-						"expression": "low.exists() or high.exists() or text.exists()",
-						"xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.id",
-				"path": "Observation.referenceRange.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.extension",
-				"path": "Observation.referenceRange.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.modifierExtension",
-				"path": "Observation.referenceRange.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.low",
-				"path": "Observation.referenceRange.low",
-				"short": "Low Range, if relevant",
-				"definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.low",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.low"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.high",
-				"path": "Observation.referenceRange.high",
-				"short": "High Range, if relevant",
-				"definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.high",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.high"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.type",
-				"path": "Observation.referenceRange.type",
-				"short": "Reference range qualifier",
-				"definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
-				"requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeMeaning"
-						}
-					],
-					"strength": "preferred",
-					"description": "Code for the meaning of a reference range.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.appliesTo",
-				"path": "Observation.referenceRange.appliesTo",
-				"short": "Reference range population",
-				"definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
-				"requirements": "Need to be able to identify the target population for proper interpretation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange.appliesTo",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeType"
-						}
-					],
-					"strength": "example",
-					"description": "Codes identifying the population the reference range applies to.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.age",
-				"path": "Observation.referenceRange.age",
-				"short": "Applicable age range, if relevant",
-				"definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
-				"requirements": "Some analytes vary greatly over age.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.age",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Range"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.text",
-				"path": "Observation.referenceRange.text",
-				"short": "Text based reference range in an observation",
-				"definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:ST"
-					}
-				]
-			},
-			{
-				"id": "Observation.hasMember",
-				"path": "Observation.hasMember",
-				"short": "Used when reporting vital signs panel components",
-				"definition": "Used when reporting vital signs panel components.",
-				"comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.hasMember",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship"
-					}
-				]
-			},
-			{
-				"id": "Observation.derivedFrom",
-				"path": "Observation.derivedFrom",
-				"short": "Related measurements the observation is made from",
-				"definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
-				"comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.derivedFrom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/DocumentReference",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy",
-							"http://hl7.org/fhir/StructureDefinition/Media",
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": ".targetObservation"
-					}
-				]
-			},
-			{
-				"id": "Observation.component",
-				"path": "Observation.component",
-				"short": "Component observations",
-				"definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
-				"comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-3",
-						"severity": "error",
-						"human": "If there is no a value a data absent reason must be present",
-						"expression": "value.exists() or dataAbsentReason.exists()",
-						"xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "containment by OBX-4?"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=COMP]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.id",
-				"path": "Observation.component.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.extension",
-				"path": "Observation.component.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.modifierExtension",
-				"path": "Observation.component.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.code",
-				"path": "Observation.component.code",
-				"short": "Type of component observation (code / type)",
-				"definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
-				"comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.value[x]",
-				"path": "Observation.component.value[x]",
-				"short": "Vital Sign Component Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
-				"comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "Quantity"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.dataAbsentReason",
-				"path": "Observation.component.dataAbsentReason",
-				"short": "Why the component result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
-				"comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.interpretation",
-				"path": "Observation.component.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.referenceRange",
-				"path": "Observation.component.referenceRange",
-				"short": "Provides guide for interpretation of component result",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "US Core Body Weight Profile",
-				"definition": "Defines constraints on Observation to represent body weight observations with a standard LOINC code and UCUM units of measure.  This profile is derived from the US Core Vital Signs Profile."
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Body Weight",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "29463-7"
-						}
-					]
-				},
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity",
-				"path": "Observation.valueQuantity",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.value",
-				"path": "Observation.valueQuantity.value",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.unit",
-				"path": "Observation.valueQuantity.unit",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.system",
-				"path": "Observation.valueQuantity.system",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.code",
-				"path": "Observation.valueQuantity.code",
-				"short": "Coded responses from the common UCUM units for vital signs value set.",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-bodyweight|4.0.1"
-				}
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-body-weight",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-weight",
+    "version": "4.0.0",
+    "name": "USCoreBodyWeightProfile",
+    "title": "US Core Body Weight Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-17",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints on Observation to represent body weight observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "sct-concept",
+            "uri": "http://snomed.info/conceptdomain",
+            "name": "SNOMED CT Concept Domain Binding"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "sct-attr",
+            "uri": "http://snomed.org/attributebinding",
+            "name": "SNOMED CT Attribute Binding"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Observation",
+    "baseDefinition": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "US Core Body Weight Profile",
+                "definition": "Defines constraints on Observation to represent body weight observations with a standard LOINC code and UCUM units of measure.  This profile is derived from the US Core Vital Signs Profile.",
+                "comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
+                "alias": [
+                    "Vital Signs",
+                    "Measurement",
+                    "Results",
+                    "Tests"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "obs-6",
+                        "severity": "error",
+                        "human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
+                        "expression": "dataAbsentReason.empty() or value.empty()",
+                        "xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "obs-7",
+                        "severity": "error",
+                        "human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
+                        "expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
+                        "xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "vs-2",
+                        "severity": "error",
+                        "human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
+                        "expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
+                        "xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.id",
+                "path": "Observation.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.meta",
+                "path": "Observation.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.implicitRules",
+                "path": "Observation.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Observation.language",
+                "path": "Observation.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Observation.text",
+                "path": "Observation.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.contained",
+                "path": "Observation.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.extension",
+                "path": "Observation.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.modifierExtension",
+                "path": "Observation.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.identifier",
+                "path": "Observation.identifier",
+                "short": "Business Identifier for observation",
+                "definition": "A unique identifier assigned to this observation.",
+                "requirements": "Allows observations to be distinguished and referenced.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "id"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.basedOn",
+                "path": "Observation.basedOn",
+                "short": "Fulfills plan, proposal or order",
+                "definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
+                "requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
+                "alias": [
+                    "Fulfills"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceRequest",
+                            "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+                            "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.basedOn"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.partOf",
+                "path": "Observation.partOf",
+                "short": "Part of referenced event",
+                "definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
+                "comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
+                "alias": [
+                    "Container"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.partOf",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationDispense",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationStatement",
+                            "http://hl7.org/fhir/StructureDefinition/Procedure",
+                            "http://hl7.org/fhir/StructureDefinition/Immunization",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.partOf"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "Varies by domain"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=FLFS].target"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.status",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
+                        "valueString": "default: final"
+                    }
+                ],
+                "path": "Observation.status",
+                "short": "registered | preliminary | final | amended +",
+                "definition": "The status of the result value.",
+                "comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
+                "requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Status"
+                        }
+                    ],
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 445584004 |Report by finality status|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-11"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category",
+                "path": "Observation.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "coding.code"
+                        },
+                        {
+                            "type": "value",
+                            "path": "coding.system"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "open"
+                },
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat",
+                "path": "Observation.category",
+                "sliceName": "VSCat",
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.id",
+                "path": "Observation.category.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.extension",
+                "path": "Observation.category.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding",
+                "path": "Observation.category.coding",
+                "short": "Code defined by a terminology system",
+                "definition": "A reference to a code defined by a terminology system.",
+                "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+                "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "CodeableConcept.coding",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1-8, C*E.10-22"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "union(., ./translation)"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.id",
+                "path": "Observation.category.coding.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.extension",
+                "path": "Observation.category.coding.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.system",
+                "path": "Observation.category.coding.system",
+                "short": "Identity of the terminology system",
+                "definition": "The identification of the code system that defines the meaning of the symbol in the code.",
+                "comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
+                "requirements": "Need to be unambiguous about the source of the definition of the symbol.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystem"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.version",
+                "path": "Observation.category.coding.version",
+                "short": "Version of the system - if relevant",
+                "definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
+                "comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.version",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystemVersion"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.code",
+                "path": "Observation.category.coding.code",
+                "short": "Symbol in syntax defined by the system",
+                "definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
+                "requirements": "Need to refer to a particular code in the system.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "vital-signs",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./code"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.display",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.coding.display",
+                "short": "Representation defined by the system",
+                "definition": "A representation of the meaning of the code in the system, following the rules of the system.",
+                "requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.display",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.2 - but note this is not well followed"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CV.displayName"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.userSelected",
+                "path": "Observation.category.coding.userSelected",
+                "short": "If this coding was chosen directly by the user",
+                "definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
+                "comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
+                "requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.userSelected",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Sometimes implied by being first"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CD.codingRationale"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.text",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.text",
+                "short": "Plain text representation of the concept",
+                "definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
+                "comment": "Very often the text is the same as a displayName of one of the codings.",
+                "requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CodeableConcept.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.9. But note many systems use C*E.2 for this"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./originalText[mediaType/code=\"text/plain\"]/data"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Body Weight",
+                "definition": "Coded Responses from C-CDA Vital Sign Results.",
+                "comment": "*All* code-value and, if present, component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
+                "alias": [
+                    "Name"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "29463-7"
+                        }
+                    ]
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "116680003 |Is a|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.subject",
+                "path": "Observation.subject",
+                "short": "Who and/or what the observation is about",
+                "definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
+                "comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
+                "requirements": "Observations have no value if you don't know who or what they're about.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=RTGT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.focus",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+                        "valueCode": "trial-use"
+                    }
+                ],
+                "path": "Observation.focus",
+                "short": "What the observation is about, when it is not about the subject of record",
+                "definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
+                "comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.focus",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SBJ]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.encounter",
+                "path": "Observation.encounter",
+                "short": "Healthcare event during which this observation is made",
+                "definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
+                "comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
+                "requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
+                "alias": [
+                    "Context"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.effective[x]",
+                "path": "Observation.effective[x]",
+                "short": "Often just a dateTime for Vital Signs",
+                "definition": "Often just a dateTime for Vital Signs.",
+                "comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
+                "requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
+                "alias": [
+                    "Occurrence"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.effective[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-1",
+                        "severity": "error",
+                        "human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
+                        "expression": "($this as dateTime).toString().length() >= 8",
+                        "xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.issued",
+                "path": "Observation.issued",
+                "short": "Date/Time this version was made available",
+                "definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
+                "comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.issued",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.performer",
+                "path": "Observation.performer",
+                "short": "Who is responsible for the observation",
+                "definition": "Who was responsible for asserting the observed value as \"true\".",
+                "requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.performer",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=PRF]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]",
+                "path": "Observation.value[x]",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "type",
+                            "path": "$this"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "closed"
+                },
+                "short": "Vital Signs Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity",
+                "path": "Observation.value[x]",
+                "sliceName": "valueQuantity",
+                "short": "Vital Signs Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.id",
+                "path": "Observation.value[x].id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.extension",
+                "path": "Observation.value[x].extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.value",
+                "path": "Observation.value[x].value",
+                "short": "Numerical value (with implicit precision)",
+                "definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
+                "comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
+                "requirements": "Precision is handled implicitly in almost all cases of measurement.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.2  / CQ - N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.comparator",
+                "path": "Observation.value[x].comparator",
+                "short": "< | <= | >= | > - how to understand the value",
+                "definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
+                "requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.comparator",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "QuantityComparator"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "How the Quantity should be understood and represented.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.1  / CQ.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "IVL properties"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.unit",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.value[x].unit",
+                "short": "Unit representation",
+                "definition": "A human-readable form of the unit.",
+                "requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.unit",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.unit"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.system",
+                "path": "Observation.value[x].system",
+                "short": "System that defines coded unit form",
+                "definition": "The identification of the system that provides the coded form of the unit.",
+                "requirements": "Need to know the system that defines the coded form of the unit.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "condition": [
+                    "qty-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CO.codeSystem, PQ.translation.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.code",
+                "path": "Observation.value[x].code",
+                "short": "Coded responses from the common UCUM units for vital signs value set.",
+                "definition": "A computer processable form of the unit in some unit representation system.",
+                "comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
+                "requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-bodyweight|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.code, MO.currency, PQ.translation.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.dataAbsentReason",
+                "path": "Observation.dataAbsentReason",
+                "short": "Why the result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
+                "comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.interpretation",
+                "path": "Observation.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.note",
+                "path": "Observation.note",
+                "short": "Comments about the observation",
+                "definition": "Comments about the observation or the results.",
+                "comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
+                "requirements": "Need to be able to provide free text additional information.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "subjectOf.observationEvent[code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.bodySite",
+                "path": "Observation.bodySite",
+                "short": "Observed body part",
+                "definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
+                "comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.bodySite",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "BodySite"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing anatomical locations. May include laterality.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/body-site"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123037004 |Body structure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-20"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "targetSiteCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "718497002 |Inherent location|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.method",
+                "path": "Observation.method",
+                "short": "How it was done",
+                "definition": "Indicates the mechanism used to perform the observation.",
+                "comment": "Only used if not implicit in code for Observation.code.",
+                "requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.method",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationMethod"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Methods for simple observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "methodCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.specimen",
+                "path": "Observation.specimen",
+                "short": "Specimen used for this observation",
+                "definition": "The specimen that was used when this observation was made.",
+                "comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.specimen",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Specimen"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123038009 |Specimen|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "SPM segment"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SPC].specimen"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "704319004 |Inherent in|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.device",
+                "path": "Observation.device",
+                "short": "(Measurement) Device",
+                "definition": "The device used to generate the observation data.",
+                "comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.device",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceMetric"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 49062001 |Device|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17 / PRT -10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=DEV]"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "424226004 |Using device|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange",
+                "path": "Observation.referenceRange",
+                "short": "Provides guide for interpretation",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "obs-3",
+                        "severity": "error",
+                        "human": "Must have at least a low or a high or text",
+                        "expression": "low.exists() or high.exists() or text.exists()",
+                        "xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.id",
+                "path": "Observation.referenceRange.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.extension",
+                "path": "Observation.referenceRange.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.modifierExtension",
+                "path": "Observation.referenceRange.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.low",
+                "path": "Observation.referenceRange.low",
+                "short": "Low Range, if relevant",
+                "definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.low",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.low"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.high",
+                "path": "Observation.referenceRange.high",
+                "short": "High Range, if relevant",
+                "definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.high",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.high"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.type",
+                "path": "Observation.referenceRange.type",
+                "short": "Reference range qualifier",
+                "definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
+                "requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeMeaning"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Code for the meaning of a reference range.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.appliesTo",
+                "path": "Observation.referenceRange.appliesTo",
+                "short": "Reference range population",
+                "definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
+                "requirements": "Need to be able to identify the target population for proper interpretation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange.appliesTo",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes identifying the population the reference range applies to.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.age",
+                "path": "Observation.referenceRange.age",
+                "short": "Applicable age range, if relevant",
+                "definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
+                "requirements": "Some analytes vary greatly over age.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.age",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Range"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.text",
+                "path": "Observation.referenceRange.text",
+                "short": "Text based reference range in an observation",
+                "definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:ST"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.hasMember",
+                "path": "Observation.hasMember",
+                "short": "Used when reporting vital signs panel components",
+                "definition": "Used when reporting vital signs panel components.",
+                "comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.hasMember",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.derivedFrom",
+                "path": "Observation.derivedFrom",
+                "short": "Related measurements the observation is made from",
+                "definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
+                "comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.derivedFrom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/DocumentReference",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy",
+                            "http://hl7.org/fhir/StructureDefinition/Media",
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".targetObservation"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component",
+                "path": "Observation.component",
+                "short": "Component observations",
+                "definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
+                "comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-3",
+                        "severity": "error",
+                        "human": "If there is no a value a data absent reason must be present",
+                        "expression": "value.exists() or dataAbsentReason.exists()",
+                        "xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "containment by OBX-4?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=COMP]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.id",
+                "path": "Observation.component.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.extension",
+                "path": "Observation.component.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.modifierExtension",
+                "path": "Observation.component.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.code",
+                "path": "Observation.component.code",
+                "short": "Type of component observation (code / type)",
+                "definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
+                "comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.value[x]",
+                "path": "Observation.component.value[x]",
+                "short": "Vital Sign Component Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
+                "comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.dataAbsentReason",
+                "path": "Observation.component.dataAbsentReason",
+                "short": "Why the component result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
+                "comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.interpretation",
+                "path": "Observation.component.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.referenceRange",
+                "path": "Observation.component.referenceRange",
+                "short": "Provides guide for interpretation of component result",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "US Core Body Weight Profile",
+                "definition": "Defines constraints on Observation to represent body weight observations with a standard LOINC code and UCUM units of measure.  This profile is derived from the US Core Vital Signs Profile."
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Body Weight",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "29463-7"
+                        }
+                    ]
+                },
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity",
+                "path": "Observation.valueQuantity",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.value",
+                "path": "Observation.valueQuantity.value",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.unit",
+                "path": "Observation.valueQuantity.unit",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.system",
+                "path": "Observation.valueQuantity.system",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.code",
+                "path": "Observation.valueQuantity.code",
+                "short": "Coded responses from the common UCUM units for vital signs value set.",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-bodyweight|4.0.1"
+                }
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-careplan.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-careplan.json
@@ -1,3326 +1,3326 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-careplan",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-careplan-definitions.html#CarePlan\" title=\"The US Core CarePlan Profile is based upon the core FHIR CarePlan Resource and created to meet the 2015 Edition Common Clinical Data Set 'Assessment and Plan of Treatment requirements.\">CarePlan</a><a name=\"CarePlan\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/careplan.html\">CarePlan</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Healthcare plan for patient or group</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-careplan-definitions.html#CarePlan.text\">text</a><a name=\"CarePlan.text\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Narrative\">Narrative</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Text summary of the resource, for human interpretation</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-careplan-definitions.html#CarePlan.text.status\">status</a><a name=\"CarePlan.text.status\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">1</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">generated | extensions | additional | empty</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-careplan-definitions.html#CarePlan.text.div\">div</a><a name=\"CarePlan.text.div\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">1</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/narrative.html#xhtml\">xhtml</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Limited xhtml content</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-narrative-status.html\">US Core Narrative Status</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>): Constrained value set of narrative statuses.<br/><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-careplan-definitions.html#CarePlan.status\">status</a><a name=\"CarePlan.status\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">draft | active | on-hold | revoked | completed | entered-in-error | unknown</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-request-status.html\">RequestStatus</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>): Indicates whether the plan is currently being acted upon, represents future intentions or is now a historical record.<br/><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-careplan-definitions.html#CarePlan.intent\">intent</a><a name=\"CarePlan.intent\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">proposal | plan | order | option</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-care-plan-intent.html\">CarePlanIntent</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>): Codes indicating the degree of authority/intentionality associated with a care plan<br/><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck13.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Slice Definition\" class=\"hierarchy\"/> <a style=\"font-style: italic\" href=\"StructureDefinition-us-core-careplan-definitions.html#CarePlan.category\" title=\"Type of plan.\">Slices for category</a><a name=\"CarePlan.category\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red; font-style: italic\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"font-style: italic\"/><span style=\"font-style: italic\">1</span><span style=\"font-style: italic\">..</span><span style=\"font-style: italic\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"font-style: italic\" href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5; font-style: italic\">Type of plan</span><br style=\"font-style: italic\"/><span style=\"font-weight:bold; font-style: italic\">Slice: </span><span style=\"font-style: italic\">Unordered, Open by pattern:$this</span><br style=\"font-style: italic\"/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck125.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-careplan-definitions.html#CarePlan.category:AssessPlan\" title=\"Slice AssessPlan: Type of plan.\">category:AssessPlan</a><a name=\"CarePlan.category\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Type of plan</span><br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1241.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#CodeableConcept.coding\">coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Code defined by a terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">(complex)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck12410.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"CodeSystem-careplan-category.html\">http://hl7.org/fhir/us/core/CodeSystem/careplan-category</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck12400.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">assess-plan</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck00.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-careplan-definitions.html#CarePlan.subject\" title=\"Who care plan is for.\">subject</a><a name=\"CarePlan.subject\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who the care plan is for</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan",
-	"version": "4.0.0",
-	"name": "USCoreCarePlanProfile",
-	"title": "US Core CarePlan Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2019-08-29",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the CarePlan resource for the minimal set of data to query and retrieve a patient's Care Plan.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "CarePlan",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/CarePlan",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "CarePlan",
-				"path": "CarePlan",
-				"short": "Healthcare plan for patient or group",
-				"definition": "The US Core CarePlan Profile is based upon the core FHIR CarePlan Resource and created to meet the 2015 Edition Common Clinical Data Set 'Assessment and Plan of Treatment requirements.",
-				"alias": [
-					"Care Team"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Request"
-					},
-					{
-						"identity": "rim",
-						"map": "Act[classCode=PCPR, moodCode=INT]"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.id",
-				"path": "CarePlan.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "CarePlan.meta",
-				"path": "CarePlan.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "CarePlan.implicitRules",
-				"path": "CarePlan.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "CarePlan.language",
-				"path": "CarePlan.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "CarePlan.text",
-				"path": "CarePlan.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.text"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.text.id",
-				"path": "CarePlan.text.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.text.extension",
-				"path": "CarePlan.text.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.text.status",
-				"path": "CarePlan.text.status",
-				"short": "generated | extensions | additional | empty",
-				"definition": "The status of the narrative - whether it's entirely generated (from just the defined data or the extensions too), or whether a human authored it and it may contain additional data.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Narrative.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "NarrativeStatus"
-						}
-					],
-					"strength": "required",
-					"description": "The status of a resource narrative.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/narrative-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.text.div",
-				"path": "CarePlan.text.div",
-				"short": "Limited xhtml content",
-				"definition": "The actual narrative content, a stripped down version of XHTML.",
-				"comment": "The contents of the html element are an XHTML fragment containing only the basic html formatting elements described in chapters 7-11 and 15 of the HTML 4.0 standard, <a> elements (either name or href), images and internally contained stylesheets. The XHTML content SHALL NOT contain a head, a body, external stylesheet references, scripts, forms, base/link/xlink, frames, iframes and objects.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Narrative.div",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "xhtml"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "txt-1",
-						"severity": "error",
-						"human": "The narrative SHALL contain only the basic html formatting elements and attributes described in chapters 7-11 (except section 4 of chapter 9) and 15 of the HTML 4.0 standard, <a> elements (either name or href), images and internally contained style attributes",
-						"expression": "htmlChecks()",
-						"xpath": "not(descendant-or-self::*[not(local-name(.)=('a', 'abbr', 'acronym', 'b', 'big', 'blockquote', 'br', 'caption', 'cite', 'code', 'col', 'colgroup', 'dd', 'dfn', 'div', 'dl', 'dt', 'em', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'i', 'img', 'li', 'ol', 'p', 'pre', 'q', 'samp', 'small', 'span', 'strong', 'sub', 'sup', 'table', 'tbody', 'td', 'tfoot', 'th', 'thead', 'tr', 'tt', 'ul', 'var'))]) and not(descendant-or-self::*/@*[not(name(.)=('abbr', 'accesskey', 'align', 'alt', 'axis', 'bgcolor', 'border', 'cellhalign', 'cellpadding', 'cellspacing', 'cellvalign', 'char', 'charoff', 'charset', 'cite', 'class', 'colspan', 'compact', 'coords', 'dir', 'frame', 'headers', 'height', 'href', 'hreflang', 'hspace', 'id', 'lang', 'longdesc', 'name', 'nowrap', 'rel', 'rev', 'rowspan', 'rules', 'scope', 'shape', 'span', 'src', 'start', 'style', 'summary', 'tabindex', 'title', 'type', 'valign', 'value', 'vspace', 'width'))])",
-						"source": "http://hl7.org/fhir/StructureDefinition/CarePlan"
-					},
-					{
-						"key": "txt-2",
-						"severity": "error",
-						"human": "The narrative SHALL have some non-whitespace content",
-						"expression": "htmlChecks()",
-						"xpath": "descendant::text()[normalize-space(.)!=''] or descendant::h:img[@src]",
-						"source": "http://hl7.org/fhir/StructureDefinition/CarePlan"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.text.status"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.contained",
-				"path": "CarePlan.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.extension",
-				"path": "CarePlan.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.modifierExtension",
-				"path": "CarePlan.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.identifier",
-				"path": "CarePlan.identifier",
-				"short": "External Ids for this plan",
-				"definition": "Business identifiers assigned to this care plan by the performer or other systems which remain constant as the resource is updated and propagates from server to server.",
-				"comment": "This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.",
-				"requirements": "Allows identification of the care plan as it is known by various participating systems and in a way that remains consistent across servers.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "PTH-3"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.instantiatesCanonical",
-				"path": "CarePlan.instantiatesCanonical",
-				"short": "Instantiates FHIR protocol or definition",
-				"definition": "The URL pointing to a FHIR-defined protocol, guideline, questionnaire or other definition that is adhered to in whole or in part by this CarePlan.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.instantiatesCanonical",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "canonical",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/PlanDefinition",
-							"http://hl7.org/fhir/StructureDefinition/Questionnaire",
-							"http://hl7.org/fhir/StructureDefinition/Measure",
-							"http://hl7.org/fhir/StructureDefinition/ActivityDefinition",
-							"http://hl7.org/fhir/StructureDefinition/OperationDefinition"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.instantiatesCanonical"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=DEFN].target"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.instantiatesUri",
-				"path": "CarePlan.instantiatesUri",
-				"short": "Instantiates external protocol or definition",
-				"definition": "The URL pointing to an externally maintained protocol, guideline, questionnaire or other definition that is adhered to in whole or in part by this CarePlan.",
-				"comment": "This might be an HTML page, PDF, etc. or could just be a non-resolvable URI identifier.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.instantiatesUri",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.instantiatesUri"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=DEFN].target"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.basedOn",
-				"path": "CarePlan.basedOn",
-				"short": "Fulfills CarePlan",
-				"definition": "A care plan that is fulfilled in whole or in part by this care plan.",
-				"requirements": "Allows tracing of the care plan and tracking whether proposals/recommendations were acted upon.",
-				"alias": [
-					"fulfills"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-hierarchy",
-								"valueBoolean": true
-							}
-						],
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.basedOn"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.replaces",
-				"path": "CarePlan.replaces",
-				"short": "CarePlan replaced by this CarePlan",
-				"definition": "Completed or terminated care plan whose function is taken by this new care plan.",
-				"comment": "The replacement could be because the initial care plan was immediately rejected (due to an issue) or because the previous care plan was completed, but the need for the action described by the care plan remains ongoing.",
-				"requirements": "Allows tracing the continuation of a therapy or administrative process instantiated through multiple care plans.",
-				"alias": [
-					"supersedes"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.replaces",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-hierarchy",
-								"valueBoolean": true
-							}
-						],
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.replaces"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.partOf",
-				"path": "CarePlan.partOf",
-				"short": "Part of referenced CarePlan",
-				"definition": "A larger care plan of which this particular care plan is a component or step.",
-				"comment": "Each care plan is an independent request, such that having a care plan be part of another care plan can cause issues with cascading statuses.  As such, this element is still being discussed.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.partOf",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-hierarchy",
-								"valueBoolean": true
-							}
-						],
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "CarePlan.status",
-				"path": "CarePlan.status",
-				"short": "draft | active | on-hold | revoked | completed | entered-in-error | unknown",
-				"definition": "Indicates whether the plan is currently being acted upon, represents future intentions or is now a historical record.",
-				"comment": "The unknown code is not to be used to convey other statuses.  The unknown code should be used when one of the statuses applies, but the authoring system doesn't know the current state of the care plan.\n\nThis element is labeled as a modifier because the status contains the code entered-in-error that marks the plan as not currently valid.",
-				"requirements": "Indicates whether the plan is currently being acted upon, represents future intentions or is now a historical record.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"description": "Indicates whether the plan is currently being acted upon, represents future intentions or is now a historical record.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/request-status"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.status {uses different ValueSet}"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "v2",
-						"map": "PTH-5"
-					},
-					{
-						"identity": "rim",
-						"map": ".statusCode planned = new active = active completed = completed"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.status"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.intent",
-				"path": "CarePlan.intent",
-				"short": "proposal | plan | order | option",
-				"definition": "Indicates the level of authority/intentionality associated with the care plan and where the care plan fits into the workflow chain.",
-				"comment": "This element is labeled as a modifier because the intent alters when and how the resource is actually applicable.",
-				"requirements": "Proposals/recommendations, plans and orders all use the same structure and can exist in the same fulfillment chain.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.intent",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element changes the interpretation of all descriptive attributes. For example \"the time the request is recommended to occur\" vs. \"the time the request is authorized to occur\" or \"who is recommended to perform the request\" vs. \"who is authorized to perform the request\"",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"description": "Codes indicating the degree of authority/intentionality associated with a care plan",
-					"valueSet": "http://hl7.org/fhir/ValueSet/care-plan-intent"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.intent"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA (new element in STU3)"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.category",
-				"path": "CarePlan.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "$this"
-						}
-					],
-					"rules": "open"
-				},
-				"short": "Type of plan",
-				"definition": "Type of plan.",
-				"comment": "There may be multiple axes of categorization and one plan may serve multiple purposes.  In some cases, this may be redundant with references to CarePlan.concern.",
-				"requirements": "Identifies what \"kind\" of plan this is to support differentiation between multiple co-existing plans; e.g. \"Home health\", \"psychiatric\", \"asthma\", \"disease management\", \"wellness plan\", etc.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "CarePlanCategory"
-						}
-					],
-					"strength": "example",
-					"description": "Identifies what \"kind\" of plan this is to support differentiation between multiple co-existing plans; e.g. \"Home health\", \"psychiatric\", \"asthma\", \"disease management\", etc.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/care-plan-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.category"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.category:AssessPlan",
-				"path": "CarePlan.category",
-				"sliceName": "AssessPlan",
-				"short": "Type of plan",
-				"definition": "Type of plan.",
-				"comment": "There may be multiple axes of categorization and one plan may serve multiple purposes.  In some cases, this may be redundant with references to CarePlan.concern.",
-				"requirements": "Identifies what \"kind\" of plan this is to support differentiation between multiple co-existing plans; e.g. \"Home health\", \"psychiatric\", \"asthma\", \"disease management\", \"wellness plan\", etc.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://hl7.org/fhir/us/core/CodeSystem/careplan-category",
-							"code": "assess-plan"
-						}
-					]
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "CarePlanCategory"
-						}
-					],
-					"strength": "example",
-					"description": "Identifies what \"kind\" of plan this is to support differentiation between multiple co-existing plans; e.g. \"Home health\", \"psychiatric\", \"asthma\", \"disease management\", etc.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/care-plan-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.category"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.title",
-				"path": "CarePlan.title",
-				"short": "Human-friendly name for the care plan",
-				"definition": "Human-friendly name for the care plan.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.title",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "CarePlan.description",
-				"path": "CarePlan.description",
-				"short": "Summary of nature of plan",
-				"definition": "A description of the scope and nature of the plan.",
-				"requirements": "Provides more detail than conveyed by category.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.description",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.subject",
-				"path": "CarePlan.subject",
-				"short": "Who the care plan is for",
-				"definition": "Who care plan is for.",
-				"requirements": "Identifies the patient or group whose intended care is described by the plan.",
-				"alias": [
-					"patient"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.subject",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=PAT].role[classCode=PAT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.subject"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.encounter",
-				"path": "CarePlan.encounter",
-				"short": "Encounter created as part of",
-				"definition": "The Encounter during which this CarePlan was created or to which the creation of this record is tightly associated.",
-				"comment": "This will typically be the encounter the event occurred within, but some activities may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter. CarePlan activities conducted as a result of the care plan may well occur as part of other encounters.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "Associated PV1"
-					},
-					{
-						"identity": "rim",
-						"map": "."
-					}
-				]
-			},
-			{
-				"id": "CarePlan.period",
-				"path": "CarePlan.period",
-				"short": "Time period plan covers",
-				"definition": "Indicates when the plan did (or is intended to) come into effect and end.",
-				"comment": "Any activities scheduled as part of the plan should be constrained to the specified period regardless of whether the activities are planned within a single encounter/episode or across multiple encounters/episodes (e.g. the longitudinal management of a chronic condition).",
-				"requirements": "Allows tracking what plan(s) are in effect at a particular time.",
-				"alias": [
-					"timing"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.planned"
-					},
-					{
-						"identity": "v2",
-						"map": "GOL-7 / GOL-8"
-					},
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.created",
-				"path": "CarePlan.created",
-				"short": "Date record was first recorded",
-				"definition": "Represents when this particular CarePlan record was created in the system, which is often a system-generated date.",
-				"alias": [
-					"authoredOn"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.created",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.authoredOn"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=AUT].time"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.author",
-				"path": "CarePlan.author",
-				"short": "Who is the designated responsible party",
-				"definition": "When populated, the author is responsible for the care plan.  The care plan is attributed to the author.",
-				"comment": "The author may also be a contributor.  For example, an organization can be an author, but not listed as a contributor.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.author",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.requester"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.author"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.contributor",
-				"path": "CarePlan.contributor",
-				"short": "Who provided the content of the care plan",
-				"definition": "Identifies the individual(s) or organization who provided the contents of the care plan.",
-				"comment": "Collaborative care plans may have multiple contributors.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.contributor",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "CarePlan.careTeam",
-				"path": "CarePlan.careTeam",
-				"short": "Who's involved in plan?",
-				"definition": "Identifies all people and organizations who are expected to be involved in the care envisioned by this plan.",
-				"requirements": "Allows representation of care teams, helps scope care plan.  In some cases may be a determiner of access permissions.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.careTeam",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CareTeam"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.performer {similar but does not entail CareTeam}"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.addresses",
-				"path": "CarePlan.addresses",
-				"short": "Health issues this plan addresses",
-				"definition": "Identifies the conditions/problems/concerns/diagnoses/etc. whose management and/or mitigation are handled by this plan.",
-				"comment": "When the diagnosis is related to an allergy or intolerance, the Condition and AllergyIntolerance resources can both be used. However, to be actionable for decision support, using Condition alone is not sufficient as the allergy or intolerance condition needs to be represented as an AllergyIntolerance.",
-				"requirements": "Links plan to the conditions it manages.  The element can identify risks addressed by the plan as well as active conditions.  (The Condition resource can include things like \"at risk for hypertension\" or \"fall risk\".)  Also scopes plans - multiple plans may exist addressing different concerns.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.addresses",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Condition"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.reasonReference"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.why[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PRB-4"
-					},
-					{
-						"identity": "rim",
-						"map": ".actRelationship[typeCode=SUBJ].target[classCode=CONC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.supportingInfo",
-				"path": "CarePlan.supportingInfo",
-				"short": "Information considered as part of plan",
-				"definition": "Identifies portions of the patient's record that specifically influenced the formation of the plan.  These might include comorbidities, recent procedures, limitations, recent assessments, etc.",
-				"comment": "Use \"concern\" to identify specific conditions addressed by the care plan.",
-				"requirements": "Identifies barriers and other considerations associated with the care plan.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.supportingInfo",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.supportingInfo"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.goal",
-				"path": "CarePlan.goal",
-				"short": "Desired outcome of plan",
-				"definition": "Describes the intended objective(s) of carrying out the care plan.",
-				"comment": "Goal can be achieving a particular change or merely maintaining a current state or even slowing a decline.",
-				"requirements": "Provides context for plan.  Allows plan effectiveness to be evaluated by clinicians.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.goal",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Goal"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "GOL.1"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode<=OBJ]."
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity",
-				"path": "CarePlan.activity",
-				"short": "Action to occur as part of plan",
-				"definition": "Identifies a planned action to occur as part of the plan.  For example, a medication to be used, lab tests to perform, self-monitoring, education, etc.",
-				"requirements": "Allows systems to prompt for performance of planned activities, and validate plans against best practice.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.activity",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "cpl-3",
-						"severity": "error",
-						"human": "Provide a reference or detail, not both",
-						"expression": "detail.empty() or reference.empty()",
-						"xpath": "not(exists(f:detail)) or not(exists(f:reference))"
-					},
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "{no mapping\nNOTE: This is a list of contained Request-Event tuples!}"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=COMP].target"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.id",
-				"path": "CarePlan.activity.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.extension",
-				"path": "CarePlan.activity.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.modifierExtension",
-				"path": "CarePlan.activity.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.outcomeCodeableConcept",
-				"path": "CarePlan.activity.outcomeCodeableConcept",
-				"short": "Results of the activity",
-				"definition": "Identifies the outcome at the point when the status of the activity is assessed.  For example, the outcome of an education activity could be patient understands (or not).",
-				"comment": "Note that this should not duplicate the activity status (e.g. completed or in progress).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.activity.outcomeCodeableConcept",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "CarePlanActivityOutcome"
-						}
-					],
-					"strength": "example",
-					"description": "Identifies the results of the activity.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/care-plan-activity-outcome"
-				}
-			},
-			{
-				"id": "CarePlan.activity.outcomeReference",
-				"path": "CarePlan.activity.outcomeReference",
-				"short": "Appointment, Encounter, Procedure, etc.",
-				"definition": "Details of the outcome or action resulting from the activity.  The reference to an \"event\" resource, such as Procedure or Encounter or Observation, is the result/outcome of the activity itself.  The activity can be conveyed using CarePlan.activity.detail OR using the CarePlan.activity.reference (a reference to a “request” resource).",
-				"comment": "The activity outcome is independent of the outcome of the related goal(s).  For example, if the goal is to achieve a target body weight of 150 lbs and an activity is defined to diet, then the activity outcome could be calories consumed whereas the goal outcome is an observation for the actual body weight measured.",
-				"requirements": "Links plan to resulting actions.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.activity.outcomeReference",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "{Event that is outcome of Request in activity.reference}"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=FLFS].source"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.progress",
-				"path": "CarePlan.activity.progress",
-				"short": "Comments about the activity status/progress",
-				"definition": "Notes about the adherence/status/progress of the activity.",
-				"comment": "This element should NOT be used to describe the activity to be performed - that occurs either within the resource pointed to by activity.detail.reference or in activity.detail.description.",
-				"requirements": "Can be used to capture information about adherence, progress, concerns, etc.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.activity.progress",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NTE?"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.reference",
-				"path": "CarePlan.activity.reference",
-				"short": "Activity details defined in specific resource",
-				"definition": "The details of the proposed activity represented in a specific resource.",
-				"comment": "Standard extension exists ([resource-pertainsToGoal](http://hl7.org/fhir/R4/extension-resource-pertainstogoal.html)) that allows goals to be referenced from any of the referenced resources in CarePlan.activity.reference.  \rThe goal should be visible when the resource referenced by CarePlan.activity.reference is viewed independently from the CarePlan.  Requests that are pointed to by a CarePlan using this element should *not* point to this CarePlan using the \"basedOn\" element.  i.e. Requests that are part of a CarePlan are not \"based on\" the CarePlan.",
-				"requirements": "Details in a form consistent with other applications and contexts of use.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.activity.reference",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Appointment",
-							"http://hl7.org/fhir/StructureDefinition/CommunicationRequest",
-							"http://hl7.org/fhir/StructureDefinition/DeviceRequest",
-							"http://hl7.org/fhir/StructureDefinition/MedicationRequest",
-							"http://hl7.org/fhir/StructureDefinition/NutritionOrder",
-							"http://hl7.org/fhir/StructureDefinition/Task",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest",
-							"http://hl7.org/fhir/StructureDefinition/VisionPrescription",
-							"http://hl7.org/fhir/StructureDefinition/RequestGroup"
-						]
-					}
-				],
-				"condition": [
-					"cpl-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "{Request that resulted in Event in activity.actionResulting}"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=COMP].target"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail",
-				"path": "CarePlan.activity.detail",
-				"short": "In-line definition of activity",
-				"definition": "A simple summary of a planned activity suitable for a general care plan system (e.g. form driven) that doesn't know about specific resources such as procedure etc.",
-				"requirements": "Details in a simple form for generic care plan systems.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.activity.detail",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"condition": [
-					"cpl-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=COMP, subsetCode=SUMM].target"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.id",
-				"path": "CarePlan.activity.detail.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.extension",
-				"path": "CarePlan.activity.detail.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.modifierExtension",
-				"path": "CarePlan.activity.detail.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.kind",
-				"path": "CarePlan.activity.detail.kind",
-				"short": "Appointment | CommunicationRequest | DeviceRequest | MedicationRequest | NutritionOrder | Task | ServiceRequest | VisionPrescription",
-				"definition": "A description of the kind of resource the in-line definition of a care plan activity is representing.  The CarePlan.activity.detail is an in-line definition when a resource is not referenced using CarePlan.activity.reference.  For example, a MedicationRequest, a ServiceRequest, or a CommunicationRequest.",
-				"requirements": "May determine what types of extensions are permitted.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.activity.detail.kind",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "CarePlanActivityKind"
-						}
-					],
-					"strength": "required",
-					"description": "Resource types defined as part of FHIR that can be represented as in-line definitions of a care plan activity.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/care-plan-activity-kind|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[classCode=LIST].code"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.instantiatesCanonical",
-				"path": "CarePlan.activity.detail.instantiatesCanonical",
-				"short": "Instantiates FHIR protocol or definition",
-				"definition": "The URL pointing to a FHIR-defined protocol, guideline, questionnaire or other definition that is adhered to in whole or in part by this CarePlan activity.",
-				"requirements": "Allows Questionnaires that the patient (or practitioner) should fill in to fulfill the care plan activity.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.activity.detail.instantiatesCanonical",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "canonical",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/PlanDefinition",
-							"http://hl7.org/fhir/StructureDefinition/ActivityDefinition",
-							"http://hl7.org/fhir/StructureDefinition/Questionnaire",
-							"http://hl7.org/fhir/StructureDefinition/Measure",
-							"http://hl7.org/fhir/StructureDefinition/OperationDefinition"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.instantiatesCanonical"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=DEFN].target"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.instantiatesUri",
-				"path": "CarePlan.activity.detail.instantiatesUri",
-				"short": "Instantiates external protocol or definition",
-				"definition": "The URL pointing to an externally maintained protocol, guideline, questionnaire or other definition that is adhered to in whole or in part by this CarePlan activity.",
-				"comment": "This might be an HTML page, PDF, etc. or could just be a non-resolvable URI identifier.",
-				"requirements": "Allows Questionnaires that the patient (or practitioner) should fill in to fulfill the care plan activity.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.activity.detail.instantiatesUri",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.instantiatesUri"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=DEFN].target"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.code",
-				"path": "CarePlan.activity.detail.code",
-				"short": "Detail type of activity",
-				"definition": "Detailed description of the type of planned activity; e.g. what lab test, what procedure, what kind of encounter.",
-				"comment": "Tends to be less relevant for activities involving particular products.  Codes should not convey negation - use \"prohibited\" instead.",
-				"requirements": "Allows matching performed to planned as well as validation against protocols.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.activity.detail.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "CarePlanActivityType"
-						}
-					],
-					"strength": "example",
-					"description": "Detailed description of the type of activity; e.g. What lab test, what procedure, what kind of encounter.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/procedure-code"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.code"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-4 / RXE-2 / RXO-1 / RXD-2"
-					},
-					{
-						"identity": "rim",
-						"map": ".code"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.reasonCode",
-				"path": "CarePlan.activity.detail.reasonCode",
-				"short": "Why activity should be done or why activity was prohibited",
-				"definition": "Provides the rationale that drove the inclusion of this particular activity as part of the plan or the reason why the activity was prohibited.",
-				"comment": "This could be a diagnosis code.  If a full condition record exists or additional detail is needed, use reasonCondition instead.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.activity.detail.reasonCode",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "CarePlanActivityReason"
-						}
-					],
-					"strength": "example",
-					"description": "Identifies why a care plan activity is needed.  Can include any health condition codes as well as such concepts as \"general wellness\", prophylaxis, surgical preparation, etc.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.reasonCode"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.reasonReference",
-				"path": "CarePlan.activity.detail.reasonReference",
-				"short": "Why activity is needed",
-				"definition": "Indicates another resource, such as the health condition(s), whose existence justifies this request and drove the inclusion of this particular activity as part of the plan.",
-				"comment": "Conditions can be identified at the activity level that are not identified as reasons for the overall plan.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.activity.detail.reasonReference",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Condition",
-							"http://hl7.org/fhir/StructureDefinition/Observation",
-							"http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
-							"http://hl7.org/fhir/StructureDefinition/DocumentReference"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.reasonReference"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.goal",
-				"path": "CarePlan.activity.detail.goal",
-				"short": "Goals this activity relates to",
-				"definition": "Internal reference that identifies the goals that this activity is intended to contribute towards meeting.",
-				"requirements": "So that participants know the link explicitly.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.activity.detail.goal",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Goal"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode<=OBJ]."
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.status",
-				"path": "CarePlan.activity.detail.status",
-				"short": "not-started | scheduled | in-progress | on-hold | completed | cancelled | stopped | unknown | entered-in-error",
-				"definition": "Identifies what progress is being made for the specific activity.",
-				"comment": "Some aspects of status can be inferred based on the resources linked in actionTaken.  Note that \"status\" is only as current as the plan was most recently updated.  \nThe unknown code is not to be used to convey other statuses.  The unknown code should be used when one of the statuses applies, but the authoring system doesn't know the current state of the activity.",
-				"requirements": "Indicates progress against the plan, whether the activity is still relevant for the plan.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.activity.detail.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labelled as a modifier because it is a status element that contains status entered-in-error which means that the activity should not be treated as valid",
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "CarePlanActivityStatus"
-						}
-					],
-					"strength": "required",
-					"description": "Codes that reflect the current state of a care plan activity within its overall life cycle.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/care-plan-activity-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.status"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC-5?"
-					},
-					{
-						"identity": "rim",
-						"map": ".statusCode not-started = new scheduled = not-started (and fulfillment relationship to appointent) in-progress = active on-hold = suspended completed = completed cancelled = aborted"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.statusReason",
-				"path": "CarePlan.activity.detail.statusReason",
-				"short": "Reason for current status",
-				"definition": "Provides reason why the activity isn't yet started, is on hold, was cancelled, etc.",
-				"comment": "Will generally not be present if status is \"complete\".  Be sure to prompt to update this (or at least remove the existing value) if the status is changed.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.activity.detail.statusReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.statusReason"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.doNotPerform",
-				"path": "CarePlan.activity.detail.doNotPerform",
-				"short": "If true, activity is prohibiting action",
-				"definition": "If true, indicates that the described activity is one that must NOT be engaged in when following the plan.  If false, or missing, indicates that the described activity is one that should be engaged in when following the plan.",
-				"comment": "This element is labeled as a modifier because it marks an activity as an activity that is not to be performed.",
-				"requirements": "Captures intention to not do something that may have been previously typical.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.activity.detail.doNotPerform",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"meaningWhenMissing": "If missing indicates that the described activity is one that should be engaged in when following the plan.",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "If true this element negates the specified action. For example, instead of a request for a procedure, it is a request for the procedure to not occur.",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.doNotPerform"
-					},
-					{
-						"identity": "rim",
-						"map": "actionNegationInd"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.scheduled[x]",
-				"path": "CarePlan.activity.detail.scheduled[x]",
-				"short": "When activity is to occur",
-				"definition": "The period, timing or frequency upon which the described activity is to occur.",
-				"requirements": "Allows prompting for activities and detection of missed planned activities.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.activity.detail.scheduled[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Timing"
-					},
-					{
-						"code": "Period"
-					},
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.occurrence[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "TQ1"
-					},
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.location",
-				"path": "CarePlan.activity.detail.location",
-				"short": "Where it should happen",
-				"definition": "Identifies the facility where the activity will occur; e.g. home, hospital, specific clinic, etc.",
-				"comment": "May reference a specific clinical location or may identify a type of location.",
-				"requirements": "Helps in planning of activity.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.activity.detail.location",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Location"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBR-24(???!!)"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=LOC].role"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.performer",
-				"path": "CarePlan.activity.detail.performer",
-				"short": "Who will be responsible?",
-				"definition": "Identifies who's expected to be involved in the activity.",
-				"comment": "A performer MAY also be a participant in the care plan.",
-				"requirements": "Helps in planning of activity.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.activity.detail.performer",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam",
-							"http://hl7.org/fhir/StructureDefinition/HealthcareService",
-							"http://hl7.org/fhir/StructureDefinition/Device"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.performer"
-					},
-					{
-						"identity": "v2",
-						"map": "PRT-5 : ( PRV-4 = (provider participations)); PRT-5 : ( PRV-4 = (non-provider person participations )) ; PRT-5 : ( PRV-4 = (patient non-subject of care) ) ; PRT-8"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=PFM]"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.product[x]",
-				"path": "CarePlan.activity.detail.product[x]",
-				"short": "What is to be administered/supplied",
-				"definition": "Identifies the food, drug or other product to be consumed or supplied in the activity.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.activity.detail.product[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Medication",
-							"http://hl7.org/fhir/StructureDefinition/Substance"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "CarePlanProduct"
-						}
-					],
-					"strength": "example",
-					"description": "A product supplied or administered as part of a care plan activity.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/medication-codes"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXE-2 / RXO-1 / RXD-2"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=PRD].role"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.dailyAmount",
-				"path": "CarePlan.activity.detail.dailyAmount",
-				"short": "How to consume/day?",
-				"definition": "Identifies the quantity expected to be consumed in a given day.",
-				"requirements": "Allows rough dose checking.",
-				"alias": [
-					"daily dose"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.activity.detail.dailyAmount",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXO-23 / RXE-19 / RXD-12"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=COMP][classCode=SBADM].doseQuantity"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.quantity",
-				"path": "CarePlan.activity.detail.quantity",
-				"short": "How much to administer/supply/consume",
-				"definition": "Identifies the quantity expected to be supplied, administered or consumed by the subject.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.activity.detail.quantity",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXO-11 / RXE-10 / RXD-4 / RXG-5 / RXA-6 /  TQ1-2.1  *and*  RXO-12 /  RXE-11 / RXD-5 / RXG-7 / RXA-7 / TQ1-2.2"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=COMP][classCode=SPLY].quantity"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.activity.detail.description",
-				"path": "CarePlan.activity.detail.description",
-				"short": "Extra info describing activity to perform",
-				"definition": "This provides a textual description of constraints on the intended activity occurrence, including relation to other activities.  It may also include objectives, pre-conditions and end-conditions.  Finally, it may convey specifics about the activity such as body site, method, route, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CarePlan.activity.detail.description",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NTE?"
-					},
-					{
-						"identity": "rim",
-						"map": ".text"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.note",
-				"path": "CarePlan.note",
-				"short": "Comments about the plan",
-				"definition": "General notes about the care plan not covered elsewhere.",
-				"requirements": "Used to capture information that applies to the plan as a whole that doesn't fit into discrete elements.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CarePlan.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.note"
-					},
-					{
-						"identity": "v2",
-						"map": "NTE?"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"annotation\"].value"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "CarePlan",
-				"path": "CarePlan",
-				"definition": "The US Core CarePlan Profile is based upon the core FHIR CarePlan Resource and created to meet the 2015 Edition Common Clinical Data Set 'Assessment and Plan of Treatment requirements.",
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.text",
-				"path": "CarePlan.text",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.text"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.text.status",
-				"path": "CarePlan.text.status",
-				"mustSupport": true
-			},
-			{
-				"id": "CarePlan.text.div",
-				"path": "CarePlan.text.div",
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"description": "Constrained value set of narrative statuses.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-narrative-status"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.text.status"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.status",
-				"path": "CarePlan.status",
-				"requirements": "Indicates whether the plan is currently being acted upon, represents future intentions or is now a historical record.",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"description": "Indicates whether the plan is currently being acted upon, represents future intentions or is now a historical record.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/request-status"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.status"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.intent",
-				"path": "CarePlan.intent",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"description": "Codes indicating the degree of authority/intentionality associated with a care plan",
-					"valueSet": "http://hl7.org/fhir/ValueSet/care-plan-intent"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA (new element in STU3)"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.category",
-				"path": "CarePlan.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "$this"
-						}
-					],
-					"rules": "open"
-				},
-				"definition": "Type of plan.",
-				"requirements": "Identifies what \"kind\" of plan this is to support differentiation between multiple co-existing plans; e.g. \"Home health\", \"psychiatric\", \"asthma\", \"disease management\", \"wellness plan\", etc.",
-				"min": 1,
-				"max": "*",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.category"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.category:AssessPlan",
-				"path": "CarePlan.category",
-				"sliceName": "AssessPlan",
-				"definition": "Type of plan.",
-				"requirements": "Identifies what \"kind\" of plan this is to support differentiation between multiple co-existing plans; e.g. \"Home health\", \"psychiatric\", \"asthma\", \"disease management\", \"wellness plan\", etc.",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://hl7.org/fhir/us/core/CodeSystem/careplan-category",
-							"code": "assess-plan"
-						}
-					]
-				},
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.category"
-					}
-				]
-			},
-			{
-				"id": "CarePlan.subject",
-				"path": "CarePlan.subject",
-				"definition": "Who care plan is for.",
-				"requirements": "Identifies the patient or group whose intended care is described by the plan.",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.subject"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-careplan",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan",
+    "version": "4.0.0",
+    "name": "USCoreCarePlanProfile",
+    "title": "US Core CarePlan Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2019-08-29",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the CarePlan resource for the minimal set of data to query and retrieve a patient's Care Plan.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "CarePlan",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/CarePlan",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "CarePlan",
+                "path": "CarePlan",
+                "short": "Healthcare plan for patient or group",
+                "definition": "The US Core CarePlan Profile is based upon the core FHIR CarePlan Resource and created to meet the 2015 Edition Common Clinical Data Set 'Assessment and Plan of Treatment requirements.",
+                "alias": [
+                    "Care Team"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Request"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Act[classCode=PCPR, moodCode=INT]"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.id",
+                "path": "CarePlan.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "CarePlan.meta",
+                "path": "CarePlan.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "CarePlan.implicitRules",
+                "path": "CarePlan.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "CarePlan.language",
+                "path": "CarePlan.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "CarePlan.text",
+                "path": "CarePlan.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.text"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.text.id",
+                "path": "CarePlan.text.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.text.extension",
+                "path": "CarePlan.text.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.text.status",
+                "path": "CarePlan.text.status",
+                "short": "generated | extensions | additional | empty",
+                "definition": "The status of the narrative - whether it's entirely generated (from just the defined data or the extensions too), or whether a human authored it and it may contain additional data.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Narrative.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "NarrativeStatus"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The status of a resource narrative.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/narrative-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.text.div",
+                "path": "CarePlan.text.div",
+                "short": "Limited xhtml content",
+                "definition": "The actual narrative content, a stripped down version of XHTML.",
+                "comment": "The contents of the html element are an XHTML fragment containing only the basic html formatting elements described in chapters 7-11 and 15 of the HTML 4.0 standard, <a> elements (either name or href), images and internally contained stylesheets. The XHTML content SHALL NOT contain a head, a body, external stylesheet references, scripts, forms, base/link/xlink, frames, iframes and objects.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Narrative.div",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "xhtml"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "txt-1",
+                        "severity": "error",
+                        "human": "The narrative SHALL contain only the basic html formatting elements and attributes described in chapters 7-11 (except section 4 of chapter 9) and 15 of the HTML 4.0 standard, <a> elements (either name or href), images and internally contained style attributes",
+                        "expression": "htmlChecks()",
+                        "xpath": "not(descendant-or-self::*[not(local-name(.)=('a', 'abbr', 'acronym', 'b', 'big', 'blockquote', 'br', 'caption', 'cite', 'code', 'col', 'colgroup', 'dd', 'dfn', 'div', 'dl', 'dt', 'em', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'i', 'img', 'li', 'ol', 'p', 'pre', 'q', 'samp', 'small', 'span', 'strong', 'sub', 'sup', 'table', 'tbody', 'td', 'tfoot', 'th', 'thead', 'tr', 'tt', 'ul', 'var'))]) and not(descendant-or-self::*/@*[not(name(.)=('abbr', 'accesskey', 'align', 'alt', 'axis', 'bgcolor', 'border', 'cellhalign', 'cellpadding', 'cellspacing', 'cellvalign', 'char', 'charoff', 'charset', 'cite', 'class', 'colspan', 'compact', 'coords', 'dir', 'frame', 'headers', 'height', 'href', 'hreflang', 'hspace', 'id', 'lang', 'longdesc', 'name', 'nowrap', 'rel', 'rev', 'rowspan', 'rules', 'scope', 'shape', 'span', 'src', 'start', 'style', 'summary', 'tabindex', 'title', 'type', 'valign', 'value', 'vspace', 'width'))])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/CarePlan"
+                    },
+                    {
+                        "key": "txt-2",
+                        "severity": "error",
+                        "human": "The narrative SHALL have some non-whitespace content",
+                        "expression": "htmlChecks()",
+                        "xpath": "descendant::text()[normalize-space(.)!=''] or descendant::h:img[@src]",
+                        "source": "http://hl7.org/fhir/StructureDefinition/CarePlan"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.text.status"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.contained",
+                "path": "CarePlan.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.extension",
+                "path": "CarePlan.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.modifierExtension",
+                "path": "CarePlan.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.identifier",
+                "path": "CarePlan.identifier",
+                "short": "External Ids for this plan",
+                "definition": "Business identifiers assigned to this care plan by the performer or other systems which remain constant as the resource is updated and propagates from server to server.",
+                "comment": "This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.",
+                "requirements": "Allows identification of the care plan as it is known by various participating systems and in a way that remains consistent across servers.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PTH-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.instantiatesCanonical",
+                "path": "CarePlan.instantiatesCanonical",
+                "short": "Instantiates FHIR protocol or definition",
+                "definition": "The URL pointing to a FHIR-defined protocol, guideline, questionnaire or other definition that is adhered to in whole or in part by this CarePlan.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.instantiatesCanonical",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "canonical",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/PlanDefinition",
+                            "http://hl7.org/fhir/StructureDefinition/Questionnaire",
+                            "http://hl7.org/fhir/StructureDefinition/Measure",
+                            "http://hl7.org/fhir/StructureDefinition/ActivityDefinition",
+                            "http://hl7.org/fhir/StructureDefinition/OperationDefinition"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.instantiatesCanonical"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=DEFN].target"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.instantiatesUri",
+                "path": "CarePlan.instantiatesUri",
+                "short": "Instantiates external protocol or definition",
+                "definition": "The URL pointing to an externally maintained protocol, guideline, questionnaire or other definition that is adhered to in whole or in part by this CarePlan.",
+                "comment": "This might be an HTML page, PDF, etc. or could just be a non-resolvable URI identifier.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.instantiatesUri",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.instantiatesUri"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=DEFN].target"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.basedOn",
+                "path": "CarePlan.basedOn",
+                "short": "Fulfills CarePlan",
+                "definition": "A care plan that is fulfilled in whole or in part by this care plan.",
+                "requirements": "Allows tracing of the care plan and tracking whether proposals/recommendations were acted upon.",
+                "alias": [
+                    "fulfills"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-hierarchy",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.basedOn"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.replaces",
+                "path": "CarePlan.replaces",
+                "short": "CarePlan replaced by this CarePlan",
+                "definition": "Completed or terminated care plan whose function is taken by this new care plan.",
+                "comment": "The replacement could be because the initial care plan was immediately rejected (due to an issue) or because the previous care plan was completed, but the need for the action described by the care plan remains ongoing.",
+                "requirements": "Allows tracing the continuation of a therapy or administrative process instantiated through multiple care plans.",
+                "alias": [
+                    "supersedes"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.replaces",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-hierarchy",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.replaces"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.partOf",
+                "path": "CarePlan.partOf",
+                "short": "Part of referenced CarePlan",
+                "definition": "A larger care plan of which this particular care plan is a component or step.",
+                "comment": "Each care plan is an independent request, such that having a care plan be part of another care plan can cause issues with cascading statuses.  As such, this element is still being discussed.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.partOf",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-hierarchy",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "CarePlan.status",
+                "path": "CarePlan.status",
+                "short": "draft | active | on-hold | revoked | completed | entered-in-error | unknown",
+                "definition": "Indicates whether the plan is currently being acted upon, represents future intentions or is now a historical record.",
+                "comment": "The unknown code is not to be used to convey other statuses.  The unknown code should be used when one of the statuses applies, but the authoring system doesn't know the current state of the care plan.\n\nThis element is labeled as a modifier because the status contains the code entered-in-error that marks the plan as not currently valid.",
+                "requirements": "Indicates whether the plan is currently being acted upon, represents future intentions or is now a historical record.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "description": "Indicates whether the plan is currently being acted upon, represents future intentions or is now a historical record.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/request-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.status {uses different ValueSet}"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PTH-5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".statusCode planned = new active = active completed = completed"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.status"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.intent",
+                "path": "CarePlan.intent",
+                "short": "proposal | plan | order | option",
+                "definition": "Indicates the level of authority/intentionality associated with the care plan and where the care plan fits into the workflow chain.",
+                "comment": "This element is labeled as a modifier because the intent alters when and how the resource is actually applicable.",
+                "requirements": "Proposals/recommendations, plans and orders all use the same structure and can exist in the same fulfillment chain.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.intent",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element changes the interpretation of all descriptive attributes. For example \"the time the request is recommended to occur\" vs. \"the time the request is authorized to occur\" or \"who is recommended to perform the request\" vs. \"who is authorized to perform the request\"",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "description": "Codes indicating the degree of authority/intentionality associated with a care plan",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/care-plan-intent"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.intent"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA (new element in STU3)"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.category",
+                "path": "CarePlan.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "$this"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "short": "Type of plan",
+                "definition": "Type of plan.",
+                "comment": "There may be multiple axes of categorization and one plan may serve multiple purposes.  In some cases, this may be redundant with references to CarePlan.concern.",
+                "requirements": "Identifies what \"kind\" of plan this is to support differentiation between multiple co-existing plans; e.g. \"Home health\", \"psychiatric\", \"asthma\", \"disease management\", \"wellness plan\", etc.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "CarePlanCategory"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Identifies what \"kind\" of plan this is to support differentiation between multiple co-existing plans; e.g. \"Home health\", \"psychiatric\", \"asthma\", \"disease management\", etc.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/care-plan-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.category"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.category:AssessPlan",
+                "path": "CarePlan.category",
+                "sliceName": "AssessPlan",
+                "short": "Type of plan",
+                "definition": "Type of plan.",
+                "comment": "There may be multiple axes of categorization and one plan may serve multiple purposes.  In some cases, this may be redundant with references to CarePlan.concern.",
+                "requirements": "Identifies what \"kind\" of plan this is to support differentiation between multiple co-existing plans; e.g. \"Home health\", \"psychiatric\", \"asthma\", \"disease management\", \"wellness plan\", etc.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/us/core/CodeSystem/careplan-category",
+                            "code": "assess-plan"
+                        }
+                    ]
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "CarePlanCategory"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Identifies what \"kind\" of plan this is to support differentiation between multiple co-existing plans; e.g. \"Home health\", \"psychiatric\", \"asthma\", \"disease management\", etc.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/care-plan-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.category"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.title",
+                "path": "CarePlan.title",
+                "short": "Human-friendly name for the care plan",
+                "definition": "Human-friendly name for the care plan.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.title",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "CarePlan.description",
+                "path": "CarePlan.description",
+                "short": "Summary of nature of plan",
+                "definition": "A description of the scope and nature of the plan.",
+                "requirements": "Provides more detail than conveyed by category.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.description",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.subject",
+                "path": "CarePlan.subject",
+                "short": "Who the care plan is for",
+                "definition": "Who care plan is for.",
+                "requirements": "Identifies the patient or group whose intended care is described by the plan.",
+                "alias": [
+                    "patient"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.subject",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=PAT].role[classCode=PAT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.subject"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.encounter",
+                "path": "CarePlan.encounter",
+                "short": "Encounter created as part of",
+                "definition": "The Encounter during which this CarePlan was created or to which the creation of this record is tightly associated.",
+                "comment": "This will typically be the encounter the event occurred within, but some activities may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter. CarePlan activities conducted as a result of the care plan may well occur as part of other encounters.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "Associated PV1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "."
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.period",
+                "path": "CarePlan.period",
+                "short": "Time period plan covers",
+                "definition": "Indicates when the plan did (or is intended to) come into effect and end.",
+                "comment": "Any activities scheduled as part of the plan should be constrained to the specified period regardless of whether the activities are planned within a single encounter/episode or across multiple encounters/episodes (e.g. the longitudinal management of a chronic condition).",
+                "requirements": "Allows tracking what plan(s) are in effect at a particular time.",
+                "alias": [
+                    "timing"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.planned"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "GOL-7 / GOL-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.created",
+                "path": "CarePlan.created",
+                "short": "Date record was first recorded",
+                "definition": "Represents when this particular CarePlan record was created in the system, which is often a system-generated date.",
+                "alias": [
+                    "authoredOn"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.created",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.authoredOn"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.author",
+                "path": "CarePlan.author",
+                "short": "Who is the designated responsible party",
+                "definition": "When populated, the author is responsible for the care plan.  The care plan is attributed to the author.",
+                "comment": "The author may also be a contributor.  For example, an organization can be an author, but not listed as a contributor.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.author",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.requester"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.author"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.contributor",
+                "path": "CarePlan.contributor",
+                "short": "Who provided the content of the care plan",
+                "definition": "Identifies the individual(s) or organization who provided the contents of the care plan.",
+                "comment": "Collaborative care plans may have multiple contributors.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.contributor",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "CarePlan.careTeam",
+                "path": "CarePlan.careTeam",
+                "short": "Who's involved in plan?",
+                "definition": "Identifies all people and organizations who are expected to be involved in the care envisioned by this plan.",
+                "requirements": "Allows representation of care teams, helps scope care plan.  In some cases may be a determiner of access permissions.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.careTeam",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.performer {similar but does not entail CareTeam}"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.addresses",
+                "path": "CarePlan.addresses",
+                "short": "Health issues this plan addresses",
+                "definition": "Identifies the conditions/problems/concerns/diagnoses/etc. whose management and/or mitigation are handled by this plan.",
+                "comment": "When the diagnosis is related to an allergy or intolerance, the Condition and AllergyIntolerance resources can both be used. However, to be actionable for decision support, using Condition alone is not sufficient as the allergy or intolerance condition needs to be represented as an AllergyIntolerance.",
+                "requirements": "Links plan to the conditions it manages.  The element can identify risks addressed by the plan as well as active conditions.  (The Condition resource can include things like \"at risk for hypertension\" or \"fall risk\".)  Also scopes plans - multiple plans may exist addressing different concerns.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.addresses",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Condition"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.reasonReference"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.why[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRB-4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".actRelationship[typeCode=SUBJ].target[classCode=CONC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.supportingInfo",
+                "path": "CarePlan.supportingInfo",
+                "short": "Information considered as part of plan",
+                "definition": "Identifies portions of the patient's record that specifically influenced the formation of the plan.  These might include comorbidities, recent procedures, limitations, recent assessments, etc.",
+                "comment": "Use \"concern\" to identify specific conditions addressed by the care plan.",
+                "requirements": "Identifies barriers and other considerations associated with the care plan.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.supportingInfo",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.supportingInfo"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.goal",
+                "path": "CarePlan.goal",
+                "short": "Desired outcome of plan",
+                "definition": "Describes the intended objective(s) of carrying out the care plan.",
+                "comment": "Goal can be achieving a particular change or merely maintaining a current state or even slowing a decline.",
+                "requirements": "Provides context for plan.  Allows plan effectiveness to be evaluated by clinicians.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.goal",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Goal"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "GOL.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode<=OBJ]."
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity",
+                "path": "CarePlan.activity",
+                "short": "Action to occur as part of plan",
+                "definition": "Identifies a planned action to occur as part of the plan.  For example, a medication to be used, lab tests to perform, self-monitoring, education, etc.",
+                "requirements": "Allows systems to prompt for performance of planned activities, and validate plans against best practice.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.activity",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "cpl-3",
+                        "severity": "error",
+                        "human": "Provide a reference or detail, not both",
+                        "expression": "detail.empty() or reference.empty()",
+                        "xpath": "not(exists(f:detail)) or not(exists(f:reference))"
+                    },
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "{no mapping\nNOTE: This is a list of contained Request-Event tuples!}"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=COMP].target"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.id",
+                "path": "CarePlan.activity.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.extension",
+                "path": "CarePlan.activity.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.modifierExtension",
+                "path": "CarePlan.activity.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.outcomeCodeableConcept",
+                "path": "CarePlan.activity.outcomeCodeableConcept",
+                "short": "Results of the activity",
+                "definition": "Identifies the outcome at the point when the status of the activity is assessed.  For example, the outcome of an education activity could be patient understands (or not).",
+                "comment": "Note that this should not duplicate the activity status (e.g. completed or in progress).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.activity.outcomeCodeableConcept",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "CarePlanActivityOutcome"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Identifies the results of the activity.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/care-plan-activity-outcome"
+                }
+            },
+            {
+                "id": "CarePlan.activity.outcomeReference",
+                "path": "CarePlan.activity.outcomeReference",
+                "short": "Appointment, Encounter, Procedure, etc.",
+                "definition": "Details of the outcome or action resulting from the activity.  The reference to an \"event\" resource, such as Procedure or Encounter or Observation, is the result/outcome of the activity itself.  The activity can be conveyed using CarePlan.activity.detail OR using the CarePlan.activity.reference (a reference to a “request” resource).",
+                "comment": "The activity outcome is independent of the outcome of the related goal(s).  For example, if the goal is to achieve a target body weight of 150 lbs and an activity is defined to diet, then the activity outcome could be calories consumed whereas the goal outcome is an observation for the actual body weight measured.",
+                "requirements": "Links plan to resulting actions.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.activity.outcomeReference",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "{Event that is outcome of Request in activity.reference}"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=FLFS].source"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.progress",
+                "path": "CarePlan.activity.progress",
+                "short": "Comments about the activity status/progress",
+                "definition": "Notes about the adherence/status/progress of the activity.",
+                "comment": "This element should NOT be used to describe the activity to be performed - that occurs either within the resource pointed to by activity.detail.reference or in activity.detail.description.",
+                "requirements": "Can be used to capture information about adherence, progress, concerns, etc.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.activity.progress",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NTE?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.reference",
+                "path": "CarePlan.activity.reference",
+                "short": "Activity details defined in specific resource",
+                "definition": "The details of the proposed activity represented in a specific resource.",
+                "comment": "Standard extension exists ([resource-pertainsToGoal](http://hl7.org/fhir/R4/extension-resource-pertainstogoal.html)) that allows goals to be referenced from any of the referenced resources in CarePlan.activity.reference.  \rThe goal should be visible when the resource referenced by CarePlan.activity.reference is viewed independently from the CarePlan.  Requests that are pointed to by a CarePlan using this element should *not* point to this CarePlan using the \"basedOn\" element.  i.e. Requests that are part of a CarePlan are not \"based on\" the CarePlan.",
+                "requirements": "Details in a form consistent with other applications and contexts of use.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.activity.reference",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Appointment",
+                            "http://hl7.org/fhir/StructureDefinition/CommunicationRequest",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceRequest",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+                            "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+                            "http://hl7.org/fhir/StructureDefinition/Task",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest",
+                            "http://hl7.org/fhir/StructureDefinition/VisionPrescription",
+                            "http://hl7.org/fhir/StructureDefinition/RequestGroup"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "cpl-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "{Request that resulted in Event in activity.actionResulting}"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=COMP].target"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail",
+                "path": "CarePlan.activity.detail",
+                "short": "In-line definition of activity",
+                "definition": "A simple summary of a planned activity suitable for a general care plan system (e.g. form driven) that doesn't know about specific resources such as procedure etc.",
+                "requirements": "Details in a simple form for generic care plan systems.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.activity.detail",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "condition": [
+                    "cpl-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=COMP, subsetCode=SUMM].target"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.id",
+                "path": "CarePlan.activity.detail.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.extension",
+                "path": "CarePlan.activity.detail.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.modifierExtension",
+                "path": "CarePlan.activity.detail.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.kind",
+                "path": "CarePlan.activity.detail.kind",
+                "short": "Appointment | CommunicationRequest | DeviceRequest | MedicationRequest | NutritionOrder | Task | ServiceRequest | VisionPrescription",
+                "definition": "A description of the kind of resource the in-line definition of a care plan activity is representing.  The CarePlan.activity.detail is an in-line definition when a resource is not referenced using CarePlan.activity.reference.  For example, a MedicationRequest, a ServiceRequest, or a CommunicationRequest.",
+                "requirements": "May determine what types of extensions are permitted.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.activity.detail.kind",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "CarePlanActivityKind"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Resource types defined as part of FHIR that can be represented as in-line definitions of a care plan activity.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/care-plan-activity-kind|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[classCode=LIST].code"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.instantiatesCanonical",
+                "path": "CarePlan.activity.detail.instantiatesCanonical",
+                "short": "Instantiates FHIR protocol or definition",
+                "definition": "The URL pointing to a FHIR-defined protocol, guideline, questionnaire or other definition that is adhered to in whole or in part by this CarePlan activity.",
+                "requirements": "Allows Questionnaires that the patient (or practitioner) should fill in to fulfill the care plan activity.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.activity.detail.instantiatesCanonical",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "canonical",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/PlanDefinition",
+                            "http://hl7.org/fhir/StructureDefinition/ActivityDefinition",
+                            "http://hl7.org/fhir/StructureDefinition/Questionnaire",
+                            "http://hl7.org/fhir/StructureDefinition/Measure",
+                            "http://hl7.org/fhir/StructureDefinition/OperationDefinition"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.instantiatesCanonical"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=DEFN].target"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.instantiatesUri",
+                "path": "CarePlan.activity.detail.instantiatesUri",
+                "short": "Instantiates external protocol or definition",
+                "definition": "The URL pointing to an externally maintained protocol, guideline, questionnaire or other definition that is adhered to in whole or in part by this CarePlan activity.",
+                "comment": "This might be an HTML page, PDF, etc. or could just be a non-resolvable URI identifier.",
+                "requirements": "Allows Questionnaires that the patient (or practitioner) should fill in to fulfill the care plan activity.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.activity.detail.instantiatesUri",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.instantiatesUri"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=DEFN].target"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.code",
+                "path": "CarePlan.activity.detail.code",
+                "short": "Detail type of activity",
+                "definition": "Detailed description of the type of planned activity; e.g. what lab test, what procedure, what kind of encounter.",
+                "comment": "Tends to be less relevant for activities involving particular products.  Codes should not convey negation - use \"prohibited\" instead.",
+                "requirements": "Allows matching performed to planned as well as validation against protocols.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.activity.detail.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "CarePlanActivityType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Detailed description of the type of activity; e.g. What lab test, what procedure, what kind of encounter.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/procedure-code"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.code"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-4 / RXE-2 / RXO-1 / RXD-2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".code"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.reasonCode",
+                "path": "CarePlan.activity.detail.reasonCode",
+                "short": "Why activity should be done or why activity was prohibited",
+                "definition": "Provides the rationale that drove the inclusion of this particular activity as part of the plan or the reason why the activity was prohibited.",
+                "comment": "This could be a diagnosis code.  If a full condition record exists or additional detail is needed, use reasonCondition instead.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.activity.detail.reasonCode",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "CarePlanActivityReason"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Identifies why a care plan activity is needed.  Can include any health condition codes as well as such concepts as \"general wellness\", prophylaxis, surgical preparation, etc.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.reasonCode"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.reasonReference",
+                "path": "CarePlan.activity.detail.reasonReference",
+                "short": "Why activity is needed",
+                "definition": "Indicates another resource, such as the health condition(s), whose existence justifies this request and drove the inclusion of this particular activity as part of the plan.",
+                "comment": "Conditions can be identified at the activity level that are not identified as reasons for the overall plan.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.activity.detail.reasonReference",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Condition",
+                            "http://hl7.org/fhir/StructureDefinition/Observation",
+                            "http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
+                            "http://hl7.org/fhir/StructureDefinition/DocumentReference"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.reasonReference"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.goal",
+                "path": "CarePlan.activity.detail.goal",
+                "short": "Goals this activity relates to",
+                "definition": "Internal reference that identifies the goals that this activity is intended to contribute towards meeting.",
+                "requirements": "So that participants know the link explicitly.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.activity.detail.goal",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Goal"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode<=OBJ]."
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.status",
+                "path": "CarePlan.activity.detail.status",
+                "short": "not-started | scheduled | in-progress | on-hold | completed | cancelled | stopped | unknown | entered-in-error",
+                "definition": "Identifies what progress is being made for the specific activity.",
+                "comment": "Some aspects of status can be inferred based on the resources linked in actionTaken.  Note that \"status\" is only as current as the plan was most recently updated.  \nThe unknown code is not to be used to convey other statuses.  The unknown code should be used when one of the statuses applies, but the authoring system doesn't know the current state of the activity.",
+                "requirements": "Indicates progress against the plan, whether the activity is still relevant for the plan.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.activity.detail.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labelled as a modifier because it is a status element that contains status entered-in-error which means that the activity should not be treated as valid",
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "CarePlanActivityStatus"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Codes that reflect the current state of a care plan activity within its overall life cycle.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/care-plan-activity-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.status"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC-5?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".statusCode not-started = new scheduled = not-started (and fulfillment relationship to appointent) in-progress = active on-hold = suspended completed = completed cancelled = aborted"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.statusReason",
+                "path": "CarePlan.activity.detail.statusReason",
+                "short": "Reason for current status",
+                "definition": "Provides reason why the activity isn't yet started, is on hold, was cancelled, etc.",
+                "comment": "Will generally not be present if status is \"complete\".  Be sure to prompt to update this (or at least remove the existing value) if the status is changed.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.activity.detail.statusReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.statusReason"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.doNotPerform",
+                "path": "CarePlan.activity.detail.doNotPerform",
+                "short": "If true, activity is prohibiting action",
+                "definition": "If true, indicates that the described activity is one that must NOT be engaged in when following the plan.  If false, or missing, indicates that the described activity is one that should be engaged in when following the plan.",
+                "comment": "This element is labeled as a modifier because it marks an activity as an activity that is not to be performed.",
+                "requirements": "Captures intention to not do something that may have been previously typical.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.activity.detail.doNotPerform",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "meaningWhenMissing": "If missing indicates that the described activity is one that should be engaged in when following the plan.",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "If true this element negates the specified action. For example, instead of a request for a procedure, it is a request for the procedure to not occur.",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.doNotPerform"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "actionNegationInd"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.scheduled[x]",
+                "path": "CarePlan.activity.detail.scheduled[x]",
+                "short": "When activity is to occur",
+                "definition": "The period, timing or frequency upon which the described activity is to occur.",
+                "requirements": "Allows prompting for activities and detection of missed planned activities.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.activity.detail.scheduled[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Timing"
+                    },
+                    {
+                        "code": "Period"
+                    },
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.occurrence[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "TQ1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.location",
+                "path": "CarePlan.activity.detail.location",
+                "short": "Where it should happen",
+                "definition": "Identifies the facility where the activity will occur; e.g. home, hospital, specific clinic, etc.",
+                "comment": "May reference a specific clinical location or may identify a type of location.",
+                "requirements": "Helps in planning of activity.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.activity.detail.location",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Location"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBR-24(???!!)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=LOC].role"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.performer",
+                "path": "CarePlan.activity.detail.performer",
+                "short": "Who will be responsible?",
+                "definition": "Identifies who's expected to be involved in the activity.",
+                "comment": "A performer MAY also be a participant in the care plan.",
+                "requirements": "Helps in planning of activity.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.activity.detail.performer",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam",
+                            "http://hl7.org/fhir/StructureDefinition/HealthcareService",
+                            "http://hl7.org/fhir/StructureDefinition/Device"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.performer"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRT-5 : ( PRV-4 = (provider participations)); PRT-5 : ( PRV-4 = (non-provider person participations )) ; PRT-5 : ( PRV-4 = (patient non-subject of care) ) ; PRT-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=PFM]"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.product[x]",
+                "path": "CarePlan.activity.detail.product[x]",
+                "short": "What is to be administered/supplied",
+                "definition": "Identifies the food, drug or other product to be consumed or supplied in the activity.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.activity.detail.product[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Medication",
+                            "http://hl7.org/fhir/StructureDefinition/Substance"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "CarePlanProduct"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "A product supplied or administered as part of a care plan activity.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/medication-codes"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXE-2 / RXO-1 / RXD-2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=PRD].role"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.dailyAmount",
+                "path": "CarePlan.activity.detail.dailyAmount",
+                "short": "How to consume/day?",
+                "definition": "Identifies the quantity expected to be consumed in a given day.",
+                "requirements": "Allows rough dose checking.",
+                "alias": [
+                    "daily dose"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.activity.detail.dailyAmount",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXO-23 / RXE-19 / RXD-12"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=COMP][classCode=SBADM].doseQuantity"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.quantity",
+                "path": "CarePlan.activity.detail.quantity",
+                "short": "How much to administer/supply/consume",
+                "definition": "Identifies the quantity expected to be supplied, administered or consumed by the subject.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.activity.detail.quantity",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXO-11 / RXE-10 / RXD-4 / RXG-5 / RXA-6 /  TQ1-2.1  *and*  RXO-12 /  RXE-11 / RXD-5 / RXG-7 / RXA-7 / TQ1-2.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=COMP][classCode=SPLY].quantity"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.activity.detail.description",
+                "path": "CarePlan.activity.detail.description",
+                "short": "Extra info describing activity to perform",
+                "definition": "This provides a textual description of constraints on the intended activity occurrence, including relation to other activities.  It may also include objectives, pre-conditions and end-conditions.  Finally, it may convey specifics about the activity such as body site, method, route, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CarePlan.activity.detail.description",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NTE?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".text"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.note",
+                "path": "CarePlan.note",
+                "short": "Comments about the plan",
+                "definition": "General notes about the care plan not covered elsewhere.",
+                "requirements": "Used to capture information that applies to the plan as a whole that doesn't fit into discrete elements.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CarePlan.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.note"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "NTE?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"annotation\"].value"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "CarePlan",
+                "path": "CarePlan",
+                "definition": "The US Core CarePlan Profile is based upon the core FHIR CarePlan Resource and created to meet the 2015 Edition Common Clinical Data Set 'Assessment and Plan of Treatment requirements.",
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.text",
+                "path": "CarePlan.text",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.text"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.text.status",
+                "path": "CarePlan.text.status",
+                "mustSupport": true
+            },
+            {
+                "id": "CarePlan.text.div",
+                "path": "CarePlan.text.div",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "description": "Constrained value set of narrative statuses.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-narrative-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.text.status"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.status",
+                "path": "CarePlan.status",
+                "requirements": "Indicates whether the plan is currently being acted upon, represents future intentions or is now a historical record.",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "description": "Indicates whether the plan is currently being acted upon, represents future intentions or is now a historical record.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/request-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.status"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.intent",
+                "path": "CarePlan.intent",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "description": "Codes indicating the degree of authority/intentionality associated with a care plan",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/care-plan-intent"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA (new element in STU3)"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.category",
+                "path": "CarePlan.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "$this"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "definition": "Type of plan.",
+                "requirements": "Identifies what \"kind\" of plan this is to support differentiation between multiple co-existing plans; e.g. \"Home health\", \"psychiatric\", \"asthma\", \"disease management\", \"wellness plan\", etc.",
+                "min": 1,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.category"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.category:AssessPlan",
+                "path": "CarePlan.category",
+                "sliceName": "AssessPlan",
+                "definition": "Type of plan.",
+                "requirements": "Identifies what \"kind\" of plan this is to support differentiation between multiple co-existing plans; e.g. \"Home health\", \"psychiatric\", \"asthma\", \"disease management\", \"wellness plan\", etc.",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/us/core/CodeSystem/careplan-category",
+                            "code": "assess-plan"
+                        }
+                    ]
+                },
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.category"
+                    }
+                ]
+            },
+            {
+                "id": "CarePlan.subject",
+                "path": "CarePlan.subject",
+                "definition": "Who care plan is for.",
+                "requirements": "Identifies the patient or group whose intended care is described by the plan.",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.subject"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-careteam.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-careteam.json
@@ -1,1521 +1,1521 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-careteam",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-careteam-definitions.html#CareTeam\" title=\"The US Core CareTeam Profile is based upon the core FHIR CareTeam Resource and created to meet the 2015 Edition Common Clinical Data Set 'Care team member(s)' requirements.\">CareTeam</a><a name=\"CareTeam\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/careteam.html\">CareTeam</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Planned participants in the coordination and delivery of care for a patient or group</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-careteam-definitions.html#CareTeam.status\">status</a><a name=\"CareTeam.status\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">proposed | active | suspended | inactive | entered-in-error</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-care-team-status.html\">CareTeamStatus</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>): Indicates whether the team is current , represents future intentions or is now a historical record.<br/><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-careteam-definitions.html#CareTeam.subject\">subject</a><a name=\"CareTeam.subject\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who care team is for</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-careteam-definitions.html#CareTeam.participant\">participant</a><a name=\"CareTeam.participant\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Members of the team</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-careteam-definitions.html#CareTeam.participant.role\">role</a><a name=\"CareTeam.participant.role\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Type of involvement</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1099.30/expansion\">Care Team Member Function</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>): Indicates specific responsibility of an individual within the care team, such as Primary physician, Team coordinator, Caregiver, etc.<br/><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-careteam-definitions.html#CareTeam.participant.member\">member</a><a name=\"CareTeam.participant.member\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-practitioner.html\">US Core Practitioner Profile</a> <span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This target must be supported\">S</span> | <a href=\"StructureDefinition-us-core-organization.html\">US Core Organization Profile</a> | <a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a> | <a href=\"StructureDefinition-us-core-practitionerrole.html\">US Core PractitionerRole Profile</a> | <a href=\"StructureDefinition-us-core-careteam.html\">US Core CareTeam Profile</a> | <a href=\"http://hl7.org/fhir/R4/relatedperson.html\">RelatedPerson</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who is involved</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam",
-	"version": "4.0.0",
-	"name": "USCoreCareTeam",
-	"title": "US Core CareTeam Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-06-26",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the CareTeam resource for the minimal set of data to query and retrieve a patient's Care Team.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "CareTeam",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/CareTeam",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "CareTeam",
-				"path": "CareTeam",
-				"short": "Planned participants in the coordination and delivery of care for a patient or group",
-				"definition": "The US Core CareTeam Profile is based upon the core FHIR CareTeam Resource and created to meet the 2015 Edition Common Clinical Data Set 'Care team member(s)' requirements.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CareTeam",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.id",
-				"path": "CareTeam.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "CareTeam.meta",
-				"path": "CareTeam.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "CareTeam.implicitRules",
-				"path": "CareTeam.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "CareTeam.language",
-				"path": "CareTeam.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "CareTeam.text",
-				"path": "CareTeam.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.contained",
-				"path": "CareTeam.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.extension",
-				"path": "CareTeam.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.modifierExtension",
-				"path": "CareTeam.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.identifier",
-				"path": "CareTeam.identifier",
-				"short": "External Ids for this team",
-				"definition": "Business identifiers assigned to this care team by the performer or other systems which remain constant as the resource is updated and propagates from server to server.",
-				"comment": "This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.",
-				"requirements": "Allows identification of the care team as it is known by various participating systems and in a way that remains consistent across servers.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CareTeam.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.status",
-				"path": "CareTeam.status",
-				"short": "proposed | active | suspended | inactive | entered-in-error",
-				"definition": "Indicates the current state of the care team.",
-				"comment": "This element is labeled as a modifier because the status contains the code entered-in-error that marks the care team as not currently valid.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CareTeam.status",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labelled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"description": "Indicates whether the team is current , represents future intentions or is now a historical record.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/care-team-status"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.status"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.category",
-				"path": "CareTeam.category",
-				"short": "Type of team",
-				"definition": "Identifies what kind of team.  This is to support differentiation between multiple co-existing teams, such as care plan team, episode of care team, longitudinal care team.",
-				"comment": "There may be multiple axis of categorization and one team may serve multiple purposes.",
-				"requirements": "Used for filtering what teams(s) are retrieved and displayed to different types of users.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CareTeam.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "CareTeamCategory"
-						}
-					],
-					"strength": "example",
-					"description": "Indicates the type of care team.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/care-team-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.name",
-				"path": "CareTeam.name",
-				"short": "Name of the team, such as crisis assessment team",
-				"definition": "A label for human use intended to distinguish like teams.  E.g. the \"red\" vs. \"green\" trauma teams.",
-				"comment": "The meaning/purpose of the team is conveyed in CareTeam.category.  This element may also convey semantics of the team (e.g. \"Red trauma team\"), but its primary purpose is to distinguish between identical teams in a human-friendly way.  (\"Team 18735\" isn't as friendly.).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CareTeam.name",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "CareTeam.subject",
-				"path": "CareTeam.subject",
-				"short": "Who care team is for",
-				"definition": "Identifies the patient or group whose intended care is handled by the team.",
-				"requirements": "Allows the team to care for a group (e.g. marriage) therapy. \nAllows for an organization to designate a team such as the PICC line team.",
-				"alias": [
-					"patient"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "CareTeam.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.subject"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.encounter",
-				"path": "CareTeam.encounter",
-				"short": "Encounter created as part of",
-				"definition": "The Encounter during which this CareTeam was created or to which the creation of this record is tightly associated.",
-				"comment": "This will typically be the encounter the event occurred within, but some activities may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CareTeam.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.period",
-				"path": "CareTeam.period",
-				"short": "Time period team covers",
-				"definition": "Indicates when the team did (or is intended to) come into effect and end.",
-				"requirements": "Allows tracking what team(s) are in effect at a particular time.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CareTeam.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.init"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.participant",
-				"path": "CareTeam.participant",
-				"short": "Members of the team",
-				"definition": "Identifies all people and organizations who are expected to be involved in the care team.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "CareTeam.participant",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"condition": [
-					"ctm-1"
-				],
-				"constraint": [
-					{
-						"key": "ctm-1",
-						"severity": "error",
-						"human": "CareTeam.participant.onBehalfOf can only be populated when CareTeam.participant.member is a Practitioner",
-						"expression": "onBehalfOf.exists() implies (member.resolve().iif(empty(), true, ofType(Practitioner).exists()))",
-						"xpath": "starts-with(f:member/f:reference/@value, 'Practitioner/') or contains(f:member/f:reference/@value, '/Practitioner/') or exists(ancestor::*/f:contains/f:Practitioner/f:id[@value=substring-after(current()/f:member/f:reference/@value, '#')]) or not(exists(f:onBehalfOf))",
-						"source": "http://hl7.org/fhir/StructureDefinition/CareTeam"
-					},
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "REL (REL.4 is always the Patient) ( or PRT?)"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=PRF]"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.participant"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.participant.id",
-				"path": "CareTeam.participant.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.participant.extension",
-				"path": "CareTeam.participant.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.participant.modifierExtension",
-				"path": "CareTeam.participant.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.participant.role",
-				"path": "CareTeam.participant.role",
-				"short": "Type of involvement",
-				"definition": "Indicates specific responsibility of an individual within the care team, such as \"Primary care physician\", \"Trained social worker counselor\", \"Caregiver\", etc.",
-				"comment": "Roles may sometimes be inferred by type of Practitioner.  These are relationships that hold only within the context of the care team.  General relationships should be handled as properties of the Patient resource directly.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "CareTeam.participant.role",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Indicates specific responsibility of an individual within the care team, such as Primary physician, Team coordinator, Caregiver, etc.",
-					"valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1099.30"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "REL.2 (or PRT-4?)"
-					},
-					{
-						"identity": "rim",
-						"map": ".functionCode"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.participant.role"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.participant.member",
-				"path": "CareTeam.participant.member",
-				"short": "Who is involved",
-				"definition": "The specific person or organization who is participating/expected to participate in the care team.",
-				"comment": "Patient only needs to be listed if they have a role other than \"subject of care\".\n\nMember is optional because some participants may be known only by their role, particularly in draft plans.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "CareTeam.participant.member",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						],
-						"_targetProfile": [
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": true
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							}
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "REL.5 (or PRT-5 : ( PRV-4 {provider participations} ) / PRT-5 : ( PRV-4  {non-provider person participations} ) / PRT-5 : ( PRV-4 = (patient non-subject of care) ) / PRT-8?)"
-					},
-					{
-						"identity": "rim",
-						"map": ".role"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.participant.member"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.participant.onBehalfOf",
-				"path": "CareTeam.participant.onBehalfOf",
-				"short": "Organization of the practitioner",
-				"definition": "The organization of the practitioner.",
-				"requirements": "Practitioners can be associated with multiple organizations.  This element indicates which organization they were acting on behalf of.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CareTeam.participant.onBehalfOf",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "CareTeam.participant.period",
-				"path": "CareTeam.participant.period",
-				"short": "Time period of participant",
-				"definition": "Indicates when the specific member or organization did (or is intended to) come into effect and end.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CareTeam.participant.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "CareTeam.reasonCode",
-				"path": "CareTeam.reasonCode",
-				"short": "Why the care team exists",
-				"definition": "Describes why the care team exists.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CareTeam.reasonCode",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "CareTeamReason"
-						}
-					],
-					"strength": "example",
-					"description": "Indicates the reason for the care team.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.why[x]"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.reasonReference",
-				"path": "CareTeam.reasonReference",
-				"short": "Why the care team exists",
-				"definition": "Condition(s) that this care team addresses.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CareTeam.reasonReference",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Condition"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.why[x]"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.managingOrganization",
-				"path": "CareTeam.managingOrganization",
-				"short": "Organization responsible for the care team",
-				"definition": "The organization responsible for the care team.",
-				"requirements": "Allows for multiple organizations to collaboratively manage cross-organizational, longitudinal care plan.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CareTeam.managingOrganization",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "CareTeam.telecom",
-				"path": "CareTeam.telecom",
-				"short": "A contact detail for the care team (that applies to all members)",
-				"definition": "A central contact detail for the care team (that applies to all members).",
-				"comment": "The ContactPoint.use code of home is not appropriate to use. These contacts are not the contact details of individual care team members.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CareTeam.telecom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "ContactPoint"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "CareTeam.note",
-				"path": "CareTeam.note",
-				"short": "Comments made about the CareTeam",
-				"definition": "Comments made about the CareTeam.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CareTeam.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "CareTeam",
-				"path": "CareTeam",
-				"definition": "The US Core CareTeam Profile is based upon the core FHIR CareTeam Resource and created to meet the 2015 Edition Common Clinical Data Set 'Care team member(s)' requirements.",
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.status",
-				"path": "CareTeam.status",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"description": "Indicates whether the team is current , represents future intentions or is now a historical record.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/care-team-status"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.status"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.subject",
-				"path": "CareTeam.subject",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.subject"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.participant",
-				"path": "CareTeam.participant",
-				"min": 1,
-				"max": "*",
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.participant"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.participant.role",
-				"path": "CareTeam.participant.role",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Indicates specific responsibility of an individual within the care team, such as Primary physician, Team coordinator, Caregiver, etc.",
-					"valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1099.30"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.participant.role"
-					}
-				]
-			},
-			{
-				"id": "CareTeam.participant.member",
-				"path": "CareTeam.participant.member",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						],
-						"_targetProfile": [
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": true
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							}
-						]
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "CarePlan.participant.member"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-careteam",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam",
+    "version": "4.0.0",
+    "name": "USCoreCareTeam",
+    "title": "US Core CareTeam Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-06-26",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the CareTeam resource for the minimal set of data to query and retrieve a patient's Care Team.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "CareTeam",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/CareTeam",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "CareTeam",
+                "path": "CareTeam",
+                "short": "Planned participants in the coordination and delivery of care for a patient or group",
+                "definition": "The US Core CareTeam Profile is based upon the core FHIR CareTeam Resource and created to meet the 2015 Edition Common Clinical Data Set 'Care team member(s)' requirements.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CareTeam",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.id",
+                "path": "CareTeam.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "CareTeam.meta",
+                "path": "CareTeam.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "CareTeam.implicitRules",
+                "path": "CareTeam.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "CareTeam.language",
+                "path": "CareTeam.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "CareTeam.text",
+                "path": "CareTeam.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.contained",
+                "path": "CareTeam.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.extension",
+                "path": "CareTeam.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.modifierExtension",
+                "path": "CareTeam.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.identifier",
+                "path": "CareTeam.identifier",
+                "short": "External Ids for this team",
+                "definition": "Business identifiers assigned to this care team by the performer or other systems which remain constant as the resource is updated and propagates from server to server.",
+                "comment": "This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.",
+                "requirements": "Allows identification of the care team as it is known by various participating systems and in a way that remains consistent across servers.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CareTeam.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.status",
+                "path": "CareTeam.status",
+                "short": "proposed | active | suspended | inactive | entered-in-error",
+                "definition": "Indicates the current state of the care team.",
+                "comment": "This element is labeled as a modifier because the status contains the code entered-in-error that marks the care team as not currently valid.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CareTeam.status",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labelled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "description": "Indicates whether the team is current , represents future intentions or is now a historical record.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/care-team-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.status"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.category",
+                "path": "CareTeam.category",
+                "short": "Type of team",
+                "definition": "Identifies what kind of team.  This is to support differentiation between multiple co-existing teams, such as care plan team, episode of care team, longitudinal care team.",
+                "comment": "There may be multiple axis of categorization and one team may serve multiple purposes.",
+                "requirements": "Used for filtering what teams(s) are retrieved and displayed to different types of users.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CareTeam.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "CareTeamCategory"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Indicates the type of care team.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/care-team-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.name",
+                "path": "CareTeam.name",
+                "short": "Name of the team, such as crisis assessment team",
+                "definition": "A label for human use intended to distinguish like teams.  E.g. the \"red\" vs. \"green\" trauma teams.",
+                "comment": "The meaning/purpose of the team is conveyed in CareTeam.category.  This element may also convey semantics of the team (e.g. \"Red trauma team\"), but its primary purpose is to distinguish between identical teams in a human-friendly way.  (\"Team 18735\" isn't as friendly.).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CareTeam.name",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "CareTeam.subject",
+                "path": "CareTeam.subject",
+                "short": "Who care team is for",
+                "definition": "Identifies the patient or group whose intended care is handled by the team.",
+                "requirements": "Allows the team to care for a group (e.g. marriage) therapy. \nAllows for an organization to designate a team such as the PICC line team.",
+                "alias": [
+                    "patient"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "CareTeam.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.subject"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.encounter",
+                "path": "CareTeam.encounter",
+                "short": "Encounter created as part of",
+                "definition": "The Encounter during which this CareTeam was created or to which the creation of this record is tightly associated.",
+                "comment": "This will typically be the encounter the event occurred within, but some activities may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CareTeam.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.period",
+                "path": "CareTeam.period",
+                "short": "Time period team covers",
+                "definition": "Indicates when the team did (or is intended to) come into effect and end.",
+                "requirements": "Allows tracking what team(s) are in effect at a particular time.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CareTeam.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.init"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.participant",
+                "path": "CareTeam.participant",
+                "short": "Members of the team",
+                "definition": "Identifies all people and organizations who are expected to be involved in the care team.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "CareTeam.participant",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "condition": [
+                    "ctm-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ctm-1",
+                        "severity": "error",
+                        "human": "CareTeam.participant.onBehalfOf can only be populated when CareTeam.participant.member is a Practitioner",
+                        "expression": "onBehalfOf.exists() implies (member.resolve().iif(empty(), true, ofType(Practitioner).exists()))",
+                        "xpath": "starts-with(f:member/f:reference/@value, 'Practitioner/') or contains(f:member/f:reference/@value, '/Practitioner/') or exists(ancestor::*/f:contains/f:Practitioner/f:id[@value=substring-after(current()/f:member/f:reference/@value, '#')]) or not(exists(f:onBehalfOf))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/CareTeam"
+                    },
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "REL (REL.4 is always the Patient) ( or PRT?)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=PRF]"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.participant"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.participant.id",
+                "path": "CareTeam.participant.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.participant.extension",
+                "path": "CareTeam.participant.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.participant.modifierExtension",
+                "path": "CareTeam.participant.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.participant.role",
+                "path": "CareTeam.participant.role",
+                "short": "Type of involvement",
+                "definition": "Indicates specific responsibility of an individual within the care team, such as \"Primary care physician\", \"Trained social worker counselor\", \"Caregiver\", etc.",
+                "comment": "Roles may sometimes be inferred by type of Practitioner.  These are relationships that hold only within the context of the care team.  General relationships should be handled as properties of the Patient resource directly.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "CareTeam.participant.role",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Indicates specific responsibility of an individual within the care team, such as Primary physician, Team coordinator, Caregiver, etc.",
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1099.30"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "REL.2 (or PRT-4?)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".functionCode"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.participant.role"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.participant.member",
+                "path": "CareTeam.participant.member",
+                "short": "Who is involved",
+                "definition": "The specific person or organization who is participating/expected to participate in the care team.",
+                "comment": "Patient only needs to be listed if they have a role other than \"subject of care\".\n\nMember is optional because some participants may be known only by their role, particularly in draft plans.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "CareTeam.participant.member",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ],
+                        "_targetProfile": [
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": true
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "REL.5 (or PRT-5 : ( PRV-4 {provider participations} ) / PRT-5 : ( PRV-4  {non-provider person participations} ) / PRT-5 : ( PRV-4 = (patient non-subject of care) ) / PRT-8?)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".role"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.participant.member"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.participant.onBehalfOf",
+                "path": "CareTeam.participant.onBehalfOf",
+                "short": "Organization of the practitioner",
+                "definition": "The organization of the practitioner.",
+                "requirements": "Practitioners can be associated with multiple organizations.  This element indicates which organization they were acting on behalf of.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CareTeam.participant.onBehalfOf",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "CareTeam.participant.period",
+                "path": "CareTeam.participant.period",
+                "short": "Time period of participant",
+                "definition": "Indicates when the specific member or organization did (or is intended to) come into effect and end.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CareTeam.participant.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "CareTeam.reasonCode",
+                "path": "CareTeam.reasonCode",
+                "short": "Why the care team exists",
+                "definition": "Describes why the care team exists.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CareTeam.reasonCode",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "CareTeamReason"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Indicates the reason for the care team.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.why[x]"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.reasonReference",
+                "path": "CareTeam.reasonReference",
+                "short": "Why the care team exists",
+                "definition": "Condition(s) that this care team addresses.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CareTeam.reasonReference",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Condition"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.why[x]"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.managingOrganization",
+                "path": "CareTeam.managingOrganization",
+                "short": "Organization responsible for the care team",
+                "definition": "The organization responsible for the care team.",
+                "requirements": "Allows for multiple organizations to collaboratively manage cross-organizational, longitudinal care plan.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CareTeam.managingOrganization",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "CareTeam.telecom",
+                "path": "CareTeam.telecom",
+                "short": "A contact detail for the care team (that applies to all members)",
+                "definition": "A central contact detail for the care team (that applies to all members).",
+                "comment": "The ContactPoint.use code of home is not appropriate to use. These contacts are not the contact details of individual care team members.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CareTeam.telecom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "ContactPoint"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "CareTeam.note",
+                "path": "CareTeam.note",
+                "short": "Comments made about the CareTeam",
+                "definition": "Comments made about the CareTeam.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CareTeam.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "CareTeam",
+                "path": "CareTeam",
+                "definition": "The US Core CareTeam Profile is based upon the core FHIR CareTeam Resource and created to meet the 2015 Edition Common Clinical Data Set 'Care team member(s)' requirements.",
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.status",
+                "path": "CareTeam.status",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "description": "Indicates whether the team is current , represents future intentions or is now a historical record.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/care-team-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.status"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.subject",
+                "path": "CareTeam.subject",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.subject"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.participant",
+                "path": "CareTeam.participant",
+                "min": 1,
+                "max": "*",
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.participant"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.participant.role",
+                "path": "CareTeam.participant.role",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Indicates specific responsibility of an individual within the care team, such as Primary physician, Team coordinator, Caregiver, etc.",
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1099.30"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.participant.role"
+                    }
+                ]
+            },
+            {
+                "id": "CareTeam.participant.member",
+                "path": "CareTeam.participant.member",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ],
+                        "_targetProfile": [
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": true
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "CarePlan.participant.member"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-condition.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-condition.json
@@ -1,2150 +1,2150 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-condition",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-condition-definitions.html#Condition\" title=\"The US Core Condition Profile is based upon the core FHIR Condition Resource and created to meet the 2015 Edition Common Clinical Data Set 'Problems' and 'Health Concerns' requirements.\">Condition</a><a name=\"Condition\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-1)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/condition.html\">Condition</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Detailed information about conditions, problems or diagnoses</span><br/><span style=\"font-weight:bold\">us-core-1: </span>A code in Condition.category SHOULD be from US Core Condition Category Codes value set.</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-condition-definitions.html#Condition.clinicalStatus\">clinicalStatus</a><a name=\"Condition.clinicalStatus\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">active | recurrence | relapse | inactive | remission | resolved</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-condition-clinical.html\">ConditionClinicalStatusCodes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-condition-definitions.html#Condition.verificationStatus\">verificationStatus</a><a name=\"Condition.verificationStatus\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">unconfirmed | provisional | differential | confirmed | refuted | entered-in-error</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-condition-ver-status.html\">ConditionVerificationStatus</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-condition-definitions.html#Condition.category\">category</a><a name=\"Condition.category\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-1)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">problem-list-item | encounter-diagnosis | health-concern<br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-condition-category.html\">US Core Condition Category Codes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)<br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-condition-definitions.html#Condition.code\">code</a><a name=\"Condition.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Identification of the condition, problem or diagnosis</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-condition-code.html\">US Core Condition Code</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>): Valueset to describe the actual problem experienced by the patient<br/><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck00.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-condition-definitions.html#Condition.subject\">subject</a><a name=\"Condition.subject\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who has the condition?</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition",
-	"version": "4.0.0",
-	"name": "USCoreCondition",
-	"title": "US Core Condition Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-06-27",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the Condition resource for the minimal set of data to query and retrieve problems and health concerns information.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "sct-concept",
-			"uri": "http://snomed.info/conceptdomain",
-			"name": "SNOMED CT Concept Domain Binding"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "sct-attr",
-			"uri": "http://snomed.org/attributebinding",
-			"name": "SNOMED CT Attribute Binding"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Condition",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Condition",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Condition",
-				"path": "Condition",
-				"short": "Detailed information about conditions, problems or diagnoses",
-				"definition": "The US Core Condition Profile is based upon the core FHIR Condition Resource and created to meet the 2015 Edition Common Clinical Data Set 'Problems' and 'Health Concerns' requirements.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Condition",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "Most systems will expect a clinicalStatus to be valued for problem-list-items that are managed over time, but might not need a clinicalStatus for point in time encounter-diagnosis."
-							}
-						],
-						"key": "con-3",
-						"severity": "warning",
-						"human": "Condition.clinicalStatus SHALL be present if verificationStatus is not entered-in-error and category is problem-list-item",
-						"expression": "clinicalStatus.exists() or verificationStatus.coding.where(system='http://terminology.hl7.org/CodeSystem/condition-ver-status' and code = 'entered-in-error').exists() or category.select($this='problem-list-item').empty()",
-						"xpath": "exists(f:clinicalStatus) or exists(f:verificationStatus/f:coding/f:code/@value='entered-in-error') or not(exists(category[@value='problem-list-item']))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Condition"
-					},
-					{
-						"key": "con-4",
-						"severity": "error",
-						"human": "If condition is abated, then clinicalStatus must be either inactive, resolved, or remission",
-						"expression": "abatement.empty() or clinicalStatus.coding.where(system='http://terminology.hl7.org/CodeSystem/condition-clinical' and (code='resolved' or code='remission' or code='inactive')).exists()",
-						"xpath": "not(exists(*[starts-with(local-name(.), 'abatement')])) or exists(f:clinicalStatus/f:coding[f:system/@value='http://terminology.hl7.org/CodeSystem/condition-clinical' and f:code/@value=('resolved', 'remission', 'inactive')])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Condition"
-					},
-					{
-						"key": "con-5",
-						"severity": "error",
-						"human": "Condition.clinicalStatus SHALL NOT be present if verification Status is entered-in-error",
-						"expression": "verificationStatus.coding.where(system='http://terminology.hl7.org/CodeSystem/condition-ver-status' and code='entered-in-error').empty() or clinicalStatus.empty()",
-						"xpath": "not(exists(f:verificationStatus/f:coding[f:system/@value='http://terminology.hl7.org/CodeSystem/condition-ver-status' and f:code/@value='entered-in-error'])) or not(exists(f:clinicalStatus))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Condition"
-					},
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							}
-						],
-						"key": "us-core-1",
-						"severity": "warning",
-						"human": "A code in Condition.category SHOULD be from US Core Condition Category Codes value set.",
-						"expression": "where(category.memberOf('http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category')).exists()",
-						"xpath": "(no xpath equivalent)"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 243796009 |Situation with explicit context| : 246090004 |Associated finding| = ( ( < 404684003 |Clinical finding| MINUS ( << 420134006 |Propensity to adverse reactions| OR << 473010000 |Hypersensitivity condition| OR << 79899007 |Drug interaction| OR << 69449002 |Drug action| OR << 441742003 |Evaluation finding| OR << 307824009 |Administrative status| OR << 385356007 |Tumor stage finding|)) OR < 272379006 |Event|)"
-					},
-					{
-						"identity": "v2",
-						"map": "PPR message"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation[classCode=OBS, moodCode=EVN, code=ASSERTION, value<Diagnosis]"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Condition"
-					}
-				]
-			},
-			{
-				"id": "Condition.id",
-				"path": "Condition.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Condition.meta",
-				"path": "Condition.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Condition.implicitRules",
-				"path": "Condition.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Condition.language",
-				"path": "Condition.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Condition.text",
-				"path": "Condition.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Condition.contained",
-				"path": "Condition.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Condition.extension",
-				"path": "Condition.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Condition.modifierExtension",
-				"path": "Condition.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Condition.identifier",
-				"path": "Condition.identifier",
-				"short": "External Ids for this condition",
-				"definition": "Business identifiers assigned to this condition by the performer or other systems which remain constant as the resource is updated and propagates from server to server.",
-				"comment": "This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.",
-				"requirements": "Allows identification of the condition as it is known by various participating systems and in a way that remains consistent across servers.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Condition.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					}
-				]
-			},
-			{
-				"id": "Condition.clinicalStatus",
-				"path": "Condition.clinicalStatus",
-				"short": "active | recurrence | relapse | inactive | remission | resolved",
-				"definition": "The clinical status of the condition.",
-				"comment": "The data type is CodeableConcept because clinicalStatus has some clinical judgment involved, such that there might need to be more specificity than the required FHIR value set allows. For example, a SNOMED coding might allow for additional specificity.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Condition.clinicalStatus",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"con-3",
-					"con-4",
-					"con-5"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the status contains codes that mark the condition as no longer active.",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/condition-clinical"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 303105007 |Disease phases|"
-					},
-					{
-						"identity": "v2",
-						"map": "PRB-14"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation ACT\n.inboundRelationship[typeCode=COMP].source[classCode=OBS, code=\"clinicalStatus\", moodCode=EVN].value"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Condition.clinicalStatus"
-					}
-				]
-			},
-			{
-				"id": "Condition.verificationStatus",
-				"path": "Condition.verificationStatus",
-				"short": "unconfirmed | provisional | differential | confirmed | refuted | entered-in-error",
-				"definition": "The verification status to support the clinical status of the condition.",
-				"comment": "verificationStatus is not required.  For example, when a patient has abdominal pain in the ED, there is not likely going to be a verification status.\nThe data type is CodeableConcept because verificationStatus has some clinical judgment involved, such that there might need to be more specificity than the required FHIR value set allows. For example, a SNOMED coding might allow for additional specificity.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Condition.verificationStatus",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"con-3",
-					"con-5"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the status contains the code refuted and entered-in-error that mark the Condition as not currently valid.",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/condition-ver-status"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 410514004 |Finding context value|"
-					},
-					{
-						"identity": "v2",
-						"map": "PRB-13"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation ACT\n.inboundRelationship[typeCode=COMP].source[classCode=OBS, code=\"verificationStatus\", moodCode=EVN].value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "408729009"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Condition.verificationStatus"
-					}
-				]
-			},
-			{
-				"id": "Condition.category",
-				"path": "Condition.category",
-				"short": "problem-list-item | encounter-diagnosis | health-concern",
-				"definition": "A category assigned to the condition.",
-				"comment": "The categorization is often highly contextual and may appear poorly differentiated or not very useful in other contexts.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Condition.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"us-core-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 404684003 |Clinical finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "'problem' if from PRB-3. 'diagnosis' if from DG1 segment in PV1 message"
-					},
-					{
-						"identity": "rim",
-						"map": ".code"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Condition.category"
-					}
-				]
-			},
-			{
-				"id": "Condition.severity",
-				"path": "Condition.severity",
-				"short": "Subjective severity of condition",
-				"definition": "A subjective assessment of the severity of the condition as evaluated by the clinician.",
-				"comment": "Coding of the severity with a terminology is preferred, where possible.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Condition.severity",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ConditionSeverity"
-						}
-					],
-					"strength": "preferred",
-					"description": "A subjective assessment of the severity of the condition as evaluated by the clinician.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/condition-severity"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.grade"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 272141005 |Severities|"
-					},
-					{
-						"identity": "v2",
-						"map": "PRB-26 / ABS-3"
-					},
-					{
-						"identity": "rim",
-						"map": "Can be pre/post-coordinated into value.  Or ./inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"severity\"].value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "246112005"
-					}
-				]
-			},
-			{
-				"id": "Condition.code",
-				"path": "Condition.code",
-				"short": "Identification of the condition, problem or diagnosis",
-				"definition": "Identification of the condition, problem or diagnosis.",
-				"requirements": "0..1 to account for primarily narrative only resources.",
-				"alias": [
-					"type"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Condition.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Valueset to describe the actual problem experienced by the patient",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-code"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "code 246090004 |Associated finding| (< 404684003 |Clinical finding| MINUS\n<< 420134006 |Propensity to adverse reactions| MINUS \n<< 473010000 |Hypersensitivity condition| MINUS \n<< 79899007 |Drug interaction| MINUS\n<< 69449002 |Drug action| MINUS \n<< 441742003 |Evaluation finding| MINUS \n<< 307824009 |Administrative status| MINUS \n<< 385356007 |Tumor stage finding|) \nOR < 413350009 |Finding with explicit context|\nOR < 272379006 |Event|"
-					},
-					{
-						"identity": "v2",
-						"map": "PRB-3"
-					},
-					{
-						"identity": "rim",
-						"map": ".value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "246090004"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Condition.code"
-					}
-				]
-			},
-			{
-				"id": "Condition.bodySite",
-				"path": "Condition.bodySite",
-				"short": "Anatomical location, if relevant",
-				"definition": "The anatomical location where this condition manifests itself.",
-				"comment": "Only used if not implicit in code found in Condition.code. If the use case requires attributes from the BodySite resource (e.g. to identify and track separately) then use the standard extension [bodySite](http://hl7.org/fhir/R4/extension-bodysite.html).  May be a summary code, or a reference to a very precise definition of the location, or both.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Condition.bodySite",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "BodySite"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing anatomical locations. May include laterality.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/body-site"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 442083009  |Anatomical or acquired body structure|"
-					},
-					{
-						"identity": "rim",
-						"map": ".targetBodySiteCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363698007"
-					}
-				]
-			},
-			{
-				"id": "Condition.subject",
-				"path": "Condition.subject",
-				"short": "Who has the condition?",
-				"definition": "Indicates the patient or group who the condition record is associated with.",
-				"requirements": "Group is typically used for veterinary or public health use cases.",
-				"alias": [
-					"patient"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Condition.subject",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=SBJ].role[classCode=PAT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Condition.patient"
-					}
-				]
-			},
-			{
-				"id": "Condition.encounter",
-				"path": "Condition.encounter",
-				"short": "Encounter created as part of",
-				"definition": "The Encounter during which this Condition was created or to which the creation of this record is tightly associated.",
-				"comment": "This will typically be the encounter the event occurred within, but some activities may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter. This record indicates the encounter this particular record is associated with.  In the case of a \"new\" diagnosis reflecting ongoing/revised information about the condition, this might be distinct from the first encounter in which the underlying condition was first \"known\".",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Condition.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1-19 (+PV1-54)"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Condition.onset[x]",
-				"path": "Condition.onset[x]",
-				"short": "Estimated or actual date,  date-time, or age",
-				"definition": "Estimated or actual date or date-time  the condition began, in the opinion of the clinician.",
-				"comment": "Age is generally used when the patient reports an age at which the Condition began to occur.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Condition.onset[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Age"
-					},
-					{
-						"code": "Period"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.init"
-					},
-					{
-						"identity": "v2",
-						"map": "PRB-16"
-					},
-					{
-						"identity": "rim",
-						"map": ".effectiveTime.low or .inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"age at onset\"].value"
-					}
-				]
-			},
-			{
-				"id": "Condition.abatement[x]",
-				"path": "Condition.abatement[x]",
-				"short": "When in resolution/remission",
-				"definition": "The date or estimated date that the condition resolved or went into remission. This is called \"abatement\" because of the many overloaded connotations associated with \"remission\" or \"resolution\" - Conditions are never really resolved, but they can abate.",
-				"comment": "There is no explicit distinction between resolution and remission because in many cases the distinction is not clear. Age is generally used when the patient reports an age at which the Condition abated.  If there is no abatement element, it is unknown whether the condition has resolved or entered remission; applications and users should generally assume that the condition is still valid.  When abatementString exists, it implies the condition is abated.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Condition.abatement[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Age"
-					},
-					{
-						"code": "Period"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "string"
-					}
-				],
-				"condition": [
-					"con-4"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".effectiveTime.high or .inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"age at remission\"].value or .inboundRelationship[typeCode=SUBJ]source[classCode=CONC, moodCode=EVN].status=completed"
-					}
-				]
-			},
-			{
-				"id": "Condition.recordedDate",
-				"path": "Condition.recordedDate",
-				"short": "Date record was first recorded",
-				"definition": "The recordedDate represents when this particular Condition record was created in the system, which is often a system-generated date.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Condition.recordedDate",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "v2",
-						"map": "REL-11"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=AUT].time"
-					}
-				]
-			},
-			{
-				"id": "Condition.recorder",
-				"path": "Condition.recorder",
-				"short": "Who recorded the condition",
-				"definition": "Individual who recorded the record and takes responsibility for its content.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Condition.recorder",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.author"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=AUT].role"
-					}
-				]
-			},
-			{
-				"id": "Condition.asserter",
-				"path": "Condition.asserter",
-				"short": "Person who asserts this condition",
-				"definition": "Individual who is making the condition statement.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Condition.asserter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.source"
-					},
-					{
-						"identity": "v2",
-						"map": "REL-7.1 identifier + REL-7.12 type code"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=INF].role"
-					}
-				]
-			},
-			{
-				"id": "Condition.stage",
-				"path": "Condition.stage",
-				"short": "Stage/grade, usually assessed formally",
-				"definition": "Clinical stage or grade of a condition. May include formal severity assessments.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Condition.stage",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "con-1",
-						"severity": "error",
-						"human": "Stage SHALL have summary or assessment",
-						"expression": "summary.exists() or assessment.exists()",
-						"xpath": "exists(f:summary) or exists(f:assessment)"
-					},
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "./inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"stage/grade\"]"
-					}
-				]
-			},
-			{
-				"id": "Condition.stage.id",
-				"path": "Condition.stage.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Condition.stage.extension",
-				"path": "Condition.stage.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Condition.stage.modifierExtension",
-				"path": "Condition.stage.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Condition.stage.summary",
-				"path": "Condition.stage.summary",
-				"short": "Simple summary (disease specific)",
-				"definition": "A simple summary of the stage such as \"Stage 3\". The determination of the stage is disease-specific.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Condition.stage.summary",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"con-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ConditionStage"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing condition stages (e.g. Cancer stages).",
-					"valueSet": "http://hl7.org/fhir/ValueSet/condition-stage"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 254291000 |Staging and scales|"
-					},
-					{
-						"identity": "v2",
-						"map": "PRB-14"
-					},
-					{
-						"identity": "rim",
-						"map": ".value"
-					}
-				]
-			},
-			{
-				"id": "Condition.stage.assessment",
-				"path": "Condition.stage.assessment",
-				"short": "Formal record of assessment",
-				"definition": "Reference to a formal record of the evidence on which the staging assessment is based.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Condition.stage.assessment",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/ClinicalImpression",
-							"http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
-							"http://hl7.org/fhir/StructureDefinition/Observation"
-						]
-					}
-				],
-				"condition": [
-					"con-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".self"
-					}
-				]
-			},
-			{
-				"id": "Condition.stage.type",
-				"path": "Condition.stage.type",
-				"short": "Kind of staging",
-				"definition": "The kind of staging, such as pathological or clinical staging.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Condition.stage.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ConditionStageType"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing the kind of condition staging (e.g. clinical or pathological).",
-					"valueSet": "http://hl7.org/fhir/ValueSet/condition-stage-type"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "./inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"stage type\"]"
-					}
-				]
-			},
-			{
-				"id": "Condition.evidence",
-				"path": "Condition.evidence",
-				"short": "Supporting evidence",
-				"definition": "Supporting evidence / manifestations that are the basis of the Condition's verification status, such as evidence that confirmed or refuted the condition.",
-				"comment": "The evidence may be a simple list of coded symptoms/manifestations, or references to observations or formal assessments, or both.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Condition.evidence",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "con-2",
-						"severity": "error",
-						"human": "evidence SHALL have code or details",
-						"expression": "code.exists() or detail.exists()",
-						"xpath": "exists(f:code) or exists(f:detail)"
-					},
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=SPRT].target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Condition.evidence.id",
-				"path": "Condition.evidence.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Condition.evidence.extension",
-				"path": "Condition.evidence.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Condition.evidence.modifierExtension",
-				"path": "Condition.evidence.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Condition.evidence.code",
-				"path": "Condition.evidence.code",
-				"short": "Manifestation/symptom",
-				"definition": "A manifestation or symptom that led to the recording of this condition.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Condition.evidence.code",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"con-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ManifestationOrSymptom"
-						}
-					],
-					"strength": "example",
-					"description": "Codes that describe the manifestation or symptoms of a condition.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/manifestation-or-symptom"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.reasonCode"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.why[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 404684003 |Clinical finding|"
-					},
-					{
-						"identity": "rim",
-						"map": "[code=\"diagnosis\"].value"
-					}
-				]
-			},
-			{
-				"id": "Condition.evidence.detail",
-				"path": "Condition.evidence.detail",
-				"short": "Supporting information found elsewhere",
-				"definition": "Links to other relevant information, including pathology reports.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Condition.evidence.detail",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"condition": [
-					"con-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.why[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".self"
-					}
-				]
-			},
-			{
-				"id": "Condition.note",
-				"path": "Condition.note",
-				"short": "Additional information about the Condition",
-				"definition": "Additional information about the Condition. This is a general notes/comments entry  for description of the Condition, its diagnosis and prognosis.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Condition.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.note"
-					},
-					{
-						"identity": "v2",
-						"map": "NTE child of PRB"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"annotation\"].value"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Condition",
-				"path": "Condition",
-				"definition": "The US Core Condition Profile is based upon the core FHIR Condition Resource and created to meet the 2015 Edition Common Clinical Data Set 'Problems' and 'Health Concerns' requirements.",
-				"constraint": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							}
-						],
-						"key": "us-core-1",
-						"severity": "warning",
-						"human": "A code in Condition.category SHOULD be from US Core Condition Category Codes value set.",
-						"expression": "where(category.memberOf('http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category')).exists()",
-						"xpath": "(no xpath equivalent)"
-					}
-				],
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Condition"
-					}
-				]
-			},
-			{
-				"id": "Condition.clinicalStatus",
-				"path": "Condition.clinicalStatus",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/condition-clinical"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Condition.clinicalStatus"
-					}
-				]
-			},
-			{
-				"id": "Condition.verificationStatus",
-				"path": "Condition.verificationStatus",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/condition-ver-status"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Condition.verificationStatus"
-					}
-				]
-			},
-			{
-				"id": "Condition.category",
-				"path": "Condition.category",
-				"short": "problem-list-item | encounter-diagnosis | health-concern",
-				"min": 1,
-				"max": "*",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"us-core-1"
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Condition.category"
-					}
-				]
-			},
-			{
-				"id": "Condition.code",
-				"path": "Condition.code",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Valueset to describe the actual problem experienced by the patient",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-code"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Condition.code"
-					}
-				]
-			},
-			{
-				"id": "Condition.subject",
-				"path": "Condition.subject",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Condition.patient"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-condition",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition",
+    "version": "4.0.0",
+    "name": "USCoreCondition",
+    "title": "US Core Condition Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-06-27",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the Condition resource for the minimal set of data to query and retrieve problems and health concerns information.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "sct-concept",
+            "uri": "http://snomed.info/conceptdomain",
+            "name": "SNOMED CT Concept Domain Binding"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "sct-attr",
+            "uri": "http://snomed.org/attributebinding",
+            "name": "SNOMED CT Attribute Binding"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Condition",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Condition",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Condition",
+                "path": "Condition",
+                "short": "Detailed information about conditions, problems or diagnoses",
+                "definition": "The US Core Condition Profile is based upon the core FHIR Condition Resource and created to meet the 2015 Edition Common Clinical Data Set 'Problems' and 'Health Concerns' requirements.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Condition",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "Most systems will expect a clinicalStatus to be valued for problem-list-items that are managed over time, but might not need a clinicalStatus for point in time encounter-diagnosis."
+                            }
+                        ],
+                        "key": "con-3",
+                        "severity": "warning",
+                        "human": "Condition.clinicalStatus SHALL be present if verificationStatus is not entered-in-error and category is problem-list-item",
+                        "expression": "clinicalStatus.exists() or verificationStatus.coding.where(system='http://terminology.hl7.org/CodeSystem/condition-ver-status' and code = 'entered-in-error').exists() or category.select($this='problem-list-item').empty()",
+                        "xpath": "exists(f:clinicalStatus) or exists(f:verificationStatus/f:coding/f:code/@value='entered-in-error') or not(exists(category[@value='problem-list-item']))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Condition"
+                    },
+                    {
+                        "key": "con-4",
+                        "severity": "error",
+                        "human": "If condition is abated, then clinicalStatus must be either inactive, resolved, or remission",
+                        "expression": "abatement.empty() or clinicalStatus.coding.where(system='http://terminology.hl7.org/CodeSystem/condition-clinical' and (code='resolved' or code='remission' or code='inactive')).exists()",
+                        "xpath": "not(exists(*[starts-with(local-name(.), 'abatement')])) or exists(f:clinicalStatus/f:coding[f:system/@value='http://terminology.hl7.org/CodeSystem/condition-clinical' and f:code/@value=('resolved', 'remission', 'inactive')])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Condition"
+                    },
+                    {
+                        "key": "con-5",
+                        "severity": "error",
+                        "human": "Condition.clinicalStatus SHALL NOT be present if verification Status is entered-in-error",
+                        "expression": "verificationStatus.coding.where(system='http://terminology.hl7.org/CodeSystem/condition-ver-status' and code='entered-in-error').empty() or clinicalStatus.empty()",
+                        "xpath": "not(exists(f:verificationStatus/f:coding[f:system/@value='http://terminology.hl7.org/CodeSystem/condition-ver-status' and f:code/@value='entered-in-error'])) or not(exists(f:clinicalStatus))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Condition"
+                    },
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "key": "us-core-1",
+                        "severity": "warning",
+                        "human": "A code in Condition.category SHOULD be from US Core Condition Category Codes value set.",
+                        "expression": "where(category.memberOf('http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category')).exists()",
+                        "xpath": "(no xpath equivalent)"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 243796009 |Situation with explicit context| : 246090004 |Associated finding| = ( ( < 404684003 |Clinical finding| MINUS ( << 420134006 |Propensity to adverse reactions| OR << 473010000 |Hypersensitivity condition| OR << 79899007 |Drug interaction| OR << 69449002 |Drug action| OR << 441742003 |Evaluation finding| OR << 307824009 |Administrative status| OR << 385356007 |Tumor stage finding|)) OR < 272379006 |Event|)"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PPR message"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation[classCode=OBS, moodCode=EVN, code=ASSERTION, value<Diagnosis]"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Condition"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.id",
+                "path": "Condition.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Condition.meta",
+                "path": "Condition.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Condition.implicitRules",
+                "path": "Condition.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Condition.language",
+                "path": "Condition.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Condition.text",
+                "path": "Condition.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.contained",
+                "path": "Condition.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.extension",
+                "path": "Condition.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.modifierExtension",
+                "path": "Condition.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.identifier",
+                "path": "Condition.identifier",
+                "short": "External Ids for this condition",
+                "definition": "Business identifiers assigned to this condition by the performer or other systems which remain constant as the resource is updated and propagates from server to server.",
+                "comment": "This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.",
+                "requirements": "Allows identification of the condition as it is known by various participating systems and in a way that remains consistent across servers.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Condition.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.clinicalStatus",
+                "path": "Condition.clinicalStatus",
+                "short": "active | recurrence | relapse | inactive | remission | resolved",
+                "definition": "The clinical status of the condition.",
+                "comment": "The data type is CodeableConcept because clinicalStatus has some clinical judgment involved, such that there might need to be more specificity than the required FHIR value set allows. For example, a SNOMED coding might allow for additional specificity.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Condition.clinicalStatus",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "con-3",
+                    "con-4",
+                    "con-5"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the status contains codes that mark the condition as no longer active.",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/condition-clinical"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 303105007 |Disease phases|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRB-14"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation ACT\n.inboundRelationship[typeCode=COMP].source[classCode=OBS, code=\"clinicalStatus\", moodCode=EVN].value"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Condition.clinicalStatus"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.verificationStatus",
+                "path": "Condition.verificationStatus",
+                "short": "unconfirmed | provisional | differential | confirmed | refuted | entered-in-error",
+                "definition": "The verification status to support the clinical status of the condition.",
+                "comment": "verificationStatus is not required.  For example, when a patient has abdominal pain in the ED, there is not likely going to be a verification status.\nThe data type is CodeableConcept because verificationStatus has some clinical judgment involved, such that there might need to be more specificity than the required FHIR value set allows. For example, a SNOMED coding might allow for additional specificity.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Condition.verificationStatus",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "con-3",
+                    "con-5"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the status contains the code refuted and entered-in-error that mark the Condition as not currently valid.",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/condition-ver-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 410514004 |Finding context value|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRB-13"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation ACT\n.inboundRelationship[typeCode=COMP].source[classCode=OBS, code=\"verificationStatus\", moodCode=EVN].value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "408729009"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Condition.verificationStatus"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.category",
+                "path": "Condition.category",
+                "short": "problem-list-item | encounter-diagnosis | health-concern",
+                "definition": "A category assigned to the condition.",
+                "comment": "The categorization is often highly contextual and may appear poorly differentiated or not very useful in other contexts.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Condition.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "us-core-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 404684003 |Clinical finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "'problem' if from PRB-3. 'diagnosis' if from DG1 segment in PV1 message"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".code"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Condition.category"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.severity",
+                "path": "Condition.severity",
+                "short": "Subjective severity of condition",
+                "definition": "A subjective assessment of the severity of the condition as evaluated by the clinician.",
+                "comment": "Coding of the severity with a terminology is preferred, where possible.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Condition.severity",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ConditionSeverity"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A subjective assessment of the severity of the condition as evaluated by the clinician.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/condition-severity"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.grade"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 272141005 |Severities|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRB-26 / ABS-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Can be pre/post-coordinated into value.  Or ./inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"severity\"].value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "246112005"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.code",
+                "path": "Condition.code",
+                "short": "Identification of the condition, problem or diagnosis",
+                "definition": "Identification of the condition, problem or diagnosis.",
+                "requirements": "0..1 to account for primarily narrative only resources.",
+                "alias": [
+                    "type"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Condition.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Valueset to describe the actual problem experienced by the patient",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-code"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "code 246090004 |Associated finding| (< 404684003 |Clinical finding| MINUS\n<< 420134006 |Propensity to adverse reactions| MINUS \n<< 473010000 |Hypersensitivity condition| MINUS \n<< 79899007 |Drug interaction| MINUS\n<< 69449002 |Drug action| MINUS \n<< 441742003 |Evaluation finding| MINUS \n<< 307824009 |Administrative status| MINUS \n<< 385356007 |Tumor stage finding|) \nOR < 413350009 |Finding with explicit context|\nOR < 272379006 |Event|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRB-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "246090004"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Condition.code"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.bodySite",
+                "path": "Condition.bodySite",
+                "short": "Anatomical location, if relevant",
+                "definition": "The anatomical location where this condition manifests itself.",
+                "comment": "Only used if not implicit in code found in Condition.code. If the use case requires attributes from the BodySite resource (e.g. to identify and track separately) then use the standard extension [bodySite](http://hl7.org/fhir/R4/extension-bodysite.html).  May be a summary code, or a reference to a very precise definition of the location, or both.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Condition.bodySite",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "BodySite"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing anatomical locations. May include laterality.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/body-site"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 442083009  |Anatomical or acquired body structure|"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".targetBodySiteCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363698007"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.subject",
+                "path": "Condition.subject",
+                "short": "Who has the condition?",
+                "definition": "Indicates the patient or group who the condition record is associated with.",
+                "requirements": "Group is typically used for veterinary or public health use cases.",
+                "alias": [
+                    "patient"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Condition.subject",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=SBJ].role[classCode=PAT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Condition.patient"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.encounter",
+                "path": "Condition.encounter",
+                "short": "Encounter created as part of",
+                "definition": "The Encounter during which this Condition was created or to which the creation of this record is tightly associated.",
+                "comment": "This will typically be the encounter the event occurred within, but some activities may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter. This record indicates the encounter this particular record is associated with.  In the case of a \"new\" diagnosis reflecting ongoing/revised information about the condition, this might be distinct from the first encounter in which the underlying condition was first \"known\".",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Condition.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1-19 (+PV1-54)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.onset[x]",
+                "path": "Condition.onset[x]",
+                "short": "Estimated or actual date,  date-time, or age",
+                "definition": "Estimated or actual date or date-time  the condition began, in the opinion of the clinician.",
+                "comment": "Age is generally used when the patient reports an age at which the Condition began to occur.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Condition.onset[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Age"
+                    },
+                    {
+                        "code": "Period"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.init"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRB-16"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime.low or .inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"age at onset\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.abatement[x]",
+                "path": "Condition.abatement[x]",
+                "short": "When in resolution/remission",
+                "definition": "The date or estimated date that the condition resolved or went into remission. This is called \"abatement\" because of the many overloaded connotations associated with \"remission\" or \"resolution\" - Conditions are never really resolved, but they can abate.",
+                "comment": "There is no explicit distinction between resolution and remission because in many cases the distinction is not clear. Age is generally used when the patient reports an age at which the Condition abated.  If there is no abatement element, it is unknown whether the condition has resolved or entered remission; applications and users should generally assume that the condition is still valid.  When abatementString exists, it implies the condition is abated.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Condition.abatement[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Age"
+                    },
+                    {
+                        "code": "Period"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "string"
+                    }
+                ],
+                "condition": [
+                    "con-4"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime.high or .inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"age at remission\"].value or .inboundRelationship[typeCode=SUBJ]source[classCode=CONC, moodCode=EVN].status=completed"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.recordedDate",
+                "path": "Condition.recordedDate",
+                "short": "Date record was first recorded",
+                "definition": "The recordedDate represents when this particular Condition record was created in the system, which is often a system-generated date.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Condition.recordedDate",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "REL-11"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.recorder",
+                "path": "Condition.recorder",
+                "short": "Who recorded the condition",
+                "definition": "Individual who recorded the record and takes responsibility for its content.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Condition.recorder",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.author"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=AUT].role"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.asserter",
+                "path": "Condition.asserter",
+                "short": "Person who asserts this condition",
+                "definition": "Individual who is making the condition statement.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Condition.asserter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.source"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "REL-7.1 identifier + REL-7.12 type code"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=INF].role"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.stage",
+                "path": "Condition.stage",
+                "short": "Stage/grade, usually assessed formally",
+                "definition": "Clinical stage or grade of a condition. May include formal severity assessments.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Condition.stage",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "con-1",
+                        "severity": "error",
+                        "human": "Stage SHALL have summary or assessment",
+                        "expression": "summary.exists() or assessment.exists()",
+                        "xpath": "exists(f:summary) or exists(f:assessment)"
+                    },
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "./inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"stage/grade\"]"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.stage.id",
+                "path": "Condition.stage.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.stage.extension",
+                "path": "Condition.stage.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.stage.modifierExtension",
+                "path": "Condition.stage.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.stage.summary",
+                "path": "Condition.stage.summary",
+                "short": "Simple summary (disease specific)",
+                "definition": "A simple summary of the stage such as \"Stage 3\". The determination of the stage is disease-specific.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Condition.stage.summary",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "con-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ConditionStage"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing condition stages (e.g. Cancer stages).",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/condition-stage"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 254291000 |Staging and scales|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRB-14"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".value"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.stage.assessment",
+                "path": "Condition.stage.assessment",
+                "short": "Formal record of assessment",
+                "definition": "Reference to a formal record of the evidence on which the staging assessment is based.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Condition.stage.assessment",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/ClinicalImpression",
+                            "http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
+                            "http://hl7.org/fhir/StructureDefinition/Observation"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "con-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".self"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.stage.type",
+                "path": "Condition.stage.type",
+                "short": "Kind of staging",
+                "definition": "The kind of staging, such as pathological or clinical staging.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Condition.stage.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ConditionStageType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing the kind of condition staging (e.g. clinical or pathological).",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/condition-stage-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "./inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"stage type\"]"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.evidence",
+                "path": "Condition.evidence",
+                "short": "Supporting evidence",
+                "definition": "Supporting evidence / manifestations that are the basis of the Condition's verification status, such as evidence that confirmed or refuted the condition.",
+                "comment": "The evidence may be a simple list of coded symptoms/manifestations, or references to observations or formal assessments, or both.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Condition.evidence",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "con-2",
+                        "severity": "error",
+                        "human": "evidence SHALL have code or details",
+                        "expression": "code.exists() or detail.exists()",
+                        "xpath": "exists(f:code) or exists(f:detail)"
+                    },
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=SPRT].target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.evidence.id",
+                "path": "Condition.evidence.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.evidence.extension",
+                "path": "Condition.evidence.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.evidence.modifierExtension",
+                "path": "Condition.evidence.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.evidence.code",
+                "path": "Condition.evidence.code",
+                "short": "Manifestation/symptom",
+                "definition": "A manifestation or symptom that led to the recording of this condition.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Condition.evidence.code",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "con-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ManifestationOrSymptom"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes that describe the manifestation or symptoms of a condition.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/manifestation-or-symptom"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.reasonCode"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.why[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 404684003 |Clinical finding|"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "[code=\"diagnosis\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.evidence.detail",
+                "path": "Condition.evidence.detail",
+                "short": "Supporting information found elsewhere",
+                "definition": "Links to other relevant information, including pathology reports.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Condition.evidence.detail",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "con-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.why[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".self"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.note",
+                "path": "Condition.note",
+                "short": "Additional information about the Condition",
+                "definition": "Additional information about the Condition. This is a general notes/comments entry  for description of the Condition, its diagnosis and prognosis.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Condition.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.note"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "NTE child of PRB"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"annotation\"].value"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Condition",
+                "path": "Condition",
+                "definition": "The US Core Condition Profile is based upon the core FHIR Condition Resource and created to meet the 2015 Edition Common Clinical Data Set 'Problems' and 'Health Concerns' requirements.",
+                "constraint": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "key": "us-core-1",
+                        "severity": "warning",
+                        "human": "A code in Condition.category SHOULD be from US Core Condition Category Codes value set.",
+                        "expression": "where(category.memberOf('http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category')).exists()",
+                        "xpath": "(no xpath equivalent)"
+                    }
+                ],
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Condition"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.clinicalStatus",
+                "path": "Condition.clinicalStatus",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/condition-clinical"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Condition.clinicalStatus"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.verificationStatus",
+                "path": "Condition.verificationStatus",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/condition-ver-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Condition.verificationStatus"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.category",
+                "path": "Condition.category",
+                "short": "problem-list-item | encounter-diagnosis | health-concern",
+                "min": 1,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "us-core-1"
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Condition.category"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.code",
+                "path": "Condition.code",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Valueset to describe the actual problem experienced by the patient",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-code"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Condition.code"
+                    }
+                ]
+            },
+            {
+                "id": "Condition.subject",
+                "path": "Condition.subject",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Condition.patient"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-diagnosticreport-lab.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-diagnosticreport-lab.json
@@ -1,1998 +1,1998 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-diagnosticreport-lab",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-lab-definitions.html#DiagnosticReport\" title=\"The US Core Diagnostic Report Profile is based upon the core FHIR DiagnosticReport Resource and created to meet the 2015 Edition Common Clinical Data Set 'Laboratory test(s) and Laboratory value(s)/result(s)' requirements.\">DiagnosticReport</a><a name=\"DiagnosticReport\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/diagnosticreport.html\">DiagnosticReport</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">A Diagnostic report - a combination of request information, atomic results, images, interpretation, as well as formatted reports</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-lab-definitions.html#DiagnosticReport.status\">status</a><a name=\"DiagnosticReport.status\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">registered | partial | preliminary | final +</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-diagnostic-report-status.html\">DiagnosticReportStatus</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck13.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Slice Definition\" class=\"hierarchy\"/> <a style=\"font-style: italic\" href=\"StructureDefinition-us-core-diagnosticreport-lab-definitions.html#DiagnosticReport.category\">Slices for category</a><a name=\"DiagnosticReport.category\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red; font-style: italic\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"font-style: italic\"/><span style=\"font-style: italic\">1</span><span style=\"font-style: italic\">..</span><span style=\"font-style: italic\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"font-style: italic\" href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5; font-style: italic\">Service category</span><br style=\"font-style: italic\"/><span style=\"font-weight:bold; font-style: italic\">Slice: </span><span style=\"font-style: italic\">Unordered, Open by pattern:$this</span><br style=\"font-style: italic\"/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck125.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-lab-definitions.html#DiagnosticReport.category:LaboratorySlice\" title=\"Slice LaboratorySlice\">category:LaboratorySlice</a><a name=\"DiagnosticReport.category\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Service category</span><br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1241.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#CodeableConcept.coding\">coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Code defined by a terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">(complex)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck12410.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"https://terminology.hl7.org/1.0.0//CodeSystem-v2-0074.html\">http://terminology.hl7.org/CodeSystem/v2-0074</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck12400.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">LAB</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-lab-definitions.html#DiagnosticReport.code\" title=\"The test, panel or battery that was ordered.\">code</a><a name=\"DiagnosticReport.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">US Core Laboratory Report Order Code<br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-diagnosticreport-lab-codes.html\">US Core Diagnostic Report Laboratory Codes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>): LOINC codes<br/><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-lab-definitions.html#DiagnosticReport.subject\">subject</a><a name=\"DiagnosticReport.subject\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The subject of the report - usually, but not always, the patient</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_choice.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Choice of Types\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-lab-definitions.html#DiagnosticReport.effective[x]\">effective[x]</a><a name=\"DiagnosticReport.effective_x_\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Clinically relevant time/time-period for report</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for dateTime Type: A date, date-time or partial date (e.g. just year or year + month).  If hours and minutes are specified, a time zone SHALL be populated. The format is a union of the schema types gYear, gYearMonth, date and dateTime. Seconds must be provided due to schema type constraints but may be zero-filled and may be ignored.                 Dates SHALL be valid dates.\">effectiveDateTime</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#dateTime\">dateTime</a> <span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This type must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for Period Type: A time period defined by a start and end date and optionally time.\">effectivePeriod</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Period\">Period</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-lab-definitions.html#DiagnosticReport.issued\">issued</a><a name=\"DiagnosticReport.issued\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#instant\">instant</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">DateTime this version was made</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-lab-definitions.html#DiagnosticReport.performer\">performer</a><a name=\"DiagnosticReport.performer\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-practitioner.html\">US Core Practitioner Profile</a> <span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This target must be supported\">S</span> | <a href=\"StructureDefinition-us-core-organization.html\">US Core Organization Profile</a> | <a href=\"StructureDefinition-us-core-careteam.html\">US Core CareTeam Profile</a> | <a href=\"StructureDefinition-us-core-practitionerrole.html\">US Core PractitionerRole Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Responsible Diagnostic Service</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck00.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-lab-definitions.html#DiagnosticReport.result\">result</a><a name=\"DiagnosticReport.result\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-observation-lab.html\">US Core Laboratory Result Observation Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Observations</span><br/></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab",
-	"version": "4.0.0",
-	"name": "USCoreDiagnosticReportProfileLaboratoryReporting",
-	"title": "US Core DiagnosticReport Profile for Laboratory Results Reporting",
-	"status": "active",
-	"experimental": false,
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the DiagnosticReport resource  for the minimal set of data to query and retrieve diagnostic reports associated with laboratory results for a patient",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "DiagnosticReport",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "DiagnosticReport",
-				"path": "DiagnosticReport",
-				"short": "A Diagnostic report - a combination of request information, atomic results, images, interpretation, as well as formatted reports",
-				"definition": "The US Core Diagnostic Report Profile is based upon the core FHIR DiagnosticReport Resource and created to meet the 2015 Edition Common Clinical Data Set 'Laboratory test(s) and Laboratory value(s)/result(s)' requirements.",
-				"comment": "This is intended to capture a single report and is not suitable for use in displaying summary information that covers multiple reports.  For example, this resource has not been designed for laboratory cumulative reporting formats nor detailed structured reports for sequencing.",
-				"alias": [
-					"Report",
-					"Test",
-					"Result",
-					"Results",
-					"Labs",
-					"Laboratory",
-					"Lab Result",
-					"Lab Report"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "v2",
-						"map": "ORU -> OBR"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.id",
-				"path": "DiagnosticReport.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "DiagnosticReport.meta",
-				"path": "DiagnosticReport.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "DiagnosticReport.implicitRules",
-				"path": "DiagnosticReport.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "DiagnosticReport.language",
-				"path": "DiagnosticReport.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "DiagnosticReport.text",
-				"path": "DiagnosticReport.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.contained",
-				"path": "DiagnosticReport.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.extension",
-				"path": "DiagnosticReport.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.modifierExtension",
-				"path": "DiagnosticReport.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.identifier",
-				"path": "DiagnosticReport.identifier",
-				"short": "Business identifier for report",
-				"definition": "Identifiers assigned to this report by the performer or other systems.",
-				"comment": "Usually assigned by the Information System of the diagnostic service provider (filler id).",
-				"requirements": "Need to know what identifier to use when making queries about this report from the source laboratory, and for linking to the report outside FHIR context.",
-				"alias": [
-					"ReportID",
-					"Filler ID",
-					"Placer ID"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-51/ for globally unique filler ID  - OBR-3 , For non-globally unique filler-id the flller/placer number must be combined with the universal service Id -  OBR-2(if present)+OBR-3+OBR-4"
-					},
-					{
-						"identity": "rim",
-						"map": "id"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.basedOn",
-				"path": "DiagnosticReport.basedOn",
-				"short": "What was requested",
-				"definition": "Details concerning a service requested.",
-				"comment": "Note: Usually there is one test request for each result, however in some circumstances multiple test requests may be represented using a single test result resource. Note that there are also cases where one request leads to multiple reports.",
-				"requirements": "This allows tracing of authorization for the report and tracking whether proposals/recommendations were acted upon.",
-				"alias": [
-					"Request"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan",
-							"http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
-							"http://hl7.org/fhir/StructureDefinition/MedicationRequest",
-							"http://hl7.org/fhir/StructureDefinition/NutritionOrder",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.basedOn"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC? OBR-2/3?"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=FLFS].target"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.status",
-				"path": "DiagnosticReport.status",
-				"short": "registered | partial | preliminary | final +",
-				"definition": "The status of the diagnostic report.",
-				"requirements": "Diagnostic services routinely issue provisional/incomplete reports, and sometimes withdraw previously released reports.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/diagnostic-report-status"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-25 (not 1:1 mapping)"
-					},
-					{
-						"identity": "rim",
-						"map": "statusCode  Note: final and amended are distinguished by whether observation is the subject of a ControlAct event of type \"revise\""
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.category",
-				"path": "DiagnosticReport.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "$this"
-						}
-					],
-					"rules": "open"
-				},
-				"short": "Service category",
-				"definition": "A code that classifies the clinical discipline, department or diagnostic service that created the report (e.g. cardiology, biochemistry, hematology, MRI). This is used for searching, sorting and display purposes.",
-				"comment": "Multiple categories are allowed using various categorization schemes.   The level of granularity is defined by the category concepts in the value set. More fine-grained filtering can be performed using the metadata and/or terminology hierarchy in DiagnosticReport.code.",
-				"alias": [
-					"Department",
-					"Sub-department",
-					"Service",
-					"Discipline"
-				],
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "DiagnosticServiceSection"
-						}
-					],
-					"strength": "example",
-					"description": "Codes for diagnostic service sections.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/diagnostic-service-sections"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-24"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=COMP].source[classCode=LIST, moodCode=EVN, code < LabService].code"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.category:LaboratorySlice",
-				"path": "DiagnosticReport.category",
-				"sliceName": "LaboratorySlice",
-				"short": "Service category",
-				"definition": "A code that classifies the clinical discipline, department or diagnostic service that created the report (e.g. cardiology, biochemistry, hematology, MRI). This is used for searching, sorting and display purposes.",
-				"comment": "Multiple categories are allowed using various categorization schemes.   The level of granularity is defined by the category concepts in the value set. More fine-grained filtering can be performed using the metadata and/or terminology hierarchy in DiagnosticReport.code.",
-				"alias": [
-					"Department",
-					"Sub-department",
-					"Service",
-					"Discipline"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://terminology.hl7.org/CodeSystem/v2-0074",
-							"code": "LAB"
-						}
-					]
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "DiagnosticServiceSection"
-						}
-					],
-					"strength": "example",
-					"description": "Codes for diagnostic service sections.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/diagnostic-service-sections"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-24"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=COMP].source[classCode=LIST, moodCode=EVN, code < LabService].code"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.code",
-				"path": "DiagnosticReport.code",
-				"short": "US Core Laboratory Report Order Code",
-				"definition": "The test, panel or battery that was ordered.",
-				"comment": "UsageNote= The typical patterns for codes are:  1)  a LOINC code either as a  translation from a \"local\" code or as a primary code, or 2)  a local code only if no suitable LOINC exists,  or 3)  both the local and the LOINC translation.   Systems SHALL be capable of sending the local code if one exists.",
-				"alias": [
-					"Type"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "LOINC codes",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-lab-codes"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-4 (HL7 v2 doesn't provide an easy way to indicate both the ordered test and the performed panel)"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.subject",
-				"path": "DiagnosticReport.subject",
-				"short": "The subject of the report - usually, but not always, the patient",
-				"definition": "The subject of the report. Usually, but not always, this is a patient. However, diagnostic services also perform analyses on specimens collected from a variety of other sources.",
-				"requirements": "SHALL know the subject context.",
-				"alias": [
-					"Patient"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3 (no HL7 v2 mapping for Group or Device)"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SBJ]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.encounter",
-				"path": "DiagnosticReport.encounter",
-				"short": "Health care event when test ordered",
-				"definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) which this DiagnosticReport is about.",
-				"comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter  but still be tied to the context of the encounter  (e.g. pre-admission laboratory tests).",
-				"requirements": "Links the request to the Encounter context.",
-				"alias": [
-					"Context"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.encounter"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1-19"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.effective[x]",
-				"path": "DiagnosticReport.effective[x]",
-				"short": "Clinically relevant time/time-period for report",
-				"definition": "The time or time-period the observed values are related to. When the subject of the report is a patient, this is usually either the time of the procedure or of specimen collection(s), but very often the source of the date/time is not known, only the date/time itself.",
-				"comment": "If the diagnostic procedure was performed on the patient, this is the time it was performed. If there are specimens, the diagnostically relevant time can be derived from the specimen collection times, but the specimen information is not always available, and the exact relationship between the specimens and the diagnostically relevant time is not always automatic.",
-				"requirements": "Need to know where in the patient history to file/present this report.",
-				"alias": [
-					"Observation time",
-					"Effective Time",
-					"Occurrence"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.effective[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-7"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.issued",
-				"path": "DiagnosticReport.issued",
-				"short": "DateTime this version was made",
-				"definition": "The date and time that this version of the report was made available to providers, typically after the report was reviewed and verified.",
-				"comment": "May be different from the update time of the resource itself, because that is the status of the record (potentially a secondary copy), not the actual release time of the report.",
-				"requirements": "Clinicians need to be able to check the date that the report was released.",
-				"alias": [
-					"Date published",
-					"Date Issued",
-					"Date Verified"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.issued",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-22"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=VRF or AUT].time"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.performer",
-				"path": "DiagnosticReport.performer",
-				"short": "Responsible Diagnostic Service",
-				"definition": "The diagnostic service that is responsible for issuing the report.",
-				"comment": "This is not necessarily the source of the atomic data items or the entity that interpreted the results. It is the entity that takes responsibility for the clinical report.",
-				"requirements": "Need to know whom to contact if there are queries about the results. Also may need to track the source of reports for secondary data analysis.",
-				"alias": [
-					"Laboratory",
-					"Service",
-					"Practitioner",
-					"Department",
-					"Company",
-					"Authorized by",
-					"Director"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.performer",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole"
-						],
-						"_targetProfile": [
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": true
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							}
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "PRT-8 (where this PRT-4-Participation = \"PO\")"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=PRF]"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.resultsInterpreter",
-				"path": "DiagnosticReport.resultsInterpreter",
-				"short": "Primary result interpreter",
-				"definition": "The practitioner or organization that is responsible for the report's conclusions and interpretations.",
-				"comment": "Might not be the same entity that takes responsibility for the clinical report.",
-				"requirements": "Need to know whom to contact if there are queries about the results. Also may need to track the source of reports for secondary data analysis.",
-				"alias": [
-					"Analyzed by",
-					"Reported by"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.resultsInterpreter",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-32, PRT-8 (where this PRT-4-Participation = \"PI\")"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=PRF]"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.specimen",
-				"path": "DiagnosticReport.specimen",
-				"short": "Specimens this report is based on",
-				"definition": "Details about the specimens on which this diagnostic report is based.",
-				"comment": "If the specimen is sufficiently specified with a code in the test result name, then this additional data may be redundant. If there are multiple specimens, these may be represented per observation or group.",
-				"requirements": "Need to be able to report information about the collected specimens on which the report is based.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.specimen",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Specimen"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SPM"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SBJ]"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.result",
-				"path": "DiagnosticReport.result",
-				"short": "Observations",
-				"definition": "[Observations](http://hl7.org/fhir/R4/observation.html)  that are part of this diagnostic report.",
-				"comment": "Observations can contain observations.",
-				"requirements": "Need to support individual results, or  groups of results, where the result grouping is arbitrary, but meaningful.",
-				"alias": [
-					"Data",
-					"Atomic Value",
-					"Result",
-					"Atomic result",
-					"Data",
-					"Test",
-					"Analyte",
-					"Battery",
-					"Organizer"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.result",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBXs"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=COMP].target"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.imagingStudy",
-				"path": "DiagnosticReport.imagingStudy",
-				"short": "Reference to full details of imaging associated with the diagnostic report",
-				"definition": "One or more links to full details of any imaging performed during the diagnostic investigation. Typically, this is imaging performed by DICOM enabled modalities, but this is not required. A fully enabled PACS viewer can use this information to provide views of the source images.",
-				"comment": "ImagingStudy and the image element are somewhat overlapping - typically, the list of image references in the image element will also be found in one of the imaging study resources. However, each caters to different types of displays for different types of purposes. Neither, either, or both may be provided.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.imagingStudy",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=COMP].target[classsCode=DGIMG, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.media",
-				"path": "DiagnosticReport.media",
-				"short": "Key images associated with this report",
-				"definition": "A list of key images associated with this report. The images are generally created during the diagnostic process, and may be directly of the patient, or of treated specimens (i.e. slides of interest).",
-				"requirements": "Many diagnostic services include images in the report as part of their service.",
-				"alias": [
-					"DICOM",
-					"Slides",
-					"Scans"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.media",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX?"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=COMP].target"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.media.id",
-				"path": "DiagnosticReport.media.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.media.extension",
-				"path": "DiagnosticReport.media.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.media.modifierExtension",
-				"path": "DiagnosticReport.media.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.media.comment",
-				"path": "DiagnosticReport.media.comment",
-				"short": "Comment about the image (e.g. explanation)",
-				"definition": "A comment about the image. Typically, this is used to provide an explanation for why the image is included, or to draw the viewer's attention to important features.",
-				"comment": "The comment should be displayed with the image. It would be common for the report to include additional discussion of the image contents in other sections such as the conclusion.",
-				"requirements": "The provider of the report should make a comment about each image included in the report.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.media.comment",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[classCode=OBS, moodCode=EVN, code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.media.link",
-				"path": "DiagnosticReport.media.link",
-				"short": "Reference to the image source",
-				"definition": "Reference to the image source.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.media.link",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Media"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".value.reference"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.conclusion",
-				"path": "DiagnosticReport.conclusion",
-				"short": "Clinical conclusion (interpretation) of test results",
-				"definition": "Concise and clinically contextualized summary conclusion (interpretation/impression) of the diagnostic report.",
-				"requirements": "Need to be able to provide a conclusion that is not lost among the basic result data.",
-				"alias": [
-					"Report"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.conclusion",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=\"SPRT\"].source[classCode=OBS, moodCode=EVN, code=LOINC:48767-8].value (type=ST)"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.conclusionCode",
-				"path": "DiagnosticReport.conclusionCode",
-				"short": "Codes for the clinical conclusion of test results",
-				"definition": "One or more codes that represent the summary conclusion (interpretation/impression) of the diagnostic report.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.conclusionCode",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AdjunctDiagnosis"
-						}
-					],
-					"strength": "example",
-					"description": "Diagnosis codes provided as adjuncts to the report.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=SPRT].source[classCode=OBS, moodCode=EVN, code=LOINC:54531-9].value (type=CD)"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.presentedForm",
-				"path": "DiagnosticReport.presentedForm",
-				"short": "Entire report as issued",
-				"definition": "Rich text representation of the entire result as issued by the diagnostic service. Multiple formats are allowed but they SHALL be semantically equivalent.",
-				"comment": "\"application/pdf\" is recommended as the most reliable and interoperable in this context.",
-				"requirements": "Gives laboratory the ability to provide its own fully formatted report for clinical fidelity.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.presentedForm",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Attachment"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "text (type=ED)"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "DiagnosticReport",
-				"path": "DiagnosticReport",
-				"definition": "The US Core Diagnostic Report Profile is based upon the core FHIR DiagnosticReport Resource and created to meet the 2015 Edition Common Clinical Data Set 'Laboratory test(s) and Laboratory value(s)/result(s)' requirements.",
-				"alias": [
-					"Lab Result",
-					"Lab Report"
-				],
-				"mustSupport": false,
-				"isModifier": false
-			},
-			{
-				"id": "DiagnosticReport.status",
-				"path": "DiagnosticReport.status",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/diagnostic-report-status"
-				}
-			},
-			{
-				"id": "DiagnosticReport.category",
-				"path": "DiagnosticReport.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "$this"
-						}
-					],
-					"rules": "open"
-				},
-				"min": 1,
-				"max": "*",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "DiagnosticReport.category:LaboratorySlice",
-				"path": "DiagnosticReport.category",
-				"sliceName": "LaboratorySlice",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://terminology.hl7.org/CodeSystem/v2-0074",
-							"code": "LAB"
-						}
-					]
-				},
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "DiagnosticReport.code",
-				"path": "DiagnosticReport.code",
-				"short": "US Core Laboratory Report Order Code",
-				"definition": "The test, panel or battery that was ordered.",
-				"comment": "UsageNote= The typical patterns for codes are:  1)  a LOINC code either as a  translation from a \"local\" code or as a primary code, or 2)  a local code only if no suitable LOINC exists,  or 3)  both the local and the LOINC translation.   Systems SHALL be capable of sending the local code if one exists.",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"binding": {
-					"strength": "extensible",
-					"description": "LOINC codes",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-lab-codes"
-				}
-			},
-			{
-				"id": "DiagnosticReport.subject",
-				"path": "DiagnosticReport.subject",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "DiagnosticReport.effective[x]",
-				"path": "DiagnosticReport.effective[x]",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "DiagnosticReport.issued",
-				"path": "DiagnosticReport.issued",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "DiagnosticReport.performer",
-				"path": "DiagnosticReport.performer",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole"
-						],
-						"_targetProfile": [
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": true
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							}
-						]
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "DiagnosticReport.result",
-				"path": "DiagnosticReport.result",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-						]
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-diagnosticreport-lab",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab",
+    "version": "4.0.0",
+    "name": "USCoreDiagnosticReportProfileLaboratoryReporting",
+    "title": "US Core DiagnosticReport Profile for Laboratory Results Reporting",
+    "status": "active",
+    "experimental": false,
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the DiagnosticReport resource  for the minimal set of data to query and retrieve diagnostic reports associated with laboratory results for a patient",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "DiagnosticReport",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "DiagnosticReport",
+                "path": "DiagnosticReport",
+                "short": "A Diagnostic report - a combination of request information, atomic results, images, interpretation, as well as formatted reports",
+                "definition": "The US Core Diagnostic Report Profile is based upon the core FHIR DiagnosticReport Resource and created to meet the 2015 Edition Common Clinical Data Set 'Laboratory test(s) and Laboratory value(s)/result(s)' requirements.",
+                "comment": "This is intended to capture a single report and is not suitable for use in displaying summary information that covers multiple reports.  For example, this resource has not been designed for laboratory cumulative reporting formats nor detailed structured reports for sequencing.",
+                "alias": [
+                    "Report",
+                    "Test",
+                    "Result",
+                    "Results",
+                    "Labs",
+                    "Laboratory",
+                    "Lab Result",
+                    "Lab Report"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORU -> OBR"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.id",
+                "path": "DiagnosticReport.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "DiagnosticReport.meta",
+                "path": "DiagnosticReport.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "DiagnosticReport.implicitRules",
+                "path": "DiagnosticReport.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "DiagnosticReport.language",
+                "path": "DiagnosticReport.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "DiagnosticReport.text",
+                "path": "DiagnosticReport.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.contained",
+                "path": "DiagnosticReport.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.extension",
+                "path": "DiagnosticReport.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.modifierExtension",
+                "path": "DiagnosticReport.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.identifier",
+                "path": "DiagnosticReport.identifier",
+                "short": "Business identifier for report",
+                "definition": "Identifiers assigned to this report by the performer or other systems.",
+                "comment": "Usually assigned by the Information System of the diagnostic service provider (filler id).",
+                "requirements": "Need to know what identifier to use when making queries about this report from the source laboratory, and for linking to the report outside FHIR context.",
+                "alias": [
+                    "ReportID",
+                    "Filler ID",
+                    "Placer ID"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-51/ for globally unique filler ID  - OBR-3 , For non-globally unique filler-id the flller/placer number must be combined with the universal service Id -  OBR-2(if present)+OBR-3+OBR-4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "id"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.basedOn",
+                "path": "DiagnosticReport.basedOn",
+                "short": "What was requested",
+                "definition": "Details concerning a service requested.",
+                "comment": "Note: Usually there is one test request for each result, however in some circumstances multiple test requests may be represented using a single test result resource. Note that there are also cases where one request leads to multiple reports.",
+                "requirements": "This allows tracing of authorization for the report and tracking whether proposals/recommendations were acted upon.",
+                "alias": [
+                    "Request"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan",
+                            "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+                            "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.basedOn"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC? OBR-2/3?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=FLFS].target"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.status",
+                "path": "DiagnosticReport.status",
+                "short": "registered | partial | preliminary | final +",
+                "definition": "The status of the diagnostic report.",
+                "requirements": "Diagnostic services routinely issue provisional/incomplete reports, and sometimes withdraw previously released reports.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/diagnostic-report-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-25 (not 1:1 mapping)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "statusCode  Note: final and amended are distinguished by whether observation is the subject of a ControlAct event of type \"revise\""
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.category",
+                "path": "DiagnosticReport.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "$this"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "short": "Service category",
+                "definition": "A code that classifies the clinical discipline, department or diagnostic service that created the report (e.g. cardiology, biochemistry, hematology, MRI). This is used for searching, sorting and display purposes.",
+                "comment": "Multiple categories are allowed using various categorization schemes.   The level of granularity is defined by the category concepts in the value set. More fine-grained filtering can be performed using the metadata and/or terminology hierarchy in DiagnosticReport.code.",
+                "alias": [
+                    "Department",
+                    "Sub-department",
+                    "Service",
+                    "Discipline"
+                ],
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "DiagnosticServiceSection"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes for diagnostic service sections.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/diagnostic-service-sections"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-24"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=COMP].source[classCode=LIST, moodCode=EVN, code < LabService].code"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.category:LaboratorySlice",
+                "path": "DiagnosticReport.category",
+                "sliceName": "LaboratorySlice",
+                "short": "Service category",
+                "definition": "A code that classifies the clinical discipline, department or diagnostic service that created the report (e.g. cardiology, biochemistry, hematology, MRI). This is used for searching, sorting and display purposes.",
+                "comment": "Multiple categories are allowed using various categorization schemes.   The level of granularity is defined by the category concepts in the value set. More fine-grained filtering can be performed using the metadata and/or terminology hierarchy in DiagnosticReport.code.",
+                "alias": [
+                    "Department",
+                    "Sub-department",
+                    "Service",
+                    "Discipline"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                            "code": "LAB"
+                        }
+                    ]
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "DiagnosticServiceSection"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes for diagnostic service sections.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/diagnostic-service-sections"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-24"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=COMP].source[classCode=LIST, moodCode=EVN, code < LabService].code"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.code",
+                "path": "DiagnosticReport.code",
+                "short": "US Core Laboratory Report Order Code",
+                "definition": "The test, panel or battery that was ordered.",
+                "comment": "UsageNote= The typical patterns for codes are:  1)  a LOINC code either as a  translation from a \"local\" code or as a primary code, or 2)  a local code only if no suitable LOINC exists,  or 3)  both the local and the LOINC translation.   Systems SHALL be capable of sending the local code if one exists.",
+                "alias": [
+                    "Type"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "LOINC codes",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-lab-codes"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-4 (HL7 v2 doesn't provide an easy way to indicate both the ordered test and the performed panel)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.subject",
+                "path": "DiagnosticReport.subject",
+                "short": "The subject of the report - usually, but not always, the patient",
+                "definition": "The subject of the report. Usually, but not always, this is a patient. However, diagnostic services also perform analyses on specimens collected from a variety of other sources.",
+                "requirements": "SHALL know the subject context.",
+                "alias": [
+                    "Patient"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3 (no HL7 v2 mapping for Group or Device)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SBJ]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.encounter",
+                "path": "DiagnosticReport.encounter",
+                "short": "Health care event when test ordered",
+                "definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) which this DiagnosticReport is about.",
+                "comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter  but still be tied to the context of the encounter  (e.g. pre-admission laboratory tests).",
+                "requirements": "Links the request to the Encounter context.",
+                "alias": [
+                    "Context"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.encounter"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1-19"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.effective[x]",
+                "path": "DiagnosticReport.effective[x]",
+                "short": "Clinically relevant time/time-period for report",
+                "definition": "The time or time-period the observed values are related to. When the subject of the report is a patient, this is usually either the time of the procedure or of specimen collection(s), but very often the source of the date/time is not known, only the date/time itself.",
+                "comment": "If the diagnostic procedure was performed on the patient, this is the time it was performed. If there are specimens, the diagnostically relevant time can be derived from the specimen collection times, but the specimen information is not always available, and the exact relationship between the specimens and the diagnostically relevant time is not always automatic.",
+                "requirements": "Need to know where in the patient history to file/present this report.",
+                "alias": [
+                    "Observation time",
+                    "Effective Time",
+                    "Occurrence"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.effective[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.issued",
+                "path": "DiagnosticReport.issued",
+                "short": "DateTime this version was made",
+                "definition": "The date and time that this version of the report was made available to providers, typically after the report was reviewed and verified.",
+                "comment": "May be different from the update time of the resource itself, because that is the status of the record (potentially a secondary copy), not the actual release time of the report.",
+                "requirements": "Clinicians need to be able to check the date that the report was released.",
+                "alias": [
+                    "Date published",
+                    "Date Issued",
+                    "Date Verified"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.issued",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-22"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=VRF or AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.performer",
+                "path": "DiagnosticReport.performer",
+                "short": "Responsible Diagnostic Service",
+                "definition": "The diagnostic service that is responsible for issuing the report.",
+                "comment": "This is not necessarily the source of the atomic data items or the entity that interpreted the results. It is the entity that takes responsibility for the clinical report.",
+                "requirements": "Need to know whom to contact if there are queries about the results. Also may need to track the source of reports for secondary data analysis.",
+                "alias": [
+                    "Laboratory",
+                    "Service",
+                    "Practitioner",
+                    "Department",
+                    "Company",
+                    "Authorized by",
+                    "Director"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.performer",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole"
+                        ],
+                        "_targetProfile": [
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": true
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRT-8 (where this PRT-4-Participation = \"PO\")"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=PRF]"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.resultsInterpreter",
+                "path": "DiagnosticReport.resultsInterpreter",
+                "short": "Primary result interpreter",
+                "definition": "The practitioner or organization that is responsible for the report's conclusions and interpretations.",
+                "comment": "Might not be the same entity that takes responsibility for the clinical report.",
+                "requirements": "Need to know whom to contact if there are queries about the results. Also may need to track the source of reports for secondary data analysis.",
+                "alias": [
+                    "Analyzed by",
+                    "Reported by"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.resultsInterpreter",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-32, PRT-8 (where this PRT-4-Participation = \"PI\")"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=PRF]"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.specimen",
+                "path": "DiagnosticReport.specimen",
+                "short": "Specimens this report is based on",
+                "definition": "Details about the specimens on which this diagnostic report is based.",
+                "comment": "If the specimen is sufficiently specified with a code in the test result name, then this additional data may be redundant. If there are multiple specimens, these may be represented per observation or group.",
+                "requirements": "Need to be able to report information about the collected specimens on which the report is based.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.specimen",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Specimen"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SPM"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SBJ]"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.result",
+                "path": "DiagnosticReport.result",
+                "short": "Observations",
+                "definition": "[Observations](http://hl7.org/fhir/R4/observation.html)  that are part of this diagnostic report.",
+                "comment": "Observations can contain observations.",
+                "requirements": "Need to support individual results, or  groups of results, where the result grouping is arbitrary, but meaningful.",
+                "alias": [
+                    "Data",
+                    "Atomic Value",
+                    "Result",
+                    "Atomic result",
+                    "Data",
+                    "Test",
+                    "Analyte",
+                    "Battery",
+                    "Organizer"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.result",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBXs"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=COMP].target"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.imagingStudy",
+                "path": "DiagnosticReport.imagingStudy",
+                "short": "Reference to full details of imaging associated with the diagnostic report",
+                "definition": "One or more links to full details of any imaging performed during the diagnostic investigation. Typically, this is imaging performed by DICOM enabled modalities, but this is not required. A fully enabled PACS viewer can use this information to provide views of the source images.",
+                "comment": "ImagingStudy and the image element are somewhat overlapping - typically, the list of image references in the image element will also be found in one of the imaging study resources. However, each caters to different types of displays for different types of purposes. Neither, either, or both may be provided.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.imagingStudy",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=COMP].target[classsCode=DGIMG, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.media",
+                "path": "DiagnosticReport.media",
+                "short": "Key images associated with this report",
+                "definition": "A list of key images associated with this report. The images are generally created during the diagnostic process, and may be directly of the patient, or of treated specimens (i.e. slides of interest).",
+                "requirements": "Many diagnostic services include images in the report as part of their service.",
+                "alias": [
+                    "DICOM",
+                    "Slides",
+                    "Scans"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.media",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=COMP].target"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.media.id",
+                "path": "DiagnosticReport.media.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.media.extension",
+                "path": "DiagnosticReport.media.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.media.modifierExtension",
+                "path": "DiagnosticReport.media.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.media.comment",
+                "path": "DiagnosticReport.media.comment",
+                "short": "Comment about the image (e.g. explanation)",
+                "definition": "A comment about the image. Typically, this is used to provide an explanation for why the image is included, or to draw the viewer's attention to important features.",
+                "comment": "The comment should be displayed with the image. It would be common for the report to include additional discussion of the image contents in other sections such as the conclusion.",
+                "requirements": "The provider of the report should make a comment about each image included in the report.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.media.comment",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[classCode=OBS, moodCode=EVN, code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.media.link",
+                "path": "DiagnosticReport.media.link",
+                "short": "Reference to the image source",
+                "definition": "Reference to the image source.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.media.link",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Media"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".value.reference"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.conclusion",
+                "path": "DiagnosticReport.conclusion",
+                "short": "Clinical conclusion (interpretation) of test results",
+                "definition": "Concise and clinically contextualized summary conclusion (interpretation/impression) of the diagnostic report.",
+                "requirements": "Need to be able to provide a conclusion that is not lost among the basic result data.",
+                "alias": [
+                    "Report"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.conclusion",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=\"SPRT\"].source[classCode=OBS, moodCode=EVN, code=LOINC:48767-8].value (type=ST)"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.conclusionCode",
+                "path": "DiagnosticReport.conclusionCode",
+                "short": "Codes for the clinical conclusion of test results",
+                "definition": "One or more codes that represent the summary conclusion (interpretation/impression) of the diagnostic report.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.conclusionCode",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AdjunctDiagnosis"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Diagnosis codes provided as adjuncts to the report.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=SPRT].source[classCode=OBS, moodCode=EVN, code=LOINC:54531-9].value (type=CD)"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.presentedForm",
+                "path": "DiagnosticReport.presentedForm",
+                "short": "Entire report as issued",
+                "definition": "Rich text representation of the entire result as issued by the diagnostic service. Multiple formats are allowed but they SHALL be semantically equivalent.",
+                "comment": "\"application/pdf\" is recommended as the most reliable and interoperable in this context.",
+                "requirements": "Gives laboratory the ability to provide its own fully formatted report for clinical fidelity.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.presentedForm",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Attachment"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "text (type=ED)"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "DiagnosticReport",
+                "path": "DiagnosticReport",
+                "definition": "The US Core Diagnostic Report Profile is based upon the core FHIR DiagnosticReport Resource and created to meet the 2015 Edition Common Clinical Data Set 'Laboratory test(s) and Laboratory value(s)/result(s)' requirements.",
+                "alias": [
+                    "Lab Result",
+                    "Lab Report"
+                ],
+                "mustSupport": false,
+                "isModifier": false
+            },
+            {
+                "id": "DiagnosticReport.status",
+                "path": "DiagnosticReport.status",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/diagnostic-report-status"
+                }
+            },
+            {
+                "id": "DiagnosticReport.category",
+                "path": "DiagnosticReport.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "$this"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "min": 1,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "DiagnosticReport.category:LaboratorySlice",
+                "path": "DiagnosticReport.category",
+                "sliceName": "LaboratorySlice",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                            "code": "LAB"
+                        }
+                    ]
+                },
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "DiagnosticReport.code",
+                "path": "DiagnosticReport.code",
+                "short": "US Core Laboratory Report Order Code",
+                "definition": "The test, panel or battery that was ordered.",
+                "comment": "UsageNote= The typical patterns for codes are:  1)  a LOINC code either as a  translation from a \"local\" code or as a primary code, or 2)  a local code only if no suitable LOINC exists,  or 3)  both the local and the LOINC translation.   Systems SHALL be capable of sending the local code if one exists.",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "LOINC codes",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-lab-codes"
+                }
+            },
+            {
+                "id": "DiagnosticReport.subject",
+                "path": "DiagnosticReport.subject",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "DiagnosticReport.effective[x]",
+                "path": "DiagnosticReport.effective[x]",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "DiagnosticReport.issued",
+                "path": "DiagnosticReport.issued",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "DiagnosticReport.performer",
+                "path": "DiagnosticReport.performer",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole"
+                        ],
+                        "_targetProfile": [
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": true
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "DiagnosticReport.result",
+                "path": "DiagnosticReport.result",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-diagnosticreport-note.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-diagnosticreport-note.json
@@ -1,1914 +1,1914 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-diagnosticreport-note",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-note-definitions.html#DiagnosticReport\" title=\"The US Core Diagnostic Report Profile for Report and Note exchange is based upon the requirements of the Argonauts to exchang imaginge reports.\">DiagnosticReport</a><a name=\"DiagnosticReport\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/diagnosticreport.html\">DiagnosticReport</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">US Core Diagnostic Report Profile for Report and Note exchange</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-note-definitions.html#DiagnosticReport.status\">status</a><a name=\"DiagnosticReport.status\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">registered | partial | preliminary | final +</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-diagnostic-report-status.html\">DiagnosticReportStatus</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-note-definitions.html#DiagnosticReport.category\">category</a><a name=\"DiagnosticReport.category\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..<span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Service category</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-diagnosticreport-category.html\">US Core DiagnosticReport Category</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-note-definitions.html#DiagnosticReport.code\" title=\"The test, panel, report, or note that was ordered.\">code</a><a name=\"DiagnosticReport.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">US Core Report Code<br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-diagnosticreport-report-and-note-codes.html\">US Core DiagnosticReport Report And Note Codes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>): LOINC codes<br/><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-note-definitions.html#DiagnosticReport.subject\" title=\"The subject of the report. Usually, but not always, this is a patient. However diagnostic services also perform analyses on specimens collected from a variety of other sources.\">subject</a><a name=\"DiagnosticReport.subject\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element is included in summaries\">Σ</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">The subject of the report - usually, but not always, the patient</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-note-definitions.html#DiagnosticReport.encounter\">encounter</a><a name=\"DiagnosticReport.encounter\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-encounter.html\">US Core Encounter Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Health care event when test ordered</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_choice.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Choice of Types\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-note-definitions.html#DiagnosticReport.effective[x]\">effective[x]</a><a name=\"DiagnosticReport.effective_x_\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Clinically relevant time/time-period for report</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for dateTime Type: A date, date-time or partial date (e.g. just year or year + month).  If hours and minutes are specified, a time zone SHALL be populated. The format is a union of the schema types gYear, gYearMonth, date and dateTime. Seconds must be provided due to schema type constraints but may be zero-filled and may be ignored.                 Dates SHALL be valid dates.\">effectiveDateTime</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#dateTime\">dateTime</a> <span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This type must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for Period Type: A time period defined by a start and end date and optionally time.\">effectivePeriod</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Period\">Period</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-note-definitions.html#DiagnosticReport.issued\">issued</a><a name=\"DiagnosticReport.issued\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#instant\">instant</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">DateTime this version was made</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-note-definitions.html#DiagnosticReport.performer\">performer</a><a name=\"DiagnosticReport.performer\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-practitioner.html\">US Core Practitioner Profile</a> <span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This target must be supported\">S</span> | <a href=\"StructureDefinition-us-core-organization.html\">US Core Organization Profile</a> <span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This target must be supported\">S</span> | <a href=\"StructureDefinition-us-core-practitionerrole.html\">US Core PractitionerRole Profile</a> | <a href=\"StructureDefinition-us-core-careteam.html\">US Core CareTeam Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Responsible Diagnostic Service</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck00.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-diagnosticreport-note-definitions.html#DiagnosticReport.presentedForm\">presentedForm</a><a name=\"DiagnosticReport.presentedForm\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Attachment\">Attachment</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Entire report as issued</span><br/></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note",
-	"version": "4.0.0",
-	"name": "USCoreDiagnosticReportProfileNoteExchange",
-	"title": "US Core DiagnosticReport Profile for Report and Note exchange",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the DiagnosticReport resource  for the minimal set of data to query and retrieve diagnostic reports associated with clinical notes for a patient",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "DiagnosticReport",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "DiagnosticReport",
-				"path": "DiagnosticReport",
-				"short": "US Core Diagnostic Report Profile for Report and Note exchange",
-				"definition": "The US Core Diagnostic Report Profile for Report and Note exchange is based upon the requirements of the Argonauts to exchang imaginge reports.",
-				"comment": "This is intended to capture a single report and is not suitable for use in displaying summary information that covers multiple reports.  For example, this resource has not been designed for laboratory cumulative reporting formats nor detailed structured reports for sequencing.",
-				"alias": [
-					"Report",
-					"Test",
-					"Result",
-					"Results",
-					"Labs",
-					"Laboratory",
-					"Imaging Report",
-					"Radiology Report"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "v2",
-						"map": "ORU -> OBR"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.id",
-				"path": "DiagnosticReport.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "DiagnosticReport.meta",
-				"path": "DiagnosticReport.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "DiagnosticReport.implicitRules",
-				"path": "DiagnosticReport.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "DiagnosticReport.language",
-				"path": "DiagnosticReport.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "DiagnosticReport.text",
-				"path": "DiagnosticReport.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.contained",
-				"path": "DiagnosticReport.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.extension",
-				"path": "DiagnosticReport.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.modifierExtension",
-				"path": "DiagnosticReport.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.identifier",
-				"path": "DiagnosticReport.identifier",
-				"short": "Business identifier for report",
-				"definition": "Identifiers assigned to this report by the performer or other systems.",
-				"comment": "Usually assigned by the Information System of the diagnostic service provider (filler id).",
-				"requirements": "Need to know what identifier to use when making queries about this report from the source laboratory, and for linking to the report outside FHIR context.",
-				"alias": [
-					"ReportID",
-					"Filler ID",
-					"Placer ID"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-51/ for globally unique filler ID  - OBR-3 , For non-globally unique filler-id the flller/placer number must be combined with the universal service Id -  OBR-2(if present)+OBR-3+OBR-4"
-					},
-					{
-						"identity": "rim",
-						"map": "id"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.basedOn",
-				"path": "DiagnosticReport.basedOn",
-				"short": "What was requested",
-				"definition": "Details concerning a service requested.",
-				"comment": "Note: Usually there is one test request for each result, however in some circumstances multiple test requests may be represented using a single test result resource. Note that there are also cases where one request leads to multiple reports.",
-				"requirements": "This allows tracing of authorization for the report and tracking whether proposals/recommendations were acted upon.",
-				"alias": [
-					"Request"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan",
-							"http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
-							"http://hl7.org/fhir/StructureDefinition/MedicationRequest",
-							"http://hl7.org/fhir/StructureDefinition/NutritionOrder",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.basedOn"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC? OBR-2/3?"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=FLFS].target"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.status",
-				"path": "DiagnosticReport.status",
-				"short": "registered | partial | preliminary | final +",
-				"definition": "The status of the diagnostic report.",
-				"requirements": "Diagnostic services routinely issue provisional/incomplete reports, and sometimes withdraw previously released reports.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/diagnostic-report-status"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-25 (not 1:1 mapping)"
-					},
-					{
-						"identity": "rim",
-						"map": "statusCode  Note: final and amended are distinguished by whether observation is the subject of a ControlAct event of type \"revise\""
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.category",
-				"path": "DiagnosticReport.category",
-				"short": "Service category",
-				"definition": "A code that classifies the clinical discipline, department or diagnostic service that created the report (e.g. cardiology, biochemistry, hematology, MRI). This is used for searching, sorting and display purposes.",
-				"comment": "Multiple categories are allowed using various categorization schemes.   The level of granularity is defined by the category concepts in the value set. More fine-grained filtering can be performed using the metadata and/or terminology hierarchy in DiagnosticReport.code.",
-				"alias": [
-					"Department",
-					"Sub-department",
-					"Service",
-					"Discipline",
-					"service",
-					"discipline"
-				],
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-24"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=COMP].source[classCode=LIST, moodCode=EVN, code < LabService].code"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.code",
-				"path": "DiagnosticReport.code",
-				"short": "US Core Report Code",
-				"definition": "The test, panel, report, or note that was ordered.",
-				"comment": "UsageNote= The typical patterns for codes are:  1)  a LOINC code either as a  translation from a \"local\" code or as a primary code, or 2)  a local code only if no suitable LOINC exists,  or 3)  both the local and the LOINC translation.   Systems SHALL be capable of sending the local code if one exists.",
-				"alias": [
-					"Type"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "LOINC codes",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-report-and-note-codes"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-4 (HL7 v2 doesn't provide an easy way to indicate both the ordered test and the performed panel)"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.subject",
-				"path": "DiagnosticReport.subject",
-				"short": "The subject of the report - usually, but not always, the patient",
-				"definition": "The subject of the report. Usually, but not always, this is a patient. However diagnostic services also perform analyses on specimens collected from a variety of other sources.",
-				"requirements": "SHALL know the subject context.",
-				"alias": [
-					"Patient"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3 (no HL7 v2 mapping for Group or Device)"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SBJ]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.encounter",
-				"path": "DiagnosticReport.encounter",
-				"short": "Health care event when test ordered",
-				"definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) which this DiagnosticReport is about.",
-				"comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter  but still be tied to the context of the encounter  (e.g. pre-admission laboratory tests).",
-				"requirements": "Links the request to the Encounter context.",
-				"alias": [
-					"Context"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.encounter"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1-19"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.effective[x]",
-				"path": "DiagnosticReport.effective[x]",
-				"short": "Clinically relevant time/time-period for report",
-				"definition": "The time or time-period the observed values are related to. When the subject of the report is a patient, this is usually either the time of the procedure or of specimen collection(s), but very often the source of the date/time is not known, only the date/time itself.",
-				"comment": "If the diagnostic procedure was performed on the patient, this is the time it was performed. If there are specimens, the diagnostically relevant time can be derived from the specimen collection times, but the specimen information is not always available, and the exact relationship between the specimens and the diagnostically relevant time is not always automatic.",
-				"requirements": "Need to know where in the patient history to file/present this report.",
-				"alias": [
-					"Observation time",
-					"Effective Time",
-					"Occurrence"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.effective[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-7"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.issued",
-				"path": "DiagnosticReport.issued",
-				"short": "DateTime this version was made",
-				"definition": "The date and time that this version of the report was made available to providers, typically after the report was reviewed and verified.",
-				"comment": "May be different from the update time of the resource itself, because that is the status of the record (potentially a secondary copy), not the actual release time of the report.",
-				"requirements": "Clinicians need to be able to check the date that the report was released.",
-				"alias": [
-					"Date published",
-					"Date Issued",
-					"Date Verified"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.issued",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-22"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=VRF or AUT].time"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.performer",
-				"path": "DiagnosticReport.performer",
-				"short": "Responsible Diagnostic Service",
-				"definition": "The diagnostic service that is responsible for issuing the report.",
-				"comment": "This is not necessarily the source of the atomic data items or the entity that interpreted the results. It is the entity that takes responsibility for the clinical report.",
-				"requirements": "Need to know whom to contact if there are queries about the results. Also may need to track the source of reports for secondary data analysis.",
-				"alias": [
-					"Laboratory",
-					"Service",
-					"Practitioner",
-					"Department",
-					"Company",
-					"Authorized by",
-					"Director"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.performer",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam"
-						],
-						"_targetProfile": [
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": true
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": true
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							}
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "PRT-8 (where this PRT-4-Participation = \"PO\")"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=PRF]"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.resultsInterpreter",
-				"path": "DiagnosticReport.resultsInterpreter",
-				"short": "Primary result interpreter",
-				"definition": "The practitioner or organization that is responsible for the report's conclusions and interpretations.",
-				"comment": "Might not be the same entity that takes responsibility for the clinical report.",
-				"requirements": "Need to know whom to contact if there are queries about the results. Also may need to track the source of reports for secondary data analysis.",
-				"alias": [
-					"Analyzed by",
-					"Reported by"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.resultsInterpreter",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-32, PRT-8 (where this PRT-4-Participation = \"PI\")"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=PRF]"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.specimen",
-				"path": "DiagnosticReport.specimen",
-				"short": "Specimens this report is based on",
-				"definition": "Details about the specimens on which this diagnostic report is based.",
-				"comment": "If the specimen is sufficiently specified with a code in the test result name, then this additional data may be redundant. If there are multiple specimens, these may be represented per observation or group.",
-				"requirements": "Need to be able to report information about the collected specimens on which the report is based.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.specimen",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Specimen"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SPM"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SBJ]"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.result",
-				"path": "DiagnosticReport.result",
-				"short": "Observations",
-				"definition": "[Observations](http://hl7.org/fhir/R4/observation.html)  that are part of this diagnostic report.",
-				"comment": "Observations can contain observations.",
-				"requirements": "Need to support individual results, or  groups of results, where the result grouping is arbitrary, but meaningful.",
-				"alias": [
-					"Data",
-					"Atomic Value",
-					"Result",
-					"Atomic result",
-					"Data",
-					"Test",
-					"Analyte",
-					"Battery",
-					"Organizer"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.result",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Observation"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBXs"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=COMP].target"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.imagingStudy",
-				"path": "DiagnosticReport.imagingStudy",
-				"short": "Reference to full details of imaging associated with the diagnostic report",
-				"definition": "One or more links to full details of any imaging performed during the diagnostic investigation. Typically, this is imaging performed by DICOM enabled modalities, but this is not required. A fully enabled PACS viewer can use this information to provide views of the source images.",
-				"comment": "ImagingStudy and the image element are somewhat overlapping - typically, the list of image references in the image element will also be found in one of the imaging study resources. However, each caters to different types of displays for different types of purposes. Neither, either, or both may be provided.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.imagingStudy",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=COMP].target[classsCode=DGIMG, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.media",
-				"path": "DiagnosticReport.media",
-				"short": "Key images associated with this report",
-				"definition": "A list of key images associated with this report. The images are generally created during the diagnostic process, and may be directly of the patient, or of treated specimens (i.e. slides of interest).",
-				"requirements": "Many diagnostic services include images in the report as part of their service.",
-				"alias": [
-					"DICOM",
-					"Slides",
-					"Scans"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.media",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX?"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=COMP].target"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.media.id",
-				"path": "DiagnosticReport.media.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.media.extension",
-				"path": "DiagnosticReport.media.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.media.modifierExtension",
-				"path": "DiagnosticReport.media.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.media.comment",
-				"path": "DiagnosticReport.media.comment",
-				"short": "Comment about the image (e.g. explanation)",
-				"definition": "A comment about the image. Typically, this is used to provide an explanation for why the image is included, or to draw the viewer's attention to important features.",
-				"comment": "The comment should be displayed with the image. It would be common for the report to include additional discussion of the image contents in other sections such as the conclusion.",
-				"requirements": "The provider of the report should make a comment about each image included in the report.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.media.comment",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[classCode=OBS, moodCode=EVN, code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.media.link",
-				"path": "DiagnosticReport.media.link",
-				"short": "Reference to the image source",
-				"definition": "Reference to the image source.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.media.link",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Media"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".value.reference"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.conclusion",
-				"path": "DiagnosticReport.conclusion",
-				"short": "Clinical conclusion (interpretation) of test results",
-				"definition": "Concise and clinically contextualized summary conclusion (interpretation/impression) of the diagnostic report.",
-				"requirements": "Need to be able to provide a conclusion that is not lost among the basic result data.",
-				"alias": [
-					"Report"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.conclusion",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=\"SPRT\"].source[classCode=OBS, moodCode=EVN, code=LOINC:48767-8].value (type=ST)"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.conclusionCode",
-				"path": "DiagnosticReport.conclusionCode",
-				"short": "Codes for the clinical conclusion of test results",
-				"definition": "One or more codes that represent the summary conclusion (interpretation/impression) of the diagnostic report.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.conclusionCode",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AdjunctDiagnosis"
-						}
-					],
-					"strength": "example",
-					"description": "Diagnosis codes provided as adjuncts to the report.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=SPRT].source[classCode=OBS, moodCode=EVN, code=LOINC:54531-9].value (type=CD)"
-					}
-				]
-			},
-			{
-				"id": "DiagnosticReport.presentedForm",
-				"path": "DiagnosticReport.presentedForm",
-				"short": "Entire report as issued",
-				"definition": "Rich text representation of the entire result as issued by the diagnostic service. Multiple formats are allowed but they SHALL be semantically equivalent.",
-				"comment": "\"application/pdf\" is recommended as the most reliable and interoperable in this context.",
-				"requirements": "Gives laboratory the ability to provide its own fully formatted report for clinical fidelity.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DiagnosticReport.presentedForm",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Attachment"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "text (type=ED)"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "DiagnosticReport",
-				"path": "DiagnosticReport",
-				"short": "US Core Diagnostic Report Profile for Report and Note exchange",
-				"definition": "The US Core Diagnostic Report Profile for Report and Note exchange is based upon the requirements of the Argonauts to exchang imaginge reports.",
-				"alias": [
-					"Imaging Report",
-					"Radiology Report"
-				],
-				"mustSupport": false,
-				"isModifier": false
-			},
-			{
-				"id": "DiagnosticReport.status",
-				"path": "DiagnosticReport.status",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/diagnostic-report-status"
-				}
-			},
-			{
-				"id": "DiagnosticReport.category",
-				"path": "DiagnosticReport.category",
-				"alias": [
-					"Department",
-					"Sub-department",
-					"service",
-					"discipline"
-				],
-				"min": 1,
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-category"
-				}
-			},
-			{
-				"id": "DiagnosticReport.code",
-				"path": "DiagnosticReport.code",
-				"short": "US Core Report Code",
-				"definition": "The test, panel, report, or note that was ordered.",
-				"comment": "UsageNote= The typical patterns for codes are:  1)  a LOINC code either as a  translation from a \"local\" code or as a primary code, or 2)  a local code only if no suitable LOINC exists,  or 3)  both the local and the LOINC translation.   Systems SHALL be capable of sending the local code if one exists.",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"binding": {
-					"strength": "extensible",
-					"description": "LOINC codes",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-report-and-note-codes"
-				}
-			},
-			{
-				"id": "DiagnosticReport.subject",
-				"path": "DiagnosticReport.subject",
-				"short": "The subject of the report - usually, but not always, the patient",
-				"definition": "The subject of the report. Usually, but not always, this is a patient. However diagnostic services also perform analyses on specimens collected from a variety of other sources.",
-				"requirements": "SHALL know the subject context.",
-				"alias": [
-					"Patient"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DiagnosticReport.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "DiagnosticReport.encounter",
-				"path": "DiagnosticReport.encounter",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
-						]
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "DiagnosticReport.effective[x]",
-				"path": "DiagnosticReport.effective[x]",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "DiagnosticReport.issued",
-				"path": "DiagnosticReport.issued",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "DiagnosticReport.performer",
-				"path": "DiagnosticReport.performer",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam"
-						],
-						"_targetProfile": [
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": true
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": true
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							}
-						]
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "DiagnosticReport.presentedForm",
-				"path": "DiagnosticReport.presentedForm",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "Attachment"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-diagnosticreport-note",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note",
+    "version": "4.0.0",
+    "name": "USCoreDiagnosticReportProfileNoteExchange",
+    "title": "US Core DiagnosticReport Profile for Report and Note exchange",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the DiagnosticReport resource  for the minimal set of data to query and retrieve diagnostic reports associated with clinical notes for a patient",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "DiagnosticReport",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "DiagnosticReport",
+                "path": "DiagnosticReport",
+                "short": "US Core Diagnostic Report Profile for Report and Note exchange",
+                "definition": "The US Core Diagnostic Report Profile for Report and Note exchange is based upon the requirements of the Argonauts to exchang imaginge reports.",
+                "comment": "This is intended to capture a single report and is not suitable for use in displaying summary information that covers multiple reports.  For example, this resource has not been designed for laboratory cumulative reporting formats nor detailed structured reports for sequencing.",
+                "alias": [
+                    "Report",
+                    "Test",
+                    "Result",
+                    "Results",
+                    "Labs",
+                    "Laboratory",
+                    "Imaging Report",
+                    "Radiology Report"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORU -> OBR"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.id",
+                "path": "DiagnosticReport.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "DiagnosticReport.meta",
+                "path": "DiagnosticReport.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "DiagnosticReport.implicitRules",
+                "path": "DiagnosticReport.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "DiagnosticReport.language",
+                "path": "DiagnosticReport.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "DiagnosticReport.text",
+                "path": "DiagnosticReport.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.contained",
+                "path": "DiagnosticReport.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.extension",
+                "path": "DiagnosticReport.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.modifierExtension",
+                "path": "DiagnosticReport.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.identifier",
+                "path": "DiagnosticReport.identifier",
+                "short": "Business identifier for report",
+                "definition": "Identifiers assigned to this report by the performer or other systems.",
+                "comment": "Usually assigned by the Information System of the diagnostic service provider (filler id).",
+                "requirements": "Need to know what identifier to use when making queries about this report from the source laboratory, and for linking to the report outside FHIR context.",
+                "alias": [
+                    "ReportID",
+                    "Filler ID",
+                    "Placer ID"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-51/ for globally unique filler ID  - OBR-3 , For non-globally unique filler-id the flller/placer number must be combined with the universal service Id -  OBR-2(if present)+OBR-3+OBR-4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "id"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.basedOn",
+                "path": "DiagnosticReport.basedOn",
+                "short": "What was requested",
+                "definition": "Details concerning a service requested.",
+                "comment": "Note: Usually there is one test request for each result, however in some circumstances multiple test requests may be represented using a single test result resource. Note that there are also cases where one request leads to multiple reports.",
+                "requirements": "This allows tracing of authorization for the report and tracking whether proposals/recommendations were acted upon.",
+                "alias": [
+                    "Request"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan",
+                            "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+                            "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.basedOn"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC? OBR-2/3?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=FLFS].target"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.status",
+                "path": "DiagnosticReport.status",
+                "short": "registered | partial | preliminary | final +",
+                "definition": "The status of the diagnostic report.",
+                "requirements": "Diagnostic services routinely issue provisional/incomplete reports, and sometimes withdraw previously released reports.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/diagnostic-report-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-25 (not 1:1 mapping)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "statusCode  Note: final and amended are distinguished by whether observation is the subject of a ControlAct event of type \"revise\""
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.category",
+                "path": "DiagnosticReport.category",
+                "short": "Service category",
+                "definition": "A code that classifies the clinical discipline, department or diagnostic service that created the report (e.g. cardiology, biochemistry, hematology, MRI). This is used for searching, sorting and display purposes.",
+                "comment": "Multiple categories are allowed using various categorization schemes.   The level of granularity is defined by the category concepts in the value set. More fine-grained filtering can be performed using the metadata and/or terminology hierarchy in DiagnosticReport.code.",
+                "alias": [
+                    "Department",
+                    "Sub-department",
+                    "Service",
+                    "Discipline",
+                    "service",
+                    "discipline"
+                ],
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-24"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=COMP].source[classCode=LIST, moodCode=EVN, code < LabService].code"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.code",
+                "path": "DiagnosticReport.code",
+                "short": "US Core Report Code",
+                "definition": "The test, panel, report, or note that was ordered.",
+                "comment": "UsageNote= The typical patterns for codes are:  1)  a LOINC code either as a  translation from a \"local\" code or as a primary code, or 2)  a local code only if no suitable LOINC exists,  or 3)  both the local and the LOINC translation.   Systems SHALL be capable of sending the local code if one exists.",
+                "alias": [
+                    "Type"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "LOINC codes",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-report-and-note-codes"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-4 (HL7 v2 doesn't provide an easy way to indicate both the ordered test and the performed panel)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.subject",
+                "path": "DiagnosticReport.subject",
+                "short": "The subject of the report - usually, but not always, the patient",
+                "definition": "The subject of the report. Usually, but not always, this is a patient. However diagnostic services also perform analyses on specimens collected from a variety of other sources.",
+                "requirements": "SHALL know the subject context.",
+                "alias": [
+                    "Patient"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3 (no HL7 v2 mapping for Group or Device)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SBJ]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.encounter",
+                "path": "DiagnosticReport.encounter",
+                "short": "Health care event when test ordered",
+                "definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) which this DiagnosticReport is about.",
+                "comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter  but still be tied to the context of the encounter  (e.g. pre-admission laboratory tests).",
+                "requirements": "Links the request to the Encounter context.",
+                "alias": [
+                    "Context"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.encounter"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1-19"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.effective[x]",
+                "path": "DiagnosticReport.effective[x]",
+                "short": "Clinically relevant time/time-period for report",
+                "definition": "The time or time-period the observed values are related to. When the subject of the report is a patient, this is usually either the time of the procedure or of specimen collection(s), but very often the source of the date/time is not known, only the date/time itself.",
+                "comment": "If the diagnostic procedure was performed on the patient, this is the time it was performed. If there are specimens, the diagnostically relevant time can be derived from the specimen collection times, but the specimen information is not always available, and the exact relationship between the specimens and the diagnostically relevant time is not always automatic.",
+                "requirements": "Need to know where in the patient history to file/present this report.",
+                "alias": [
+                    "Observation time",
+                    "Effective Time",
+                    "Occurrence"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.effective[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.issued",
+                "path": "DiagnosticReport.issued",
+                "short": "DateTime this version was made",
+                "definition": "The date and time that this version of the report was made available to providers, typically after the report was reviewed and verified.",
+                "comment": "May be different from the update time of the resource itself, because that is the status of the record (potentially a secondary copy), not the actual release time of the report.",
+                "requirements": "Clinicians need to be able to check the date that the report was released.",
+                "alias": [
+                    "Date published",
+                    "Date Issued",
+                    "Date Verified"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.issued",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-22"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=VRF or AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.performer",
+                "path": "DiagnosticReport.performer",
+                "short": "Responsible Diagnostic Service",
+                "definition": "The diagnostic service that is responsible for issuing the report.",
+                "comment": "This is not necessarily the source of the atomic data items or the entity that interpreted the results. It is the entity that takes responsibility for the clinical report.",
+                "requirements": "Need to know whom to contact if there are queries about the results. Also may need to track the source of reports for secondary data analysis.",
+                "alias": [
+                    "Laboratory",
+                    "Service",
+                    "Practitioner",
+                    "Department",
+                    "Company",
+                    "Authorized by",
+                    "Director"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.performer",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam"
+                        ],
+                        "_targetProfile": [
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": true
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": true
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRT-8 (where this PRT-4-Participation = \"PO\")"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=PRF]"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.resultsInterpreter",
+                "path": "DiagnosticReport.resultsInterpreter",
+                "short": "Primary result interpreter",
+                "definition": "The practitioner or organization that is responsible for the report's conclusions and interpretations.",
+                "comment": "Might not be the same entity that takes responsibility for the clinical report.",
+                "requirements": "Need to know whom to contact if there are queries about the results. Also may need to track the source of reports for secondary data analysis.",
+                "alias": [
+                    "Analyzed by",
+                    "Reported by"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.resultsInterpreter",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-32, PRT-8 (where this PRT-4-Participation = \"PI\")"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=PRF]"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.specimen",
+                "path": "DiagnosticReport.specimen",
+                "short": "Specimens this report is based on",
+                "definition": "Details about the specimens on which this diagnostic report is based.",
+                "comment": "If the specimen is sufficiently specified with a code in the test result name, then this additional data may be redundant. If there are multiple specimens, these may be represented per observation or group.",
+                "requirements": "Need to be able to report information about the collected specimens on which the report is based.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.specimen",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Specimen"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SPM"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SBJ]"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.result",
+                "path": "DiagnosticReport.result",
+                "short": "Observations",
+                "definition": "[Observations](http://hl7.org/fhir/R4/observation.html)  that are part of this diagnostic report.",
+                "comment": "Observations can contain observations.",
+                "requirements": "Need to support individual results, or  groups of results, where the result grouping is arbitrary, but meaningful.",
+                "alias": [
+                    "Data",
+                    "Atomic Value",
+                    "Result",
+                    "Atomic result",
+                    "Data",
+                    "Test",
+                    "Analyte",
+                    "Battery",
+                    "Organizer"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.result",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Observation"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBXs"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=COMP].target"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.imagingStudy",
+                "path": "DiagnosticReport.imagingStudy",
+                "short": "Reference to full details of imaging associated with the diagnostic report",
+                "definition": "One or more links to full details of any imaging performed during the diagnostic investigation. Typically, this is imaging performed by DICOM enabled modalities, but this is not required. A fully enabled PACS viewer can use this information to provide views of the source images.",
+                "comment": "ImagingStudy and the image element are somewhat overlapping - typically, the list of image references in the image element will also be found in one of the imaging study resources. However, each caters to different types of displays for different types of purposes. Neither, either, or both may be provided.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.imagingStudy",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=COMP].target[classsCode=DGIMG, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.media",
+                "path": "DiagnosticReport.media",
+                "short": "Key images associated with this report",
+                "definition": "A list of key images associated with this report. The images are generally created during the diagnostic process, and may be directly of the patient, or of treated specimens (i.e. slides of interest).",
+                "requirements": "Many diagnostic services include images in the report as part of their service.",
+                "alias": [
+                    "DICOM",
+                    "Slides",
+                    "Scans"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.media",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=COMP].target"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.media.id",
+                "path": "DiagnosticReport.media.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.media.extension",
+                "path": "DiagnosticReport.media.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.media.modifierExtension",
+                "path": "DiagnosticReport.media.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.media.comment",
+                "path": "DiagnosticReport.media.comment",
+                "short": "Comment about the image (e.g. explanation)",
+                "definition": "A comment about the image. Typically, this is used to provide an explanation for why the image is included, or to draw the viewer's attention to important features.",
+                "comment": "The comment should be displayed with the image. It would be common for the report to include additional discussion of the image contents in other sections such as the conclusion.",
+                "requirements": "The provider of the report should make a comment about each image included in the report.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.media.comment",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[classCode=OBS, moodCode=EVN, code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.media.link",
+                "path": "DiagnosticReport.media.link",
+                "short": "Reference to the image source",
+                "definition": "Reference to the image source.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.media.link",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Media"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".value.reference"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.conclusion",
+                "path": "DiagnosticReport.conclusion",
+                "short": "Clinical conclusion (interpretation) of test results",
+                "definition": "Concise and clinically contextualized summary conclusion (interpretation/impression) of the diagnostic report.",
+                "requirements": "Need to be able to provide a conclusion that is not lost among the basic result data.",
+                "alias": [
+                    "Report"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.conclusion",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=\"SPRT\"].source[classCode=OBS, moodCode=EVN, code=LOINC:48767-8].value (type=ST)"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.conclusionCode",
+                "path": "DiagnosticReport.conclusionCode",
+                "short": "Codes for the clinical conclusion of test results",
+                "definition": "One or more codes that represent the summary conclusion (interpretation/impression) of the diagnostic report.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.conclusionCode",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AdjunctDiagnosis"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Diagnosis codes provided as adjuncts to the report.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=SPRT].source[classCode=OBS, moodCode=EVN, code=LOINC:54531-9].value (type=CD)"
+                    }
+                ]
+            },
+            {
+                "id": "DiagnosticReport.presentedForm",
+                "path": "DiagnosticReport.presentedForm",
+                "short": "Entire report as issued",
+                "definition": "Rich text representation of the entire result as issued by the diagnostic service. Multiple formats are allowed but they SHALL be semantically equivalent.",
+                "comment": "\"application/pdf\" is recommended as the most reliable and interoperable in this context.",
+                "requirements": "Gives laboratory the ability to provide its own fully formatted report for clinical fidelity.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DiagnosticReport.presentedForm",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Attachment"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "text (type=ED)"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "DiagnosticReport",
+                "path": "DiagnosticReport",
+                "short": "US Core Diagnostic Report Profile for Report and Note exchange",
+                "definition": "The US Core Diagnostic Report Profile for Report and Note exchange is based upon the requirements of the Argonauts to exchang imaginge reports.",
+                "alias": [
+                    "Imaging Report",
+                    "Radiology Report"
+                ],
+                "mustSupport": false,
+                "isModifier": false
+            },
+            {
+                "id": "DiagnosticReport.status",
+                "path": "DiagnosticReport.status",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/diagnostic-report-status"
+                }
+            },
+            {
+                "id": "DiagnosticReport.category",
+                "path": "DiagnosticReport.category",
+                "alias": [
+                    "Department",
+                    "Sub-department",
+                    "service",
+                    "discipline"
+                ],
+                "min": 1,
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-category"
+                }
+            },
+            {
+                "id": "DiagnosticReport.code",
+                "path": "DiagnosticReport.code",
+                "short": "US Core Report Code",
+                "definition": "The test, panel, report, or note that was ordered.",
+                "comment": "UsageNote= The typical patterns for codes are:  1)  a LOINC code either as a  translation from a \"local\" code or as a primary code, or 2)  a local code only if no suitable LOINC exists,  or 3)  both the local and the LOINC translation.   Systems SHALL be capable of sending the local code if one exists.",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "LOINC codes",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-report-and-note-codes"
+                }
+            },
+            {
+                "id": "DiagnosticReport.subject",
+                "path": "DiagnosticReport.subject",
+                "short": "The subject of the report - usually, but not always, the patient",
+                "definition": "The subject of the report. Usually, but not always, this is a patient. However diagnostic services also perform analyses on specimens collected from a variety of other sources.",
+                "requirements": "SHALL know the subject context.",
+                "alias": [
+                    "Patient"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DiagnosticReport.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "DiagnosticReport.encounter",
+                "path": "DiagnosticReport.encounter",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "DiagnosticReport.effective[x]",
+                "path": "DiagnosticReport.effective[x]",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "DiagnosticReport.issued",
+                "path": "DiagnosticReport.issued",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "DiagnosticReport.performer",
+                "path": "DiagnosticReport.performer",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam"
+                        ],
+                        "_targetProfile": [
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": true
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": true
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "DiagnosticReport.presentedForm",
+                "path": "DiagnosticReport.presentedForm",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "Attachment"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-direct.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-direct.json
@@ -1,361 +1,361 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-direct",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-direct-definitions.html#Extension\" title=\"This email address is associated with a &quot;direct&quot; service - e.g. http://wiki.directproject.org/Addressing+Specification. This extension can only be used on contact points where the system = 'email'\">Extension</a><a name=\"Extension\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/extensibility.html#Extension\">Extension</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Email is a &quot;direct&quot; email</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-direct-definitions.html#Extension.url\">url</a><a name=\"Extension.url\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">1</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"color: darkgreen\">&quot;http://hl7.org/fhir/us/core/StructureDefinition/us-core-direct&quot;</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck00.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-direct-definitions.html#Extension.valueBoolean\">valueBoolean</a><a name=\"Extension.valueBoolean\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#boolean\">boolean</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Value of extension</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-direct",
-	"version": "4.0.0",
-	"name": "USCoreDirectEmailExtension",
-	"title": "US Core Direct email Extension",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "This email address is associated with a [direct](http://wiki.directproject.org/Addressing+Specification) service.  This extension can only be used on contact points where the system = 'email'",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		}
-	],
-	"kind": "complex-type",
-	"abstract": false,
-	"context": [
-		{
-			"type": "element",
-			"expression": "ContactPoint"
-		}
-	],
-	"type": "Extension",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Extension",
-				"path": "Extension",
-				"short": "Email is a \"direct\" email",
-				"definition": "This email address is associated with a \"direct\" service - e.g. http://wiki.directproject.org/Addressing+Specification. This extension can only be used on contact points where the system = 'email'",
-				"comment": "This extension can only be used on contact points where the system = 'email'.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Extension",
-					"min": 0,
-					"max": "*"
-				},
-				"condition": [
-					"ele-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "No v2 equivalent"
-					},
-					{
-						"identity": "rim",
-						"map": "No RIM equivalent"
-					}
-				]
-			},
-			{
-				"id": "Extension.id",
-				"path": "Extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension",
-				"path": "Extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.url",
-				"path": "Extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "uri"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-direct",
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.value[x]",
-				"path": "Extension.value[x]",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "type",
-							"path": "$this"
-						}
-					],
-					"ordered": false,
-					"rules": "closed"
-				},
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.value[x]:valueBoolean",
-				"path": "Extension.value[x]",
-				"sliceName": "valueBoolean",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Extension",
-				"path": "Extension",
-				"short": "Email is a \"direct\" email",
-				"definition": "This email address is associated with a \"direct\" service - e.g. http://wiki.directproject.org/Addressing+Specification. This extension can only be used on contact points where the system = 'email'",
-				"comment": "This extension can only be used on contact points where the system = 'email'.",
-				"min": 0,
-				"max": "1",
-				"isModifier": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "No v2 equivalent"
-					},
-					{
-						"identity": "rim",
-						"map": "No RIM equivalent"
-					}
-				]
-			},
-			{
-				"id": "Extension.url",
-				"path": "Extension.url",
-				"fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-direct"
-			},
-			{
-				"id": "Extension.valueBoolean",
-				"path": "Extension.valueBoolean",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "boolean"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-direct",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-direct",
+    "version": "4.0.0",
+    "name": "USCoreDirectEmailExtension",
+    "title": "US Core Direct email Extension",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "This email address is associated with a [direct](http://wiki.directproject.org/Addressing+Specification) service.  This extension can only be used on contact points where the system = 'email'",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        }
+    ],
+    "kind": "complex-type",
+    "abstract": false,
+    "context": [
+        {
+            "type": "element",
+            "expression": "ContactPoint"
+        }
+    ],
+    "type": "Extension",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Extension",
+                "path": "Extension",
+                "short": "Email is a \"direct\" email",
+                "definition": "This email address is associated with a \"direct\" service - e.g. http://wiki.directproject.org/Addressing+Specification. This extension can only be used on contact points where the system = 'email'",
+                "comment": "This extension can only be used on contact points where the system = 'email'.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "condition": [
+                    "ele-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "No v2 equivalent"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "No RIM equivalent"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.id",
+                "path": "Extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension",
+                "path": "Extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.url",
+                "path": "Extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "uri"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-direct",
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.value[x]",
+                "path": "Extension.value[x]",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "type",
+                            "path": "$this"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "closed"
+                },
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.value[x]:valueBoolean",
+                "path": "Extension.value[x]",
+                "sliceName": "valueBoolean",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Extension",
+                "path": "Extension",
+                "short": "Email is a \"direct\" email",
+                "definition": "This email address is associated with a \"direct\" service - e.g. http://wiki.directproject.org/Addressing+Specification. This extension can only be used on contact points where the system = 'email'",
+                "comment": "This extension can only be used on contact points where the system = 'email'.",
+                "min": 0,
+                "max": "1",
+                "isModifier": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "No v2 equivalent"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "No RIM equivalent"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.url",
+                "path": "Extension.url",
+                "fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-direct"
+            },
+            {
+                "id": "Extension.valueBoolean",
+                "path": "Extension.valueBoolean",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-documentreference.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-documentreference.json
@@ -1,3172 +1,3172 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-documentreference",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference\" title=\"This is a basic constraint on DocumentRefernce for use in the US Core IG.\">DocumentReference</a><a name=\"DocumentReference\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/documentreference.html\">DocumentReference</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">A reference to a document</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.identifier\">identifier</a><a name=\"DocumentReference.identifier\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Identifier\">Identifier</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Other identifiers for the document</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.status\">status</a><a name=\"DocumentReference.status\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">current | superseded | entered-in-error</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-document-reference-status.html\">DocumentReferenceStatus</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.type\">type</a><a name=\"DocumentReference.type\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Kind of document (LOINC if possible)</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-documentreference-type.html\">US Core DocumentReference Type</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>): All LOINC  values whose SCALE is DOC in the LOINC database and the HL7 v3 Code System NullFlavor concept 'unknown'<br/><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.category\">category</a><a name=\"DocumentReference.category\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Categorization of document</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-documentreference-category.html\">US Core DocumentReference Category</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>): The US Core DocumentReferences Type Value Set is a 'starter set' of categories supported for fetching and storing clinical notes.<br/><br/><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.subject\">subject</a><a name=\"DocumentReference.subject\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who/what is the subject of the document</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.date\">date</a><a name=\"DocumentReference.date\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#instant\">instant</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">When this document reference was created</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.author\">author</a><a name=\"DocumentReference.author\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-practitioner.html\">US Core Practitioner Profile</a> <span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This target must be supported\">S</span> | <a href=\"StructureDefinition-us-core-organization.html\">US Core Organization Profile</a> | <a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a> | <a href=\"StructureDefinition-us-core-practitionerrole.html\">US Core PractitionerRole Profile</a> | <a href=\"http://hl7.org/fhir/R4/relatedperson.html\">RelatedPerson</a> | <a href=\"http://hl7.org/fhir/R4/device.html\">Device</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who and/or what authored the document</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.content\">content</a><a name=\"DocumentReference.content\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Document referenced</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck111.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.content.attachment\">attachment</a><a name=\"DocumentReference.content.attachment\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-6)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Attachment\">Attachment</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Where to access the document</span><br/><span style=\"font-weight:bold\">us-core-6: </span>DocumentReference.content.attachment.url or  DocumentReference.content.attachment.data or both SHALL be present.</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.content.attachment.contentType\">contentType</a><a name=\"DocumentReference.content.attachment.contentType\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Mime type of the content, with charset etc.</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.content.attachment.data\">data</a><a name=\"DocumentReference.content.attachment.data\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-6)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#base64Binary\">base64Binary</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Data inline, base64ed</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.content.attachment.url\">url</a><a name=\"DocumentReference.content.attachment.url\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-6)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#url\">url</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Uri where the data can be found</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.content.format\">format</a><a name=\"DocumentReference.content.format\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Format/content rules for the document</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-formatcodes.html\">DocumentReferenceFormatCodeSet</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.context\">context</a><a name=\"DocumentReference.context\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Clinical context of document</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.context.encounter\">encounter</a><a name=\"DocumentReference.context.encounter\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-encounter.html\">US Core Encounter Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Context of the document  content</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-documentreference-definitions.html#DocumentReference.context.period\">period</a><a name=\"DocumentReference.context.period\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Period\">Period</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Time of service that is being documented</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference",
-	"version": "4.0.0",
-	"name": "USCoreDocumentReferenceProfile",
-	"title": "US Core DocumentReference Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-02",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The document reference profile used in US Core.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "fhircomposition",
-			"uri": "http://hl7.org/fhir/composition",
-			"name": "FHIR Composition"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "cda",
-			"uri": "http://hl7.org/v3/cda",
-			"name": "CDA (R2)"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "xds",
-			"uri": "http://ihe.net/xds",
-			"name": "XDS metadata equivalent"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "DocumentReference",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/DocumentReference",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "DocumentReference",
-				"path": "DocumentReference",
-				"short": "A reference to a document",
-				"definition": "This is a basic constraint on DocumentRefernce for use in the US Core IG.",
-				"comment": "Usually, this is used for documents other than those defined by FHIR.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DocumentReference",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "fhircomposition",
-						"map": "when describing a Composition"
-					},
-					{
-						"identity": "rim",
-						"map": "Document[classCode=\"DOC\" and moodCode=\"EVN\"]"
-					},
-					{
-						"identity": "cda",
-						"map": "when describing a CDA"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.id",
-				"path": "DocumentReference.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "DocumentReference.meta",
-				"path": "DocumentReference.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "DocumentReference.implicitRules",
-				"path": "DocumentReference.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "DocumentReference.language",
-				"path": "DocumentReference.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "DocumentReference.text",
-				"path": "DocumentReference.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.contained",
-				"path": "DocumentReference.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.extension",
-				"path": "DocumentReference.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.modifierExtension",
-				"path": "DocumentReference.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.masterIdentifier",
-				"path": "DocumentReference.masterIdentifier",
-				"short": "Master Version Specific Identifier",
-				"definition": "Document identifier as assigned by the source of the document. This identifier is specific to this version of the document. This unique identifier may be used elsewhere to identify this version of the document.",
-				"comment": "CDA Document Id extension and root.",
-				"requirements": "The structure and format of this Id shall be consistent with the specification corresponding to the formatCode attribute. (e.g. for a DICOM standard document a 64-character numeric UID, for an HL7 CDA format a serialization of the CDA Document Id extension and root in the form \"oid^extension\", where OID is a 64 digits max, and the Id is a 16 UTF-8 char max. If the OID is coded without the extension then the '^' character shall not be included.).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.masterIdentifier",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "TXA-12"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.uniqueId"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/id"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.identifier",
-				"path": "DocumentReference.identifier",
-				"short": "Other identifiers for the document",
-				"definition": "Other identifiers associated with the document, including version independent identifiers.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DocumentReference.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "TXA-16?"
-					},
-					{
-						"identity": "rim",
-						"map": ".id / .setId"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.entryUUID"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.status",
-				"path": "DocumentReference.status",
-				"short": "current | superseded | entered-in-error",
-				"definition": "The status of this document reference.",
-				"comment": "This is the status of the DocumentReference object, which might be independent from the docStatus element.\n\nThis element is labeled as a modifier because the status contains the codes that mark the document or reference as not currently valid.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labelled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/document-reference-status"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "v2",
-						"map": "TXA-19"
-					},
-					{
-						"identity": "rim",
-						"map": "interim: .completionCode=\"IN\" & ./statusCode[isNormalDatatype()]=\"active\";  final: .completionCode=\"AU\" &&  ./statusCode[isNormalDatatype()]=\"complete\" and not(./inboundRelationship[typeCode=\"SUBJ\" and isNormalActRelationship()]/source[subsumesCode(\"ActClass#CACT\") and moodCode=\"EVN\" and domainMember(\"ReviseDocument\", code) and isNormalAct()]);  amended: .completionCode=\"AU\" &&  ./statusCode[isNormalDatatype()]=\"complete\" and ./inboundRelationship[typeCode=\"SUBJ\" and isNormalActRelationship()]/source[subsumesCode(\"ActClass#CACT\") and moodCode=\"EVN\" and domainMember(\"ReviseDocument\", code) and isNormalAct() and statusCode=\"completed\"];  withdrawn : .completionCode=NI &&  ./statusCode[isNormalDatatype()]=\"obsolete\""
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.availabilityStatus"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.docStatus",
-				"path": "DocumentReference.docStatus",
-				"short": "preliminary | final | amended | entered-in-error",
-				"definition": "The status of the underlying document.",
-				"comment": "The document that is pointed to might be in various lifecycle states.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.docStatus",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ReferredDocumentStatus"
-						}
-					],
-					"strength": "required",
-					"description": "Status of the underlying document.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/composition-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.status"
-					},
-					{
-						"identity": "v2",
-						"map": "TXA-17"
-					},
-					{
-						"identity": "rim",
-						"map": ".statusCode"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.type",
-				"path": "DocumentReference.type",
-				"short": "Kind of document (LOINC if possible)",
-				"definition": "Specifies the particular kind of document referenced  (e.g. History and Physical, Discharge Summary, Progress Note). This usually equates to the purpose of making the document referenced.",
-				"comment": "Key metadata element describing the document that describes he exact type of document. Helps humans to assess whether the document is of interest when viewing a list of documents.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-minValueSet",
-							"valueCanonical": "http://hl7.org/fhir/us/core/ValueSet/us-core-clinical-note-type"
-						}
-					],
-					"strength": "required",
-					"description": "All LOINC  values whose SCALE is DOC in the LOINC database and the HL7 v3 Code System NullFlavor concept 'unknown'",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-type"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.type"
-					},
-					{
-						"identity": "v2",
-						"map": "TXA-2"
-					},
-					{
-						"identity": "rim",
-						"map": "./code"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.type"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/code/@code \n\nThe typeCode should be mapped from the ClinicalDocument/code element to a set of document type codes configured in the affinity domain. One suggested coding system to use for typeCode is LOINC, in which case the mapping step can be omitted."
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.category",
-				"path": "DocumentReference.category",
-				"short": "Categorization of document",
-				"definition": "A categorization for the type of document referenced - helps for indexing and searching. This may be implied by or derived from the code specified in the DocumentReference.type.",
-				"comment": "Key metadata element describing the the category or classification of the document. This is a broader perspective that groups similar documents based on how they would be used. This is a primary key used in searching.",
-				"alias": [
-					"claxs"
-				],
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "DocumentReference.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The US Core DocumentReferences Type Value Set is a &#39;starter set&#39; of categories supported for fetching and storing clinical notes.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.class"
-					},
-					{
-						"identity": "cda",
-						"map": "Derived from a mapping of /ClinicalDocument/code/@code to an Affinity Domain specified coded value to use and coding system. Affinity Domains are encouraged to use the appropriate value for Type of Service, based on the LOINC Type of Service (see Page 53 of the LOINC User's Manual). Must be consistent with /ClinicalDocument/code/@code"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.subject",
-				"path": "DocumentReference.subject",
-				"short": "Who/what is the subject of the document",
-				"definition": "Who or what the document is about. The document can be about a person, (patient or healthcare practitioner), a device (e.g. a machine) or even a group of subjects (such as a document about a herd of farm animals, or a set of patients that share a common exposure).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.subject"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3 (No standard way to define a Practitioner or Group subject in HL7 v2 MDM message)"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=\"SBJ\"].role[typeCode=\"PAT\"]"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.patientId"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/recordTarget/"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.date",
-				"path": "DocumentReference.date",
-				"short": "When this document reference was created",
-				"definition": "When the document reference was created.",
-				"comment": "Referencing/indexing time is used for tracking, organizing versions and searching.",
-				"alias": [
-					"indexed"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.date",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.date"
-					},
-					{
-						"identity": "rim",
-						"map": ".availabilityTime[type=\"TS\"]"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.author",
-				"path": "DocumentReference.author",
-				"short": "Who and/or what authored the document",
-				"definition": "Identifies who is responsible for adding the information to the document.",
-				"comment": "Not necessarily who did the actual data entry (i.e. typist) or who was the source (informant).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DocumentReference.author",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson",
-							"http://hl7.org/fhir/StructureDefinition/Device"
-						],
-						"_targetProfile": [
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": true
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							}
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.author"
-					},
-					{
-						"identity": "v2",
-						"map": "TXA-9 (No standard way to indicate a Device in HL7 v2 MDM message)"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=\"AUT\"].role[classCode=\"ASSIGNED\"]"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.author"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/author"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.authenticator",
-				"path": "DocumentReference.authenticator",
-				"short": "Who/what authenticated the document",
-				"definition": "Which person or organization authenticates that this document is valid.",
-				"comment": "Represents a participant within the author institution who has legally authenticated or attested the document. Legal authentication implies that a document has been signed manually or electronically by the legal Authenticator.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.authenticator",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.witness"
-					},
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.attester"
-					},
-					{
-						"identity": "v2",
-						"map": "TXA-10"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=\"AUTHEN\"].role[classCode=\"ASSIGNED\"]"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.legalAuthenticator"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/legalAuthenticator"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.custodian",
-				"path": "DocumentReference.custodian",
-				"short": "Organization which maintains the document",
-				"definition": "Identifies the organization or group who is responsible for ongoing maintenance of and access to the document.",
-				"comment": "Identifies the logical organization (software system, vendor, or department) to go to find the current version, where to report issues, etc. This is different from the physical location (URL, disk drive, or server) of the document, which is the technical location of the document, which host may be delegated to the management of some other organization.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.custodian",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.custodian"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=\"RCV\"].role[classCode=\"CUST\"].scoper[classCode=\"ORG\" and determinerCode=\"INST\"]"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.relatesTo",
-				"path": "DocumentReference.relatesTo",
-				"short": "Relationships to other documents",
-				"definition": "Relationships that this document has with other document references that already exist.",
-				"comment": "This element is labeled as a modifier because documents that append to other documents are incomplete on their own.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DocumentReference.relatesTo",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.relatesTo"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry Associations"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.relatesTo.id",
-				"path": "DocumentReference.relatesTo.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.relatesTo.extension",
-				"path": "DocumentReference.relatesTo.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.relatesTo.modifierExtension",
-				"path": "DocumentReference.relatesTo.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.relatesTo.code",
-				"path": "DocumentReference.relatesTo.code",
-				"short": "replaces | transforms | signs | appends",
-				"definition": "The type of relationship that this document has with anther document.",
-				"comment": "If this document appends another document, then the document cannot be fully understood without also accessing the referenced document.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.relatesTo.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "DocumentRelationshipType"
-						}
-					],
-					"strength": "required",
-					"description": "The type of relationship between documents.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/document-relationship-type|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.relatesTo.code"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship.typeCode"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry Associations type"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.relatesTo.target",
-				"path": "DocumentReference.relatesTo.target",
-				"short": "Target of the relationship",
-				"definition": "The target document of this relationship.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.relatesTo.target",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/DocumentReference"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.relatesTo.target"
-					},
-					{
-						"identity": "rim",
-						"map": ".target[classCode=\"DOC\", moodCode=\"EVN\"].id"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry Associations reference"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.description",
-				"path": "DocumentReference.description",
-				"short": "Human-readable description",
-				"definition": "Human-readable description of the source document.",
-				"comment": "What the document is about,  a terse summary of the document.",
-				"requirements": "Helps humans to assess whether the document is of interest.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.description",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "TXA-25"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"SUBJ\"].target.text"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.comments"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.securityLabel",
-				"path": "DocumentReference.securityLabel",
-				"short": "Document security-tags",
-				"definition": "A set of Security-Tag codes specifying the level of privacy/security of the Document. Note that DocumentReference.meta.security contains the security labels of the \"reference\" to the document, while DocumentReference.securityLabel contains a snapshot of the security labels on the document the reference refers to.",
-				"comment": "The confidentiality codes can carry multiple vocabulary items. HL7 has developed an understanding of security and privacy tags that might be desirable in a Document Sharing environment, called HL7 Healthcare Privacy and Security Classification System (HCS). The following specification is recommended but not mandated, as the vocabulary bindings are an administrative domain responsibility. The use of this method is up to the policy domain such as the XDS Affinity Domain or other Trust Domain where all parties including sender and recipients are trusted to appropriately tag and enforce.   \n\nIn the HL7 Healthcare Privacy and Security Classification (HCS) there are code systems specific to Confidentiality, Sensitivity, Integrity, and Handling Caveats. Some values would come from a local vocabulary as they are related to workflow roles and special projects.",
-				"requirements": "Use of the Health Care Privacy/Security Classification (HCS) system of security-tag use is recommended.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DocumentReference.securityLabel",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "SecurityLabels"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "extensible",
-					"description": "Security Labels from the Healthcare Privacy and Security Classification System.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/security-labels"
-				},
-				"mapping": [
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.confidentiality, Composition.meta.security"
-					},
-					{
-						"identity": "v2",
-						"map": "TXA-18"
-					},
-					{
-						"identity": "rim",
-						"map": ".confidentialityCode"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.confidentialityCode"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/confidentialityCode/@code"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content",
-				"path": "DocumentReference.content",
-				"short": "Document referenced",
-				"definition": "The document and format referenced. There may be multiple content element repetitions, each with a different format.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "DocumentReference.content",
-					"min": 1,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "fhircomposition",
-						"map": "Bundle(Composition+*)"
-					},
-					{
-						"identity": "rim",
-						"map": "document.text"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content.id",
-				"path": "DocumentReference.content.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content.extension",
-				"path": "DocumentReference.content.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content.modifierExtension",
-				"path": "DocumentReference.content.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content.attachment",
-				"path": "DocumentReference.content.attachment",
-				"short": "Where to access the document",
-				"definition": "The document or URL of the document along with critical metadata to prove content has integrity.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.content.attachment",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Attachment"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "us-core-6",
-						"severity": "error",
-						"human": "DocumentReference.content.attachment.url or  DocumentReference.content.attachment.data or both SHALL be present.",
-						"expression": "url.exists() or data.exists()",
-						"xpath": "f:url or f:content"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.language, \nComposition.title, \nComposition.date"
-					},
-					{
-						"identity": "v2",
-						"map": "TXA-3 for mime type"
-					},
-					{
-						"identity": "rim",
-						"map": "document.text"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.mimeType, DocumentEntry.languageCode, DocumentEntry.URI, DocumentEntry.size, DocumentEntry.hash, DocumentEntry.title, DocumentEntry.creationTime"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/languageCode, ClinicalDocument/title, ClinicalDocument/date"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content.attachment.id",
-				"path": "DocumentReference.content.attachment.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content.attachment.extension",
-				"path": "DocumentReference.content.attachment.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content.attachment.contentType",
-				"path": "DocumentReference.content.attachment.contentType",
-				"short": "Mime type of the content, with charset etc.",
-				"definition": "Identifies the type of the data in the attachment and allows a method to be chosen to interpret or render the data. Includes mime type parameters such as charset where appropriate.",
-				"requirements": "Processors of the data need to be able to know how to interpret the data.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Attachment.contentType",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueCode": "text/plain; charset=UTF-8, image/png"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "MimeType"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "required",
-					"description": "The mime type of an attachment. Any valid mime type is allowed.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/mimetypes|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "ED.2+ED.3/RP.2+RP.3. Note conversion may be needed if old style values are being used"
-					},
-					{
-						"identity": "rim",
-						"map": "./mediaType, ./charset"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content.attachment.language",
-				"path": "DocumentReference.content.attachment.language",
-				"short": "Human language of the content (BCP-47)",
-				"definition": "The human language of the content. The value can be any valid value according to BCP 47.",
-				"requirements": "Users need to be able to choose between the languages in a set of attachments.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Attachment.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueCode": "en-AU"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "./language"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content.attachment.data",
-				"path": "DocumentReference.content.attachment.data",
-				"short": "Data inline, base64ed",
-				"definition": "The actual data of the attachment - a sequence of bytes, base64 encoded.",
-				"comment": "The base64-encoded data SHALL be expressed in the same character set as the base resource XML or JSON.",
-				"requirements": "The data needs to able to be transmitted inline.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Attachment.data",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "base64Binary"
-					}
-				],
-				"condition": [
-					"us-core-6"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "ED.5"
-					},
-					{
-						"identity": "rim",
-						"map": "./data"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content.attachment.url",
-				"path": "DocumentReference.content.attachment.url",
-				"short": "Uri where the data can be found",
-				"definition": "A location where the data can be accessed.",
-				"comment": "If both data and url are provided, the url SHALL point to the same content as the data contains. Urls may be relative references or may reference transient locations such as a wrapping envelope using cid: though this has ramifications for using signatures. Relative URLs are interpreted relative to the service url, like a resource reference, rather than relative to the resource itself. If a URL is provided, it SHALL resolve to actual data.",
-				"requirements": "The data needs to be transmitted by reference.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Attachment.url",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "url"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueUrl": "http://www.acme.com/logo-small.png"
-					}
-				],
-				"condition": [
-					"us-core-6"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RP.1+RP.2 - if they refer to a URL (see v2.6)"
-					},
-					{
-						"identity": "rim",
-						"map": "./reference/literal"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content.attachment.size",
-				"path": "DocumentReference.content.attachment.size",
-				"short": "Number of bytes of content (if url provided)",
-				"definition": "The number of bytes of data that make up this attachment (before base64 encoding, if that is done).",
-				"comment": "The number of bytes is redundant if the data is provided as a base64binary, but is useful if the data is provided as a url reference.",
-				"requirements": "Representing the size allows applications to determine whether they should fetch the content automatically in advance, or refuse to fetch it at all.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Attachment.size",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "unsignedInt"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A (needs data type R3 proposal)"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content.attachment.hash",
-				"path": "DocumentReference.content.attachment.hash",
-				"short": "Hash of the data (sha-1, base64ed)",
-				"definition": "The calculated hash of the data using SHA-1. Represented using base64.",
-				"comment": "The hash is calculated on the data prior to base64 encoding, if the data is based64 encoded. The hash is not intended to support digital signatures. Where protection against malicious threats a digital signature should be considered, see [Provenance.signature](http://hl7.org/fhir/R4/provenance-definitions.html#Provenance.signature) for mechanism to protect a resource with a digital signature.",
-				"requirements": "Included so that applications can verify that the contents of a location have not changed due to technical failures (e.g., storage rot, transport glitch, incorrect version).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Attachment.hash",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "base64Binary"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".integrityCheck[parent::ED/integrityCheckAlgorithm=\"SHA-1\"]"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content.attachment.title",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "DocumentReference.content.attachment.title",
-				"short": "Label to display in place of the data",
-				"definition": "A label or set of text to display in place of the data.",
-				"requirements": "Applications need a label to display to a human user in place of the actual data if the data cannot be rendered or perceived by the viewer.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Attachment.title",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "Official Corporate Logo"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "./title/data"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content.attachment.creation",
-				"path": "DocumentReference.content.attachment.creation",
-				"short": "Date attachment was first created",
-				"definition": "The date that the attachment was first created.",
-				"requirements": "This is often tracked as an integrity issue for use of the attachment.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Attachment.creation",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A (needs data type R3 proposal)"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.content.format",
-				"path": "DocumentReference.content.format",
-				"short": "Format/content rules for the document",
-				"definition": "An identifier of the document encoding, structure, and template that the document conforms to beyond the base format indicated in the mimeType.",
-				"comment": "Note that while IHE mostly issues URNs for format types, not all documents can be identified by a URI.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.content.format",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/ValueSet/formatcodes"
-				},
-				"mapping": [
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.meta.profile"
-					},
-					{
-						"identity": "rim",
-						"map": "document.text"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.formatCode"
-					},
-					{
-						"identity": "cda",
-						"map": "derived from the IHE Profile or Implementation Guide templateID"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.context",
-				"path": "DocumentReference.context",
-				"short": "Clinical context of document",
-				"definition": "The clinical context in which the document was prepared.",
-				"comment": "These values are primarily added to help with searching for interesting/relevant documents.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.context",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=\"SUBJ\"].target[classCode<'ACT']"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.context.id",
-				"path": "DocumentReference.context.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.context.extension",
-				"path": "DocumentReference.context.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.context.modifierExtension",
-				"path": "DocumentReference.context.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.context.encounter",
-				"path": "DocumentReference.context.encounter",
-				"short": "Context of the document  content",
-				"definition": "Describes the clinical encounter or type of care that the document content is associated with.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.context.encounter",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.encounter"
-					},
-					{
-						"identity": "rim",
-						"map": "unique(highest(./outboundRelationship[typeCode=\"SUBJ\" and isNormalActRelationship()], priorityNumber)/target[moodCode=\"EVN\" and classCode=(\"ENC\", \"PCPR\") and isNormalAct])"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.context.event",
-				"path": "DocumentReference.context.event",
-				"short": "Main clinical acts documented",
-				"definition": "This list of codes represents the main clinical acts, such as a colonoscopy or an appendectomy, being documented. In some cases, the event is inherent in the type Code, such as a \"History and Physical Report\" in which the procedure being documented is necessarily a \"History and Physical\" act.",
-				"comment": "An event can further specialize the act inherent in the type, such as  where it is simply \"Procedure Report\" and the procedure was a \"colonoscopy\". If one or more event codes are included, they shall not conflict with the values inherent in the class or type elements as such a conflict would create an ambiguous situation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DocumentReference.context.event",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "DocumentEventType"
-						}
-					],
-					"strength": "example",
-					"description": "This list of codes represents the main clinical acts being documented.",
-					"valueSet": "http://terminology.hl7.org/ValueSet/v3-ActCode"
-				},
-				"mapping": [
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.event.code"
-					},
-					{
-						"identity": "rim",
-						"map": ".code"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.eventCodeList"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.context.period",
-				"path": "DocumentReference.context.period",
-				"short": "Time of service that is being documented",
-				"definition": "The time period over which the service that is described by the document was provided.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.context.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.event.period"
-					},
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.serviceStartTime, DocumentEntry.serviceStopTime"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/documentationOf/\nserviceEvent/effectiveTime/low/\n@value --> ClinicalDocument/documentationOf/\nserviceEvent/effectiveTime/high/\n@value"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.context.facilityType",
-				"path": "DocumentReference.context.facilityType",
-				"short": "Kind of facility where patient was seen",
-				"definition": "The kind of facility where the patient was seen.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.context.facilityType",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "DocumentC80FacilityType"
-						}
-					],
-					"strength": "example",
-					"description": "XDS Facility Type.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/c80-facilitycodes"
-				},
-				"mapping": [
-					{
-						"identity": "fhircomposition",
-						"map": "usually from a mapping to a local ValueSet"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=\"LOC\"].role[classCode=\"DSDLOC\"].code"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.healthcareFacilityTypeCode"
-					},
-					{
-						"identity": "cda",
-						"map": "usually a mapping to a local ValueSet. Must be consistent with /clinicalDocument/code"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.context.practiceSetting",
-				"path": "DocumentReference.context.practiceSetting",
-				"short": "Additional details about where the content was created (e.g. clinical specialty)",
-				"definition": "This property may convey specifics about the practice setting where the content was created, often reflecting the clinical specialty.",
-				"comment": "This element should be based on a coarse classification system for the class of specialty practice. Recommend the use of the classification system for Practice Setting, such as that described by the Subject Matter Domain in LOINC.",
-				"requirements": "This is an important piece of metadata that providers often rely upon to quickly sort and/or filter out to find specific content.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.context.practiceSetting",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "DocumentC80PracticeSetting"
-						}
-					],
-					"strength": "example",
-					"description": "Additional details about where the content was created (e.g. clinical specialty).",
-					"valueSet": "http://hl7.org/fhir/ValueSet/c80-practice-codes"
-				},
-				"mapping": [
-					{
-						"identity": "fhircomposition",
-						"map": "usually from a mapping to a local ValueSet"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=\"LOC\"].role[classCode=\"DSDLOC\"].code"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.practiceSettingCode"
-					},
-					{
-						"identity": "cda",
-						"map": "usually from a mapping to a local ValueSet"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.context.sourcePatientInfo",
-				"path": "DocumentReference.context.sourcePatientInfo",
-				"short": "Patient demographics from source",
-				"definition": "The Patient Information as known when the document was published. May be a reference to a version specific, or contained.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DocumentReference.context.sourcePatientInfo",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Patient"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.subject"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=\"SBJ\"].role[typeCode=\"PAT\"]"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.sourcePatientInfo, DocumentEntry.sourcePatientId"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/recordTarget/"
-					}
-				]
-			},
-			{
-				"id": "DocumentReference.context.related",
-				"path": "DocumentReference.context.related",
-				"short": "Related identifiers or resources",
-				"definition": "Related identifiers or resources associated with the DocumentReference.",
-				"comment": "May be identifiers or resources that caused the DocumentReference or referenced Document to be created.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DocumentReference.context.related",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "fhircomposition",
-						"map": "Composition.event.detail"
-					},
-					{
-						"identity": "rim",
-						"map": "./outboundRelationship[typeCode=\"PERT\" and isNormalActRelationship()] / target[isNormalAct]"
-					},
-					{
-						"identity": "xds",
-						"map": "DocumentEntry.referenceIdList"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/relatedDocument"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "DocumentReference",
-				"path": "DocumentReference",
-				"definition": "This is a basic constraint on DocumentRefernce for use in the US Core IG.",
-				"mustSupport": false
-			},
-			{
-				"id": "DocumentReference.identifier",
-				"path": "DocumentReference.identifier",
-				"min": 0,
-				"max": "*",
-				"mustSupport": true
-			},
-			{
-				"id": "DocumentReference.status",
-				"path": "DocumentReference.status",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/document-reference-status"
-				}
-			},
-			{
-				"id": "DocumentReference.type",
-				"path": "DocumentReference.type",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-minValueSet",
-							"valueCanonical": "http://hl7.org/fhir/us/core/ValueSet/us-core-clinical-note-type"
-						}
-					],
-					"strength": "required",
-					"description": "All LOINC  values whose SCALE is DOC in the LOINC database and the HL7 v3 Code System NullFlavor concept 'unknown'",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-type"
-				}
-			},
-			{
-				"id": "DocumentReference.category",
-				"path": "DocumentReference.category",
-				"min": 1,
-				"max": "*",
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The US Core DocumentReferences Type Value Set is a &#39;starter set&#39; of categories supported for fetching and storing clinical notes.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-category"
-				}
-			},
-			{
-				"id": "DocumentReference.subject",
-				"path": "DocumentReference.subject",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "DocumentReference.date",
-				"path": "DocumentReference.date",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "DocumentReference.author",
-				"path": "DocumentReference.author",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson",
-							"http://hl7.org/fhir/StructureDefinition/Device"
-						],
-						"_targetProfile": [
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": true
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							}
-						]
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "DocumentReference.content",
-				"path": "DocumentReference.content",
-				"min": 1,
-				"max": "*",
-				"mustSupport": true
-			},
-			{
-				"id": "DocumentReference.content.attachment",
-				"path": "DocumentReference.content.attachment",
-				"min": 1,
-				"max": "1",
-				"constraint": [
-					{
-						"key": "us-core-6",
-						"severity": "error",
-						"human": "DocumentReference.content.attachment.url or  DocumentReference.content.attachment.data or both SHALL be present.",
-						"expression": "url.exists() or data.exists()",
-						"xpath": "f:url or f:content"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "DocumentReference.content.attachment.contentType",
-				"path": "DocumentReference.content.attachment.contentType",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "DocumentReference.content.attachment.data",
-				"path": "DocumentReference.content.attachment.data",
-				"min": 0,
-				"max": "1",
-				"condition": [
-					"us-core-6"
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "DocumentReference.content.attachment.url",
-				"path": "DocumentReference.content.attachment.url",
-				"min": 0,
-				"max": "1",
-				"condition": [
-					"us-core-6"
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "DocumentReference.content.format",
-				"path": "DocumentReference.content.format",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/ValueSet/formatcodes"
-				}
-			},
-			{
-				"id": "DocumentReference.context",
-				"path": "DocumentReference.context",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "DocumentReference.context.encounter",
-				"path": "DocumentReference.context.encounter",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
-						]
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "DocumentReference.context.period",
-				"path": "DocumentReference.context.period",
-				"mustSupport": true
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-documentreference",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference",
+    "version": "4.0.0",
+    "name": "USCoreDocumentReferenceProfile",
+    "title": "US Core DocumentReference Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-02",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The document reference profile used in US Core.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "fhircomposition",
+            "uri": "http://hl7.org/fhir/composition",
+            "name": "FHIR Composition"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "cda",
+            "uri": "http://hl7.org/v3/cda",
+            "name": "CDA (R2)"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "xds",
+            "uri": "http://ihe.net/xds",
+            "name": "XDS metadata equivalent"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "DocumentReference",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/DocumentReference",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "DocumentReference",
+                "path": "DocumentReference",
+                "short": "A reference to a document",
+                "definition": "This is a basic constraint on DocumentRefernce for use in the US Core IG.",
+                "comment": "Usually, this is used for documents other than those defined by FHIR.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DocumentReference",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "fhircomposition",
+                        "map": "when describing a Composition"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Document[classCode=\"DOC\" and moodCode=\"EVN\"]"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "when describing a CDA"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.id",
+                "path": "DocumentReference.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "DocumentReference.meta",
+                "path": "DocumentReference.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "DocumentReference.implicitRules",
+                "path": "DocumentReference.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "DocumentReference.language",
+                "path": "DocumentReference.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "DocumentReference.text",
+                "path": "DocumentReference.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.contained",
+                "path": "DocumentReference.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.extension",
+                "path": "DocumentReference.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.modifierExtension",
+                "path": "DocumentReference.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.masterIdentifier",
+                "path": "DocumentReference.masterIdentifier",
+                "short": "Master Version Specific Identifier",
+                "definition": "Document identifier as assigned by the source of the document. This identifier is specific to this version of the document. This unique identifier may be used elsewhere to identify this version of the document.",
+                "comment": "CDA Document Id extension and root.",
+                "requirements": "The structure and format of this Id shall be consistent with the specification corresponding to the formatCode attribute. (e.g. for a DICOM standard document a 64-character numeric UID, for an HL7 CDA format a serialization of the CDA Document Id extension and root in the form \"oid^extension\", where OID is a 64 digits max, and the Id is a 16 UTF-8 char max. If the OID is coded without the extension then the '^' character shall not be included.).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.masterIdentifier",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "TXA-12"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.uniqueId"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/id"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.identifier",
+                "path": "DocumentReference.identifier",
+                "short": "Other identifiers for the document",
+                "definition": "Other identifiers associated with the document, including version independent identifiers.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DocumentReference.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "TXA-16?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id / .setId"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.entryUUID"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.status",
+                "path": "DocumentReference.status",
+                "short": "current | superseded | entered-in-error",
+                "definition": "The status of this document reference.",
+                "comment": "This is the status of the DocumentReference object, which might be independent from the docStatus element.\n\nThis element is labeled as a modifier because the status contains the codes that mark the document or reference as not currently valid.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labelled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/document-reference-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "TXA-19"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interim: .completionCode=\"IN\" & ./statusCode[isNormalDatatype()]=\"active\";  final: .completionCode=\"AU\" &&  ./statusCode[isNormalDatatype()]=\"complete\" and not(./inboundRelationship[typeCode=\"SUBJ\" and isNormalActRelationship()]/source[subsumesCode(\"ActClass#CACT\") and moodCode=\"EVN\" and domainMember(\"ReviseDocument\", code) and isNormalAct()]);  amended: .completionCode=\"AU\" &&  ./statusCode[isNormalDatatype()]=\"complete\" and ./inboundRelationship[typeCode=\"SUBJ\" and isNormalActRelationship()]/source[subsumesCode(\"ActClass#CACT\") and moodCode=\"EVN\" and domainMember(\"ReviseDocument\", code) and isNormalAct() and statusCode=\"completed\"];  withdrawn : .completionCode=NI &&  ./statusCode[isNormalDatatype()]=\"obsolete\""
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.availabilityStatus"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.docStatus",
+                "path": "DocumentReference.docStatus",
+                "short": "preliminary | final | amended | entered-in-error",
+                "definition": "The status of the underlying document.",
+                "comment": "The document that is pointed to might be in various lifecycle states.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.docStatus",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ReferredDocumentStatus"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Status of the underlying document.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/composition-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.status"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "TXA-17"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".statusCode"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.type",
+                "path": "DocumentReference.type",
+                "short": "Kind of document (LOINC if possible)",
+                "definition": "Specifies the particular kind of document referenced  (e.g. History and Physical, Discharge Summary, Progress Note). This usually equates to the purpose of making the document referenced.",
+                "comment": "Key metadata element describing the document that describes he exact type of document. Helps humans to assess whether the document is of interest when viewing a list of documents.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-minValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/us/core/ValueSet/us-core-clinical-note-type"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "All LOINC  values whose SCALE is DOC in the LOINC database and the HL7 v3 Code System NullFlavor concept 'unknown'",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.type"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "TXA-2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./code"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.type"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/code/@code \n\nThe typeCode should be mapped from the ClinicalDocument/code element to a set of document type codes configured in the affinity domain. One suggested coding system to use for typeCode is LOINC, in which case the mapping step can be omitted."
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.category",
+                "path": "DocumentReference.category",
+                "short": "Categorization of document",
+                "definition": "A categorization for the type of document referenced - helps for indexing and searching. This may be implied by or derived from the code specified in the DocumentReference.type.",
+                "comment": "Key metadata element describing the the category or classification of the document. This is a broader perspective that groups similar documents based on how they would be used. This is a primary key used in searching.",
+                "alias": [
+                    "claxs"
+                ],
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "DocumentReference.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The US Core DocumentReferences Type Value Set is a &#39;starter set&#39; of categories supported for fetching and storing clinical notes.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.class"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "Derived from a mapping of /ClinicalDocument/code/@code to an Affinity Domain specified coded value to use and coding system. Affinity Domains are encouraged to use the appropriate value for Type of Service, based on the LOINC Type of Service (see Page 53 of the LOINC User's Manual). Must be consistent with /ClinicalDocument/code/@code"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.subject",
+                "path": "DocumentReference.subject",
+                "short": "Who/what is the subject of the document",
+                "definition": "Who or what the document is about. The document can be about a person, (patient or healthcare practitioner), a device (e.g. a machine) or even a group of subjects (such as a document about a herd of farm animals, or a set of patients that share a common exposure).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.subject"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3 (No standard way to define a Practitioner or Group subject in HL7 v2 MDM message)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=\"SBJ\"].role[typeCode=\"PAT\"]"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.patientId"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/recordTarget/"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.date",
+                "path": "DocumentReference.date",
+                "short": "When this document reference was created",
+                "definition": "When the document reference was created.",
+                "comment": "Referencing/indexing time is used for tracking, organizing versions and searching.",
+                "alias": [
+                    "indexed"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.date",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.date"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".availabilityTime[type=\"TS\"]"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.author",
+                "path": "DocumentReference.author",
+                "short": "Who and/or what authored the document",
+                "definition": "Identifies who is responsible for adding the information to the document.",
+                "comment": "Not necessarily who did the actual data entry (i.e. typist) or who was the source (informant).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DocumentReference.author",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+                            "http://hl7.org/fhir/StructureDefinition/Device"
+                        ],
+                        "_targetProfile": [
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": true
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.author"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "TXA-9 (No standard way to indicate a Device in HL7 v2 MDM message)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=\"AUT\"].role[classCode=\"ASSIGNED\"]"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.author"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/author"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.authenticator",
+                "path": "DocumentReference.authenticator",
+                "short": "Who/what authenticated the document",
+                "definition": "Which person or organization authenticates that this document is valid.",
+                "comment": "Represents a participant within the author institution who has legally authenticated or attested the document. Legal authentication implies that a document has been signed manually or electronically by the legal Authenticator.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.authenticator",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.witness"
+                    },
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.attester"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "TXA-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=\"AUTHEN\"].role[classCode=\"ASSIGNED\"]"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.legalAuthenticator"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/legalAuthenticator"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.custodian",
+                "path": "DocumentReference.custodian",
+                "short": "Organization which maintains the document",
+                "definition": "Identifies the organization or group who is responsible for ongoing maintenance of and access to the document.",
+                "comment": "Identifies the logical organization (software system, vendor, or department) to go to find the current version, where to report issues, etc. This is different from the physical location (URL, disk drive, or server) of the document, which is the technical location of the document, which host may be delegated to the management of some other organization.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.custodian",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.custodian"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=\"RCV\"].role[classCode=\"CUST\"].scoper[classCode=\"ORG\" and determinerCode=\"INST\"]"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.relatesTo",
+                "path": "DocumentReference.relatesTo",
+                "short": "Relationships to other documents",
+                "definition": "Relationships that this document has with other document references that already exist.",
+                "comment": "This element is labeled as a modifier because documents that append to other documents are incomplete on their own.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DocumentReference.relatesTo",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.relatesTo"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry Associations"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.relatesTo.id",
+                "path": "DocumentReference.relatesTo.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.relatesTo.extension",
+                "path": "DocumentReference.relatesTo.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.relatesTo.modifierExtension",
+                "path": "DocumentReference.relatesTo.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.relatesTo.code",
+                "path": "DocumentReference.relatesTo.code",
+                "short": "replaces | transforms | signs | appends",
+                "definition": "The type of relationship that this document has with anther document.",
+                "comment": "If this document appends another document, then the document cannot be fully understood without also accessing the referenced document.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.relatesTo.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "DocumentRelationshipType"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The type of relationship between documents.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/document-relationship-type|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.relatesTo.code"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship.typeCode"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry Associations type"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.relatesTo.target",
+                "path": "DocumentReference.relatesTo.target",
+                "short": "Target of the relationship",
+                "definition": "The target document of this relationship.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.relatesTo.target",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/DocumentReference"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.relatesTo.target"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".target[classCode=\"DOC\", moodCode=\"EVN\"].id"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry Associations reference"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.description",
+                "path": "DocumentReference.description",
+                "short": "Human-readable description",
+                "definition": "Human-readable description of the source document.",
+                "comment": "What the document is about,  a terse summary of the document.",
+                "requirements": "Helps humans to assess whether the document is of interest.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.description",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "TXA-25"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"SUBJ\"].target.text"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.comments"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.securityLabel",
+                "path": "DocumentReference.securityLabel",
+                "short": "Document security-tags",
+                "definition": "A set of Security-Tag codes specifying the level of privacy/security of the Document. Note that DocumentReference.meta.security contains the security labels of the \"reference\" to the document, while DocumentReference.securityLabel contains a snapshot of the security labels on the document the reference refers to.",
+                "comment": "The confidentiality codes can carry multiple vocabulary items. HL7 has developed an understanding of security and privacy tags that might be desirable in a Document Sharing environment, called HL7 Healthcare Privacy and Security Classification System (HCS). The following specification is recommended but not mandated, as the vocabulary bindings are an administrative domain responsibility. The use of this method is up to the policy domain such as the XDS Affinity Domain or other Trust Domain where all parties including sender and recipients are trusted to appropriately tag and enforce.   \n\nIn the HL7 Healthcare Privacy and Security Classification (HCS) there are code systems specific to Confidentiality, Sensitivity, Integrity, and Handling Caveats. Some values would come from a local vocabulary as they are related to workflow roles and special projects.",
+                "requirements": "Use of the Health Care Privacy/Security Classification (HCS) system of security-tag use is recommended.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DocumentReference.securityLabel",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "SecurityLabels"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Security Labels from the Healthcare Privacy and Security Classification System.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/security-labels"
+                },
+                "mapping": [
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.confidentiality, Composition.meta.security"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "TXA-18"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".confidentialityCode"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.confidentialityCode"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/confidentialityCode/@code"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content",
+                "path": "DocumentReference.content",
+                "short": "Document referenced",
+                "definition": "The document and format referenced. There may be multiple content element repetitions, each with a different format.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "DocumentReference.content",
+                    "min": 1,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Bundle(Composition+*)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "document.text"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content.id",
+                "path": "DocumentReference.content.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content.extension",
+                "path": "DocumentReference.content.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content.modifierExtension",
+                "path": "DocumentReference.content.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content.attachment",
+                "path": "DocumentReference.content.attachment",
+                "short": "Where to access the document",
+                "definition": "The document or URL of the document along with critical metadata to prove content has integrity.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.content.attachment",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Attachment"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "us-core-6",
+                        "severity": "error",
+                        "human": "DocumentReference.content.attachment.url or  DocumentReference.content.attachment.data or both SHALL be present.",
+                        "expression": "url.exists() or data.exists()",
+                        "xpath": "f:url or f:content"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.language, \nComposition.title, \nComposition.date"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "TXA-3 for mime type"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "document.text"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.mimeType, DocumentEntry.languageCode, DocumentEntry.URI, DocumentEntry.size, DocumentEntry.hash, DocumentEntry.title, DocumentEntry.creationTime"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/languageCode, ClinicalDocument/title, ClinicalDocument/date"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content.attachment.id",
+                "path": "DocumentReference.content.attachment.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content.attachment.extension",
+                "path": "DocumentReference.content.attachment.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content.attachment.contentType",
+                "path": "DocumentReference.content.attachment.contentType",
+                "short": "Mime type of the content, with charset etc.",
+                "definition": "Identifies the type of the data in the attachment and allows a method to be chosen to interpret or render the data. Includes mime type parameters such as charset where appropriate.",
+                "requirements": "Processors of the data need to be able to know how to interpret the data.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Attachment.contentType",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueCode": "text/plain; charset=UTF-8, image/png"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "MimeType"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The mime type of an attachment. Any valid mime type is allowed.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/mimetypes|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "ED.2+ED.3/RP.2+RP.3. Note conversion may be needed if old style values are being used"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./mediaType, ./charset"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content.attachment.language",
+                "path": "DocumentReference.content.attachment.language",
+                "short": "Human language of the content (BCP-47)",
+                "definition": "The human language of the content. The value can be any valid value according to BCP 47.",
+                "requirements": "Users need to be able to choose between the languages in a set of attachments.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Attachment.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueCode": "en-AU"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "./language"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content.attachment.data",
+                "path": "DocumentReference.content.attachment.data",
+                "short": "Data inline, base64ed",
+                "definition": "The actual data of the attachment - a sequence of bytes, base64 encoded.",
+                "comment": "The base64-encoded data SHALL be expressed in the same character set as the base resource XML or JSON.",
+                "requirements": "The data needs to able to be transmitted inline.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Attachment.data",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "base64Binary"
+                    }
+                ],
+                "condition": [
+                    "us-core-6"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "ED.5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./data"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content.attachment.url",
+                "path": "DocumentReference.content.attachment.url",
+                "short": "Uri where the data can be found",
+                "definition": "A location where the data can be accessed.",
+                "comment": "If both data and url are provided, the url SHALL point to the same content as the data contains. Urls may be relative references or may reference transient locations such as a wrapping envelope using cid: though this has ramifications for using signatures. Relative URLs are interpreted relative to the service url, like a resource reference, rather than relative to the resource itself. If a URL is provided, it SHALL resolve to actual data.",
+                "requirements": "The data needs to be transmitted by reference.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Attachment.url",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "url"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueUrl": "http://www.acme.com/logo-small.png"
+                    }
+                ],
+                "condition": [
+                    "us-core-6"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RP.1+RP.2 - if they refer to a URL (see v2.6)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./reference/literal"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content.attachment.size",
+                "path": "DocumentReference.content.attachment.size",
+                "short": "Number of bytes of content (if url provided)",
+                "definition": "The number of bytes of data that make up this attachment (before base64 encoding, if that is done).",
+                "comment": "The number of bytes is redundant if the data is provided as a base64binary, but is useful if the data is provided as a url reference.",
+                "requirements": "Representing the size allows applications to determine whether they should fetch the content automatically in advance, or refuse to fetch it at all.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Attachment.size",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "unsignedInt"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A (needs data type R3 proposal)"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content.attachment.hash",
+                "path": "DocumentReference.content.attachment.hash",
+                "short": "Hash of the data (sha-1, base64ed)",
+                "definition": "The calculated hash of the data using SHA-1. Represented using base64.",
+                "comment": "The hash is calculated on the data prior to base64 encoding, if the data is based64 encoded. The hash is not intended to support digital signatures. Where protection against malicious threats a digital signature should be considered, see [Provenance.signature](http://hl7.org/fhir/R4/provenance-definitions.html#Provenance.signature) for mechanism to protect a resource with a digital signature.",
+                "requirements": "Included so that applications can verify that the contents of a location have not changed due to technical failures (e.g., storage rot, transport glitch, incorrect version).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Attachment.hash",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "base64Binary"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".integrityCheck[parent::ED/integrityCheckAlgorithm=\"SHA-1\"]"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content.attachment.title",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "DocumentReference.content.attachment.title",
+                "short": "Label to display in place of the data",
+                "definition": "A label or set of text to display in place of the data.",
+                "requirements": "Applications need a label to display to a human user in place of the actual data if the data cannot be rendered or perceived by the viewer.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Attachment.title",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "Official Corporate Logo"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "./title/data"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content.attachment.creation",
+                "path": "DocumentReference.content.attachment.creation",
+                "short": "Date attachment was first created",
+                "definition": "The date that the attachment was first created.",
+                "requirements": "This is often tracked as an integrity issue for use of the attachment.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Attachment.creation",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A (needs data type R3 proposal)"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.content.format",
+                "path": "DocumentReference.content.format",
+                "short": "Format/content rules for the document",
+                "definition": "An identifier of the document encoding, structure, and template that the document conforms to beyond the base format indicated in the mimeType.",
+                "comment": "Note that while IHE mostly issues URNs for format types, not all documents can be identified by a URI.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.content.format",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/formatcodes"
+                },
+                "mapping": [
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.meta.profile"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "document.text"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.formatCode"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "derived from the IHE Profile or Implementation Guide templateID"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.context",
+                "path": "DocumentReference.context",
+                "short": "Clinical context of document",
+                "definition": "The clinical context in which the document was prepared.",
+                "comment": "These values are primarily added to help with searching for interesting/relevant documents.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.context",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=\"SUBJ\"].target[classCode<'ACT']"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.context.id",
+                "path": "DocumentReference.context.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.context.extension",
+                "path": "DocumentReference.context.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.context.modifierExtension",
+                "path": "DocumentReference.context.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.context.encounter",
+                "path": "DocumentReference.context.encounter",
+                "short": "Context of the document  content",
+                "definition": "Describes the clinical encounter or type of care that the document content is associated with.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.context.encounter",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.encounter"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "unique(highest(./outboundRelationship[typeCode=\"SUBJ\" and isNormalActRelationship()], priorityNumber)/target[moodCode=\"EVN\" and classCode=(\"ENC\", \"PCPR\") and isNormalAct])"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.context.event",
+                "path": "DocumentReference.context.event",
+                "short": "Main clinical acts documented",
+                "definition": "This list of codes represents the main clinical acts, such as a colonoscopy or an appendectomy, being documented. In some cases, the event is inherent in the type Code, such as a \"History and Physical Report\" in which the procedure being documented is necessarily a \"History and Physical\" act.",
+                "comment": "An event can further specialize the act inherent in the type, such as  where it is simply \"Procedure Report\" and the procedure was a \"colonoscopy\". If one or more event codes are included, they shall not conflict with the values inherent in the class or type elements as such a conflict would create an ambiguous situation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DocumentReference.context.event",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "DocumentEventType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "This list of codes represents the main clinical acts being documented.",
+                    "valueSet": "http://terminology.hl7.org/ValueSet/v3-ActCode"
+                },
+                "mapping": [
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.event.code"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".code"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.eventCodeList"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.context.period",
+                "path": "DocumentReference.context.period",
+                "short": "Time of service that is being documented",
+                "definition": "The time period over which the service that is described by the document was provided.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.context.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.event.period"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.serviceStartTime, DocumentEntry.serviceStopTime"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/documentationOf/\nserviceEvent/effectiveTime/low/\n@value --> ClinicalDocument/documentationOf/\nserviceEvent/effectiveTime/high/\n@value"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.context.facilityType",
+                "path": "DocumentReference.context.facilityType",
+                "short": "Kind of facility where patient was seen",
+                "definition": "The kind of facility where the patient was seen.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.context.facilityType",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "DocumentC80FacilityType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "XDS Facility Type.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/c80-facilitycodes"
+                },
+                "mapping": [
+                    {
+                        "identity": "fhircomposition",
+                        "map": "usually from a mapping to a local ValueSet"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=\"LOC\"].role[classCode=\"DSDLOC\"].code"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.healthcareFacilityTypeCode"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "usually a mapping to a local ValueSet. Must be consistent with /clinicalDocument/code"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.context.practiceSetting",
+                "path": "DocumentReference.context.practiceSetting",
+                "short": "Additional details about where the content was created (e.g. clinical specialty)",
+                "definition": "This property may convey specifics about the practice setting where the content was created, often reflecting the clinical specialty.",
+                "comment": "This element should be based on a coarse classification system for the class of specialty practice. Recommend the use of the classification system for Practice Setting, such as that described by the Subject Matter Domain in LOINC.",
+                "requirements": "This is an important piece of metadata that providers often rely upon to quickly sort and/or filter out to find specific content.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.context.practiceSetting",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "DocumentC80PracticeSetting"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Additional details about where the content was created (e.g. clinical specialty).",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/c80-practice-codes"
+                },
+                "mapping": [
+                    {
+                        "identity": "fhircomposition",
+                        "map": "usually from a mapping to a local ValueSet"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=\"LOC\"].role[classCode=\"DSDLOC\"].code"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.practiceSettingCode"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "usually from a mapping to a local ValueSet"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.context.sourcePatientInfo",
+                "path": "DocumentReference.context.sourcePatientInfo",
+                "short": "Patient demographics from source",
+                "definition": "The Patient Information as known when the document was published. May be a reference to a version specific, or contained.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DocumentReference.context.sourcePatientInfo",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Patient"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.subject"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=\"SBJ\"].role[typeCode=\"PAT\"]"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.sourcePatientInfo, DocumentEntry.sourcePatientId"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/recordTarget/"
+                    }
+                ]
+            },
+            {
+                "id": "DocumentReference.context.related",
+                "path": "DocumentReference.context.related",
+                "short": "Related identifiers or resources",
+                "definition": "Related identifiers or resources associated with the DocumentReference.",
+                "comment": "May be identifiers or resources that caused the DocumentReference or referenced Document to be created.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DocumentReference.context.related",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "fhircomposition",
+                        "map": "Composition.event.detail"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./outboundRelationship[typeCode=\"PERT\" and isNormalActRelationship()] / target[isNormalAct]"
+                    },
+                    {
+                        "identity": "xds",
+                        "map": "DocumentEntry.referenceIdList"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/relatedDocument"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "DocumentReference",
+                "path": "DocumentReference",
+                "definition": "This is a basic constraint on DocumentRefernce for use in the US Core IG.",
+                "mustSupport": false
+            },
+            {
+                "id": "DocumentReference.identifier",
+                "path": "DocumentReference.identifier",
+                "min": 0,
+                "max": "*",
+                "mustSupport": true
+            },
+            {
+                "id": "DocumentReference.status",
+                "path": "DocumentReference.status",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/document-reference-status"
+                }
+            },
+            {
+                "id": "DocumentReference.type",
+                "path": "DocumentReference.type",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-minValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/us/core/ValueSet/us-core-clinical-note-type"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "All LOINC  values whose SCALE is DOC in the LOINC database and the HL7 v3 Code System NullFlavor concept 'unknown'",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-type"
+                }
+            },
+            {
+                "id": "DocumentReference.category",
+                "path": "DocumentReference.category",
+                "min": 1,
+                "max": "*",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The US Core DocumentReferences Type Value Set is a &#39;starter set&#39; of categories supported for fetching and storing clinical notes.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-category"
+                }
+            },
+            {
+                "id": "DocumentReference.subject",
+                "path": "DocumentReference.subject",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "DocumentReference.date",
+                "path": "DocumentReference.date",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "DocumentReference.author",
+                "path": "DocumentReference.author",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+                            "http://hl7.org/fhir/StructureDefinition/Device"
+                        ],
+                        "_targetProfile": [
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": true
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "DocumentReference.content",
+                "path": "DocumentReference.content",
+                "min": 1,
+                "max": "*",
+                "mustSupport": true
+            },
+            {
+                "id": "DocumentReference.content.attachment",
+                "path": "DocumentReference.content.attachment",
+                "min": 1,
+                "max": "1",
+                "constraint": [
+                    {
+                        "key": "us-core-6",
+                        "severity": "error",
+                        "human": "DocumentReference.content.attachment.url or  DocumentReference.content.attachment.data or both SHALL be present.",
+                        "expression": "url.exists() or data.exists()",
+                        "xpath": "f:url or f:content"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "DocumentReference.content.attachment.contentType",
+                "path": "DocumentReference.content.attachment.contentType",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "DocumentReference.content.attachment.data",
+                "path": "DocumentReference.content.attachment.data",
+                "min": 0,
+                "max": "1",
+                "condition": [
+                    "us-core-6"
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "DocumentReference.content.attachment.url",
+                "path": "DocumentReference.content.attachment.url",
+                "min": 0,
+                "max": "1",
+                "condition": [
+                    "us-core-6"
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "DocumentReference.content.format",
+                "path": "DocumentReference.content.format",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/formatcodes"
+                }
+            },
+            {
+                "id": "DocumentReference.context",
+                "path": "DocumentReference.context",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "DocumentReference.context.encounter",
+                "path": "DocumentReference.context.encounter",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+                        ]
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "DocumentReference.context.period",
+                "path": "DocumentReference.context.period",
+                "mustSupport": true
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-encounter.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-encounter.json
@@ -1,4282 +1,4282 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-encounter",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter\" title=\"This is basic constraint on Encounter for use in US Core resources.\">Encounter</a><a name=\"Encounter\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/encounter.html\">Encounter</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">An interaction during which services are provided to the patient</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.identifier\">identifier</a><a name=\"Encounter.identifier\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Identifier\">Identifier</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Identifier(s) by which this encounter is known</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.identifier.system\">system</a><a name=\"Encounter.identifier.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The namespace for the identifier value</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.identifier.value\">value</a><a name=\"Encounter.identifier.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The value that is unique</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.status\">status</a><a name=\"Encounter.status\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">planned | arrived | triaged | in-progress | onleave | finished | cancelled +</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.class\">class</a><a name=\"Encounter.class\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Classification of patient encounter</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.type\">type</a><a name=\"Encounter.type\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Specific type of encounter</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-encounter-type.html\">US Core Encounter Type</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>): Valueset to describe the Encounter Type<br/><br/><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.subject\">subject</a><a name=\"Encounter.subject\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The patient or group present at the encounter</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.participant\">participant</a><a name=\"Encounter.participant\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">List of participants involved in the encounter</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.participant.type\">type</a><a name=\"Encounter.participant.type\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Role of participant in encounter</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.participant.period\">period</a><a name=\"Encounter.participant.period\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Period\">Period</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Period of time during the encounter that the participant participated</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.participant.individual\">individual</a><a name=\"Encounter.participant.individual\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-practitioner.html\">US Core Practitioner Profile</a> <span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This target must be supported\">S</span> | <a href=\"StructureDefinition-us-core-practitionerrole.html\">US Core PractitionerRole Profile</a> | <a href=\"http://hl7.org/fhir/R4/relatedperson.html\">RelatedPerson</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Persons involved in the encounter other than the patient</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.period\">period</a><a name=\"Encounter.period\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Period\">Period</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The start and end time of the encounter</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.reasonCode\">reasonCode</a><a name=\"Encounter.reasonCode\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Coded reason the encounter takes place</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.reasonReference\">reasonReference</a><a name=\"Encounter.reasonReference\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-condition.html\">US Core Condition Profile</a> <span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This target must be supported\">S</span> | <a href=\"StructureDefinition-us-core-procedure.html\">US Core Procedure Profile</a> | <a href=\"http://hl7.org/fhir/R4/observation.html\">Observation</a> | <a href=\"http://hl7.org/fhir/R4/immunizationrecommendation.html\">ImmunizationRecommendation</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Reason the encounter takes place (reference)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.hospitalization\">hospitalization</a><a name=\"Encounter.hospitalization\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Details about the admission to a healthcare service</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.hospitalization.dischargeDisposition\">dischargeDisposition</a><a name=\"Encounter.hospitalization.dischargeDisposition\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Category or kind of location after discharge</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.location\">location</a><a name=\"Encounter.location\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">List of locations where the patient has been</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.location.location\">location</a><a name=\"Encounter.location.location\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"http://hl7.org/fhir/R4/location.html\">Location</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Location the encounter takes place</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck00.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-encounter-definitions.html#Encounter.serviceProvider\">serviceProvider</a><a name=\"Encounter.serviceProvider\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-organization.html\">US Core Organization Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The organization (facility) responsible for this encounter</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter",
-	"version": "4.0.0",
-	"name": "USCoreEncounterProfile",
-	"title": "US Core Encounter Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The Encounter referenced in the US Core profiles.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Encounter",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Encounter",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Encounter",
-				"path": "Encounter",
-				"short": "An interaction during which services are provided to the patient",
-				"definition": "This is basic constraint on Encounter for use in US Core resources.",
-				"alias": [
-					"Visit"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "rim",
-						"map": "Encounter[@moodCode='EVN']"
-					}
-				]
-			},
-			{
-				"id": "Encounter.id",
-				"path": "Encounter.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Encounter.meta",
-				"path": "Encounter.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Encounter.implicitRules",
-				"path": "Encounter.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Encounter.language",
-				"path": "Encounter.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Encounter.text",
-				"path": "Encounter.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Encounter.contained",
-				"path": "Encounter.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Encounter.extension",
-				"path": "Encounter.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Encounter.modifierExtension",
-				"path": "Encounter.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Encounter.identifier",
-				"path": "Encounter.identifier",
-				"short": "Identifier(s) by which this encounter is known",
-				"definition": "Identifier(s) by which this encounter is known.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1-19"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					}
-				]
-			},
-			{
-				"id": "Encounter.identifier.id",
-				"path": "Encounter.identifier.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.identifier.extension",
-				"path": "Encounter.identifier.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.identifier.use",
-				"path": "Encounter.identifier.use",
-				"short": "usual | official | temp | secondary | old (If known)",
-				"definition": "The purpose of this identifier.",
-				"comment": "Applications can assume that an identifier is permanent unless it explicitly says that it is temporary.",
-				"requirements": "Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.use",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary id for a permanent one.",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "IdentifierUse"
-						}
-					],
-					"strength": "required",
-					"description": "Identifies the purpose for this identifier, if known .",
-					"valueSet": "http://hl7.org/fhir/ValueSet/identifier-use|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "Role.code or implied by context"
-					}
-				]
-			},
-			{
-				"id": "Encounter.identifier.type",
-				"path": "Encounter.identifier.type",
-				"short": "Description of identifier",
-				"definition": "A coded type for the identifier that can be used to determine which identifier to use for a specific purpose.",
-				"comment": "This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage.   Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type.",
-				"requirements": "Allows users to make use of identifiers when the identifier system is not known.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "IdentifierType"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "extensible",
-					"description": "A coded type for an identifier that can be used to determine which identifier to use for a specific purpose.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/identifier-type"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.5"
-					},
-					{
-						"identity": "rim",
-						"map": "Role.code or implied by context"
-					}
-				]
-			},
-			{
-				"id": "Encounter.identifier.system",
-				"path": "Encounter.identifier.system",
-				"short": "The namespace for the identifier value",
-				"definition": "Establishes the namespace for the value - that is, a URL that describes a set values that are unique.",
-				"comment": "Identifier.system is always case sensitive.",
-				"requirements": "There are many sets  of identifiers.  To perform matching of two identifiers, we need to know what set we're dealing with. The system identifies a particular set of unique identifiers.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Identifier.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueUri": "http://www.acme.com/identifiers/patient"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.4 / EI-2-4"
-					},
-					{
-						"identity": "rim",
-						"map": "II.root or Role.id.root"
-					},
-					{
-						"identity": "servd",
-						"map": "./IdentifierType"
-					}
-				]
-			},
-			{
-				"id": "Encounter.identifier.value",
-				"path": "Encounter.identifier.value",
-				"short": "The value that is unique",
-				"definition": "The portion of the identifier typically relevant to the user and which is unique within the context of the system.",
-				"comment": "If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986.  The value's primary purpose is computational mapping.  As a result, it may be normalized for comparison purposes (e.g. removing non-significant whitespace, dashes, etc.)  A value formatted for human display can be conveyed using the [Rendered Value extension](http://hl7.org/fhir/R4/extension-rendered-value.html). Identifier.value is to be treated as case sensitive unless knowledge of the Identifier.system allows the processer to be confident that non-case-sensitive processing is safe.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Identifier.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "123456"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.1 / EI.1"
-					},
-					{
-						"identity": "rim",
-						"map": "II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)"
-					},
-					{
-						"identity": "servd",
-						"map": "./Value"
-					}
-				]
-			},
-			{
-				"id": "Encounter.identifier.period",
-				"path": "Encounter.identifier.period",
-				"short": "Time period when id is/was valid for use",
-				"definition": "Time period during which identifier is/was valid for use.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.7 + CX.8"
-					},
-					{
-						"identity": "rim",
-						"map": "Role.effectiveTime or implied by context"
-					},
-					{
-						"identity": "servd",
-						"map": "./StartDate and ./EndDate"
-					}
-				]
-			},
-			{
-				"id": "Encounter.identifier.assigner",
-				"path": "Encounter.identifier.assigner",
-				"short": "Organization that issued id (may be just text)",
-				"definition": "Organization that issued/manages the identifier.",
-				"comment": "The Identifier.assigner may omit the .reference element and only contain a .display element reflecting the name or other textual information about the assigning organization.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.assigner",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.4 / (CX.4,CX.9,CX.10)"
-					},
-					{
-						"identity": "rim",
-						"map": "II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper"
-					},
-					{
-						"identity": "servd",
-						"map": "./IdentifierIssuingAuthority"
-					}
-				]
-			},
-			{
-				"id": "Encounter.status",
-				"path": "Encounter.status",
-				"short": "planned | arrived | triaged | in-progress | onleave | finished | cancelled +",
-				"definition": "planned | arrived | triaged | in-progress | onleave | finished | cancelled +.",
-				"comment": "Note that internal business rules will determine the appropriate transitions that may occur between statuses (and also classes).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Encounter.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "EncounterStatus"
-						}
-					],
-					"strength": "required",
-					"description": "Current state of the encounter.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/encounter-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "v2",
-						"map": "No clear equivalent in HL7 v2; active/finished could be inferred from PV1-44, PV1-45, PV2-24; inactive could be inferred from PV2-16"
-					},
-					{
-						"identity": "rim",
-						"map": ".statusCode"
-					}
-				]
-			},
-			{
-				"id": "Encounter.statusHistory",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name",
-						"valueString": "StatusHistory"
-					}
-				],
-				"path": "Encounter.statusHistory",
-				"short": "List of past encounter statuses",
-				"definition": "The status history permits the encounter resource to contain the status history without needing to read through the historical versions of the resource, or even have the server store them.",
-				"comment": "The current status is always found in the current version of the resource, not the status history.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter.statusHistory",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.statusHistory.id",
-				"path": "Encounter.statusHistory.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.statusHistory.extension",
-				"path": "Encounter.statusHistory.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.statusHistory.modifierExtension",
-				"path": "Encounter.statusHistory.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Encounter.statusHistory.status",
-				"path": "Encounter.statusHistory.status",
-				"short": "planned | arrived | triaged | in-progress | onleave | finished | cancelled +",
-				"definition": "planned | arrived | triaged | in-progress | onleave | finished | cancelled +.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Encounter.statusHistory.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "EncounterStatus"
-						}
-					],
-					"strength": "required",
-					"description": "Current state of the encounter.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/encounter-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.statusHistory.period",
-				"path": "Encounter.statusHistory.period",
-				"short": "The time that the episode was in the specified status",
-				"definition": "The time that the episode was in the specified status.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Encounter.statusHistory.period",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.class",
-				"path": "Encounter.class",
-				"short": "Classification of patient encounter",
-				"definition": "Concepts representing classification of patient encounter such as ambulatory (outpatient), inpatient, emergency, home health or others due to local variations.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Encounter.class",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "EncounterClass"
-						}
-					],
-					"strength": "extensible",
-					"description": "Classification of the encounter.",
-					"valueSet": "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1-2"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=SUBJ].source[classCode=LIST].code"
-					}
-				]
-			},
-			{
-				"id": "Encounter.classHistory",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name",
-						"valueString": "ClassHistory"
-					}
-				],
-				"path": "Encounter.classHistory",
-				"short": "List of past encounter classes",
-				"definition": "The class history permits the tracking of the encounters transitions without needing to go  through the resource history.  This would be used for a case where an admission starts of as an emergency encounter, then transitions into an inpatient scenario. Doing this and not restarting a new encounter ensures that any lab/diagnostic results can more easily follow the patient and not require re-processing and not get lost or cancelled during a kind of discharge from emergency to inpatient.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter.classHistory",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.classHistory.id",
-				"path": "Encounter.classHistory.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.classHistory.extension",
-				"path": "Encounter.classHistory.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.classHistory.modifierExtension",
-				"path": "Encounter.classHistory.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Encounter.classHistory.class",
-				"path": "Encounter.classHistory.class",
-				"short": "inpatient | outpatient | ambulatory | emergency +",
-				"definition": "inpatient | outpatient | ambulatory | emergency +.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Encounter.classHistory.class",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "EncounterClass"
-						}
-					],
-					"strength": "extensible",
-					"description": "Classification of the encounter.",
-					"valueSet": "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.classHistory.period",
-				"path": "Encounter.classHistory.period",
-				"short": "The time that the episode was in the specified class",
-				"definition": "The time that the episode was in the specified class.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Encounter.classHistory.period",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.type",
-				"path": "Encounter.type",
-				"short": "Specific type of encounter",
-				"definition": "Specific type of encounter (e.g. e-mail consultation, surgical day-care, skilled nursing, rehabilitation).",
-				"comment": "Since there are many ways to further classify encounters, this element is 0..*.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Encounter.type",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Valueset to describe the Encounter Type",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-encounter-type"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1-4 / PV1-18"
-					},
-					{
-						"identity": "rim",
-						"map": ".code"
-					}
-				]
-			},
-			{
-				"id": "Encounter.serviceType",
-				"path": "Encounter.serviceType",
-				"short": "Specific type of service",
-				"definition": "Broad categorization of the service that is to be provided (e.g. cardiology).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.serviceType",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "EncounterServiceType"
-						}
-					],
-					"strength": "example",
-					"description": "Broad categorization of the service that is to be provided.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/service-type"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1-10"
-					},
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.priority",
-				"path": "Encounter.priority",
-				"short": "Indicates the urgency of the encounter",
-				"definition": "Indicates the urgency of the encounter.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.priority",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Priority"
-						}
-					],
-					"strength": "example",
-					"description": "Indicates the urgency of the encounter.",
-					"valueSet": "http://terminology.hl7.org/ValueSet/v3-ActPriority"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.grade"
-					},
-					{
-						"identity": "v2",
-						"map": "PV2-25"
-					},
-					{
-						"identity": "rim",
-						"map": ".priorityCode"
-					}
-				]
-			},
-			{
-				"id": "Encounter.subject",
-				"path": "Encounter.subject",
-				"short": "The patient or group present at the encounter",
-				"definition": "The patient or group present at the encounter.",
-				"comment": "While the encounter is always about the patient, the patient might not actually be known in all contexts of use, and there may be a group of patients that could be anonymous (such as in a group therapy for Alcoholics Anonymous - where the recording of the encounter could be used for billing on the number of people/staff and not important to the context of the specific patients) or alternately in veterinary care a herd of sheep receiving treatment (where the animals are not individually tracked).",
-				"alias": [
-					"patient"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Encounter.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=SBJ]/role[classCode=PAT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Encounter.episodeOfCare",
-				"path": "Encounter.episodeOfCare",
-				"short": "Episode(s) of care that this encounter should be recorded against",
-				"definition": "Where a specific encounter should be classified as a part of a specific episode(s) of care this field should be used. This association can facilitate grouping of related encounters together for a specific purpose, such as government reporting, issue tracking, association via a common problem.  The association is recorded on the encounter as these are typically created after the episode of care and grouped on entry rather than editing the episode of care to append another encounter to it (the episode of care could span years).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter.episodeOfCare",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/EpisodeOfCare"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1-54, PV1-53"
-					},
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.basedOn",
-				"path": "Encounter.basedOn",
-				"short": "The ServiceRequest that initiated this encounter",
-				"definition": "The request this encounter satisfies (e.g. incoming referral or procedure request).",
-				"alias": [
-					"incomingReferral"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.basedOn"
-					},
-					{
-						"identity": "rim",
-						"map": ".reason.ClinicalDocument"
-					}
-				]
-			},
-			{
-				"id": "Encounter.participant",
-				"path": "Encounter.participant",
-				"short": "List of participants involved in the encounter",
-				"definition": "The list of people responsible for providing the service.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter.participant",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer"
-					},
-					{
-						"identity": "v2",
-						"map": "ROL"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=PFM]"
-					}
-				]
-			},
-			{
-				"id": "Encounter.participant.id",
-				"path": "Encounter.participant.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.participant.extension",
-				"path": "Encounter.participant.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.participant.modifierExtension",
-				"path": "Encounter.participant.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Encounter.participant.type",
-				"path": "Encounter.participant.type",
-				"short": "Role of participant in encounter",
-				"definition": "Role of participant in encounter.",
-				"comment": "The participant type indicates how an individual participates in an encounter. It includes non-practitioner participants, and for practitioners this is to describe the action type in the context of this encounter (e.g. Admitting Dr, Attending Dr, Translator, Consulting Dr). This is different to the practitioner roles which are functional roles, derived from terms of employment, education, licensing, etc.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter.participant.type",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ParticipantType"
-						}
-					],
-					"strength": "extensible",
-					"description": "Role of participant in encounter.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/encounter-participant-type"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.function"
-					},
-					{
-						"identity": "v2",
-						"map": "ROL-3 (or maybe PRT-4)"
-					},
-					{
-						"identity": "rim",
-						"map": ".functionCode"
-					}
-				]
-			},
-			{
-				"id": "Encounter.participant.period",
-				"path": "Encounter.participant.period",
-				"short": "Period of time during the encounter that the participant participated",
-				"definition": "The period of time that the specified participant participated in the encounter. These can overlap or be sub-sets of the overall encounter's period.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.participant.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "ROL-5, ROL-6 (or maybe PRT-5)"
-					},
-					{
-						"identity": "rim",
-						"map": ".time"
-					}
-				]
-			},
-			{
-				"id": "Encounter.participant.individual",
-				"path": "Encounter.participant.individual",
-				"short": "Persons involved in the encounter other than the patient",
-				"definition": "Persons involved in the encounter other than the patient.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.participant.individual",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						],
-						"_targetProfile": [
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": true
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							}
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.who"
-					},
-					{
-						"identity": "v2",
-						"map": "ROL-4"
-					},
-					{
-						"identity": "rim",
-						"map": ".role"
-					}
-				]
-			},
-			{
-				"id": "Encounter.appointment",
-				"path": "Encounter.appointment",
-				"short": "The appointment that scheduled this encounter",
-				"definition": "The appointment that scheduled this encounter.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter.appointment",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Appointment"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.basedOn"
-					},
-					{
-						"identity": "v2",
-						"map": "SCH-1 / SCH-2"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=FLFS].target[classCode=ENC, moodCode=APT]"
-					}
-				]
-			},
-			{
-				"id": "Encounter.period",
-				"path": "Encounter.period",
-				"short": "The start and end time of the encounter",
-				"definition": "The start and end time of the encounter.",
-				"comment": "If not (yet) known, the end of the Period may be omitted.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1-44, PV1-45"
-					},
-					{
-						"identity": "rim",
-						"map": ".effectiveTime (low & high)"
-					}
-				]
-			},
-			{
-				"id": "Encounter.length",
-				"path": "Encounter.length",
-				"short": "Quantity of time the encounter lasted (less time absent)",
-				"definition": "Quantity of time the encounter lasted. This excludes the time during leaves of absence.",
-				"comment": "May differ from the time the Encounter.period lasted because of leave of absence.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.length",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Duration"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "(PV1-45 less PV1-44) iff ( (PV1-44 not empty) and (PV1-45 not empty) ); units in minutes"
-					},
-					{
-						"identity": "rim",
-						"map": ".lengthOfStayQuantity"
-					}
-				]
-			},
-			{
-				"id": "Encounter.reasonCode",
-				"path": "Encounter.reasonCode",
-				"short": "Coded reason the encounter takes place",
-				"definition": "Reason the encounter takes place, expressed as a code. For admissions, this can be used for a coded admission diagnosis.",
-				"comment": "For systems that need to know which was the primary diagnosis, these will be marked with the standard extension primaryDiagnosis (which is a sequence value rather than a flag, 1 = primary diagnosis).",
-				"alias": [
-					"Indication",
-					"Admission diagnosis"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter.reasonCode",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "EncounterReason"
-						}
-					],
-					"strength": "preferred",
-					"description": "Reason why the encounter takes place.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/encounter-reason"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.reasonCode"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.why[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "EVN-4 / PV2-3 (note: PV2-3 is nominally constrained to inpatient admissions; HL7 v2 makes no vocabulary suggestions for PV2-3; would not expect PV2 segment or PV2-3 to be in use in all implementations )"
-					},
-					{
-						"identity": "rim",
-						"map": ".reasonCode"
-					}
-				]
-			},
-			{
-				"id": "Encounter.reasonReference",
-				"path": "Encounter.reasonReference",
-				"short": "Reason the encounter takes place (reference)",
-				"definition": "Reason the encounter takes place, expressed as a code. For admissions, this can be used for a coded admission diagnosis.",
-				"comment": "For systems that need to know which was the primary diagnosis, these will be marked with the standard extension primaryDiagnosis (which is a sequence value rather than a flag, 1 = primary diagnosis).",
-				"alias": [
-					"Indication",
-					"Admission diagnosis"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.reasonReference",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure",
-							"http://hl7.org/fhir/StructureDefinition/Observation",
-							"http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation"
-						],
-						"_targetProfile": [
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": true
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							}
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.reasonCode"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.why[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "EVN-4 / PV2-3 (note: PV2-3 is nominally constrained to inpatient admissions; HL7 v2 makes no vocabulary suggestions for PV2-3; would not expect PV2 segment or PV2-3 to be in use in all implementations )"
-					},
-					{
-						"identity": "rim",
-						"map": ".reasonCode"
-					}
-				]
-			},
-			{
-				"id": "Encounter.diagnosis",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name",
-						"valueString": "Diagnosis"
-					}
-				],
-				"path": "Encounter.diagnosis",
-				"short": "The list of diagnosis relevant to this encounter",
-				"definition": "The list of diagnosis relevant to this encounter.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter.diagnosis",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=RSON]"
-					}
-				]
-			},
-			{
-				"id": "Encounter.diagnosis.id",
-				"path": "Encounter.diagnosis.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.diagnosis.extension",
-				"path": "Encounter.diagnosis.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.diagnosis.modifierExtension",
-				"path": "Encounter.diagnosis.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Encounter.diagnosis.condition",
-				"path": "Encounter.diagnosis.condition",
-				"short": "The diagnosis or procedure relevant to the encounter",
-				"definition": "Reason the encounter takes place, as specified using information from another resource. For admissions, this is the admission diagnosis. The indication will typically be a Condition (with other resources referenced in the evidence.detail), or a Procedure.",
-				"comment": "For systems that need to know which was the primary diagnosis, these will be marked with the standard extension primaryDiagnosis (which is a sequence value rather than a flag, 1 = primary diagnosis).",
-				"alias": [
-					"Admission diagnosis",
-					"discharge diagnosis",
-					"indication"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Encounter.diagnosis.condition",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Condition",
-							"http://hl7.org/fhir/StructureDefinition/Procedure"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.reasonReference"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.why[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "Resources that would commonly referenced at Encounter.indication would be Condition and/or Procedure. These most closely align with DG1/PRB and PR1 respectively."
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=RSON].target"
-					}
-				]
-			},
-			{
-				"id": "Encounter.diagnosis.use",
-				"path": "Encounter.diagnosis.use",
-				"short": "Role that this diagnosis has within the encounter (e.g. admission, billing, discharge …)",
-				"definition": "Role that this diagnosis has within the encounter (e.g. admission, billing, discharge …).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.diagnosis.use",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "DiagnosisRole"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "The type of diagnosis this condition represents.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/diagnosis-role"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.diagnosis.rank",
-				"path": "Encounter.diagnosis.rank",
-				"short": "Ranking of the diagnosis (for each role type)",
-				"definition": "Ranking of the diagnosis (for each role type).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.diagnosis.rank",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "positiveInt"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=RSON].priority"
-					}
-				]
-			},
-			{
-				"id": "Encounter.account",
-				"path": "Encounter.account",
-				"short": "The set of accounts that may be used for billing for this Encounter",
-				"definition": "The set of accounts that may be used for billing for this Encounter.",
-				"comment": "The billing system may choose to allocate billable items associated with the Encounter to different referenced Accounts based on internal business rules.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter.account",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Account"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".pertains.A_Account"
-					}
-				]
-			},
-			{
-				"id": "Encounter.hospitalization",
-				"path": "Encounter.hospitalization",
-				"short": "Details about the admission to a healthcare service",
-				"definition": "Details about the admission to a healthcare service.",
-				"comment": "An Encounter may cover more than just the inpatient stay. Contexts such as outpatients, community clinics, and aged care facilities are also included.\r\rThe duration recorded in the period of this encounter covers the entire scope of this hospitalization record.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.hospitalization",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=COMP].target[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Encounter.hospitalization.id",
-				"path": "Encounter.hospitalization.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.hospitalization.extension",
-				"path": "Encounter.hospitalization.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.hospitalization.modifierExtension",
-				"path": "Encounter.hospitalization.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Encounter.hospitalization.preAdmissionIdentifier",
-				"path": "Encounter.hospitalization.preAdmissionIdentifier",
-				"short": "Pre-admission identifier",
-				"definition": "Pre-admission identifier.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.hospitalization.preAdmissionIdentifier",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PV1-5"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					}
-				]
-			},
-			{
-				"id": "Encounter.hospitalization.origin",
-				"path": "Encounter.hospitalization.origin",
-				"short": "The location/organization from which the patient came before admission",
-				"definition": "The location/organization from which the patient came before admission.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.hospitalization.origin",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Location",
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=ORG].role"
-					}
-				]
-			},
-			{
-				"id": "Encounter.hospitalization.admitSource",
-				"path": "Encounter.hospitalization.admitSource",
-				"short": "From where patient was admitted (physician referral, transfer)",
-				"definition": "From where patient was admitted (physician referral, transfer).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.hospitalization.admitSource",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AdmitSource"
-						}
-					],
-					"strength": "preferred",
-					"description": "From where the patient was admitted.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/encounter-admit-source"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PV1-14"
-					},
-					{
-						"identity": "rim",
-						"map": ".admissionReferralSourceCode"
-					}
-				]
-			},
-			{
-				"id": "Encounter.hospitalization.reAdmission",
-				"path": "Encounter.hospitalization.reAdmission",
-				"short": "The type of hospital re-admission that has occurred (if any). If the value is absent, then this is not identified as a readmission",
-				"definition": "Whether this hospitalization is a readmission and why if known.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.hospitalization.reAdmission",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ReAdmissionType"
-						}
-					],
-					"strength": "example",
-					"description": "The reason for re-admission of this hospitalization encounter.",
-					"valueSet": "http://terminology.hl7.org/ValueSet/v2-0092"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PV1-13"
-					},
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.hospitalization.dietPreference",
-				"path": "Encounter.hospitalization.dietPreference",
-				"short": "Diet preferences reported by the patient",
-				"definition": "Diet preferences reported by the patient.",
-				"comment": "For example, a patient may request both a dairy-free and nut-free diet preference (not mutually exclusive).",
-				"requirements": "Used to track patient's diet restrictions and/or preference. For a complete description of the nutrition needs of a patient during their stay, one should use the nutritionOrder resource which links to Encounter.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter.hospitalization.dietPreference",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "PatientDiet"
-						}
-					],
-					"strength": "example",
-					"description": "Medical, cultural or ethical food preferences to help with catering requirements.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/encounter-diet"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PV1-38"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=COMP].target[classCode=SBADM, moodCode=EVN, code=\"diet\"]"
-					}
-				]
-			},
-			{
-				"id": "Encounter.hospitalization.specialCourtesy",
-				"path": "Encounter.hospitalization.specialCourtesy",
-				"short": "Special courtesies (VIP, board member)",
-				"definition": "Special courtesies (VIP, board member).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter.hospitalization.specialCourtesy",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Courtesies"
-						}
-					],
-					"strength": "preferred",
-					"description": "Special courtesies.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/encounter-special-courtesy"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PV1-16"
-					},
-					{
-						"identity": "rim",
-						"map": ".specialCourtesiesCode"
-					}
-				]
-			},
-			{
-				"id": "Encounter.hospitalization.specialArrangement",
-				"path": "Encounter.hospitalization.specialArrangement",
-				"short": "Wheelchair, translator, stretcher, etc.",
-				"definition": "Any special requests that have been made for this hospitalization encounter, such as the provision of specific equipment or other things.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter.hospitalization.specialArrangement",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Arrangements"
-						}
-					],
-					"strength": "preferred",
-					"description": "Special arrangements.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/encounter-special-arrangements"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PV1-15 / OBR-30 / OBR-43"
-					},
-					{
-						"identity": "rim",
-						"map": ".specialArrangementCode"
-					}
-				]
-			},
-			{
-				"id": "Encounter.hospitalization.destination",
-				"path": "Encounter.hospitalization.destination",
-				"short": "Location/organization to which the patient is discharged",
-				"definition": "Location/organization to which the patient is discharged.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.hospitalization.destination",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Location",
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PV1-37"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=DST]"
-					}
-				]
-			},
-			{
-				"id": "Encounter.hospitalization.dischargeDisposition",
-				"path": "Encounter.hospitalization.dischargeDisposition",
-				"short": "Category or kind of location after discharge",
-				"definition": "Category or kind of location after discharge.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.hospitalization.dischargeDisposition",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "DischargeDisp"
-						}
-					],
-					"strength": "example",
-					"description": "Discharge Disposition.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/encounter-discharge-disposition"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PV1-36"
-					},
-					{
-						"identity": "rim",
-						"map": ".dischargeDispositionCode"
-					}
-				]
-			},
-			{
-				"id": "Encounter.location",
-				"path": "Encounter.location",
-				"short": "List of locations where the patient has been",
-				"definition": "List of locations where  the patient has been during this encounter.",
-				"comment": "Virtual encounters can be recorded in the Encounter by specifying a location reference to a location of type \"kind\" such as \"client's home\" and an encounter.class = \"virtual\".",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Encounter.location",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=LOC]"
-					}
-				]
-			},
-			{
-				"id": "Encounter.location.id",
-				"path": "Encounter.location.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.location.extension",
-				"path": "Encounter.location.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Encounter.location.modifierExtension",
-				"path": "Encounter.location.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Encounter.location.location",
-				"path": "Encounter.location.location",
-				"short": "Location the encounter takes place",
-				"definition": "The location where the encounter takes place.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Encounter.location.location",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Location"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.location"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.where[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1-3 / PV1-6 / PV1-11 / PV1-42 / PV1-43"
-					},
-					{
-						"identity": "rim",
-						"map": ".role"
-					}
-				]
-			},
-			{
-				"id": "Encounter.location.status",
-				"path": "Encounter.location.status",
-				"short": "planned | active | reserved | completed",
-				"definition": "The status of the participants' presence at the specified location during the period specified. If the participant is no longer at the location, then the period will have an end date/time.",
-				"comment": "When the patient is no longer active at a location, then the period end date is entered, and the status may be changed to completed.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.location.status",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "EncounterLocationStatus"
-						}
-					],
-					"strength": "required",
-					"description": "The status of the location.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/encounter-location-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".role.statusCode"
-					}
-				]
-			},
-			{
-				"id": "Encounter.location.physicalType",
-				"path": "Encounter.location.physicalType",
-				"short": "The physical type of the location (usually the level in the location hierachy - bed room ward etc.)",
-				"definition": "This will be used to specify the required levels (bed/ward/room/etc.) desired to be recorded to simplify either messaging or query.",
-				"comment": "This information is de-normalized from the Location resource to support the easier understanding of the encounter resource and processing in messaging or query.\n\nThere may be many levels in the hierachy, and this may only pic specific levels that are required for a specific usage scenario.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.location.physicalType",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "PhysicalType"
-						}
-					],
-					"strength": "example",
-					"description": "Physical form of the location.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/location-physical-type"
-				}
-			},
-			{
-				"id": "Encounter.location.period",
-				"path": "Encounter.location.period",
-				"short": "Time period during which the patient was present at the location",
-				"definition": "Time period during which the patient was present at the location.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.location.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".time"
-					}
-				]
-			},
-			{
-				"id": "Encounter.serviceProvider",
-				"path": "Encounter.serviceProvider",
-				"short": "The organization (facility) responsible for this encounter",
-				"definition": "The organization that is primarily responsible for this Encounter's services. This MAY be the same as the organization on the Patient record, however it could be different, such as if the actor performing the services was from an external organization (which may be billed seperately) for an external consultation.  Refer to the example bundle showing an abbreviated set of Encounters for a colonoscopy.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.serviceProvider",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "PL.6  & PL.1"
-					},
-					{
-						"identity": "rim",
-						"map": ".particiaption[typeCode=PFM].role"
-					}
-				]
-			},
-			{
-				"id": "Encounter.partOf",
-				"path": "Encounter.partOf",
-				"short": "Another Encounter this encounter is part of",
-				"definition": "Another Encounter of which this encounter is a part of (administratively or in time).",
-				"comment": "This is also used for associating a child's encounter back to the mother's encounter.\r\rRefer to the Notes section in the Patient resource for further details.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Encounter.partOf",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-hierarchy",
-								"valueBoolean": true
-							}
-						],
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.partOf"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[classCode=COMP, moodCode=EVN]"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Encounter",
-				"path": "Encounter",
-				"definition": "This is basic constraint on Encounter for use in US Core resources.",
-				"alias": [
-					"Visit"
-				],
-				"mustSupport": false
-			},
-			{
-				"id": "Encounter.identifier",
-				"path": "Encounter.identifier",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.identifier.system",
-				"path": "Encounter.identifier.system",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.identifier.value",
-				"path": "Encounter.identifier.value",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.status",
-				"path": "Encounter.status",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.class",
-				"path": "Encounter.class",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.type",
-				"path": "Encounter.type",
-				"min": 1,
-				"max": "*",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Valueset to describe the Encounter Type",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-encounter-type"
-				}
-			},
-			{
-				"id": "Encounter.subject",
-				"path": "Encounter.subject",
-				"alias": [
-					"patient"
-				],
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.participant",
-				"path": "Encounter.participant",
-				"min": 0,
-				"max": "*",
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.participant.type",
-				"path": "Encounter.participant.type",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.participant.period",
-				"path": "Encounter.participant.period",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.participant.individual",
-				"path": "Encounter.participant.individual",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						],
-						"_targetProfile": [
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": true
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							}
-						]
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.period",
-				"path": "Encounter.period",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.reasonCode",
-				"path": "Encounter.reasonCode",
-				"alias": [
-					"Indication",
-					"Admission diagnosis"
-				],
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.reasonReference",
-				"path": "Encounter.reasonReference",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure",
-							"http://hl7.org/fhir/StructureDefinition/Observation",
-							"http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation"
-						],
-						"_targetProfile": [
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": true
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							}
-						]
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.hospitalization",
-				"path": "Encounter.hospitalization",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.hospitalization.dischargeDisposition",
-				"path": "Encounter.hospitalization.dischargeDisposition",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.location",
-				"path": "Encounter.location",
-				"min": 0,
-				"max": "*",
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.location.location",
-				"path": "Encounter.location.location",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Location"
-						]
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Encounter.serviceProvider",
-				"path": "Encounter.serviceProvider",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
-						]
-					}
-				],
-				"mustSupport": true
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-encounter",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter",
+    "version": "4.0.0",
+    "name": "USCoreEncounterProfile",
+    "title": "US Core Encounter Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The Encounter referenced in the US Core profiles.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Encounter",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Encounter",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Encounter",
+                "path": "Encounter",
+                "short": "An interaction during which services are provided to the patient",
+                "definition": "This is basic constraint on Encounter for use in US Core resources.",
+                "alias": [
+                    "Visit"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Encounter[@moodCode='EVN']"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.id",
+                "path": "Encounter.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Encounter.meta",
+                "path": "Encounter.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Encounter.implicitRules",
+                "path": "Encounter.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Encounter.language",
+                "path": "Encounter.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Encounter.text",
+                "path": "Encounter.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.contained",
+                "path": "Encounter.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.extension",
+                "path": "Encounter.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.modifierExtension",
+                "path": "Encounter.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.identifier",
+                "path": "Encounter.identifier",
+                "short": "Identifier(s) by which this encounter is known",
+                "definition": "Identifier(s) by which this encounter is known.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1-19"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.identifier.id",
+                "path": "Encounter.identifier.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.identifier.extension",
+                "path": "Encounter.identifier.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.identifier.use",
+                "path": "Encounter.identifier.use",
+                "short": "usual | official | temp | secondary | old (If known)",
+                "definition": "The purpose of this identifier.",
+                "comment": "Applications can assume that an identifier is permanent unless it explicitly says that it is temporary.",
+                "requirements": "Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.use",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary id for a permanent one.",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "IdentifierUse"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Identifies the purpose for this identifier, if known .",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/identifier-use|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Role.code or implied by context"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.identifier.type",
+                "path": "Encounter.identifier.type",
+                "short": "Description of identifier",
+                "definition": "A coded type for the identifier that can be used to determine which identifier to use for a specific purpose.",
+                "comment": "This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage.   Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type.",
+                "requirements": "Allows users to make use of identifiers when the identifier system is not known.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "IdentifierType"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "A coded type for an identifier that can be used to determine which identifier to use for a specific purpose.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/identifier-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Role.code or implied by context"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.identifier.system",
+                "path": "Encounter.identifier.system",
+                "short": "The namespace for the identifier value",
+                "definition": "Establishes the namespace for the value - that is, a URL that describes a set values that are unique.",
+                "comment": "Identifier.system is always case sensitive.",
+                "requirements": "There are many sets  of identifiers.  To perform matching of two identifiers, we need to know what set we're dealing with. The system identifies a particular set of unique identifiers.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueUri": "http://www.acme.com/identifiers/patient"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.4 / EI-2-4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "II.root or Role.id.root"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./IdentifierType"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.identifier.value",
+                "path": "Encounter.identifier.value",
+                "short": "The value that is unique",
+                "definition": "The portion of the identifier typically relevant to the user and which is unique within the context of the system.",
+                "comment": "If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986.  The value's primary purpose is computational mapping.  As a result, it may be normalized for comparison purposes (e.g. removing non-significant whitespace, dashes, etc.)  A value formatted for human display can be conveyed using the [Rendered Value extension](http://hl7.org/fhir/R4/extension-rendered-value.html). Identifier.value is to be treated as case sensitive unless knowledge of the Identifier.system allows the processer to be confident that non-case-sensitive processing is safe.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "123456"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.1 / EI.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Value"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.identifier.period",
+                "path": "Encounter.identifier.period",
+                "short": "Time period when id is/was valid for use",
+                "definition": "Time period during which identifier is/was valid for use.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.7 + CX.8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Role.effectiveTime or implied by context"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./StartDate and ./EndDate"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.identifier.assigner",
+                "path": "Encounter.identifier.assigner",
+                "short": "Organization that issued id (may be just text)",
+                "definition": "Organization that issued/manages the identifier.",
+                "comment": "The Identifier.assigner may omit the .reference element and only contain a .display element reflecting the name or other textual information about the assigning organization.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.assigner",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.4 / (CX.4,CX.9,CX.10)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./IdentifierIssuingAuthority"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.status",
+                "path": "Encounter.status",
+                "short": "planned | arrived | triaged | in-progress | onleave | finished | cancelled +",
+                "definition": "planned | arrived | triaged | in-progress | onleave | finished | cancelled +.",
+                "comment": "Note that internal business rules will determine the appropriate transitions that may occur between statuses (and also classes).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "EncounterStatus"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Current state of the encounter.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/encounter-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "No clear equivalent in HL7 v2; active/finished could be inferred from PV1-44, PV1-45, PV2-24; inactive could be inferred from PV2-16"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".statusCode"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.statusHistory",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name",
+                        "valueString": "StatusHistory"
+                    }
+                ],
+                "path": "Encounter.statusHistory",
+                "short": "List of past encounter statuses",
+                "definition": "The status history permits the encounter resource to contain the status history without needing to read through the historical versions of the resource, or even have the server store them.",
+                "comment": "The current status is always found in the current version of the resource, not the status history.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.statusHistory",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.statusHistory.id",
+                "path": "Encounter.statusHistory.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.statusHistory.extension",
+                "path": "Encounter.statusHistory.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.statusHistory.modifierExtension",
+                "path": "Encounter.statusHistory.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.statusHistory.status",
+                "path": "Encounter.statusHistory.status",
+                "short": "planned | arrived | triaged | in-progress | onleave | finished | cancelled +",
+                "definition": "planned | arrived | triaged | in-progress | onleave | finished | cancelled +.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.statusHistory.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "EncounterStatus"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Current state of the encounter.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/encounter-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.statusHistory.period",
+                "path": "Encounter.statusHistory.period",
+                "short": "The time that the episode was in the specified status",
+                "definition": "The time that the episode was in the specified status.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.statusHistory.period",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.class",
+                "path": "Encounter.class",
+                "short": "Classification of patient encounter",
+                "definition": "Concepts representing classification of patient encounter such as ambulatory (outpatient), inpatient, emergency, home health or others due to local variations.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.class",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "EncounterClass"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Classification of the encounter.",
+                    "valueSet": "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1-2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=SUBJ].source[classCode=LIST].code"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.classHistory",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name",
+                        "valueString": "ClassHistory"
+                    }
+                ],
+                "path": "Encounter.classHistory",
+                "short": "List of past encounter classes",
+                "definition": "The class history permits the tracking of the encounters transitions without needing to go  through the resource history.  This would be used for a case where an admission starts of as an emergency encounter, then transitions into an inpatient scenario. Doing this and not restarting a new encounter ensures that any lab/diagnostic results can more easily follow the patient and not require re-processing and not get lost or cancelled during a kind of discharge from emergency to inpatient.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.classHistory",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.classHistory.id",
+                "path": "Encounter.classHistory.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.classHistory.extension",
+                "path": "Encounter.classHistory.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.classHistory.modifierExtension",
+                "path": "Encounter.classHistory.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.classHistory.class",
+                "path": "Encounter.classHistory.class",
+                "short": "inpatient | outpatient | ambulatory | emergency +",
+                "definition": "inpatient | outpatient | ambulatory | emergency +.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.classHistory.class",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "EncounterClass"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Classification of the encounter.",
+                    "valueSet": "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.classHistory.period",
+                "path": "Encounter.classHistory.period",
+                "short": "The time that the episode was in the specified class",
+                "definition": "The time that the episode was in the specified class.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.classHistory.period",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.type",
+                "path": "Encounter.type",
+                "short": "Specific type of encounter",
+                "definition": "Specific type of encounter (e.g. e-mail consultation, surgical day-care, skilled nursing, rehabilitation).",
+                "comment": "Since there are many ways to further classify encounters, this element is 0..*.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.type",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Valueset to describe the Encounter Type",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-encounter-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1-4 / PV1-18"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".code"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.serviceType",
+                "path": "Encounter.serviceType",
+                "short": "Specific type of service",
+                "definition": "Broad categorization of the service that is to be provided (e.g. cardiology).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.serviceType",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "EncounterServiceType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Broad categorization of the service that is to be provided.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/service-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.priority",
+                "path": "Encounter.priority",
+                "short": "Indicates the urgency of the encounter",
+                "definition": "Indicates the urgency of the encounter.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.priority",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Priority"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Indicates the urgency of the encounter.",
+                    "valueSet": "http://terminology.hl7.org/ValueSet/v3-ActPriority"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.grade"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV2-25"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".priorityCode"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.subject",
+                "path": "Encounter.subject",
+                "short": "The patient or group present at the encounter",
+                "definition": "The patient or group present at the encounter.",
+                "comment": "While the encounter is always about the patient, the patient might not actually be known in all contexts of use, and there may be a group of patients that could be anonymous (such as in a group therapy for Alcoholics Anonymous - where the recording of the encounter could be used for billing on the number of people/staff and not important to the context of the specific patients) or alternately in veterinary care a herd of sheep receiving treatment (where the animals are not individually tracked).",
+                "alias": [
+                    "patient"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=SBJ]/role[classCode=PAT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.episodeOfCare",
+                "path": "Encounter.episodeOfCare",
+                "short": "Episode(s) of care that this encounter should be recorded against",
+                "definition": "Where a specific encounter should be classified as a part of a specific episode(s) of care this field should be used. This association can facilitate grouping of related encounters together for a specific purpose, such as government reporting, issue tracking, association via a common problem.  The association is recorded on the encounter as these are typically created after the episode of care and grouped on entry rather than editing the episode of care to append another encounter to it (the episode of care could span years).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.episodeOfCare",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/EpisodeOfCare"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1-54, PV1-53"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.basedOn",
+                "path": "Encounter.basedOn",
+                "short": "The ServiceRequest that initiated this encounter",
+                "definition": "The request this encounter satisfies (e.g. incoming referral or procedure request).",
+                "alias": [
+                    "incomingReferral"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.basedOn"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".reason.ClinicalDocument"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.participant",
+                "path": "Encounter.participant",
+                "short": "List of participants involved in the encounter",
+                "definition": "The list of people responsible for providing the service.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.participant",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ROL"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=PFM]"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.participant.id",
+                "path": "Encounter.participant.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.participant.extension",
+                "path": "Encounter.participant.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.participant.modifierExtension",
+                "path": "Encounter.participant.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.participant.type",
+                "path": "Encounter.participant.type",
+                "short": "Role of participant in encounter",
+                "definition": "Role of participant in encounter.",
+                "comment": "The participant type indicates how an individual participates in an encounter. It includes non-practitioner participants, and for practitioners this is to describe the action type in the context of this encounter (e.g. Admitting Dr, Attending Dr, Translator, Consulting Dr). This is different to the practitioner roles which are functional roles, derived from terms of employment, education, licensing, etc.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.participant.type",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ParticipantType"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Role of participant in encounter.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/encounter-participant-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.function"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ROL-3 (or maybe PRT-4)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".functionCode"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.participant.period",
+                "path": "Encounter.participant.period",
+                "short": "Period of time during the encounter that the participant participated",
+                "definition": "The period of time that the specified participant participated in the encounter. These can overlap or be sub-sets of the overall encounter's period.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.participant.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "ROL-5, ROL-6 (or maybe PRT-5)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".time"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.participant.individual",
+                "path": "Encounter.participant.individual",
+                "short": "Persons involved in the encounter other than the patient",
+                "definition": "Persons involved in the encounter other than the patient.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.participant.individual",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ],
+                        "_targetProfile": [
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": true
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.who"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ROL-4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".role"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.appointment",
+                "path": "Encounter.appointment",
+                "short": "The appointment that scheduled this encounter",
+                "definition": "The appointment that scheduled this encounter.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.appointment",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Appointment"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.basedOn"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "SCH-1 / SCH-2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=FLFS].target[classCode=ENC, moodCode=APT]"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.period",
+                "path": "Encounter.period",
+                "short": "The start and end time of the encounter",
+                "definition": "The start and end time of the encounter.",
+                "comment": "If not (yet) known, the end of the Period may be omitted.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1-44, PV1-45"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime (low & high)"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.length",
+                "path": "Encounter.length",
+                "short": "Quantity of time the encounter lasted (less time absent)",
+                "definition": "Quantity of time the encounter lasted. This excludes the time during leaves of absence.",
+                "comment": "May differ from the time the Encounter.period lasted because of leave of absence.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.length",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Duration"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "(PV1-45 less PV1-44) iff ( (PV1-44 not empty) and (PV1-45 not empty) ); units in minutes"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".lengthOfStayQuantity"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.reasonCode",
+                "path": "Encounter.reasonCode",
+                "short": "Coded reason the encounter takes place",
+                "definition": "Reason the encounter takes place, expressed as a code. For admissions, this can be used for a coded admission diagnosis.",
+                "comment": "For systems that need to know which was the primary diagnosis, these will be marked with the standard extension primaryDiagnosis (which is a sequence value rather than a flag, 1 = primary diagnosis).",
+                "alias": [
+                    "Indication",
+                    "Admission diagnosis"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.reasonCode",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "EncounterReason"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Reason why the encounter takes place.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/encounter-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.reasonCode"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.why[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "EVN-4 / PV2-3 (note: PV2-3 is nominally constrained to inpatient admissions; HL7 v2 makes no vocabulary suggestions for PV2-3; would not expect PV2 segment or PV2-3 to be in use in all implementations )"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".reasonCode"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.reasonReference",
+                "path": "Encounter.reasonReference",
+                "short": "Reason the encounter takes place (reference)",
+                "definition": "Reason the encounter takes place, expressed as a code. For admissions, this can be used for a coded admission diagnosis.",
+                "comment": "For systems that need to know which was the primary diagnosis, these will be marked with the standard extension primaryDiagnosis (which is a sequence value rather than a flag, 1 = primary diagnosis).",
+                "alias": [
+                    "Indication",
+                    "Admission diagnosis"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.reasonReference",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure",
+                            "http://hl7.org/fhir/StructureDefinition/Observation",
+                            "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation"
+                        ],
+                        "_targetProfile": [
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": true
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.reasonCode"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.why[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "EVN-4 / PV2-3 (note: PV2-3 is nominally constrained to inpatient admissions; HL7 v2 makes no vocabulary suggestions for PV2-3; would not expect PV2 segment or PV2-3 to be in use in all implementations )"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".reasonCode"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.diagnosis",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name",
+                        "valueString": "Diagnosis"
+                    }
+                ],
+                "path": "Encounter.diagnosis",
+                "short": "The list of diagnosis relevant to this encounter",
+                "definition": "The list of diagnosis relevant to this encounter.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.diagnosis",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=RSON]"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.diagnosis.id",
+                "path": "Encounter.diagnosis.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.diagnosis.extension",
+                "path": "Encounter.diagnosis.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.diagnosis.modifierExtension",
+                "path": "Encounter.diagnosis.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.diagnosis.condition",
+                "path": "Encounter.diagnosis.condition",
+                "short": "The diagnosis or procedure relevant to the encounter",
+                "definition": "Reason the encounter takes place, as specified using information from another resource. For admissions, this is the admission diagnosis. The indication will typically be a Condition (with other resources referenced in the evidence.detail), or a Procedure.",
+                "comment": "For systems that need to know which was the primary diagnosis, these will be marked with the standard extension primaryDiagnosis (which is a sequence value rather than a flag, 1 = primary diagnosis).",
+                "alias": [
+                    "Admission diagnosis",
+                    "discharge diagnosis",
+                    "indication"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.diagnosis.condition",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Condition",
+                            "http://hl7.org/fhir/StructureDefinition/Procedure"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.reasonReference"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.why[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "Resources that would commonly referenced at Encounter.indication would be Condition and/or Procedure. These most closely align with DG1/PRB and PR1 respectively."
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=RSON].target"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.diagnosis.use",
+                "path": "Encounter.diagnosis.use",
+                "short": "Role that this diagnosis has within the encounter (e.g. admission, billing, discharge …)",
+                "definition": "Role that this diagnosis has within the encounter (e.g. admission, billing, discharge …).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.diagnosis.use",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "DiagnosisRole"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "The type of diagnosis this condition represents.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/diagnosis-role"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.diagnosis.rank",
+                "path": "Encounter.diagnosis.rank",
+                "short": "Ranking of the diagnosis (for each role type)",
+                "definition": "Ranking of the diagnosis (for each role type).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.diagnosis.rank",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "positiveInt"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=RSON].priority"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.account",
+                "path": "Encounter.account",
+                "short": "The set of accounts that may be used for billing for this Encounter",
+                "definition": "The set of accounts that may be used for billing for this Encounter.",
+                "comment": "The billing system may choose to allocate billable items associated with the Encounter to different referenced Accounts based on internal business rules.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.account",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Account"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".pertains.A_Account"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.hospitalization",
+                "path": "Encounter.hospitalization",
+                "short": "Details about the admission to a healthcare service",
+                "definition": "Details about the admission to a healthcare service.",
+                "comment": "An Encounter may cover more than just the inpatient stay. Contexts such as outpatients, community clinics, and aged care facilities are also included.\r\rThe duration recorded in the period of this encounter covers the entire scope of this hospitalization record.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.hospitalization",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=COMP].target[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.hospitalization.id",
+                "path": "Encounter.hospitalization.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.hospitalization.extension",
+                "path": "Encounter.hospitalization.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.hospitalization.modifierExtension",
+                "path": "Encounter.hospitalization.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.hospitalization.preAdmissionIdentifier",
+                "path": "Encounter.hospitalization.preAdmissionIdentifier",
+                "short": "Pre-admission identifier",
+                "definition": "Pre-admission identifier.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.hospitalization.preAdmissionIdentifier",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PV1-5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.hospitalization.origin",
+                "path": "Encounter.hospitalization.origin",
+                "short": "The location/organization from which the patient came before admission",
+                "definition": "The location/organization from which the patient came before admission.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.hospitalization.origin",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Location",
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=ORG].role"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.hospitalization.admitSource",
+                "path": "Encounter.hospitalization.admitSource",
+                "short": "From where patient was admitted (physician referral, transfer)",
+                "definition": "From where patient was admitted (physician referral, transfer).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.hospitalization.admitSource",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AdmitSource"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "From where the patient was admitted.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/encounter-admit-source"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PV1-14"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".admissionReferralSourceCode"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.hospitalization.reAdmission",
+                "path": "Encounter.hospitalization.reAdmission",
+                "short": "The type of hospital re-admission that has occurred (if any). If the value is absent, then this is not identified as a readmission",
+                "definition": "Whether this hospitalization is a readmission and why if known.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.hospitalization.reAdmission",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ReAdmissionType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "The reason for re-admission of this hospitalization encounter.",
+                    "valueSet": "http://terminology.hl7.org/ValueSet/v2-0092"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PV1-13"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.hospitalization.dietPreference",
+                "path": "Encounter.hospitalization.dietPreference",
+                "short": "Diet preferences reported by the patient",
+                "definition": "Diet preferences reported by the patient.",
+                "comment": "For example, a patient may request both a dairy-free and nut-free diet preference (not mutually exclusive).",
+                "requirements": "Used to track patient's diet restrictions and/or preference. For a complete description of the nutrition needs of a patient during their stay, one should use the nutritionOrder resource which links to Encounter.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.hospitalization.dietPreference",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "PatientDiet"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Medical, cultural or ethical food preferences to help with catering requirements.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/encounter-diet"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PV1-38"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=COMP].target[classCode=SBADM, moodCode=EVN, code=\"diet\"]"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.hospitalization.specialCourtesy",
+                "path": "Encounter.hospitalization.specialCourtesy",
+                "short": "Special courtesies (VIP, board member)",
+                "definition": "Special courtesies (VIP, board member).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.hospitalization.specialCourtesy",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Courtesies"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Special courtesies.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/encounter-special-courtesy"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PV1-16"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".specialCourtesiesCode"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.hospitalization.specialArrangement",
+                "path": "Encounter.hospitalization.specialArrangement",
+                "short": "Wheelchair, translator, stretcher, etc.",
+                "definition": "Any special requests that have been made for this hospitalization encounter, such as the provision of specific equipment or other things.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.hospitalization.specialArrangement",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Arrangements"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Special arrangements.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/encounter-special-arrangements"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PV1-15 / OBR-30 / OBR-43"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".specialArrangementCode"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.hospitalization.destination",
+                "path": "Encounter.hospitalization.destination",
+                "short": "Location/organization to which the patient is discharged",
+                "definition": "Location/organization to which the patient is discharged.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.hospitalization.destination",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Location",
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PV1-37"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=DST]"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.hospitalization.dischargeDisposition",
+                "path": "Encounter.hospitalization.dischargeDisposition",
+                "short": "Category or kind of location after discharge",
+                "definition": "Category or kind of location after discharge.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.hospitalization.dischargeDisposition",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "DischargeDisp"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Discharge Disposition.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/encounter-discharge-disposition"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PV1-36"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".dischargeDispositionCode"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.location",
+                "path": "Encounter.location",
+                "short": "List of locations where the patient has been",
+                "definition": "List of locations where  the patient has been during this encounter.",
+                "comment": "Virtual encounters can be recorded in the Encounter by specifying a location reference to a location of type \"kind\" such as \"client's home\" and an encounter.class = \"virtual\".",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Encounter.location",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=LOC]"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.location.id",
+                "path": "Encounter.location.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.location.extension",
+                "path": "Encounter.location.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.location.modifierExtension",
+                "path": "Encounter.location.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.location.location",
+                "path": "Encounter.location.location",
+                "short": "Location the encounter takes place",
+                "definition": "The location where the encounter takes place.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.location.location",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Location"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.location"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.where[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1-3 / PV1-6 / PV1-11 / PV1-42 / PV1-43"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".role"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.location.status",
+                "path": "Encounter.location.status",
+                "short": "planned | active | reserved | completed",
+                "definition": "The status of the participants' presence at the specified location during the period specified. If the participant is no longer at the location, then the period will have an end date/time.",
+                "comment": "When the patient is no longer active at a location, then the period end date is entered, and the status may be changed to completed.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.location.status",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "EncounterLocationStatus"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The status of the location.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/encounter-location-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".role.statusCode"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.location.physicalType",
+                "path": "Encounter.location.physicalType",
+                "short": "The physical type of the location (usually the level in the location hierachy - bed room ward etc.)",
+                "definition": "This will be used to specify the required levels (bed/ward/room/etc.) desired to be recorded to simplify either messaging or query.",
+                "comment": "This information is de-normalized from the Location resource to support the easier understanding of the encounter resource and processing in messaging or query.\n\nThere may be many levels in the hierachy, and this may only pic specific levels that are required for a specific usage scenario.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.location.physicalType",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "PhysicalType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Physical form of the location.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/location-physical-type"
+                }
+            },
+            {
+                "id": "Encounter.location.period",
+                "path": "Encounter.location.period",
+                "short": "Time period during which the patient was present at the location",
+                "definition": "Time period during which the patient was present at the location.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.location.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".time"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.serviceProvider",
+                "path": "Encounter.serviceProvider",
+                "short": "The organization (facility) responsible for this encounter",
+                "definition": "The organization that is primarily responsible for this Encounter's services. This MAY be the same as the organization on the Patient record, however it could be different, such as if the actor performing the services was from an external organization (which may be billed seperately) for an external consultation.  Refer to the example bundle showing an abbreviated set of Encounters for a colonoscopy.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.serviceProvider",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PL.6  & PL.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".particiaption[typeCode=PFM].role"
+                    }
+                ]
+            },
+            {
+                "id": "Encounter.partOf",
+                "path": "Encounter.partOf",
+                "short": "Another Encounter this encounter is part of",
+                "definition": "Another Encounter of which this encounter is a part of (administratively or in time).",
+                "comment": "This is also used for associating a child's encounter back to the mother's encounter.\r\rRefer to the Notes section in the Patient resource for further details.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Encounter.partOf",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-hierarchy",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.partOf"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[classCode=COMP, moodCode=EVN]"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Encounter",
+                "path": "Encounter",
+                "definition": "This is basic constraint on Encounter for use in US Core resources.",
+                "alias": [
+                    "Visit"
+                ],
+                "mustSupport": false
+            },
+            {
+                "id": "Encounter.identifier",
+                "path": "Encounter.identifier",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.identifier.system",
+                "path": "Encounter.identifier.system",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.identifier.value",
+                "path": "Encounter.identifier.value",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.status",
+                "path": "Encounter.status",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.class",
+                "path": "Encounter.class",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.type",
+                "path": "Encounter.type",
+                "min": 1,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Valueset to describe the Encounter Type",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-encounter-type"
+                }
+            },
+            {
+                "id": "Encounter.subject",
+                "path": "Encounter.subject",
+                "alias": [
+                    "patient"
+                ],
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.participant",
+                "path": "Encounter.participant",
+                "min": 0,
+                "max": "*",
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.participant.type",
+                "path": "Encounter.participant.type",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.participant.period",
+                "path": "Encounter.participant.period",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.participant.individual",
+                "path": "Encounter.participant.individual",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ],
+                        "_targetProfile": [
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": true
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.period",
+                "path": "Encounter.period",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.reasonCode",
+                "path": "Encounter.reasonCode",
+                "alias": [
+                    "Indication",
+                    "Admission diagnosis"
+                ],
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.reasonReference",
+                "path": "Encounter.reasonReference",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure",
+                            "http://hl7.org/fhir/StructureDefinition/Observation",
+                            "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation"
+                        ],
+                        "_targetProfile": [
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": true
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.hospitalization",
+                "path": "Encounter.hospitalization",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.hospitalization.dischargeDisposition",
+                "path": "Encounter.hospitalization.dischargeDisposition",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.location",
+                "path": "Encounter.location",
+                "min": 0,
+                "max": "*",
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.location.location",
+                "path": "Encounter.location.location",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Location"
+                        ]
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Encounter.serviceProvider",
+                "path": "Encounter.serviceProvider",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
+                        ]
+                    }
+                ],
+                "mustSupport": true
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-ethnicity.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-ethnicity.json
@@ -1,2142 +1,2142 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-ethnicity",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-ethnicity-definitions.html#Extension\" title=\"Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.\">Extension</a><a name=\"Extension\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/extensibility.html#Extension\">Extension</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">US Core ethnicity Extension</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck15.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-ethnicity-definitions.html#Extension.extension:ombCategory\" title=\"Slice ombCategory: The 2 ethnicity category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).\">extension:ombCategory</a><a name=\"Extension.extension\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/extensibility.html#Extension\">Extension</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Hispanic or Latino|Not Hispanic or Latino</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck150.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-ethnicity-definitions.html#Extension.extension:ombCategory.url\">url</a><a name=\"Extension.extension.url\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"color: darkgreen\">&quot;ombCategory&quot;</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck140.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-ethnicity-definitions.html#Extension.extension:ombCategory.value[x]\">value[x]</a><a name=\"Extension.extension.value_x_\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Value of extension</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-omb-ethnicity-category.html\">OMB Ethnicity Categories</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck15.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-ethnicity-definitions.html#Extension.extension:detailed\" title=\"Slice detailed: The 41 CDC ethnicity codes that are grouped under one of the 2 OMB ethnicity category codes.\">extension:detailed</a><a name=\"Extension.extension\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/extensibility.html#Extension\">Extension</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Extended ethnicity codes<br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck150.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-ethnicity-definitions.html#Extension.extension:detailed.url\">url</a><a name=\"Extension.extension.url\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"color: darkgreen\">&quot;detailed&quot;</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck140.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-ethnicity-definitions.html#Extension.extension:detailed.value[x]\">value[x]</a><a name=\"Extension.extension.value_x_\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Value of extension</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-detailed-ethnicity.html\">Detailed ethnicity</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck15.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-ethnicity-definitions.html#Extension.extension:text\" title=\"Slice text: Plain text representation of the ethnicity concept(s).\">extension:text</a><a name=\"Extension.extension\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/extensibility.html#Extension\">Extension</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">ethnicity Text</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck150.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-ethnicity-definitions.html#Extension.extension:text.url\">url</a><a name=\"Extension.extension.url\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"color: darkgreen\">&quot;text&quot;</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck140.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-ethnicity-definitions.html#Extension.extension:text.value[x]\">value[x]</a><a name=\"Extension.extension.value_x_\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Value of extension</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-ethnicity-definitions.html#Extension.url\">url</a><a name=\"Extension.url\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"color: darkgreen\">&quot;http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity&quot;</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck00.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <span style=\"text-decoration:line-through\">value[x]</span><a name=\"Extension.value_x_\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"text-decoration:line-through\"/><span style=\"text-decoration:line-through\">0</span><span style=\"text-decoration:line-through\">..</span><span style=\"text-decoration:line-through\">0</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
-	"version": "4.0.0",
-	"name": "USCoreEthnicityExtension",
-	"title": "US Core Ethnicity Extension",
-	"status": "active",
-	"date": "2019-05-21T00:00:00-04:00",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"purpose": "Complies with 2015 Edition Common Clinical Data Set for patient race.",
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		}
-	],
-	"kind": "complex-type",
-	"abstract": false,
-	"context": [
-		{
-			"type": "element",
-			"expression": "Patient"
-		},
-		{
-			"type": "element",
-			"expression": "RelatedPerson"
-		},
-		{
-			"type": "element",
-			"expression": "Person"
-		},
-		{
-			"type": "element",
-			"expression": "Practitioner"
-		}
-	],
-	"type": "Extension",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Extension",
-				"path": "Extension",
-				"short": "US Core ethnicity Extension",
-				"definition": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Extension",
-					"min": 0,
-					"max": "*"
-				},
-				"condition": [
-					"ele-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false
-			},
-			{
-				"id": "Extension.id",
-				"path": "Extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension",
-				"path": "Extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory",
-				"path": "Extension.extension",
-				"sliceName": "ombCategory",
-				"short": "Hispanic or Latino|Not Hispanic or Latino",
-				"definition": "The 2 ethnicity category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "iso11179",
-						"map": "/ClinicalDocument/recordTarget/patientRole/patient/ethnicGroupCode"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.id",
-				"path": "Extension.extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.extension",
-				"path": "Extension.extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.extension.id",
-				"path": "Extension.extension.extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.extension.extension",
-				"path": "Extension.extension.extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.extension.url",
-				"path": "Extension.extension.extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "uri"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.extension.value[x]",
-				"path": "Extension.extension.extension.value[x]",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "base64Binary"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "canonical"
-					},
-					{
-						"code": "code"
-					},
-					{
-						"code": "date"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "decimal"
-					},
-					{
-						"code": "id"
-					},
-					{
-						"code": "instant"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "markdown"
-					},
-					{
-						"code": "oid"
-					},
-					{
-						"code": "positiveInt"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "unsignedInt"
-					},
-					{
-						"code": "uri"
-					},
-					{
-						"code": "url"
-					},
-					{
-						"code": "uuid"
-					},
-					{
-						"code": "Address"
-					},
-					{
-						"code": "Age"
-					},
-					{
-						"code": "Annotation"
-					},
-					{
-						"code": "Attachment"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "Coding"
-					},
-					{
-						"code": "ContactPoint"
-					},
-					{
-						"code": "Count"
-					},
-					{
-						"code": "Distance"
-					},
-					{
-						"code": "Duration"
-					},
-					{
-						"code": "HumanName"
-					},
-					{
-						"code": "Identifier"
-					},
-					{
-						"code": "Money"
-					},
-					{
-						"code": "Period"
-					},
-					{
-						"code": "Quantity"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "Reference"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "Signature"
-					},
-					{
-						"code": "Timing"
-					},
-					{
-						"code": "ContactDetail"
-					},
-					{
-						"code": "Contributor"
-					},
-					{
-						"code": "DataRequirement"
-					},
-					{
-						"code": "Expression"
-					},
-					{
-						"code": "ParameterDefinition"
-					},
-					{
-						"code": "RelatedArtifact"
-					},
-					{
-						"code": "TriggerDefinition"
-					},
-					{
-						"code": "UsageContext"
-					},
-					{
-						"code": "Dosage"
-					},
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.url",
-				"path": "Extension.extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "ombCategory",
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.value[x]",
-				"path": "Extension.extension.value[x]",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/omb-ethnicity-category"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed",
-				"path": "Extension.extension",
-				"sliceName": "detailed",
-				"short": "Extended ethnicity codes",
-				"definition": "The 41 CDC ethnicity codes that are grouped under one of the 2 OMB ethnicity category codes.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "iso11179",
-						"map": "/ClinicalDocument/recordTarget/patientRole/patient/sdtc:ethnicGroupCode"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.id",
-				"path": "Extension.extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.extension",
-				"path": "Extension.extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.extension.id",
-				"path": "Extension.extension.extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.extension.extension",
-				"path": "Extension.extension.extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.extension.url",
-				"path": "Extension.extension.extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "uri"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.extension.value[x]",
-				"path": "Extension.extension.extension.value[x]",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "base64Binary"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "canonical"
-					},
-					{
-						"code": "code"
-					},
-					{
-						"code": "date"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "decimal"
-					},
-					{
-						"code": "id"
-					},
-					{
-						"code": "instant"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "markdown"
-					},
-					{
-						"code": "oid"
-					},
-					{
-						"code": "positiveInt"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "unsignedInt"
-					},
-					{
-						"code": "uri"
-					},
-					{
-						"code": "url"
-					},
-					{
-						"code": "uuid"
-					},
-					{
-						"code": "Address"
-					},
-					{
-						"code": "Age"
-					},
-					{
-						"code": "Annotation"
-					},
-					{
-						"code": "Attachment"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "Coding"
-					},
-					{
-						"code": "ContactPoint"
-					},
-					{
-						"code": "Count"
-					},
-					{
-						"code": "Distance"
-					},
-					{
-						"code": "Duration"
-					},
-					{
-						"code": "HumanName"
-					},
-					{
-						"code": "Identifier"
-					},
-					{
-						"code": "Money"
-					},
-					{
-						"code": "Period"
-					},
-					{
-						"code": "Quantity"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "Reference"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "Signature"
-					},
-					{
-						"code": "Timing"
-					},
-					{
-						"code": "ContactDetail"
-					},
-					{
-						"code": "Contributor"
-					},
-					{
-						"code": "DataRequirement"
-					},
-					{
-						"code": "Expression"
-					},
-					{
-						"code": "ParameterDefinition"
-					},
-					{
-						"code": "RelatedArtifact"
-					},
-					{
-						"code": "TriggerDefinition"
-					},
-					{
-						"code": "UsageContext"
-					},
-					{
-						"code": "Dosage"
-					},
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.url",
-				"path": "Extension.extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "detailed",
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.value[x]",
-				"path": "Extension.extension.value[x]",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/detailed-ethnicity"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text",
-				"path": "Extension.extension",
-				"sliceName": "text",
-				"short": "ethnicity Text",
-				"definition": "Plain text representation of the ethnicity concept(s).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Extension.extension:text.id",
-				"path": "Extension.extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text.extension",
-				"path": "Extension.extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text.extension.id",
-				"path": "Extension.extension.extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text.extension.extension",
-				"path": "Extension.extension.extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text.extension.url",
-				"path": "Extension.extension.extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "uri"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text.extension.value[x]",
-				"path": "Extension.extension.extension.value[x]",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "base64Binary"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "canonical"
-					},
-					{
-						"code": "code"
-					},
-					{
-						"code": "date"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "decimal"
-					},
-					{
-						"code": "id"
-					},
-					{
-						"code": "instant"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "markdown"
-					},
-					{
-						"code": "oid"
-					},
-					{
-						"code": "positiveInt"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "unsignedInt"
-					},
-					{
-						"code": "uri"
-					},
-					{
-						"code": "url"
-					},
-					{
-						"code": "uuid"
-					},
-					{
-						"code": "Address"
-					},
-					{
-						"code": "Age"
-					},
-					{
-						"code": "Annotation"
-					},
-					{
-						"code": "Attachment"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "Coding"
-					},
-					{
-						"code": "ContactPoint"
-					},
-					{
-						"code": "Count"
-					},
-					{
-						"code": "Distance"
-					},
-					{
-						"code": "Duration"
-					},
-					{
-						"code": "HumanName"
-					},
-					{
-						"code": "Identifier"
-					},
-					{
-						"code": "Money"
-					},
-					{
-						"code": "Period"
-					},
-					{
-						"code": "Quantity"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "Reference"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "Signature"
-					},
-					{
-						"code": "Timing"
-					},
-					{
-						"code": "ContactDetail"
-					},
-					{
-						"code": "Contributor"
-					},
-					{
-						"code": "DataRequirement"
-					},
-					{
-						"code": "Expression"
-					},
-					{
-						"code": "ParameterDefinition"
-					},
-					{
-						"code": "RelatedArtifact"
-					},
-					{
-						"code": "TriggerDefinition"
-					},
-					{
-						"code": "UsageContext"
-					},
-					{
-						"code": "Dosage"
-					},
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text.url",
-				"path": "Extension.extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "text",
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text.value[x]",
-				"path": "Extension.extension.value[x]",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.url",
-				"path": "Extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "uri"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.value[x]",
-				"path": "Extension.value[x]",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 0,
-				"max": "0",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "base64Binary"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "canonical"
-					},
-					{
-						"code": "code"
-					},
-					{
-						"code": "date"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "decimal"
-					},
-					{
-						"code": "id"
-					},
-					{
-						"code": "instant"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "markdown"
-					},
-					{
-						"code": "oid"
-					},
-					{
-						"code": "positiveInt"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "unsignedInt"
-					},
-					{
-						"code": "uri"
-					},
-					{
-						"code": "url"
-					},
-					{
-						"code": "uuid"
-					},
-					{
-						"code": "Address"
-					},
-					{
-						"code": "Age"
-					},
-					{
-						"code": "Annotation"
-					},
-					{
-						"code": "Attachment"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "Coding"
-					},
-					{
-						"code": "ContactPoint"
-					},
-					{
-						"code": "Count"
-					},
-					{
-						"code": "Distance"
-					},
-					{
-						"code": "Duration"
-					},
-					{
-						"code": "HumanName"
-					},
-					{
-						"code": "Identifier"
-					},
-					{
-						"code": "Money"
-					},
-					{
-						"code": "Period"
-					},
-					{
-						"code": "Quantity"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "Reference"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "Signature"
-					},
-					{
-						"code": "Timing"
-					},
-					{
-						"code": "ContactDetail"
-					},
-					{
-						"code": "Contributor"
-					},
-					{
-						"code": "DataRequirement"
-					},
-					{
-						"code": "Expression"
-					},
-					{
-						"code": "ParameterDefinition"
-					},
-					{
-						"code": "RelatedArtifact"
-					},
-					{
-						"code": "TriggerDefinition"
-					},
-					{
-						"code": "UsageContext"
-					},
-					{
-						"code": "Dosage"
-					},
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Extension",
-				"path": "Extension",
-				"short": "US Core ethnicity Extension",
-				"definition": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.",
-				"min": 0,
-				"max": "1"
-			},
-			{
-				"id": "Extension.extension:ombCategory",
-				"path": "Extension.extension",
-				"sliceName": "ombCategory",
-				"short": "Hispanic or Latino|Not Hispanic or Latino",
-				"definition": "The 2 ethnicity category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "iso11179",
-						"map": "/ClinicalDocument/recordTarget/patientRole/patient/ethnicGroupCode"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.url",
-				"path": "Extension.extension.url",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "ombCategory"
-			},
-			{
-				"id": "Extension.extension:ombCategory.value[x]",
-				"path": "Extension.extension.value[x]",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/omb-ethnicity-category"
-				}
-			},
-			{
-				"id": "Extension.extension:detailed",
-				"path": "Extension.extension",
-				"sliceName": "detailed",
-				"short": "Extended ethnicity codes",
-				"definition": "The 41 CDC ethnicity codes that are grouped under one of the 2 OMB ethnicity category codes.",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"mapping": [
-					{
-						"identity": "iso11179",
-						"map": "/ClinicalDocument/recordTarget/patientRole/patient/sdtc:ethnicGroupCode"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.url",
-				"path": "Extension.extension.url",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "detailed"
-			},
-			{
-				"id": "Extension.extension:detailed.value[x]",
-				"path": "Extension.extension.value[x]",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/detailed-ethnicity"
-				}
-			},
-			{
-				"id": "Extension.extension:text",
-				"path": "Extension.extension",
-				"sliceName": "text",
-				"short": "ethnicity Text",
-				"definition": "Plain text representation of the ethnicity concept(s).",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Extension.extension:text.url",
-				"path": "Extension.extension.url",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "text"
-			},
-			{
-				"id": "Extension.extension:text.value[x]",
-				"path": "Extension.extension.value[x]",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				]
-			},
-			{
-				"id": "Extension.url",
-				"path": "Extension.url",
-				"min": 1,
-				"max": "1",
-				"fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
-			},
-			{
-				"id": "Extension.value[x]",
-				"path": "Extension.value[x]",
-				"min": 0,
-				"max": "0"
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-ethnicity",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+    "version": "4.0.0",
+    "name": "USCoreEthnicityExtension",
+    "title": "US Core Ethnicity Extension",
+    "status": "active",
+    "date": "2019-05-21T00:00:00-04:00",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "purpose": "Complies with 2015 Edition Common Clinical Data Set for patient race.",
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        }
+    ],
+    "kind": "complex-type",
+    "abstract": false,
+    "context": [
+        {
+            "type": "element",
+            "expression": "Patient"
+        },
+        {
+            "type": "element",
+            "expression": "RelatedPerson"
+        },
+        {
+            "type": "element",
+            "expression": "Person"
+        },
+        {
+            "type": "element",
+            "expression": "Practitioner"
+        }
+    ],
+    "type": "Extension",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Extension",
+                "path": "Extension",
+                "short": "US Core ethnicity Extension",
+                "definition": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "condition": [
+                    "ele-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false
+            },
+            {
+                "id": "Extension.id",
+                "path": "Extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension",
+                "path": "Extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory",
+                "path": "Extension.extension",
+                "sliceName": "ombCategory",
+                "short": "Hispanic or Latino|Not Hispanic or Latino",
+                "definition": "The 2 ethnicity category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "iso11179",
+                        "map": "/ClinicalDocument/recordTarget/patientRole/patient/ethnicGroupCode"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.id",
+                "path": "Extension.extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.extension",
+                "path": "Extension.extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.extension.id",
+                "path": "Extension.extension.extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.extension.extension",
+                "path": "Extension.extension.extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.extension.url",
+                "path": "Extension.extension.extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "uri"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.extension.value[x]",
+                "path": "Extension.extension.extension.value[x]",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "base64Binary"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "canonical"
+                    },
+                    {
+                        "code": "code"
+                    },
+                    {
+                        "code": "date"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "decimal"
+                    },
+                    {
+                        "code": "id"
+                    },
+                    {
+                        "code": "instant"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "markdown"
+                    },
+                    {
+                        "code": "oid"
+                    },
+                    {
+                        "code": "positiveInt"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "unsignedInt"
+                    },
+                    {
+                        "code": "uri"
+                    },
+                    {
+                        "code": "url"
+                    },
+                    {
+                        "code": "uuid"
+                    },
+                    {
+                        "code": "Address"
+                    },
+                    {
+                        "code": "Age"
+                    },
+                    {
+                        "code": "Annotation"
+                    },
+                    {
+                        "code": "Attachment"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "Coding"
+                    },
+                    {
+                        "code": "ContactPoint"
+                    },
+                    {
+                        "code": "Count"
+                    },
+                    {
+                        "code": "Distance"
+                    },
+                    {
+                        "code": "Duration"
+                    },
+                    {
+                        "code": "HumanName"
+                    },
+                    {
+                        "code": "Identifier"
+                    },
+                    {
+                        "code": "Money"
+                    },
+                    {
+                        "code": "Period"
+                    },
+                    {
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "Reference"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "Signature"
+                    },
+                    {
+                        "code": "Timing"
+                    },
+                    {
+                        "code": "ContactDetail"
+                    },
+                    {
+                        "code": "Contributor"
+                    },
+                    {
+                        "code": "DataRequirement"
+                    },
+                    {
+                        "code": "Expression"
+                    },
+                    {
+                        "code": "ParameterDefinition"
+                    },
+                    {
+                        "code": "RelatedArtifact"
+                    },
+                    {
+                        "code": "TriggerDefinition"
+                    },
+                    {
+                        "code": "UsageContext"
+                    },
+                    {
+                        "code": "Dosage"
+                    },
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.url",
+                "path": "Extension.extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "ombCategory",
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.value[x]",
+                "path": "Extension.extension.value[x]",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/omb-ethnicity-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed",
+                "path": "Extension.extension",
+                "sliceName": "detailed",
+                "short": "Extended ethnicity codes",
+                "definition": "The 41 CDC ethnicity codes that are grouped under one of the 2 OMB ethnicity category codes.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "iso11179",
+                        "map": "/ClinicalDocument/recordTarget/patientRole/patient/sdtc:ethnicGroupCode"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.id",
+                "path": "Extension.extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.extension",
+                "path": "Extension.extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.extension.id",
+                "path": "Extension.extension.extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.extension.extension",
+                "path": "Extension.extension.extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.extension.url",
+                "path": "Extension.extension.extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "uri"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.extension.value[x]",
+                "path": "Extension.extension.extension.value[x]",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "base64Binary"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "canonical"
+                    },
+                    {
+                        "code": "code"
+                    },
+                    {
+                        "code": "date"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "decimal"
+                    },
+                    {
+                        "code": "id"
+                    },
+                    {
+                        "code": "instant"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "markdown"
+                    },
+                    {
+                        "code": "oid"
+                    },
+                    {
+                        "code": "positiveInt"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "unsignedInt"
+                    },
+                    {
+                        "code": "uri"
+                    },
+                    {
+                        "code": "url"
+                    },
+                    {
+                        "code": "uuid"
+                    },
+                    {
+                        "code": "Address"
+                    },
+                    {
+                        "code": "Age"
+                    },
+                    {
+                        "code": "Annotation"
+                    },
+                    {
+                        "code": "Attachment"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "Coding"
+                    },
+                    {
+                        "code": "ContactPoint"
+                    },
+                    {
+                        "code": "Count"
+                    },
+                    {
+                        "code": "Distance"
+                    },
+                    {
+                        "code": "Duration"
+                    },
+                    {
+                        "code": "HumanName"
+                    },
+                    {
+                        "code": "Identifier"
+                    },
+                    {
+                        "code": "Money"
+                    },
+                    {
+                        "code": "Period"
+                    },
+                    {
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "Reference"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "Signature"
+                    },
+                    {
+                        "code": "Timing"
+                    },
+                    {
+                        "code": "ContactDetail"
+                    },
+                    {
+                        "code": "Contributor"
+                    },
+                    {
+                        "code": "DataRequirement"
+                    },
+                    {
+                        "code": "Expression"
+                    },
+                    {
+                        "code": "ParameterDefinition"
+                    },
+                    {
+                        "code": "RelatedArtifact"
+                    },
+                    {
+                        "code": "TriggerDefinition"
+                    },
+                    {
+                        "code": "UsageContext"
+                    },
+                    {
+                        "code": "Dosage"
+                    },
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.url",
+                "path": "Extension.extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "detailed",
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.value[x]",
+                "path": "Extension.extension.value[x]",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/detailed-ethnicity"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text",
+                "path": "Extension.extension",
+                "sliceName": "text",
+                "short": "ethnicity Text",
+                "definition": "Plain text representation of the ethnicity concept(s).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Extension.extension:text.id",
+                "path": "Extension.extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text.extension",
+                "path": "Extension.extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text.extension.id",
+                "path": "Extension.extension.extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text.extension.extension",
+                "path": "Extension.extension.extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text.extension.url",
+                "path": "Extension.extension.extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "uri"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text.extension.value[x]",
+                "path": "Extension.extension.extension.value[x]",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "base64Binary"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "canonical"
+                    },
+                    {
+                        "code": "code"
+                    },
+                    {
+                        "code": "date"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "decimal"
+                    },
+                    {
+                        "code": "id"
+                    },
+                    {
+                        "code": "instant"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "markdown"
+                    },
+                    {
+                        "code": "oid"
+                    },
+                    {
+                        "code": "positiveInt"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "unsignedInt"
+                    },
+                    {
+                        "code": "uri"
+                    },
+                    {
+                        "code": "url"
+                    },
+                    {
+                        "code": "uuid"
+                    },
+                    {
+                        "code": "Address"
+                    },
+                    {
+                        "code": "Age"
+                    },
+                    {
+                        "code": "Annotation"
+                    },
+                    {
+                        "code": "Attachment"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "Coding"
+                    },
+                    {
+                        "code": "ContactPoint"
+                    },
+                    {
+                        "code": "Count"
+                    },
+                    {
+                        "code": "Distance"
+                    },
+                    {
+                        "code": "Duration"
+                    },
+                    {
+                        "code": "HumanName"
+                    },
+                    {
+                        "code": "Identifier"
+                    },
+                    {
+                        "code": "Money"
+                    },
+                    {
+                        "code": "Period"
+                    },
+                    {
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "Reference"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "Signature"
+                    },
+                    {
+                        "code": "Timing"
+                    },
+                    {
+                        "code": "ContactDetail"
+                    },
+                    {
+                        "code": "Contributor"
+                    },
+                    {
+                        "code": "DataRequirement"
+                    },
+                    {
+                        "code": "Expression"
+                    },
+                    {
+                        "code": "ParameterDefinition"
+                    },
+                    {
+                        "code": "RelatedArtifact"
+                    },
+                    {
+                        "code": "TriggerDefinition"
+                    },
+                    {
+                        "code": "UsageContext"
+                    },
+                    {
+                        "code": "Dosage"
+                    },
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text.url",
+                "path": "Extension.extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "text",
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text.value[x]",
+                "path": "Extension.extension.value[x]",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.url",
+                "path": "Extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "uri"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity",
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.value[x]",
+                "path": "Extension.value[x]",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 0,
+                "max": "0",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "base64Binary"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "canonical"
+                    },
+                    {
+                        "code": "code"
+                    },
+                    {
+                        "code": "date"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "decimal"
+                    },
+                    {
+                        "code": "id"
+                    },
+                    {
+                        "code": "instant"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "markdown"
+                    },
+                    {
+                        "code": "oid"
+                    },
+                    {
+                        "code": "positiveInt"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "unsignedInt"
+                    },
+                    {
+                        "code": "uri"
+                    },
+                    {
+                        "code": "url"
+                    },
+                    {
+                        "code": "uuid"
+                    },
+                    {
+                        "code": "Address"
+                    },
+                    {
+                        "code": "Age"
+                    },
+                    {
+                        "code": "Annotation"
+                    },
+                    {
+                        "code": "Attachment"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "Coding"
+                    },
+                    {
+                        "code": "ContactPoint"
+                    },
+                    {
+                        "code": "Count"
+                    },
+                    {
+                        "code": "Distance"
+                    },
+                    {
+                        "code": "Duration"
+                    },
+                    {
+                        "code": "HumanName"
+                    },
+                    {
+                        "code": "Identifier"
+                    },
+                    {
+                        "code": "Money"
+                    },
+                    {
+                        "code": "Period"
+                    },
+                    {
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "Reference"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "Signature"
+                    },
+                    {
+                        "code": "Timing"
+                    },
+                    {
+                        "code": "ContactDetail"
+                    },
+                    {
+                        "code": "Contributor"
+                    },
+                    {
+                        "code": "DataRequirement"
+                    },
+                    {
+                        "code": "Expression"
+                    },
+                    {
+                        "code": "ParameterDefinition"
+                    },
+                    {
+                        "code": "RelatedArtifact"
+                    },
+                    {
+                        "code": "TriggerDefinition"
+                    },
+                    {
+                        "code": "UsageContext"
+                    },
+                    {
+                        "code": "Dosage"
+                    },
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Extension",
+                "path": "Extension",
+                "short": "US Core ethnicity Extension",
+                "definition": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.",
+                "min": 0,
+                "max": "1"
+            },
+            {
+                "id": "Extension.extension:ombCategory",
+                "path": "Extension.extension",
+                "sliceName": "ombCategory",
+                "short": "Hispanic or Latino|Not Hispanic or Latino",
+                "definition": "The 2 ethnicity category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "iso11179",
+                        "map": "/ClinicalDocument/recordTarget/patientRole/patient/ethnicGroupCode"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.url",
+                "path": "Extension.extension.url",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "ombCategory"
+            },
+            {
+                "id": "Extension.extension:ombCategory.value[x]",
+                "path": "Extension.extension.value[x]",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/omb-ethnicity-category"
+                }
+            },
+            {
+                "id": "Extension.extension:detailed",
+                "path": "Extension.extension",
+                "sliceName": "detailed",
+                "short": "Extended ethnicity codes",
+                "definition": "The 41 CDC ethnicity codes that are grouped under one of the 2 OMB ethnicity category codes.",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "mapping": [
+                    {
+                        "identity": "iso11179",
+                        "map": "/ClinicalDocument/recordTarget/patientRole/patient/sdtc:ethnicGroupCode"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.url",
+                "path": "Extension.extension.url",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "detailed"
+            },
+            {
+                "id": "Extension.extension:detailed.value[x]",
+                "path": "Extension.extension.value[x]",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/detailed-ethnicity"
+                }
+            },
+            {
+                "id": "Extension.extension:text",
+                "path": "Extension.extension",
+                "sliceName": "text",
+                "short": "ethnicity Text",
+                "definition": "Plain text representation of the ethnicity concept(s).",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Extension.extension:text.url",
+                "path": "Extension.extension.url",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "text"
+            },
+            {
+                "id": "Extension.extension:text.value[x]",
+                "path": "Extension.extension.value[x]",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.url",
+                "path": "Extension.url",
+                "min": 1,
+                "max": "1",
+                "fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
+            },
+            {
+                "id": "Extension.value[x]",
+                "path": "Extension.value[x]",
+                "min": 0,
+                "max": "0"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-goal.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-goal.json
@@ -1,1601 +1,1601 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-goal",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-goal-definitions.html#Goal\" title=\"The US Core Goal Profile is based upon the core FHIR Goal Resource and created to meet the 2015 Edition Common Clinical Data Set 'Goals' requirements.\">Goal</a><a name=\"Goal\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/goal.html\">Goal</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Describes the intended objective(s) for a patient, group or organization</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-goal-definitions.html#Goal.lifecycleStatus\">lifecycleStatus</a><a name=\"Goal.lifecycleStatus\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">proposed | planned | accepted | active | on-hold | completed | cancelled | entered-in-error | rejected</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-goal-status.html\">GoalLifecycleStatus</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-goal-definitions.html#Goal.description\">description</a><a name=\"Goal.description\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Code or text describing goal</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-goal-definitions.html#Goal.subject\">subject</a><a name=\"Goal.subject\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who this goal is intended for</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-goal-definitions.html#Goal.target\">target</a><a name=\"Goal.target\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Target outcome for the goal</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck001.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_choice.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Choice of Types\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-goal-definitions.html#Goal.target.due[x]\">due[x]</a><a name=\"Goal.target.due_x_\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Reach goal on or before</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for date Type: A date or partial date (e.g. just year or year + month). There is no time zone. The format is a union of the schema types gYear, gYearMonth and date.  Dates SHALL be valid dates.\">dueDate</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#date\">date</a> <span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This type must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for Duration Type: A length of time.\">dueDuration</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Duration\">Duration</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal",
-	"version": "4.0.0",
-	"name": "USCoreGoalProfile",
-	"title": "US Core Goal Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-07-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the Goal resource for the minimal set of data to query and retrieve a patient's goal(s).",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Goal",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Goal",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Goal",
-				"path": "Goal",
-				"short": "Describes the intended objective(s) for a patient, group or organization",
-				"definition": "The US Core Goal Profile is based upon the core FHIR Goal Resource and created to meet the 2015 Edition Common Clinical Data Set 'Goals' requirements.",
-				"comment": "Goal can be achieving a particular change or merely maintaining a current state or even slowing a decline.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Goal",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "v2",
-						"map": "GOL.1"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode<=OBJ]."
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Goal"
-					}
-				]
-			},
-			{
-				"id": "Goal.id",
-				"path": "Goal.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Goal.meta",
-				"path": "Goal.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Goal.implicitRules",
-				"path": "Goal.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Goal.language",
-				"path": "Goal.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Goal.text",
-				"path": "Goal.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Goal.contained",
-				"path": "Goal.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Goal.extension",
-				"path": "Goal.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Goal.modifierExtension",
-				"path": "Goal.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Goal.identifier",
-				"path": "Goal.identifier",
-				"short": "External Ids for this goal",
-				"definition": "Business identifiers assigned to this goal by the performer or other systems which remain constant as the resource is updated and propagates from server to server.",
-				"comment": "This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.",
-				"requirements": "Allows identification of the goal as it is known by various participating systems and in a way that remains consistent across servers.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Goal.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					}
-				]
-			},
-			{
-				"id": "Goal.lifecycleStatus",
-				"path": "Goal.lifecycleStatus",
-				"short": "proposed | planned | accepted | active | on-hold | completed | cancelled | entered-in-error | rejected",
-				"definition": "The state of the goal throughout its lifecycle.",
-				"comment": "This element is labeled as a modifier because the lifecycleStatus contains codes that mark the resource as not currently valid.",
-				"requirements": "Allows knowing whether goal needs to be further tracked.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Goal.lifecycleStatus",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labelled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/goal-status"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "v2",
-						"map": "GOL-18-goal life cycle status"
-					},
-					{
-						"identity": "rim",
-						"map": ".statusCode in-progress = active (classCode = OBJ) cancelled = aborted"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Goal.status"
-					}
-				]
-			},
-			{
-				"id": "Goal.achievementStatus",
-				"path": "Goal.achievementStatus",
-				"short": "in-progress | improving | worsening | no-change | achieved | sustaining | not-achieved | no-progress | not-attainable",
-				"definition": "Describes the progression, or lack thereof, towards the goal against the target.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Goal.achievementStatus",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "GoalAchievementStatus"
-						}
-					],
-					"strength": "preferred",
-					"description": "Indicates the progression, or lack thereof, towards the goal against the target.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/goal-achievement"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".statusCode achieved = complete sustaining = active"
-					}
-				]
-			},
-			{
-				"id": "Goal.category",
-				"path": "Goal.category",
-				"short": "E.g. Treatment, dietary, behavioral, etc.",
-				"definition": "Indicates a category the goal falls within.",
-				"requirements": "Allows goals to be filtered and sorted.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Goal.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "GoalCategory"
-						}
-					],
-					"strength": "example",
-					"description": "Codes for grouping and sorting goals.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/goal-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					}
-				]
-			},
-			{
-				"id": "Goal.priority",
-				"path": "Goal.priority",
-				"short": "high-priority | medium-priority | low-priority",
-				"definition": "Identifies the mutually agreed level of importance associated with reaching/sustaining the goal.",
-				"comment": "Extensions are available to track priorities as established by each participant (i.e. Priority from the patient's perspective, different practitioners' perspectives, family member's perspectives)\r\rThe ordinal extension on Coding can be used to convey a numerically comparable ranking to priority.  (Keep in mind that different coding systems may use a \"low value=important\".",
-				"requirements": "Used for sorting and presenting goals.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Goal.priority",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "GoalPriority"
-						}
-					],
-					"strength": "preferred",
-					"description": "The level of importance associated with a goal.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/goal-priority"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.grade"
-					},
-					{
-						"identity": "rim",
-						"map": ".priorityCode"
-					}
-				]
-			},
-			{
-				"id": "Goal.description",
-				"path": "Goal.description",
-				"short": "Code or text describing goal",
-				"definition": "Human-readable and/or coded description of a specific desired objective of care, such as \"control blood pressure\" or \"negotiate an obstacle course\" or \"dance with child at wedding\".",
-				"comment": "If no code is available, use CodeableConcept.text.",
-				"requirements": "Without a description of what's trying to be achieved, element has no purpose.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Goal.description",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "GoalDescription"
-						}
-					],
-					"strength": "example",
-					"description": "Codes providing the details of a particular goal.  This will generally be system or implementation guide-specific.  In many systems, only the text element will be used.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "GOL-3.2-goal ID.text"
-					},
-					{
-						"identity": "rim",
-						"map": ".text"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Goal.description"
-					}
-				]
-			},
-			{
-				"id": "Goal.subject",
-				"path": "Goal.subject",
-				"short": "Who this goal is intended for",
-				"definition": "Identifies the patient, group or organization for whom the goal is being established.",
-				"requirements": "Subject is optional to support annonymized reporting.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Goal.subject",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3-patient ID list"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=PAT].role[classCode=PAT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Goal.subject"
-					}
-				]
-			},
-			{
-				"id": "Goal.start[x]",
-				"path": "Goal.start[x]",
-				"short": "When goal pursuit begins",
-				"definition": "The date or event after which the goal should begin being pursued.",
-				"requirements": "Goals can be established prior to there being an intention to start pursuing them; e.g. Goals for post-surgical recovery established prior to surgery.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Goal.start[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "date"
-					},
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "GoalStartEvent"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing events that can trigger the initiation of a goal.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/goal-start-event"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.planned"
-					}
-				]
-			},
-			{
-				"id": "Goal.target",
-				"path": "Goal.target",
-				"short": "Target outcome for the goal",
-				"definition": "Indicates what should be done by when.",
-				"comment": "When multiple targets are present for a single goal instance, all targets must be met for the overall goal to be met.",
-				"requirements": "Allows the progress of the goal to be monitored against an observation or due date.  Target is 0..* to support Observations with multiple components, such as blood pressure goals with both a systolic and diastolic target.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Goal.target",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"condition": [
-					"gol-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "gol-1",
-						"severity": "error",
-						"human": "Goal.target.measure is required if Goal.target.detail is populated",
-						"expression": "(detail.exists() and measure.exists()) or detail.exists().not()",
-						"xpath": "(exists(f:*[starts-with(local-name(.), 'detail')]) and exists(f:measure)) or not(exists(f:*[starts-with(local-name(.), 'detail')]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Goal"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Goal.target.id",
-				"path": "Goal.target.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Goal.target.extension",
-				"path": "Goal.target.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Goal.target.modifierExtension",
-				"path": "Goal.target.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Goal.target.measure",
-				"path": "Goal.target.measure",
-				"short": "The parameter whose value is being tracked",
-				"definition": "The parameter whose value is being tracked, e.g. body weight, blood pressure, or hemoglobin A1c level.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Goal.target.measure",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"gol-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "GoalTargetMeasure"
-						}
-					],
-					"strength": "example",
-					"description": "Codes to identify the value being tracked, e.g. body weight, blood pressure, or hemoglobin A1c level.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-codes"
-				}
-			},
-			{
-				"id": "Goal.target.detail[x]",
-				"path": "Goal.target.detail[x]",
-				"short": "The target value to be achieved",
-				"definition": "The target value of the focus to be achieved to signify the fulfillment of the goal, e.g. 150 pounds, 7.0%. Either the high or low or both values of the range can be specified. When a low value is missing, it indicates that the goal is achieved at any focus value at or below the high value. Similarly, if the high value is missing, it indicates that the goal is achieved at any focus value at or above the low value.",
-				"comment": "A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Goal.target.measure defines a coded value.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Goal.target.detail[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "Ratio"
-					}
-				],
-				"condition": [
-					"gol-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "GoalTargetDetail"
-						}
-					],
-					"strength": "example",
-					"description": "Codes to identify the target value of the focus to be achieved to signify the fulfillment of the goal."
-				}
-			},
-			{
-				"id": "Goal.target.due[x]",
-				"path": "Goal.target.due[x]",
-				"short": "Reach goal on or before",
-				"definition": "Indicates either the date or the duration after start by which the goal should be met.",
-				"requirements": "Identifies when the goal should be evaluated.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Goal.target.due[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "date"
-					},
-					{
-						"code": "Duration"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					}
-				]
-			},
-			{
-				"id": "Goal.statusDate",
-				"path": "Goal.statusDate",
-				"short": "When goal status took effect",
-				"definition": "Identifies when the current status.  I.e. When initially created, when achieved, when cancelled, etc.",
-				"comment": "To see the date for past statuses, query history.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Goal.statusDate",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "date"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					}
-				]
-			},
-			{
-				"id": "Goal.statusReason",
-				"path": "Goal.statusReason",
-				"short": "Reason for current status",
-				"definition": "Captures the reason for the current status.",
-				"comment": "This will typically be captured for statuses such as rejected, on-hold or cancelled, but could be present for others.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Goal.statusReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Goal.expressedBy",
-				"path": "Goal.expressedBy",
-				"short": "Who's responsible for creating Goal?",
-				"definition": "Indicates whose goal this is - patient goal, practitioner goal, etc.",
-				"comment": "This is the individual responsible for establishing the goal, not necessarily who recorded it.  (For that, use the Provenance resource.).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Goal.expressedBy",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.source"
-					}
-				]
-			},
-			{
-				"id": "Goal.addresses",
-				"path": "Goal.addresses",
-				"short": "Issues addressed by this goal",
-				"definition": "The identified conditions and other health record elements that are intended to be addressed by the goal.",
-				"requirements": "Allows specific goals to explicitly linked to the concerns they're dealing with - makes the goal more understandable.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Goal.addresses",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Condition",
-							"http://hl7.org/fhir/StructureDefinition/Observation",
-							"http://hl7.org/fhir/StructureDefinition/MedicationStatement",
-							"http://hl7.org/fhir/StructureDefinition/NutritionOrder",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest",
-							"http://hl7.org/fhir/StructureDefinition/RiskAssessment"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.why[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=SUBJ].target[classCode=CONC]"
-					}
-				]
-			},
-			{
-				"id": "Goal.note",
-				"path": "Goal.note",
-				"short": "Comments about the goal",
-				"definition": "Any comments related to the goal.",
-				"comment": "May be used for progress notes, concerns or other related information that doesn't actually describe the goal itself.",
-				"requirements": "There's a need to capture information about the goal that doesn't actually describe the goal.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Goal.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "GOL-16-goal evaluation + NTE?"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "Goal.outcomeCode",
-				"path": "Goal.outcomeCode",
-				"short": "What result was achieved regarding the goal?",
-				"definition": "Identifies the change (or lack of change) at the point when the status of the goal is assessed.",
-				"comment": "Note that this should not duplicate the goal status.",
-				"requirements": "Outcome tracking is a key aspect of care planning.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Goal.outcomeCode",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "GoalOutcome"
-						}
-					],
-					"strength": "example",
-					"description": "The result of the goal; e.g. \"25% increase in shoulder mobility\", \"Anxiety reduced to moderate levels\".  \"15 kg weight loss sustained over 6 months\".",
-					"valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
-				}
-			},
-			{
-				"id": "Goal.outcomeReference",
-				"path": "Goal.outcomeReference",
-				"short": "Observation that resulted from goal",
-				"definition": "Details of what's changed (or not changed).",
-				"comment": "The goal outcome is independent of the outcome of the related activities.  For example, if the Goal is to achieve a target body weight of 150 lb and a care plan activity is defined to diet, then the care plan’s activity outcome could be calories consumed whereas goal outcome is an observation for the actual body weight measured.",
-				"requirements": "Outcome tracking is a key aspect of care planning.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Goal.outcomeReference",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Observation"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Goal",
-				"path": "Goal",
-				"definition": "The US Core Goal Profile is based upon the core FHIR Goal Resource and created to meet the 2015 Edition Common Clinical Data Set 'Goals' requirements.",
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Goal"
-					}
-				]
-			},
-			{
-				"id": "Goal.lifecycleStatus",
-				"path": "Goal.lifecycleStatus",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/goal-status"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Goal.status"
-					}
-				]
-			},
-			{
-				"id": "Goal.description",
-				"path": "Goal.description",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Goal.description"
-					}
-				]
-			},
-			{
-				"id": "Goal.subject",
-				"path": "Goal.subject",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Goal.subject"
-					}
-				]
-			},
-			{
-				"id": "Goal.target",
-				"path": "Goal.target",
-				"min": 0,
-				"max": "*",
-				"mustSupport": true
-			},
-			{
-				"id": "Goal.target.due[x]",
-				"path": "Goal.target.due[x]",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "date"
-					},
-					{
-						"code": "Duration"
-					}
-				],
-				"mustSupport": true
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-goal",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal",
+    "version": "4.0.0",
+    "name": "USCoreGoalProfile",
+    "title": "US Core Goal Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-07-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the Goal resource for the minimal set of data to query and retrieve a patient's goal(s).",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Goal",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Goal",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Goal",
+                "path": "Goal",
+                "short": "Describes the intended objective(s) for a patient, group or organization",
+                "definition": "The US Core Goal Profile is based upon the core FHIR Goal Resource and created to meet the 2015 Edition Common Clinical Data Set 'Goals' requirements.",
+                "comment": "Goal can be achieving a particular change or merely maintaining a current state or even slowing a decline.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Goal",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "GOL.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode<=OBJ]."
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Goal"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.id",
+                "path": "Goal.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Goal.meta",
+                "path": "Goal.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Goal.implicitRules",
+                "path": "Goal.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Goal.language",
+                "path": "Goal.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Goal.text",
+                "path": "Goal.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.contained",
+                "path": "Goal.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.extension",
+                "path": "Goal.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.modifierExtension",
+                "path": "Goal.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.identifier",
+                "path": "Goal.identifier",
+                "short": "External Ids for this goal",
+                "definition": "Business identifiers assigned to this goal by the performer or other systems which remain constant as the resource is updated and propagates from server to server.",
+                "comment": "This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and a Person resource instance might share the same social insurance number.",
+                "requirements": "Allows identification of the goal as it is known by various participating systems and in a way that remains consistent across servers.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Goal.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.lifecycleStatus",
+                "path": "Goal.lifecycleStatus",
+                "short": "proposed | planned | accepted | active | on-hold | completed | cancelled | entered-in-error | rejected",
+                "definition": "The state of the goal throughout its lifecycle.",
+                "comment": "This element is labeled as a modifier because the lifecycleStatus contains codes that mark the resource as not currently valid.",
+                "requirements": "Allows knowing whether goal needs to be further tracked.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Goal.lifecycleStatus",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labelled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/goal-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "GOL-18-goal life cycle status"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".statusCode in-progress = active (classCode = OBJ) cancelled = aborted"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Goal.status"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.achievementStatus",
+                "path": "Goal.achievementStatus",
+                "short": "in-progress | improving | worsening | no-change | achieved | sustaining | not-achieved | no-progress | not-attainable",
+                "definition": "Describes the progression, or lack thereof, towards the goal against the target.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Goal.achievementStatus",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "GoalAchievementStatus"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Indicates the progression, or lack thereof, towards the goal against the target.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/goal-achievement"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".statusCode achieved = complete sustaining = active"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.category",
+                "path": "Goal.category",
+                "short": "E.g. Treatment, dietary, behavioral, etc.",
+                "definition": "Indicates a category the goal falls within.",
+                "requirements": "Allows goals to be filtered and sorted.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Goal.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "GoalCategory"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes for grouping and sorting goals.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/goal-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.priority",
+                "path": "Goal.priority",
+                "short": "high-priority | medium-priority | low-priority",
+                "definition": "Identifies the mutually agreed level of importance associated with reaching/sustaining the goal.",
+                "comment": "Extensions are available to track priorities as established by each participant (i.e. Priority from the patient's perspective, different practitioners' perspectives, family member's perspectives)\r\rThe ordinal extension on Coding can be used to convey a numerically comparable ranking to priority.  (Keep in mind that different coding systems may use a \"low value=important\".",
+                "requirements": "Used for sorting and presenting goals.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Goal.priority",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "GoalPriority"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "The level of importance associated with a goal.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/goal-priority"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.grade"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".priorityCode"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.description",
+                "path": "Goal.description",
+                "short": "Code or text describing goal",
+                "definition": "Human-readable and/or coded description of a specific desired objective of care, such as \"control blood pressure\" or \"negotiate an obstacle course\" or \"dance with child at wedding\".",
+                "comment": "If no code is available, use CodeableConcept.text.",
+                "requirements": "Without a description of what's trying to be achieved, element has no purpose.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Goal.description",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "GoalDescription"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes providing the details of a particular goal.  This will generally be system or implementation guide-specific.  In many systems, only the text element will be used.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "GOL-3.2-goal ID.text"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".text"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Goal.description"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.subject",
+                "path": "Goal.subject",
+                "short": "Who this goal is intended for",
+                "definition": "Identifies the patient, group or organization for whom the goal is being established.",
+                "requirements": "Subject is optional to support annonymized reporting.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Goal.subject",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3-patient ID list"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=PAT].role[classCode=PAT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Goal.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.start[x]",
+                "path": "Goal.start[x]",
+                "short": "When goal pursuit begins",
+                "definition": "The date or event after which the goal should begin being pursued.",
+                "requirements": "Goals can be established prior to there being an intention to start pursuing them; e.g. Goals for post-surgical recovery established prior to surgery.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Goal.start[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "date"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "GoalStartEvent"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing events that can trigger the initiation of a goal.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/goal-start-event"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.planned"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.target",
+                "path": "Goal.target",
+                "short": "Target outcome for the goal",
+                "definition": "Indicates what should be done by when.",
+                "comment": "When multiple targets are present for a single goal instance, all targets must be met for the overall goal to be met.",
+                "requirements": "Allows the progress of the goal to be monitored against an observation or due date.  Target is 0..* to support Observations with multiple components, such as blood pressure goals with both a systolic and diastolic target.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Goal.target",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "condition": [
+                    "gol-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "gol-1",
+                        "severity": "error",
+                        "human": "Goal.target.measure is required if Goal.target.detail is populated",
+                        "expression": "(detail.exists() and measure.exists()) or detail.exists().not()",
+                        "xpath": "(exists(f:*[starts-with(local-name(.), 'detail')]) and exists(f:measure)) or not(exists(f:*[starts-with(local-name(.), 'detail')]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Goal"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Goal.target.id",
+                "path": "Goal.target.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.target.extension",
+                "path": "Goal.target.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.target.modifierExtension",
+                "path": "Goal.target.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.target.measure",
+                "path": "Goal.target.measure",
+                "short": "The parameter whose value is being tracked",
+                "definition": "The parameter whose value is being tracked, e.g. body weight, blood pressure, or hemoglobin A1c level.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Goal.target.measure",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "gol-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "GoalTargetMeasure"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes to identify the value being tracked, e.g. body weight, blood pressure, or hemoglobin A1c level.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-codes"
+                }
+            },
+            {
+                "id": "Goal.target.detail[x]",
+                "path": "Goal.target.detail[x]",
+                "short": "The target value to be achieved",
+                "definition": "The target value of the focus to be achieved to signify the fulfillment of the goal, e.g. 150 pounds, 7.0%. Either the high or low or both values of the range can be specified. When a low value is missing, it indicates that the goal is achieved at any focus value at or below the high value. Similarly, if the high value is missing, it indicates that the goal is achieved at any focus value at or above the low value.",
+                "comment": "A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Goal.target.measure defines a coded value.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Goal.target.detail[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "Ratio"
+                    }
+                ],
+                "condition": [
+                    "gol-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "GoalTargetDetail"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes to identify the target value of the focus to be achieved to signify the fulfillment of the goal."
+                }
+            },
+            {
+                "id": "Goal.target.due[x]",
+                "path": "Goal.target.due[x]",
+                "short": "Reach goal on or before",
+                "definition": "Indicates either the date or the duration after start by which the goal should be met.",
+                "requirements": "Identifies when the goal should be evaluated.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Goal.target.due[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "date"
+                    },
+                    {
+                        "code": "Duration"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.statusDate",
+                "path": "Goal.statusDate",
+                "short": "When goal status took effect",
+                "definition": "Identifies when the current status.  I.e. When initially created, when achieved, when cancelled, etc.",
+                "comment": "To see the date for past statuses, query history.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Goal.statusDate",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "date"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.statusReason",
+                "path": "Goal.statusReason",
+                "short": "Reason for current status",
+                "definition": "Captures the reason for the current status.",
+                "comment": "This will typically be captured for statuses such as rejected, on-hold or cancelled, but could be present for others.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Goal.statusReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Goal.expressedBy",
+                "path": "Goal.expressedBy",
+                "short": "Who's responsible for creating Goal?",
+                "definition": "Indicates whose goal this is - patient goal, practitioner goal, etc.",
+                "comment": "This is the individual responsible for establishing the goal, not necessarily who recorded it.  (For that, use the Provenance resource.).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Goal.expressedBy",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.source"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.addresses",
+                "path": "Goal.addresses",
+                "short": "Issues addressed by this goal",
+                "definition": "The identified conditions and other health record elements that are intended to be addressed by the goal.",
+                "requirements": "Allows specific goals to explicitly linked to the concerns they're dealing with - makes the goal more understandable.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Goal.addresses",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Condition",
+                            "http://hl7.org/fhir/StructureDefinition/Observation",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationStatement",
+                            "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest",
+                            "http://hl7.org/fhir/StructureDefinition/RiskAssessment"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.why[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=SUBJ].target[classCode=CONC]"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.note",
+                "path": "Goal.note",
+                "short": "Comments about the goal",
+                "definition": "Any comments related to the goal.",
+                "comment": "May be used for progress notes, concerns or other related information that doesn't actually describe the goal itself.",
+                "requirements": "There's a need to capture information about the goal that doesn't actually describe the goal.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Goal.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "GOL-16-goal evaluation + NTE?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.outcomeCode",
+                "path": "Goal.outcomeCode",
+                "short": "What result was achieved regarding the goal?",
+                "definition": "Identifies the change (or lack of change) at the point when the status of the goal is assessed.",
+                "comment": "Note that this should not duplicate the goal status.",
+                "requirements": "Outcome tracking is a key aspect of care planning.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Goal.outcomeCode",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "GoalOutcome"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "The result of the goal; e.g. \"25% increase in shoulder mobility\", \"Anxiety reduced to moderate levels\".  \"15 kg weight loss sustained over 6 months\".",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/clinical-findings"
+                }
+            },
+            {
+                "id": "Goal.outcomeReference",
+                "path": "Goal.outcomeReference",
+                "short": "Observation that resulted from goal",
+                "definition": "Details of what's changed (or not changed).",
+                "comment": "The goal outcome is independent of the outcome of the related activities.  For example, if the Goal is to achieve a target body weight of 150 lb and a care plan activity is defined to diet, then the care plan’s activity outcome could be calories consumed whereas goal outcome is an observation for the actual body weight measured.",
+                "requirements": "Outcome tracking is a key aspect of care planning.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Goal.outcomeReference",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Observation"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Goal",
+                "path": "Goal",
+                "definition": "The US Core Goal Profile is based upon the core FHIR Goal Resource and created to meet the 2015 Edition Common Clinical Data Set 'Goals' requirements.",
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Goal"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.lifecycleStatus",
+                "path": "Goal.lifecycleStatus",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/goal-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Goal.status"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.description",
+                "path": "Goal.description",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Goal.description"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.subject",
+                "path": "Goal.subject",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Goal.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Goal.target",
+                "path": "Goal.target",
+                "min": 0,
+                "max": "*",
+                "mustSupport": true
+            },
+            {
+                "id": "Goal.target.due[x]",
+                "path": "Goal.target.due[x]",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "date"
+                    },
+                    {
+                        "code": "Duration"
+                    }
+                ],
+                "mustSupport": true
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-head-circumference.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-head-circumference.json
@@ -1,3814 +1,3814 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-head-circumference",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-head-circumference-definitions.html#Observation\" title=\"Defines constraints on Observation to represent head circumference observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.\">Observation</a><a name=\"Observation\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"StructureDefinition-us-core-vital-signs.html\">USCoreVitalSignsProfile</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">US Core Head Circumference Profile</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-head-circumference-definitions.html#Observation.code\">code</a><a name=\"Observation.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">1</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Head Circumference<br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck101.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#CodeableConcept.coding\">coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Code defined by a terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">(complex)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/loinc.html\">http://loinc.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">9843-4</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-head-circumference-definitions.html#Observation.valueQuantity\">valueQuantity</a><a name=\"Observation.valueQuantity\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Quantity\">Quantity</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Vital Signs Value</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-head-circumference-definitions.html#Observation.valueQuantity.value\">value</a><a name=\"Observation.valueQuantity.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#decimal\">decimal</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Numerical value (with implicit precision)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-head-circumference-definitions.html#Observation.valueQuantity.unit\">unit</a><a name=\"Observation.valueQuantity.unit\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Unit representation</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-head-circumference-definitions.html#Observation.valueQuantity.system\">system</a><a name=\"Observation.valueQuantity.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">System that defines coded unit form</span><br/><span style=\"font-weight:bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/ucum.html\">http://unitsofmeasure.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-head-circumference-definitions.html#Observation.valueQuantity.code\">code</a><a name=\"Observation.valueQuantity.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Coded responses from the common UCUM units for vital signs value set.<br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-ucum-bodylength.html\">BodyLengthUnits</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-head-circumference",
-	"version": "4.0.0",
-	"name": "USCoreHeadCircumferenceProfile",
-	"title": "US Core Head Circumference Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-18",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints on Observation to represent head circumference observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "sct-concept",
-			"uri": "http://snomed.info/conceptdomain",
-			"name": "SNOMED CT Concept Domain Binding"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "sct-attr",
-			"uri": "http://snomed.org/attributebinding",
-			"name": "SNOMED CT Attribute Binding"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Observation",
-	"baseDefinition": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "US Core Head Circumference Profile",
-				"definition": "Defines constraints on Observation to represent head circumference observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
-				"alias": [
-					"Vital Signs",
-					"Measurement",
-					"Results",
-					"Tests"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "obs-6",
-						"severity": "error",
-						"human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
-						"expression": "dataAbsentReason.empty() or value.empty()",
-						"xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "obs-7",
-						"severity": "error",
-						"human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
-						"expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
-						"xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "vs-2",
-						"severity": "error",
-						"human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
-						"expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
-						"xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.id",
-				"path": "Observation.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.meta",
-				"path": "Observation.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.implicitRules",
-				"path": "Observation.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Observation.language",
-				"path": "Observation.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Observation.text",
-				"path": "Observation.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Observation.contained",
-				"path": "Observation.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.extension",
-				"path": "Observation.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.modifierExtension",
-				"path": "Observation.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.identifier",
-				"path": "Observation.identifier",
-				"short": "Business Identifier for observation",
-				"definition": "A unique identifier assigned to this observation.",
-				"requirements": "Allows observations to be distinguished and referenced.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
-					},
-					{
-						"identity": "rim",
-						"map": "id"
-					}
-				]
-			},
-			{
-				"id": "Observation.basedOn",
-				"path": "Observation.basedOn",
-				"short": "Fulfills plan, proposal or order",
-				"definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
-				"requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
-				"alias": [
-					"Fulfills"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan",
-							"http://hl7.org/fhir/StructureDefinition/DeviceRequest",
-							"http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
-							"http://hl7.org/fhir/StructureDefinition/MedicationRequest",
-							"http://hl7.org/fhir/StructureDefinition/NutritionOrder",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.basedOn"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.partOf",
-				"path": "Observation.partOf",
-				"short": "Part of referenced event",
-				"definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
-				"comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
-				"alias": [
-					"Container"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.partOf",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
-							"http://hl7.org/fhir/StructureDefinition/MedicationDispense",
-							"http://hl7.org/fhir/StructureDefinition/MedicationStatement",
-							"http://hl7.org/fhir/StructureDefinition/Procedure",
-							"http://hl7.org/fhir/StructureDefinition/Immunization",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.partOf"
-					},
-					{
-						"identity": "v2",
-						"map": "Varies by domain"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=FLFS].target"
-					}
-				]
-			},
-			{
-				"id": "Observation.status",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
-						"valueString": "default: final"
-					}
-				],
-				"path": "Observation.status",
-				"short": "registered | preliminary | final | amended +",
-				"definition": "The status of the result value.",
-				"comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
-				"requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Status"
-						}
-					],
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 445584004 |Report by finality status|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-11"
-					},
-					{
-						"identity": "rim",
-						"map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
-					}
-				]
-			},
-			{
-				"id": "Observation.category",
-				"path": "Observation.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "coding.code"
-						},
-						{
-							"type": "value",
-							"path": "coding.system"
-						}
-					],
-					"ordered": false,
-					"rules": "open"
-				},
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat",
-				"path": "Observation.category",
-				"sliceName": "VSCat",
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.id",
-				"path": "Observation.category.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.extension",
-				"path": "Observation.category.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding",
-				"path": "Observation.category.coding",
-				"short": "Code defined by a terminology system",
-				"definition": "A reference to a code defined by a terminology system.",
-				"comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
-				"requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "CodeableConcept.coding",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1-8, C*E.10-22"
-					},
-					{
-						"identity": "rim",
-						"map": "union(., ./translation)"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.id",
-				"path": "Observation.category.coding.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.extension",
-				"path": "Observation.category.coding.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.system",
-				"path": "Observation.category.coding.system",
-				"short": "Identity of the terminology system",
-				"definition": "The identification of the code system that defines the meaning of the symbol in the code.",
-				"comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
-				"requirements": "Need to be unambiguous about the source of the definition of the symbol.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.3"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystem"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.version",
-				"path": "Observation.category.coding.version",
-				"short": "Version of the system - if relevant",
-				"definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
-				"comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.version",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.7"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystemVersion"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.code",
-				"path": "Observation.category.coding.code",
-				"short": "Symbol in syntax defined by the system",
-				"definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
-				"requirements": "Need to refer to a particular code in the system.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "vital-signs",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1"
-					},
-					{
-						"identity": "rim",
-						"map": "./code"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.display",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.coding.display",
-				"short": "Representation defined by the system",
-				"definition": "A representation of the meaning of the code in the system, following the rules of the system.",
-				"requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.display",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.2 - but note this is not well followed"
-					},
-					{
-						"identity": "rim",
-						"map": "CV.displayName"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.userSelected",
-				"path": "Observation.category.coding.userSelected",
-				"short": "If this coding was chosen directly by the user",
-				"definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
-				"comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
-				"requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.userSelected",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Sometimes implied by being first"
-					},
-					{
-						"identity": "rim",
-						"map": "CD.codingRationale"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.text",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.text",
-				"short": "Plain text representation of the concept",
-				"definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
-				"comment": "Very often the text is the same as a displayName of one of the codings.",
-				"requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CodeableConcept.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.9. But note many systems use C*E.2 for this"
-					},
-					{
-						"identity": "rim",
-						"map": "./originalText[mediaType/code=\"text/plain\"]/data"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
-					}
-				]
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Head Circumference",
-				"definition": "Coded Responses from C-CDA Vital Sign Results.",
-				"comment": "*All* code-value and, if present, component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
-				"alias": [
-					"Name"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "9843-4"
-						}
-					]
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "116680003 |Is a|"
-					}
-				]
-			},
-			{
-				"id": "Observation.subject",
-				"path": "Observation.subject",
-				"short": "Who and/or what the observation is about",
-				"definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
-				"comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
-				"requirements": "Observations have no value if you don't know who or what they're about.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=RTGT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.focus",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
-						"valueCode": "trial-use"
-					}
-				],
-				"path": "Observation.focus",
-				"short": "What the observation is about, when it is not about the subject of record",
-				"definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
-				"comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.focus",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SBJ]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.encounter",
-				"path": "Observation.encounter",
-				"short": "Healthcare event during which this observation is made",
-				"definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
-				"comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
-				"requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
-				"alias": [
-					"Context"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.effective[x]",
-				"path": "Observation.effective[x]",
-				"short": "Often just a dateTime for Vital Signs",
-				"definition": "Often just a dateTime for Vital Signs.",
-				"comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
-				"requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
-				"alias": [
-					"Occurrence"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.effective[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-1",
-						"severity": "error",
-						"human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
-						"expression": "($this as dateTime).toString().length() >= 8",
-						"xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "Observation.issued",
-				"path": "Observation.issued",
-				"short": "Date/Time this version was made available",
-				"definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
-				"comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.issued",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=AUT].time"
-					}
-				]
-			},
-			{
-				"id": "Observation.performer",
-				"path": "Observation.performer",
-				"short": "Who is responsible for the observation",
-				"definition": "Who was responsible for asserting the observed value as \"true\".",
-				"requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.performer",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=PRF]"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]",
-				"path": "Observation.value[x]",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "type",
-							"path": "$this"
-						}
-					],
-					"ordered": false,
-					"rules": "closed"
-				},
-				"short": "Vital Signs Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity",
-				"path": "Observation.value[x]",
-				"sliceName": "valueQuantity",
-				"short": "Vital Signs Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.id",
-				"path": "Observation.value[x].id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.extension",
-				"path": "Observation.value[x].extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.value",
-				"path": "Observation.value[x].value",
-				"short": "Numerical value (with implicit precision)",
-				"definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
-				"comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
-				"requirements": "Precision is handled implicitly in almost all cases of measurement.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.2  / CQ - N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.comparator",
-				"path": "Observation.value[x].comparator",
-				"short": "< | <= | >= | > - how to understand the value",
-				"definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
-				"requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Quantity.comparator",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "QuantityComparator"
-						}
-					],
-					"strength": "required",
-					"description": "How the Quantity should be understood and represented.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.1  / CQ.1"
-					},
-					{
-						"identity": "rim",
-						"map": "IVL properties"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.unit",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.value[x].unit",
-				"short": "Unit representation",
-				"definition": "A human-readable form of the unit.",
-				"requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.unit",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.unit"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.system",
-				"path": "Observation.value[x].system",
-				"short": "System that defines coded unit form",
-				"definition": "The identification of the system that provides the coded form of the unit.",
-				"requirements": "Need to know the system that defines the coded form of the unit.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"condition": [
-					"qty-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "CO.codeSystem, PQ.translation.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.code",
-				"path": "Observation.value[x].code",
-				"short": "Coded responses from the common UCUM units for vital signs value set.",
-				"definition": "A computer processable form of the unit in some unit representation system.",
-				"comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
-				"requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-bodylength|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.code, MO.currency, PQ.translation.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.dataAbsentReason",
-				"path": "Observation.dataAbsentReason",
-				"short": "Why the result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
-				"comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.interpretation",
-				"path": "Observation.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.note",
-				"path": "Observation.note",
-				"short": "Comments about the observation",
-				"definition": "Comments about the observation or the results.",
-				"comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
-				"requirements": "Need to be able to provide free text additional information.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
-					},
-					{
-						"identity": "rim",
-						"map": "subjectOf.observationEvent[code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.bodySite",
-				"path": "Observation.bodySite",
-				"short": "Observed body part",
-				"definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
-				"comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.bodySite",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "BodySite"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing anatomical locations. May include laterality.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/body-site"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123037004 |Body structure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-20"
-					},
-					{
-						"identity": "rim",
-						"map": "targetSiteCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "718497002 |Inherent location|"
-					}
-				]
-			},
-			{
-				"id": "Observation.method",
-				"path": "Observation.method",
-				"short": "How it was done",
-				"definition": "Indicates the mechanism used to perform the observation.",
-				"comment": "Only used if not implicit in code for Observation.code.",
-				"requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.method",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationMethod"
-						}
-					],
-					"strength": "example",
-					"description": "Methods for simple observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-17"
-					},
-					{
-						"identity": "rim",
-						"map": "methodCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.specimen",
-				"path": "Observation.specimen",
-				"short": "Specimen used for this observation",
-				"definition": "The specimen that was used when this observation was made.",
-				"comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.specimen",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Specimen"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123038009 |Specimen|"
-					},
-					{
-						"identity": "v2",
-						"map": "SPM segment"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SPC].specimen"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "704319004 |Inherent in|"
-					}
-				]
-			},
-			{
-				"id": "Observation.device",
-				"path": "Observation.device",
-				"short": "(Measurement) Device",
-				"definition": "The device used to generate the observation data.",
-				"comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.device",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/DeviceMetric"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 49062001 |Device|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-17 / PRT -10"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=DEV]"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "424226004 |Using device|"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange",
-				"path": "Observation.referenceRange",
-				"short": "Provides guide for interpretation",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "obs-3",
-						"severity": "error",
-						"human": "Must have at least a low or a high or text",
-						"expression": "low.exists() or high.exists() or text.exists()",
-						"xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.id",
-				"path": "Observation.referenceRange.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.extension",
-				"path": "Observation.referenceRange.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.modifierExtension",
-				"path": "Observation.referenceRange.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.low",
-				"path": "Observation.referenceRange.low",
-				"short": "Low Range, if relevant",
-				"definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.low",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.low"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.high",
-				"path": "Observation.referenceRange.high",
-				"short": "High Range, if relevant",
-				"definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.high",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.high"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.type",
-				"path": "Observation.referenceRange.type",
-				"short": "Reference range qualifier",
-				"definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
-				"requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeMeaning"
-						}
-					],
-					"strength": "preferred",
-					"description": "Code for the meaning of a reference range.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.appliesTo",
-				"path": "Observation.referenceRange.appliesTo",
-				"short": "Reference range population",
-				"definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
-				"requirements": "Need to be able to identify the target population for proper interpretation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange.appliesTo",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeType"
-						}
-					],
-					"strength": "example",
-					"description": "Codes identifying the population the reference range applies to.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.age",
-				"path": "Observation.referenceRange.age",
-				"short": "Applicable age range, if relevant",
-				"definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
-				"requirements": "Some analytes vary greatly over age.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.age",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Range"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.text",
-				"path": "Observation.referenceRange.text",
-				"short": "Text based reference range in an observation",
-				"definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:ST"
-					}
-				]
-			},
-			{
-				"id": "Observation.hasMember",
-				"path": "Observation.hasMember",
-				"short": "Used when reporting vital signs panel components",
-				"definition": "Used when reporting vital signs panel components.",
-				"comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.hasMember",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship"
-					}
-				]
-			},
-			{
-				"id": "Observation.derivedFrom",
-				"path": "Observation.derivedFrom",
-				"short": "Related measurements the observation is made from",
-				"definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
-				"comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.derivedFrom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/DocumentReference",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy",
-							"http://hl7.org/fhir/StructureDefinition/Media",
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": ".targetObservation"
-					}
-				]
-			},
-			{
-				"id": "Observation.component",
-				"path": "Observation.component",
-				"short": "Component observations",
-				"definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
-				"comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-3",
-						"severity": "error",
-						"human": "If there is no a value a data absent reason must be present",
-						"expression": "value.exists() or dataAbsentReason.exists()",
-						"xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "containment by OBX-4?"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=COMP]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.id",
-				"path": "Observation.component.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.extension",
-				"path": "Observation.component.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.modifierExtension",
-				"path": "Observation.component.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.code",
-				"path": "Observation.component.code",
-				"short": "Type of component observation (code / type)",
-				"definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
-				"comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.value[x]",
-				"path": "Observation.component.value[x]",
-				"short": "Vital Sign Component Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
-				"comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "Quantity"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.dataAbsentReason",
-				"path": "Observation.component.dataAbsentReason",
-				"short": "Why the component result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
-				"comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.interpretation",
-				"path": "Observation.component.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.referenceRange",
-				"path": "Observation.component.referenceRange",
-				"short": "Provides guide for interpretation of component result",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "US Core Head Circumference Profile",
-				"definition": "Defines constraints on Observation to represent head circumference observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile."
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Head Circumference",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "9843-4"
-						}
-					]
-				},
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity",
-				"path": "Observation.valueQuantity",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.value",
-				"path": "Observation.valueQuantity.value",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.unit",
-				"path": "Observation.valueQuantity.unit",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.system",
-				"path": "Observation.valueQuantity.system",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.code",
-				"path": "Observation.valueQuantity.code",
-				"short": "Coded responses from the common UCUM units for vital signs value set.",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-bodylength|4.0.1"
-				}
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-head-circumference",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-head-circumference",
+    "version": "4.0.0",
+    "name": "USCoreHeadCircumferenceProfile",
+    "title": "US Core Head Circumference Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-18",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints on Observation to represent head circumference observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "sct-concept",
+            "uri": "http://snomed.info/conceptdomain",
+            "name": "SNOMED CT Concept Domain Binding"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "sct-attr",
+            "uri": "http://snomed.org/attributebinding",
+            "name": "SNOMED CT Attribute Binding"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Observation",
+    "baseDefinition": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "US Core Head Circumference Profile",
+                "definition": "Defines constraints on Observation to represent head circumference observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
+                "alias": [
+                    "Vital Signs",
+                    "Measurement",
+                    "Results",
+                    "Tests"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "obs-6",
+                        "severity": "error",
+                        "human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
+                        "expression": "dataAbsentReason.empty() or value.empty()",
+                        "xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "obs-7",
+                        "severity": "error",
+                        "human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
+                        "expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
+                        "xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "vs-2",
+                        "severity": "error",
+                        "human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
+                        "expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
+                        "xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.id",
+                "path": "Observation.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.meta",
+                "path": "Observation.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.implicitRules",
+                "path": "Observation.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Observation.language",
+                "path": "Observation.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Observation.text",
+                "path": "Observation.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.contained",
+                "path": "Observation.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.extension",
+                "path": "Observation.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.modifierExtension",
+                "path": "Observation.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.identifier",
+                "path": "Observation.identifier",
+                "short": "Business Identifier for observation",
+                "definition": "A unique identifier assigned to this observation.",
+                "requirements": "Allows observations to be distinguished and referenced.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "id"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.basedOn",
+                "path": "Observation.basedOn",
+                "short": "Fulfills plan, proposal or order",
+                "definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
+                "requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
+                "alias": [
+                    "Fulfills"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceRequest",
+                            "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+                            "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.basedOn"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.partOf",
+                "path": "Observation.partOf",
+                "short": "Part of referenced event",
+                "definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
+                "comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
+                "alias": [
+                    "Container"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.partOf",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationDispense",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationStatement",
+                            "http://hl7.org/fhir/StructureDefinition/Procedure",
+                            "http://hl7.org/fhir/StructureDefinition/Immunization",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.partOf"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "Varies by domain"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=FLFS].target"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.status",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
+                        "valueString": "default: final"
+                    }
+                ],
+                "path": "Observation.status",
+                "short": "registered | preliminary | final | amended +",
+                "definition": "The status of the result value.",
+                "comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
+                "requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Status"
+                        }
+                    ],
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 445584004 |Report by finality status|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-11"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category",
+                "path": "Observation.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "coding.code"
+                        },
+                        {
+                            "type": "value",
+                            "path": "coding.system"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "open"
+                },
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat",
+                "path": "Observation.category",
+                "sliceName": "VSCat",
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.id",
+                "path": "Observation.category.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.extension",
+                "path": "Observation.category.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding",
+                "path": "Observation.category.coding",
+                "short": "Code defined by a terminology system",
+                "definition": "A reference to a code defined by a terminology system.",
+                "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+                "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "CodeableConcept.coding",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1-8, C*E.10-22"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "union(., ./translation)"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.id",
+                "path": "Observation.category.coding.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.extension",
+                "path": "Observation.category.coding.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.system",
+                "path": "Observation.category.coding.system",
+                "short": "Identity of the terminology system",
+                "definition": "The identification of the code system that defines the meaning of the symbol in the code.",
+                "comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
+                "requirements": "Need to be unambiguous about the source of the definition of the symbol.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystem"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.version",
+                "path": "Observation.category.coding.version",
+                "short": "Version of the system - if relevant",
+                "definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
+                "comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.version",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystemVersion"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.code",
+                "path": "Observation.category.coding.code",
+                "short": "Symbol in syntax defined by the system",
+                "definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
+                "requirements": "Need to refer to a particular code in the system.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "vital-signs",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./code"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.display",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.coding.display",
+                "short": "Representation defined by the system",
+                "definition": "A representation of the meaning of the code in the system, following the rules of the system.",
+                "requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.display",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.2 - but note this is not well followed"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CV.displayName"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.userSelected",
+                "path": "Observation.category.coding.userSelected",
+                "short": "If this coding was chosen directly by the user",
+                "definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
+                "comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
+                "requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.userSelected",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Sometimes implied by being first"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CD.codingRationale"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.text",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.text",
+                "short": "Plain text representation of the concept",
+                "definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
+                "comment": "Very often the text is the same as a displayName of one of the codings.",
+                "requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CodeableConcept.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.9. But note many systems use C*E.2 for this"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./originalText[mediaType/code=\"text/plain\"]/data"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Head Circumference",
+                "definition": "Coded Responses from C-CDA Vital Sign Results.",
+                "comment": "*All* code-value and, if present, component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
+                "alias": [
+                    "Name"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "9843-4"
+                        }
+                    ]
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "116680003 |Is a|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.subject",
+                "path": "Observation.subject",
+                "short": "Who and/or what the observation is about",
+                "definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
+                "comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
+                "requirements": "Observations have no value if you don't know who or what they're about.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=RTGT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.focus",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+                        "valueCode": "trial-use"
+                    }
+                ],
+                "path": "Observation.focus",
+                "short": "What the observation is about, when it is not about the subject of record",
+                "definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
+                "comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.focus",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SBJ]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.encounter",
+                "path": "Observation.encounter",
+                "short": "Healthcare event during which this observation is made",
+                "definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
+                "comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
+                "requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
+                "alias": [
+                    "Context"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.effective[x]",
+                "path": "Observation.effective[x]",
+                "short": "Often just a dateTime for Vital Signs",
+                "definition": "Often just a dateTime for Vital Signs.",
+                "comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
+                "requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
+                "alias": [
+                    "Occurrence"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.effective[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-1",
+                        "severity": "error",
+                        "human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
+                        "expression": "($this as dateTime).toString().length() >= 8",
+                        "xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.issued",
+                "path": "Observation.issued",
+                "short": "Date/Time this version was made available",
+                "definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
+                "comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.issued",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.performer",
+                "path": "Observation.performer",
+                "short": "Who is responsible for the observation",
+                "definition": "Who was responsible for asserting the observed value as \"true\".",
+                "requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.performer",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=PRF]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]",
+                "path": "Observation.value[x]",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "type",
+                            "path": "$this"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "closed"
+                },
+                "short": "Vital Signs Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity",
+                "path": "Observation.value[x]",
+                "sliceName": "valueQuantity",
+                "short": "Vital Signs Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.id",
+                "path": "Observation.value[x].id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.extension",
+                "path": "Observation.value[x].extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.value",
+                "path": "Observation.value[x].value",
+                "short": "Numerical value (with implicit precision)",
+                "definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
+                "comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
+                "requirements": "Precision is handled implicitly in almost all cases of measurement.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.2  / CQ - N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.comparator",
+                "path": "Observation.value[x].comparator",
+                "short": "< | <= | >= | > - how to understand the value",
+                "definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
+                "requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.comparator",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "QuantityComparator"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "How the Quantity should be understood and represented.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.1  / CQ.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "IVL properties"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.unit",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.value[x].unit",
+                "short": "Unit representation",
+                "definition": "A human-readable form of the unit.",
+                "requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.unit",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.unit"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.system",
+                "path": "Observation.value[x].system",
+                "short": "System that defines coded unit form",
+                "definition": "The identification of the system that provides the coded form of the unit.",
+                "requirements": "Need to know the system that defines the coded form of the unit.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "condition": [
+                    "qty-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CO.codeSystem, PQ.translation.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.code",
+                "path": "Observation.value[x].code",
+                "short": "Coded responses from the common UCUM units for vital signs value set.",
+                "definition": "A computer processable form of the unit in some unit representation system.",
+                "comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
+                "requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-bodylength|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.code, MO.currency, PQ.translation.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.dataAbsentReason",
+                "path": "Observation.dataAbsentReason",
+                "short": "Why the result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
+                "comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.interpretation",
+                "path": "Observation.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.note",
+                "path": "Observation.note",
+                "short": "Comments about the observation",
+                "definition": "Comments about the observation or the results.",
+                "comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
+                "requirements": "Need to be able to provide free text additional information.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "subjectOf.observationEvent[code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.bodySite",
+                "path": "Observation.bodySite",
+                "short": "Observed body part",
+                "definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
+                "comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.bodySite",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "BodySite"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing anatomical locations. May include laterality.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/body-site"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123037004 |Body structure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-20"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "targetSiteCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "718497002 |Inherent location|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.method",
+                "path": "Observation.method",
+                "short": "How it was done",
+                "definition": "Indicates the mechanism used to perform the observation.",
+                "comment": "Only used if not implicit in code for Observation.code.",
+                "requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.method",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationMethod"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Methods for simple observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "methodCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.specimen",
+                "path": "Observation.specimen",
+                "short": "Specimen used for this observation",
+                "definition": "The specimen that was used when this observation was made.",
+                "comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.specimen",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Specimen"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123038009 |Specimen|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "SPM segment"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SPC].specimen"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "704319004 |Inherent in|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.device",
+                "path": "Observation.device",
+                "short": "(Measurement) Device",
+                "definition": "The device used to generate the observation data.",
+                "comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.device",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceMetric"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 49062001 |Device|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17 / PRT -10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=DEV]"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "424226004 |Using device|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange",
+                "path": "Observation.referenceRange",
+                "short": "Provides guide for interpretation",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "obs-3",
+                        "severity": "error",
+                        "human": "Must have at least a low or a high or text",
+                        "expression": "low.exists() or high.exists() or text.exists()",
+                        "xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.id",
+                "path": "Observation.referenceRange.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.extension",
+                "path": "Observation.referenceRange.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.modifierExtension",
+                "path": "Observation.referenceRange.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.low",
+                "path": "Observation.referenceRange.low",
+                "short": "Low Range, if relevant",
+                "definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.low",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.low"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.high",
+                "path": "Observation.referenceRange.high",
+                "short": "High Range, if relevant",
+                "definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.high",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.high"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.type",
+                "path": "Observation.referenceRange.type",
+                "short": "Reference range qualifier",
+                "definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
+                "requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeMeaning"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Code for the meaning of a reference range.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.appliesTo",
+                "path": "Observation.referenceRange.appliesTo",
+                "short": "Reference range population",
+                "definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
+                "requirements": "Need to be able to identify the target population for proper interpretation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange.appliesTo",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes identifying the population the reference range applies to.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.age",
+                "path": "Observation.referenceRange.age",
+                "short": "Applicable age range, if relevant",
+                "definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
+                "requirements": "Some analytes vary greatly over age.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.age",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Range"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.text",
+                "path": "Observation.referenceRange.text",
+                "short": "Text based reference range in an observation",
+                "definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:ST"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.hasMember",
+                "path": "Observation.hasMember",
+                "short": "Used when reporting vital signs panel components",
+                "definition": "Used when reporting vital signs panel components.",
+                "comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.hasMember",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.derivedFrom",
+                "path": "Observation.derivedFrom",
+                "short": "Related measurements the observation is made from",
+                "definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
+                "comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.derivedFrom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/DocumentReference",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy",
+                            "http://hl7.org/fhir/StructureDefinition/Media",
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".targetObservation"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component",
+                "path": "Observation.component",
+                "short": "Component observations",
+                "definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
+                "comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-3",
+                        "severity": "error",
+                        "human": "If there is no a value a data absent reason must be present",
+                        "expression": "value.exists() or dataAbsentReason.exists()",
+                        "xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "containment by OBX-4?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=COMP]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.id",
+                "path": "Observation.component.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.extension",
+                "path": "Observation.component.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.modifierExtension",
+                "path": "Observation.component.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.code",
+                "path": "Observation.component.code",
+                "short": "Type of component observation (code / type)",
+                "definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
+                "comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.value[x]",
+                "path": "Observation.component.value[x]",
+                "short": "Vital Sign Component Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
+                "comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.dataAbsentReason",
+                "path": "Observation.component.dataAbsentReason",
+                "short": "Why the component result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
+                "comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.interpretation",
+                "path": "Observation.component.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.referenceRange",
+                "path": "Observation.component.referenceRange",
+                "short": "Provides guide for interpretation of component result",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "US Core Head Circumference Profile",
+                "definition": "Defines constraints on Observation to represent head circumference observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile."
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Head Circumference",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "9843-4"
+                        }
+                    ]
+                },
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity",
+                "path": "Observation.valueQuantity",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.value",
+                "path": "Observation.valueQuantity.value",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.unit",
+                "path": "Observation.valueQuantity.unit",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.system",
+                "path": "Observation.valueQuantity.system",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.code",
+                "path": "Observation.valueQuantity.code",
+                "short": "Coded responses from the common UCUM units for vital signs value set.",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-bodylength|4.0.1"
+                }
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-heart-rate.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-heart-rate.json
@@ -1,3808 +1,3808 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-heart-rate",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-heart-rate-definitions.html#Observation\" title=\"Defines constraints on Observation to represent heart rate observations with a standard LOINC code and UCUM units of measure.  This profile is derived from the US Core Vital Signs Profile.\">Observation</a><a name=\"Observation\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"StructureDefinition-us-core-vital-signs.html\">USCoreVitalSignsProfile</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">US Core Heart Rate Profile</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-heart-rate-definitions.html#Observation.code\">code</a><a name=\"Observation.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">1</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Heart Rate<br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck101.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#CodeableConcept.coding\">coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Code defined by a terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">(complex)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/loinc.html\">http://loinc.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">8867-4</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-heart-rate-definitions.html#Observation.valueQuantity\">valueQuantity</a><a name=\"Observation.valueQuantity\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Quantity\">Quantity</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Vital Signs Value</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-heart-rate-definitions.html#Observation.valueQuantity.value\">value</a><a name=\"Observation.valueQuantity.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#decimal\">decimal</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Numerical value (with implicit precision)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-heart-rate-definitions.html#Observation.valueQuantity.unit\">unit</a><a name=\"Observation.valueQuantity.unit\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Unit representation</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-heart-rate-definitions.html#Observation.valueQuantity.system\">system</a><a name=\"Observation.valueQuantity.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">System that defines coded unit form</span><br/><span style=\"font-weight:bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/ucum.html\">http://unitsofmeasure.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-heart-rate-definitions.html#Observation.valueQuantity.code\">code</a><a name=\"Observation.valueQuantity.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Coded responses from the common UCUM units for vital signs value set.<br/><span style=\"font-weight:bold\">Fixed Value: </span><span style=\"color: darkgreen\">/min</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate",
-	"version": "4.0.0",
-	"name": "USCoreHeartRateProfile",
-	"title": "US Core Heart Rate Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-17",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints on Observation to represent heart rate observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "sct-concept",
-			"uri": "http://snomed.info/conceptdomain",
-			"name": "SNOMED CT Concept Domain Binding"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "sct-attr",
-			"uri": "http://snomed.org/attributebinding",
-			"name": "SNOMED CT Attribute Binding"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Observation",
-	"baseDefinition": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "US Core Heart Rate Profile",
-				"definition": "Defines constraints on Observation to represent heart rate observations with a standard LOINC code and UCUM units of measure.  This profile is derived from the US Core Vital Signs Profile.",
-				"comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
-				"alias": [
-					"Vital Signs",
-					"Measurement",
-					"Results",
-					"Tests"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "obs-6",
-						"severity": "error",
-						"human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
-						"expression": "dataAbsentReason.empty() or value.empty()",
-						"xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "obs-7",
-						"severity": "error",
-						"human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
-						"expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
-						"xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "vs-2",
-						"severity": "error",
-						"human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
-						"expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
-						"xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.id",
-				"path": "Observation.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.meta",
-				"path": "Observation.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.implicitRules",
-				"path": "Observation.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Observation.language",
-				"path": "Observation.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Observation.text",
-				"path": "Observation.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Observation.contained",
-				"path": "Observation.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.extension",
-				"path": "Observation.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.modifierExtension",
-				"path": "Observation.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.identifier",
-				"path": "Observation.identifier",
-				"short": "Business Identifier for observation",
-				"definition": "A unique identifier assigned to this observation.",
-				"requirements": "Allows observations to be distinguished and referenced.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
-					},
-					{
-						"identity": "rim",
-						"map": "id"
-					}
-				]
-			},
-			{
-				"id": "Observation.basedOn",
-				"path": "Observation.basedOn",
-				"short": "Fulfills plan, proposal or order",
-				"definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
-				"requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
-				"alias": [
-					"Fulfills"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan",
-							"http://hl7.org/fhir/StructureDefinition/DeviceRequest",
-							"http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
-							"http://hl7.org/fhir/StructureDefinition/MedicationRequest",
-							"http://hl7.org/fhir/StructureDefinition/NutritionOrder",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.basedOn"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.partOf",
-				"path": "Observation.partOf",
-				"short": "Part of referenced event",
-				"definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
-				"comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
-				"alias": [
-					"Container"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.partOf",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
-							"http://hl7.org/fhir/StructureDefinition/MedicationDispense",
-							"http://hl7.org/fhir/StructureDefinition/MedicationStatement",
-							"http://hl7.org/fhir/StructureDefinition/Procedure",
-							"http://hl7.org/fhir/StructureDefinition/Immunization",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.partOf"
-					},
-					{
-						"identity": "v2",
-						"map": "Varies by domain"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=FLFS].target"
-					}
-				]
-			},
-			{
-				"id": "Observation.status",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
-						"valueString": "default: final"
-					}
-				],
-				"path": "Observation.status",
-				"short": "registered | preliminary | final | amended +",
-				"definition": "The status of the result value.",
-				"comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
-				"requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Status"
-						}
-					],
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 445584004 |Report by finality status|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-11"
-					},
-					{
-						"identity": "rim",
-						"map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
-					}
-				]
-			},
-			{
-				"id": "Observation.category",
-				"path": "Observation.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "coding.code"
-						},
-						{
-							"type": "value",
-							"path": "coding.system"
-						}
-					],
-					"ordered": false,
-					"rules": "open"
-				},
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat",
-				"path": "Observation.category",
-				"sliceName": "VSCat",
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.id",
-				"path": "Observation.category.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.extension",
-				"path": "Observation.category.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding",
-				"path": "Observation.category.coding",
-				"short": "Code defined by a terminology system",
-				"definition": "A reference to a code defined by a terminology system.",
-				"comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
-				"requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "CodeableConcept.coding",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1-8, C*E.10-22"
-					},
-					{
-						"identity": "rim",
-						"map": "union(., ./translation)"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.id",
-				"path": "Observation.category.coding.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.extension",
-				"path": "Observation.category.coding.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.system",
-				"path": "Observation.category.coding.system",
-				"short": "Identity of the terminology system",
-				"definition": "The identification of the code system that defines the meaning of the symbol in the code.",
-				"comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
-				"requirements": "Need to be unambiguous about the source of the definition of the symbol.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.3"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystem"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.version",
-				"path": "Observation.category.coding.version",
-				"short": "Version of the system - if relevant",
-				"definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
-				"comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.version",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.7"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystemVersion"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.code",
-				"path": "Observation.category.coding.code",
-				"short": "Symbol in syntax defined by the system",
-				"definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
-				"requirements": "Need to refer to a particular code in the system.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "vital-signs",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1"
-					},
-					{
-						"identity": "rim",
-						"map": "./code"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.display",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.coding.display",
-				"short": "Representation defined by the system",
-				"definition": "A representation of the meaning of the code in the system, following the rules of the system.",
-				"requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.display",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.2 - but note this is not well followed"
-					},
-					{
-						"identity": "rim",
-						"map": "CV.displayName"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.userSelected",
-				"path": "Observation.category.coding.userSelected",
-				"short": "If this coding was chosen directly by the user",
-				"definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
-				"comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
-				"requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.userSelected",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Sometimes implied by being first"
-					},
-					{
-						"identity": "rim",
-						"map": "CD.codingRationale"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.text",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.text",
-				"short": "Plain text representation of the concept",
-				"definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
-				"comment": "Very often the text is the same as a displayName of one of the codings.",
-				"requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CodeableConcept.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.9. But note many systems use C*E.2 for this"
-					},
-					{
-						"identity": "rim",
-						"map": "./originalText[mediaType/code=\"text/plain\"]/data"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
-					}
-				]
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Heart Rate",
-				"definition": "Coded Responses from C-CDA Vital Sign Results.",
-				"comment": "*All* code-value and, if present, component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
-				"alias": [
-					"Name"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "8867-4"
-						}
-					]
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "116680003 |Is a|"
-					}
-				]
-			},
-			{
-				"id": "Observation.subject",
-				"path": "Observation.subject",
-				"short": "Who and/or what the observation is about",
-				"definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
-				"comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
-				"requirements": "Observations have no value if you don't know who or what they're about.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=RTGT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.focus",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
-						"valueCode": "trial-use"
-					}
-				],
-				"path": "Observation.focus",
-				"short": "What the observation is about, when it is not about the subject of record",
-				"definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
-				"comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.focus",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SBJ]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.encounter",
-				"path": "Observation.encounter",
-				"short": "Healthcare event during which this observation is made",
-				"definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
-				"comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
-				"requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
-				"alias": [
-					"Context"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.effective[x]",
-				"path": "Observation.effective[x]",
-				"short": "Often just a dateTime for Vital Signs",
-				"definition": "Often just a dateTime for Vital Signs.",
-				"comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
-				"requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
-				"alias": [
-					"Occurrence"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.effective[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-1",
-						"severity": "error",
-						"human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
-						"expression": "($this as dateTime).toString().length() >= 8",
-						"xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "Observation.issued",
-				"path": "Observation.issued",
-				"short": "Date/Time this version was made available",
-				"definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
-				"comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.issued",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=AUT].time"
-					}
-				]
-			},
-			{
-				"id": "Observation.performer",
-				"path": "Observation.performer",
-				"short": "Who is responsible for the observation",
-				"definition": "Who was responsible for asserting the observed value as \"true\".",
-				"requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.performer",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=PRF]"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]",
-				"path": "Observation.value[x]",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "type",
-							"path": "$this"
-						}
-					],
-					"ordered": false,
-					"rules": "closed"
-				},
-				"short": "Vital Signs Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity",
-				"path": "Observation.value[x]",
-				"sliceName": "valueQuantity",
-				"short": "Vital Signs Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.id",
-				"path": "Observation.value[x].id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.extension",
-				"path": "Observation.value[x].extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.value",
-				"path": "Observation.value[x].value",
-				"short": "Numerical value (with implicit precision)",
-				"definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
-				"comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
-				"requirements": "Precision is handled implicitly in almost all cases of measurement.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.2  / CQ - N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.comparator",
-				"path": "Observation.value[x].comparator",
-				"short": "< | <= | >= | > - how to understand the value",
-				"definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
-				"requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Quantity.comparator",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "QuantityComparator"
-						}
-					],
-					"strength": "required",
-					"description": "How the Quantity should be understood and represented.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.1  / CQ.1"
-					},
-					{
-						"identity": "rim",
-						"map": "IVL properties"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.unit",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.value[x].unit",
-				"short": "Unit representation",
-				"definition": "A human-readable form of the unit.",
-				"requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.unit",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.unit"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.system",
-				"path": "Observation.value[x].system",
-				"short": "System that defines coded unit form",
-				"definition": "The identification of the system that provides the coded form of the unit.",
-				"requirements": "Need to know the system that defines the coded form of the unit.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"condition": [
-					"qty-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "CO.codeSystem, PQ.translation.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.code",
-				"path": "Observation.value[x].code",
-				"short": "Coded responses from the common UCUM units for vital signs value set.",
-				"definition": "A computer processable form of the unit in some unit representation system.",
-				"comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
-				"requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "/min",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.code, MO.currency, PQ.translation.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.dataAbsentReason",
-				"path": "Observation.dataAbsentReason",
-				"short": "Why the result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
-				"comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.interpretation",
-				"path": "Observation.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.note",
-				"path": "Observation.note",
-				"short": "Comments about the observation",
-				"definition": "Comments about the observation or the results.",
-				"comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
-				"requirements": "Need to be able to provide free text additional information.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
-					},
-					{
-						"identity": "rim",
-						"map": "subjectOf.observationEvent[code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.bodySite",
-				"path": "Observation.bodySite",
-				"short": "Observed body part",
-				"definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
-				"comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.bodySite",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "BodySite"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing anatomical locations. May include laterality.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/body-site"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123037004 |Body structure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-20"
-					},
-					{
-						"identity": "rim",
-						"map": "targetSiteCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "718497002 |Inherent location|"
-					}
-				]
-			},
-			{
-				"id": "Observation.method",
-				"path": "Observation.method",
-				"short": "How it was done",
-				"definition": "Indicates the mechanism used to perform the observation.",
-				"comment": "Only used if not implicit in code for Observation.code.",
-				"requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.method",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationMethod"
-						}
-					],
-					"strength": "example",
-					"description": "Methods for simple observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-17"
-					},
-					{
-						"identity": "rim",
-						"map": "methodCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.specimen",
-				"path": "Observation.specimen",
-				"short": "Specimen used for this observation",
-				"definition": "The specimen that was used when this observation was made.",
-				"comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.specimen",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Specimen"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123038009 |Specimen|"
-					},
-					{
-						"identity": "v2",
-						"map": "SPM segment"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SPC].specimen"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "704319004 |Inherent in|"
-					}
-				]
-			},
-			{
-				"id": "Observation.device",
-				"path": "Observation.device",
-				"short": "(Measurement) Device",
-				"definition": "The device used to generate the observation data.",
-				"comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.device",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/DeviceMetric"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 49062001 |Device|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-17 / PRT -10"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=DEV]"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "424226004 |Using device|"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange",
-				"path": "Observation.referenceRange",
-				"short": "Provides guide for interpretation",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "obs-3",
-						"severity": "error",
-						"human": "Must have at least a low or a high or text",
-						"expression": "low.exists() or high.exists() or text.exists()",
-						"xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.id",
-				"path": "Observation.referenceRange.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.extension",
-				"path": "Observation.referenceRange.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.modifierExtension",
-				"path": "Observation.referenceRange.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.low",
-				"path": "Observation.referenceRange.low",
-				"short": "Low Range, if relevant",
-				"definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.low",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.low"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.high",
-				"path": "Observation.referenceRange.high",
-				"short": "High Range, if relevant",
-				"definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.high",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.high"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.type",
-				"path": "Observation.referenceRange.type",
-				"short": "Reference range qualifier",
-				"definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
-				"requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeMeaning"
-						}
-					],
-					"strength": "preferred",
-					"description": "Code for the meaning of a reference range.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.appliesTo",
-				"path": "Observation.referenceRange.appliesTo",
-				"short": "Reference range population",
-				"definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
-				"requirements": "Need to be able to identify the target population for proper interpretation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange.appliesTo",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeType"
-						}
-					],
-					"strength": "example",
-					"description": "Codes identifying the population the reference range applies to.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.age",
-				"path": "Observation.referenceRange.age",
-				"short": "Applicable age range, if relevant",
-				"definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
-				"requirements": "Some analytes vary greatly over age.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.age",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Range"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.text",
-				"path": "Observation.referenceRange.text",
-				"short": "Text based reference range in an observation",
-				"definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:ST"
-					}
-				]
-			},
-			{
-				"id": "Observation.hasMember",
-				"path": "Observation.hasMember",
-				"short": "Used when reporting vital signs panel components",
-				"definition": "Used when reporting vital signs panel components.",
-				"comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.hasMember",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship"
-					}
-				]
-			},
-			{
-				"id": "Observation.derivedFrom",
-				"path": "Observation.derivedFrom",
-				"short": "Related measurements the observation is made from",
-				"definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
-				"comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.derivedFrom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/DocumentReference",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy",
-							"http://hl7.org/fhir/StructureDefinition/Media",
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": ".targetObservation"
-					}
-				]
-			},
-			{
-				"id": "Observation.component",
-				"path": "Observation.component",
-				"short": "Component observations",
-				"definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
-				"comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-3",
-						"severity": "error",
-						"human": "If there is no a value a data absent reason must be present",
-						"expression": "value.exists() or dataAbsentReason.exists()",
-						"xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "containment by OBX-4?"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=COMP]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.id",
-				"path": "Observation.component.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.extension",
-				"path": "Observation.component.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.modifierExtension",
-				"path": "Observation.component.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.code",
-				"path": "Observation.component.code",
-				"short": "Type of component observation (code / type)",
-				"definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
-				"comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.value[x]",
-				"path": "Observation.component.value[x]",
-				"short": "Vital Sign Component Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
-				"comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "Quantity"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.dataAbsentReason",
-				"path": "Observation.component.dataAbsentReason",
-				"short": "Why the component result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
-				"comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.interpretation",
-				"path": "Observation.component.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.referenceRange",
-				"path": "Observation.component.referenceRange",
-				"short": "Provides guide for interpretation of component result",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "US Core Heart Rate Profile",
-				"definition": "Defines constraints on Observation to represent heart rate observations with a standard LOINC code and UCUM units of measure.  This profile is derived from the US Core Vital Signs Profile."
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Heart Rate",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "8867-4"
-						}
-					]
-				},
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity",
-				"path": "Observation.valueQuantity",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.value",
-				"path": "Observation.valueQuantity.value",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.unit",
-				"path": "Observation.valueQuantity.unit",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.system",
-				"path": "Observation.valueQuantity.system",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.code",
-				"path": "Observation.valueQuantity.code",
-				"short": "Coded responses from the common UCUM units for vital signs value set.",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "/min",
-				"mustSupport": true
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-heart-rate",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate",
+    "version": "4.0.0",
+    "name": "USCoreHeartRateProfile",
+    "title": "US Core Heart Rate Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-17",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints on Observation to represent heart rate observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "sct-concept",
+            "uri": "http://snomed.info/conceptdomain",
+            "name": "SNOMED CT Concept Domain Binding"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "sct-attr",
+            "uri": "http://snomed.org/attributebinding",
+            "name": "SNOMED CT Attribute Binding"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Observation",
+    "baseDefinition": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "US Core Heart Rate Profile",
+                "definition": "Defines constraints on Observation to represent heart rate observations with a standard LOINC code and UCUM units of measure.  This profile is derived from the US Core Vital Signs Profile.",
+                "comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
+                "alias": [
+                    "Vital Signs",
+                    "Measurement",
+                    "Results",
+                    "Tests"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "obs-6",
+                        "severity": "error",
+                        "human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
+                        "expression": "dataAbsentReason.empty() or value.empty()",
+                        "xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "obs-7",
+                        "severity": "error",
+                        "human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
+                        "expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
+                        "xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "vs-2",
+                        "severity": "error",
+                        "human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
+                        "expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
+                        "xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.id",
+                "path": "Observation.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.meta",
+                "path": "Observation.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.implicitRules",
+                "path": "Observation.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Observation.language",
+                "path": "Observation.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Observation.text",
+                "path": "Observation.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.contained",
+                "path": "Observation.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.extension",
+                "path": "Observation.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.modifierExtension",
+                "path": "Observation.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.identifier",
+                "path": "Observation.identifier",
+                "short": "Business Identifier for observation",
+                "definition": "A unique identifier assigned to this observation.",
+                "requirements": "Allows observations to be distinguished and referenced.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "id"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.basedOn",
+                "path": "Observation.basedOn",
+                "short": "Fulfills plan, proposal or order",
+                "definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
+                "requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
+                "alias": [
+                    "Fulfills"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceRequest",
+                            "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+                            "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.basedOn"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.partOf",
+                "path": "Observation.partOf",
+                "short": "Part of referenced event",
+                "definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
+                "comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
+                "alias": [
+                    "Container"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.partOf",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationDispense",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationStatement",
+                            "http://hl7.org/fhir/StructureDefinition/Procedure",
+                            "http://hl7.org/fhir/StructureDefinition/Immunization",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.partOf"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "Varies by domain"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=FLFS].target"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.status",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
+                        "valueString": "default: final"
+                    }
+                ],
+                "path": "Observation.status",
+                "short": "registered | preliminary | final | amended +",
+                "definition": "The status of the result value.",
+                "comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
+                "requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Status"
+                        }
+                    ],
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 445584004 |Report by finality status|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-11"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category",
+                "path": "Observation.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "coding.code"
+                        },
+                        {
+                            "type": "value",
+                            "path": "coding.system"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "open"
+                },
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat",
+                "path": "Observation.category",
+                "sliceName": "VSCat",
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.id",
+                "path": "Observation.category.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.extension",
+                "path": "Observation.category.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding",
+                "path": "Observation.category.coding",
+                "short": "Code defined by a terminology system",
+                "definition": "A reference to a code defined by a terminology system.",
+                "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+                "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "CodeableConcept.coding",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1-8, C*E.10-22"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "union(., ./translation)"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.id",
+                "path": "Observation.category.coding.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.extension",
+                "path": "Observation.category.coding.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.system",
+                "path": "Observation.category.coding.system",
+                "short": "Identity of the terminology system",
+                "definition": "The identification of the code system that defines the meaning of the symbol in the code.",
+                "comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
+                "requirements": "Need to be unambiguous about the source of the definition of the symbol.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystem"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.version",
+                "path": "Observation.category.coding.version",
+                "short": "Version of the system - if relevant",
+                "definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
+                "comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.version",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystemVersion"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.code",
+                "path": "Observation.category.coding.code",
+                "short": "Symbol in syntax defined by the system",
+                "definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
+                "requirements": "Need to refer to a particular code in the system.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "vital-signs",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./code"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.display",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.coding.display",
+                "short": "Representation defined by the system",
+                "definition": "A representation of the meaning of the code in the system, following the rules of the system.",
+                "requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.display",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.2 - but note this is not well followed"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CV.displayName"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.userSelected",
+                "path": "Observation.category.coding.userSelected",
+                "short": "If this coding was chosen directly by the user",
+                "definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
+                "comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
+                "requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.userSelected",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Sometimes implied by being first"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CD.codingRationale"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.text",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.text",
+                "short": "Plain text representation of the concept",
+                "definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
+                "comment": "Very often the text is the same as a displayName of one of the codings.",
+                "requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CodeableConcept.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.9. But note many systems use C*E.2 for this"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./originalText[mediaType/code=\"text/plain\"]/data"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Heart Rate",
+                "definition": "Coded Responses from C-CDA Vital Sign Results.",
+                "comment": "*All* code-value and, if present, component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
+                "alias": [
+                    "Name"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "8867-4"
+                        }
+                    ]
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "116680003 |Is a|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.subject",
+                "path": "Observation.subject",
+                "short": "Who and/or what the observation is about",
+                "definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
+                "comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
+                "requirements": "Observations have no value if you don't know who or what they're about.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=RTGT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.focus",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+                        "valueCode": "trial-use"
+                    }
+                ],
+                "path": "Observation.focus",
+                "short": "What the observation is about, when it is not about the subject of record",
+                "definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
+                "comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.focus",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SBJ]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.encounter",
+                "path": "Observation.encounter",
+                "short": "Healthcare event during which this observation is made",
+                "definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
+                "comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
+                "requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
+                "alias": [
+                    "Context"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.effective[x]",
+                "path": "Observation.effective[x]",
+                "short": "Often just a dateTime for Vital Signs",
+                "definition": "Often just a dateTime for Vital Signs.",
+                "comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
+                "requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
+                "alias": [
+                    "Occurrence"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.effective[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-1",
+                        "severity": "error",
+                        "human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
+                        "expression": "($this as dateTime).toString().length() >= 8",
+                        "xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.issued",
+                "path": "Observation.issued",
+                "short": "Date/Time this version was made available",
+                "definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
+                "comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.issued",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.performer",
+                "path": "Observation.performer",
+                "short": "Who is responsible for the observation",
+                "definition": "Who was responsible for asserting the observed value as \"true\".",
+                "requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.performer",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=PRF]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]",
+                "path": "Observation.value[x]",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "type",
+                            "path": "$this"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "closed"
+                },
+                "short": "Vital Signs Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity",
+                "path": "Observation.value[x]",
+                "sliceName": "valueQuantity",
+                "short": "Vital Signs Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.id",
+                "path": "Observation.value[x].id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.extension",
+                "path": "Observation.value[x].extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.value",
+                "path": "Observation.value[x].value",
+                "short": "Numerical value (with implicit precision)",
+                "definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
+                "comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
+                "requirements": "Precision is handled implicitly in almost all cases of measurement.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.2  / CQ - N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.comparator",
+                "path": "Observation.value[x].comparator",
+                "short": "< | <= | >= | > - how to understand the value",
+                "definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
+                "requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.comparator",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "QuantityComparator"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "How the Quantity should be understood and represented.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.1  / CQ.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "IVL properties"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.unit",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.value[x].unit",
+                "short": "Unit representation",
+                "definition": "A human-readable form of the unit.",
+                "requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.unit",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.unit"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.system",
+                "path": "Observation.value[x].system",
+                "short": "System that defines coded unit form",
+                "definition": "The identification of the system that provides the coded form of the unit.",
+                "requirements": "Need to know the system that defines the coded form of the unit.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "condition": [
+                    "qty-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CO.codeSystem, PQ.translation.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.code",
+                "path": "Observation.value[x].code",
+                "short": "Coded responses from the common UCUM units for vital signs value set.",
+                "definition": "A computer processable form of the unit in some unit representation system.",
+                "comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
+                "requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "/min",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.code, MO.currency, PQ.translation.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.dataAbsentReason",
+                "path": "Observation.dataAbsentReason",
+                "short": "Why the result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
+                "comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.interpretation",
+                "path": "Observation.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.note",
+                "path": "Observation.note",
+                "short": "Comments about the observation",
+                "definition": "Comments about the observation or the results.",
+                "comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
+                "requirements": "Need to be able to provide free text additional information.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "subjectOf.observationEvent[code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.bodySite",
+                "path": "Observation.bodySite",
+                "short": "Observed body part",
+                "definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
+                "comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.bodySite",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "BodySite"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing anatomical locations. May include laterality.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/body-site"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123037004 |Body structure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-20"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "targetSiteCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "718497002 |Inherent location|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.method",
+                "path": "Observation.method",
+                "short": "How it was done",
+                "definition": "Indicates the mechanism used to perform the observation.",
+                "comment": "Only used if not implicit in code for Observation.code.",
+                "requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.method",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationMethod"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Methods for simple observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "methodCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.specimen",
+                "path": "Observation.specimen",
+                "short": "Specimen used for this observation",
+                "definition": "The specimen that was used when this observation was made.",
+                "comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.specimen",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Specimen"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123038009 |Specimen|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "SPM segment"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SPC].specimen"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "704319004 |Inherent in|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.device",
+                "path": "Observation.device",
+                "short": "(Measurement) Device",
+                "definition": "The device used to generate the observation data.",
+                "comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.device",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceMetric"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 49062001 |Device|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17 / PRT -10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=DEV]"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "424226004 |Using device|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange",
+                "path": "Observation.referenceRange",
+                "short": "Provides guide for interpretation",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "obs-3",
+                        "severity": "error",
+                        "human": "Must have at least a low or a high or text",
+                        "expression": "low.exists() or high.exists() or text.exists()",
+                        "xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.id",
+                "path": "Observation.referenceRange.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.extension",
+                "path": "Observation.referenceRange.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.modifierExtension",
+                "path": "Observation.referenceRange.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.low",
+                "path": "Observation.referenceRange.low",
+                "short": "Low Range, if relevant",
+                "definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.low",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.low"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.high",
+                "path": "Observation.referenceRange.high",
+                "short": "High Range, if relevant",
+                "definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.high",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.high"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.type",
+                "path": "Observation.referenceRange.type",
+                "short": "Reference range qualifier",
+                "definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
+                "requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeMeaning"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Code for the meaning of a reference range.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.appliesTo",
+                "path": "Observation.referenceRange.appliesTo",
+                "short": "Reference range population",
+                "definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
+                "requirements": "Need to be able to identify the target population for proper interpretation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange.appliesTo",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes identifying the population the reference range applies to.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.age",
+                "path": "Observation.referenceRange.age",
+                "short": "Applicable age range, if relevant",
+                "definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
+                "requirements": "Some analytes vary greatly over age.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.age",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Range"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.text",
+                "path": "Observation.referenceRange.text",
+                "short": "Text based reference range in an observation",
+                "definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:ST"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.hasMember",
+                "path": "Observation.hasMember",
+                "short": "Used when reporting vital signs panel components",
+                "definition": "Used when reporting vital signs panel components.",
+                "comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.hasMember",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.derivedFrom",
+                "path": "Observation.derivedFrom",
+                "short": "Related measurements the observation is made from",
+                "definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
+                "comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.derivedFrom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/DocumentReference",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy",
+                            "http://hl7.org/fhir/StructureDefinition/Media",
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".targetObservation"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component",
+                "path": "Observation.component",
+                "short": "Component observations",
+                "definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
+                "comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-3",
+                        "severity": "error",
+                        "human": "If there is no a value a data absent reason must be present",
+                        "expression": "value.exists() or dataAbsentReason.exists()",
+                        "xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "containment by OBX-4?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=COMP]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.id",
+                "path": "Observation.component.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.extension",
+                "path": "Observation.component.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.modifierExtension",
+                "path": "Observation.component.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.code",
+                "path": "Observation.component.code",
+                "short": "Type of component observation (code / type)",
+                "definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
+                "comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.value[x]",
+                "path": "Observation.component.value[x]",
+                "short": "Vital Sign Component Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
+                "comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.dataAbsentReason",
+                "path": "Observation.component.dataAbsentReason",
+                "short": "Why the component result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
+                "comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.interpretation",
+                "path": "Observation.component.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.referenceRange",
+                "path": "Observation.component.referenceRange",
+                "short": "Provides guide for interpretation of component result",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "US Core Heart Rate Profile",
+                "definition": "Defines constraints on Observation to represent heart rate observations with a standard LOINC code and UCUM units of measure.  This profile is derived from the US Core Vital Signs Profile."
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Heart Rate",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "8867-4"
+                        }
+                    ]
+                },
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity",
+                "path": "Observation.valueQuantity",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.value",
+                "path": "Observation.valueQuantity.value",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.unit",
+                "path": "Observation.valueQuantity.unit",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.system",
+                "path": "Observation.valueQuantity.system",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.code",
+                "path": "Observation.valueQuantity.code",
+                "short": "Coded responses from the common UCUM units for vital signs value set.",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "/min",
+                "mustSupport": true
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-immunization.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-immunization.json
@@ -1,3203 +1,3203 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-immunization",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-immunization-definitions.html#Immunization\" title=\"The US Core Immunization Profile is based upon the core FHIR Immunization Resource and created to meet the 2015 Edition Common Clinical Data Set 'Immunizations' requirements.\">Immunization</a><a name=\"Immunization\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/immunization.html\">Immunization</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Immunization event information</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-immunization-definitions.html#Immunization.status\">status</a><a name=\"Immunization.status\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">completed | entered-in-error | not-done</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-immunization-status.html\">ImmunizationStatusCodes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-immunization-definitions.html#Immunization.statusReason\">statusReason</a><a name=\"Immunization.statusReason\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Reason not done</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-immunization-status-reason.html\">ImmunizationStatusReasonCodes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#example\" title=\"Instances are not expected or even encouraged to draw from the specified value set.  The value set merely provides examples of the types of concepts intended to be included.\">example</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-immunization-definitions.html#Immunization.vaccineCode\">vaccineCode</a><a name=\"Immunization.vaccineCode\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-1, us-core-1)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Vaccine Product Type (bind to CVX)<br/><span style=\"font-weight:bold\">Binding: </span><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1010.6/expansion\">CVX Vaccines Administered Vaccine Set</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)<br/><span style=\"font-weight:bold\">us-core-1: </span>SHOULD have a translation to the NDC value set</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-immunization-definitions.html#Immunization.patient\">patient</a><a name=\"Immunization.patient\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who was immunized</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_choice.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Choice of Types\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-immunization-definitions.html#Immunization.occurrence[x]\">occurrence[x]</a><a name=\"Immunization.occurrence_x_\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Vaccine administration date</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for dateTime Type: A date, date-time or partial date (e.g. just year or year + month).  If hours and minutes are specified, a time zone SHALL be populated. The format is a union of the schema types gYear, gYearMonth, date and dateTime. Seconds must be provided due to schema type constraints but may be zero-filled and may be ignored.                 Dates SHALL be valid dates.\">occurrenceDateTime</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#dateTime\">dateTime</a> <span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This type must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for string Type: A sequence of Unicode characters\">occurrenceString</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck00.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-immunization-definitions.html#Immunization.primarySource\">primarySource</a><a name=\"Immunization.primarySource\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#boolean\">boolean</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Indicates context the data was recorded in</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization",
-	"version": "4.0.0",
-	"name": "USCoreImmunizationProfile",
-	"title": "US Core Immunization Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2019-08-26",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the Immunization resource for the minimal set of data to query and retrieve  patient's immunization information.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "cda",
-			"uri": "http://hl7.org/v3/cda",
-			"name": "CDA (R2)"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Immunization",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Immunization",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Immunization",
-				"path": "Immunization",
-				"short": "Immunization event information",
-				"definition": "The US Core Immunization Profile is based upon the core FHIR Immunization Resource and created to meet the 2015 Edition Common Clinical Data Set 'Immunizations' requirements.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Immunization",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "v2",
-						"map": "VXU_V04"
-					},
-					{
-						"identity": "rim",
-						"map": "SubstanceAdministration"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Immunization"
-					}
-				]
-			},
-			{
-				"id": "Immunization.id",
-				"path": "Immunization.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Immunization.meta",
-				"path": "Immunization.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Immunization.implicitRules",
-				"path": "Immunization.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Immunization.language",
-				"path": "Immunization.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Immunization.text",
-				"path": "Immunization.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Immunization.contained",
-				"path": "Immunization.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.extension",
-				"path": "Immunization.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.modifierExtension",
-				"path": "Immunization.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.identifier",
-				"path": "Immunization.identifier",
-				"short": "Business identifier",
-				"definition": "A unique identifier assigned to this immunization record.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Immunization.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/component/StructuredBody/component/section/entry/substanceAdministration/id"
-					}
-				]
-			},
-			{
-				"id": "Immunization.status",
-				"path": "Immunization.status",
-				"short": "completed | entered-in-error | not-done",
-				"definition": "Indicates the current status of the immunization event.",
-				"comment": "Will generally be set to show that the immunization has been completed or not done.  This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Immunization.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains statuses entered-in-error and not-done which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/immunization-status"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "rim",
-						"map": "statusCode"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Immunization.status"
-					}
-				]
-			},
-			{
-				"id": "Immunization.statusReason",
-				"path": "Immunization.statusReason",
-				"short": "Reason not done",
-				"definition": "Indicates the reason the immunization event was not performed.",
-				"comment": "This is generally only used for the status of \"not-done\". The reason for performing the immunization event is captured in reasonCode, not here.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.statusReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"strength": "example",
-					"valueSet": "http://hl7.org/fhir/ValueSet/immunization-status-reason"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.statusReason"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=SUBJ].source[classCode=CACT, moodCode=EVN].reasonCOde"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Immunization.wasNotGiven"
-					}
-				]
-			},
-			{
-				"id": "Immunization.vaccineCode",
-				"path": "Immunization.vaccineCode",
-				"short": "Vaccine Product Type (bind to CVX)",
-				"definition": "Vaccine that was administered or was to be administered.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Immunization.vaccineCode",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"us-core-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							}
-						],
-						"key": "us-core-1",
-						"severity": "warning",
-						"human": "SHOULD have a translation to the NDC value set",
-						"expression": "coding.where(system='http://hl7.org/fhir/sid/ndc').empty()",
-						"xpath": "not(exists(f:coding/f:system[@value='http://hl7.org/fhir/sid/ndc']))"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.6"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "RXA-5"
-					},
-					{
-						"identity": "rim",
-						"map": ".code"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/component/StructuredBody/component/section/entry/substanceAdministration/consumable/manfacturedProduct/manufacturedMaterial/realmCode/code"
-					},
-					{
-						"identity": "quick",
-						"map": "vaccine"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Immunization.vaccineCode"
-					}
-				]
-			},
-			{
-				"id": "Immunization.patient",
-				"path": "Immunization.patient",
-				"short": "Who was immunized",
-				"definition": "The patient who either received or did not receive the immunization.",
-				"alias": [
-					"Patient"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Immunization.patient",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": ".partipication[ttypeCode=].role"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					},
-					{
-						"identity": "quick",
-						"map": "subject"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Immunization.patient"
-					}
-				]
-			},
-			{
-				"id": "Immunization.encounter",
-				"path": "Immunization.encounter",
-				"short": "Encounter immunization was part of",
-				"definition": "The visit or admission or other contact between patient and health care provider the immunization was performed as part of.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1-19"
-					},
-					{
-						"identity": "rim",
-						"map": "component->EncounterEvent"
-					}
-				]
-			},
-			{
-				"id": "Immunization.occurrence[x]",
-				"path": "Immunization.occurrence[x]",
-				"short": "Vaccine administration date",
-				"definition": "Date vaccine administered or was to be administered.",
-				"comment": "When immunizations are given a specific date and time should always be known.   When immunizations are patient reported, a specific date might not be known.  Although partial dates are allowed, an adult patient might not be able to recall the year a childhood immunization was given. An exact date is always preferable, but the use of the String data type is acceptable when an exact date is not known. A small number of vaccines (e.g. live oral typhoid vaccine) are given as a series of patient self-administered dose over a span of time. In cases like this, often, only the first dose (typically a provider supervised dose) is recorded with the occurrence indicating the date/time of the first dose.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Immunization.occurrence[x]",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "dateTime"
-					},
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "RXA-3"
-					},
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/component/StructuredBody/component/section/entry/substanceAdministration/effectiveTime/value"
-					},
-					{
-						"identity": "quick",
-						"map": "performanceTime"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Immunization.date"
-					}
-				]
-			},
-			{
-				"id": "Immunization.recorded",
-				"path": "Immunization.recorded",
-				"short": "When the immunization was first captured in the subject's record",
-				"definition": "The date the occurrence of the immunization was first captured in the record - potentially significantly after the occurrence of the event.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.recorded",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=AUT].time"
-					}
-				]
-			},
-			{
-				"id": "Immunization.primarySource",
-				"path": "Immunization.primarySource",
-				"short": "Indicates context the data was recorded in",
-				"definition": "An indication that the content of the record is based on information from the person who administered the vaccine. This reflects the context under which the data was originally recorded.",
-				"comment": "Reflects the “reliability” of the content.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Immunization.primarySource",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.source"
-					},
-					{
-						"identity": "v2",
-						"map": "RXA-9"
-					},
-					{
-						"identity": "rim",
-						"map": "immunization.uncertaintycode (if primary source=false, uncertainty=U)"
-					},
-					{
-						"identity": "quick",
-						"map": "reported"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Immunization.reported"
-					}
-				]
-			},
-			{
-				"id": "Immunization.reportOrigin",
-				"path": "Immunization.reportOrigin",
-				"short": "Indicates the source of a secondarily reported record",
-				"definition": "The source of the data when the report of the immunization event is not based on information from the person who administered the vaccine.",
-				"comment": "Should not be populated if primarySource = True, not required even if primarySource = False.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.reportOrigin",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ImmunizationReportOrigin"
-						}
-					],
-					"strength": "example",
-					"description": "The source of the data for a record which is not from a primary source.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/immunization-origin"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.source"
-					},
-					{
-						"identity": "v2",
-						"map": "RXA-9"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=INF].role[classCode=PAT] (this syntax for self-reported) .participation[typeCode=INF].role[classCode=LIC] (this syntax for health care professional) .participation[typeCode=INF].role[classCode=PRS] (this syntax for family member)"
-					}
-				]
-			},
-			{
-				"id": "Immunization.location",
-				"path": "Immunization.location",
-				"short": "Where immunization occurred",
-				"definition": "The service delivery location where the vaccine administration occurred.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.location",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Location"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.location"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.where[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "RXA-27  (or RXA-11, deprecated as of v2.7)"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=LOC].COCT_MT240000UV"
-					}
-				]
-			},
-			{
-				"id": "Immunization.manufacturer",
-				"path": "Immunization.manufacturer",
-				"short": "Vaccine manufacturer",
-				"definition": "Name of vaccine manufacturer.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.manufacturer",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXA-17"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=CSM].role[classCode=INST].scopedRole.scoper[classCode=ORG]"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/component/StructuredBody/component/section/entry/substanceAdministration/consumable/manfacturedProduct/manufacuturerOrganization/name"
-					}
-				]
-			},
-			{
-				"id": "Immunization.lotNumber",
-				"path": "Immunization.lotNumber",
-				"short": "Vaccine lot number",
-				"definition": "Lot number of the  vaccine product.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.lotNumber",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXA-15"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=CSM].role[classCode=INST].scopedRole.scoper[classCode=MMAT].id"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/component/StructuredBody/component/section/entry/substanceAdministration/consumable/manfacturedProduct/manufacturedMaterial/lotNumberText"
-					}
-				]
-			},
-			{
-				"id": "Immunization.expirationDate",
-				"path": "Immunization.expirationDate",
-				"short": "Vaccine expiration date",
-				"definition": "Date vaccine batch expires.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.expirationDate",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "date"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXA-16"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=CSM].role[classCode=INST].scopedRole.scoper[classCode=MMAT].expirationTime"
-					}
-				]
-			},
-			{
-				"id": "Immunization.site",
-				"path": "Immunization.site",
-				"short": "Body site vaccine  was administered",
-				"definition": "Body site where vaccine was administered.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.site",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ImmunizationSite"
-						}
-					],
-					"strength": "example",
-					"description": "The site at which the vaccine was administered.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/immunization-site"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXR-2"
-					},
-					{
-						"identity": "rim",
-						"map": "observation.targetSiteCode"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/component/StructuredBody/component/section/entry/substanceAdministration/approachSiteCode/code"
-					}
-				]
-			},
-			{
-				"id": "Immunization.route",
-				"path": "Immunization.route",
-				"short": "How vaccine entered body",
-				"definition": "The path by which the vaccine product is taken into the body.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.route",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ImmunizationRoute"
-						}
-					],
-					"strength": "example",
-					"description": "The route by which the vaccine was administered.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/immunization-route"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXR-1"
-					},
-					{
-						"identity": "rim",
-						"map": ".routeCode"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument/component/StructuredBody/component/section/entry/substanceAdministration/routeCode/code"
-					}
-				]
-			},
-			{
-				"id": "Immunization.doseQuantity",
-				"path": "Immunization.doseQuantity",
-				"short": "Amount of vaccine administered",
-				"definition": "The quantity of vaccine product that was administered.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.doseQuantity",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXA-6 / RXA-7"
-					},
-					{
-						"identity": "rim",
-						"map": ".doseQuantity"
-					}
-				]
-			},
-			{
-				"id": "Immunization.performer",
-				"path": "Immunization.performer",
-				"short": "Who performed event",
-				"definition": "Indicates who performed the immunization event.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Immunization.performer",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC-12 / RXA-10"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=PRF].role[scoper.determinerCode=INSTANCE]"
-					}
-				]
-			},
-			{
-				"id": "Immunization.performer.id",
-				"path": "Immunization.performer.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Immunization.performer.extension",
-				"path": "Immunization.performer.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Immunization.performer.modifierExtension",
-				"path": "Immunization.performer.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.performer.function",
-				"path": "Immunization.performer.function",
-				"short": "What type of performance was done",
-				"definition": "Describes the type of performance (e.g. ordering provider, administering provider, etc.).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.performer.function",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ImmunizationFunction"
-						}
-					],
-					"strength": "extensible",
-					"description": "The role a practitioner or organization plays in the immunization event.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/immunization-function"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.function"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation.functionCode"
-					}
-				]
-			},
-			{
-				"id": "Immunization.performer.actor",
-				"path": "Immunization.performer.actor",
-				"short": "Individual or organization who was performing",
-				"definition": "The practitioner or organization who performed the action.",
-				"comment": "When the individual practitioner who performed the action is known, it is best to send.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Immunization.performer.actor",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "rim",
-						"map": ".player"
-					}
-				]
-			},
-			{
-				"id": "Immunization.note",
-				"path": "Immunization.note",
-				"short": "Additional immunization notes",
-				"definition": "Extra information about the immunization that is not conveyed by the other attributes.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Immunization.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.note"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-5 : OBX-3 = 48767-8"
-					},
-					{
-						"identity": "rim",
-						"map": "note"
-					}
-				]
-			},
-			{
-				"id": "Immunization.reasonCode",
-				"path": "Immunization.reasonCode",
-				"short": "Why immunization occurred",
-				"definition": "Reasons why the vaccine was administered.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Immunization.reasonCode",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ImmunizationReason"
-						}
-					],
-					"strength": "example",
-					"description": "The reason why a vaccine was administered.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/immunization-reason"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.reasonCode"
-					},
-					{
-						"identity": "rim",
-						"map": "[actionNegationInd=false].reasonCode"
-					}
-				]
-			},
-			{
-				"id": "Immunization.reasonReference",
-				"path": "Immunization.reasonReference",
-				"short": "Why immunization occurred",
-				"definition": "Condition, Observation or DiagnosticReport that supports why the immunization was administered.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Immunization.reasonReference",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Condition",
-							"http://hl7.org/fhir/StructureDefinition/Observation",
-							"http://hl7.org/fhir/StructureDefinition/DiagnosticReport"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.reasonReference"
-					},
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.isSubpotent",
-				"path": "Immunization.isSubpotent",
-				"short": "Dose potency",
-				"definition": "Indication if a dose is considered to be subpotent. By default, a dose should be considered to be potent.",
-				"comment": "Typically, the recognition of the dose being sub-potent is retrospective, after the administration (ex. notification of a manufacturer recall after administration). However, in the case of a partial administration (the patient moves unexpectedly and only some of the dose is actually administered), subpotency may be recognized immediately, but it is still important to record the event.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.isSubpotent",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"meaningWhenMissing": "By default, a dose should be considered to be potent.",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because an immunization event with a subpotent vaccine doesn't protect the patient the same way as a potent dose.",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXA-20 = PA (partial administration)"
-					},
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.subpotentReason",
-				"path": "Immunization.subpotentReason",
-				"short": "Reason for being subpotent",
-				"definition": "Reason why a dose is considered to be subpotent.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Immunization.subpotentReason",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "SubpotentReason"
-						}
-					],
-					"strength": "example",
-					"description": "The reason why a dose is considered to be subpotent.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/immunization-subpotent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.education",
-				"path": "Immunization.education",
-				"short": "Educational material presented to patient",
-				"definition": "Educational material presented to the patient (or guardian) at the time of vaccine administration.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Immunization.education",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "imm-1",
-						"severity": "error",
-						"human": "One of documentType or reference SHALL be present",
-						"expression": "documentType.exists() or reference.exists()",
-						"xpath": "exists(f:documentType) or exists(f:reference)"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.education.id",
-				"path": "Immunization.education.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Immunization.education.extension",
-				"path": "Immunization.education.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Immunization.education.modifierExtension",
-				"path": "Immunization.education.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.education.documentType",
-				"path": "Immunization.education.documentType",
-				"short": "Educational material document identifier",
-				"definition": "Identifier of the material presented to the patient.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.education.documentType",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-5 : OBX-3 = 69764-9"
-					},
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.education.reference",
-				"path": "Immunization.education.reference",
-				"short": "Educational material reference pointer",
-				"definition": "Reference pointer to the educational material given to the patient if the information was on line.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.education.reference",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.education.publicationDate",
-				"path": "Immunization.education.publicationDate",
-				"short": "Educational material publication date",
-				"definition": "Date the educational material was published.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.education.publicationDate",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-5 : OBX-3 = 29768-9"
-					},
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.education.presentationDate",
-				"path": "Immunization.education.presentationDate",
-				"short": "Educational material presentation date",
-				"definition": "Date the educational material was given to the patient.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.education.presentationDate",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-5 : OBX-3 = 29769-7"
-					},
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.programEligibility",
-				"path": "Immunization.programEligibility",
-				"short": "Patient eligibility for a vaccination program",
-				"definition": "Indicates a patient's eligibility for a funding program.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Immunization.programEligibility",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProgramEligibility"
-						}
-					],
-					"strength": "example",
-					"description": "The patient's eligibility for a vaccation program.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/immunization-program-eligibility"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-5 : OBX-3 = 64994-7"
-					},
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.fundingSource",
-				"path": "Immunization.fundingSource",
-				"short": "Funding source for the vaccine",
-				"definition": "Indicates the source of the vaccine actually administered. This may be different than the patient eligibility (e.g. the patient may be eligible for a publically purchased vaccine but due to inventory issues, vaccine purchased with private funds was actually administered).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.fundingSource",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "FundingSource"
-						}
-					],
-					"strength": "example",
-					"description": "The source of funding used to purchase the vaccine administered.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/immunization-funding-source"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.reaction",
-				"path": "Immunization.reaction",
-				"short": "Details of a reaction that follows immunization",
-				"definition": "Categorical data indicating that an adverse event is associated in time to an immunization.",
-				"comment": "A reaction may be an indication of an allergy or intolerance and, if this is determined to be the case, it should be recorded as a new AllergyIntolerance resource instance as most systems will not query against past Immunization.reaction elements.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Immunization.reaction",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation[classCode=obs].code"
-					}
-				]
-			},
-			{
-				"id": "Immunization.reaction.id",
-				"path": "Immunization.reaction.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Immunization.reaction.extension",
-				"path": "Immunization.reaction.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Immunization.reaction.modifierExtension",
-				"path": "Immunization.reaction.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.reaction.date",
-				"path": "Immunization.reaction.date",
-				"short": "When reaction started",
-				"definition": "Date of reaction to the immunization.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.reaction.date",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-14 (ideally this would be reported in an IAM segment, but IAM is not part of the HL7 v2 VXU message - most likely would appear in OBX segments if at all)"
-					},
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "Immunization.reaction.detail",
-				"path": "Immunization.reaction.detail",
-				"short": "Additional information on reaction",
-				"definition": "Details of the reaction.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.reaction.detail",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Observation"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-5"
-					},
-					{
-						"identity": "rim",
-						"map": ".value"
-					}
-				]
-			},
-			{
-				"id": "Immunization.reaction.reported",
-				"path": "Immunization.reaction.reported",
-				"short": "Indicates self-reported reaction",
-				"definition": "Self-reported indicator.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.reaction.reported",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(HL7 v2 doesn't seem to provide for this)"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=INF].role[classCode=PAT] (this syntax for self-reported=true)"
-					}
-				]
-			},
-			{
-				"id": "Immunization.protocolApplied",
-				"path": "Immunization.protocolApplied",
-				"short": "Protocol followed by the provider",
-				"definition": "The protocol (set of recommendations) being followed by the provider who administered the dose.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Immunization.protocolApplied",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.protocolApplied.id",
-				"path": "Immunization.protocolApplied.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Immunization.protocolApplied.extension",
-				"path": "Immunization.protocolApplied.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Immunization.protocolApplied.modifierExtension",
-				"path": "Immunization.protocolApplied.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.protocolApplied.series",
-				"path": "Immunization.protocolApplied.series",
-				"short": "Name of vaccine series",
-				"definition": "One possible path to achieve presumed immunity against a disease - within the context of an authority.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.protocolApplied.series",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.protocolApplied.authority",
-				"path": "Immunization.protocolApplied.authority",
-				"short": "Who is responsible for publishing the recommendations",
-				"definition": "Indicates the authority who published the protocol (e.g. ACIP) that is being followed.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.protocolApplied.authority",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.protocolApplied.targetDisease",
-				"path": "Immunization.protocolApplied.targetDisease",
-				"short": "Vaccine preventatable disease being targetted",
-				"definition": "The vaccine preventable disease the dose is being administered against.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Immunization.protocolApplied.targetDisease",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "TargetDisease"
-						}
-					],
-					"strength": "example",
-					"description": "The vaccine preventable disease the dose is being administered for.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/immunization-target-disease"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.protocolApplied.doseNumber[x]",
-				"path": "Immunization.protocolApplied.doseNumber[x]",
-				"short": "Dose number within series",
-				"definition": "Nominal position in a series.",
-				"comment": "The use of an integer is preferred if known. A string should only be used in cases where an integer is not available (such as when documenting a recurring booster dose).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Immunization.protocolApplied.doseNumber[x]",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "positiveInt"
-					},
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Immunization.protocolApplied.seriesDoses[x]",
-				"path": "Immunization.protocolApplied.seriesDoses[x]",
-				"short": "Recommended number of doses for immunity",
-				"definition": "The recommended number of doses to achieve immunity.",
-				"comment": "The use of an integer is preferred if known. A string should only be used in cases where an integer is not available (such as when documenting a recurring booster dose).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Immunization.protocolApplied.seriesDoses[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "positiveInt"
-					},
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Immunization",
-				"path": "Immunization",
-				"definition": "The US Core Immunization Profile is based upon the core FHIR Immunization Resource and created to meet the 2015 Edition Common Clinical Data Set 'Immunizations' requirements.",
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Immunization"
-					}
-				]
-			},
-			{
-				"id": "Immunization.status",
-				"path": "Immunization.status",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/immunization-status"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Immunization.status"
-					}
-				]
-			},
-			{
-				"id": "Immunization.statusReason",
-				"path": "Immunization.statusReason",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true,
-				"binding": {
-					"strength": "example",
-					"valueSet": "http://hl7.org/fhir/ValueSet/immunization-status-reason"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Immunization.wasNotGiven"
-					}
-				]
-			},
-			{
-				"id": "Immunization.vaccineCode",
-				"path": "Immunization.vaccineCode",
-				"short": "Vaccine Product Type (bind to CVX)",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"us-core-1"
-				],
-				"constraint": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							}
-						],
-						"key": "us-core-1",
-						"severity": "warning",
-						"human": "SHOULD have a translation to the NDC value set",
-						"expression": "coding.where(system='http://hl7.org/fhir/sid/ndc').empty()",
-						"xpath": "not(exists(f:coding/f:system[@value='http://hl7.org/fhir/sid/ndc']))"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.6"
-				},
-				"mapping": [
-					{
-						"identity": "quick",
-						"map": "vaccine"
-					},
-					{
-						"identity": "quick",
-						"map": "vaccine"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Immunization.vaccineCode"
-					}
-				]
-			},
-			{
-				"id": "Immunization.patient",
-				"path": "Immunization.patient",
-				"alias": [
-					"Patient"
-				],
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "quick",
-						"map": "subject"
-					},
-					{
-						"identity": "quick",
-						"map": "subject"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Immunization.patient"
-					}
-				]
-			},
-			{
-				"id": "Immunization.occurrence[x]",
-				"path": "Immunization.occurrence[x]",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "dateTime"
-					},
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "quick",
-						"map": "performanceTime"
-					},
-					{
-						"identity": "quick",
-						"map": "performanceTime"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Immunization.date"
-					}
-				]
-			},
-			{
-				"id": "Immunization.primarySource",
-				"path": "Immunization.primarySource",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "quick",
-						"map": "reported"
-					},
-					{
-						"identity": "quick",
-						"map": "reported"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Immunization.reported"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-immunization",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization",
+    "version": "4.0.0",
+    "name": "USCoreImmunizationProfile",
+    "title": "US Core Immunization Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2019-08-26",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the Immunization resource for the minimal set of data to query and retrieve  patient's immunization information.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "cda",
+            "uri": "http://hl7.org/v3/cda",
+            "name": "CDA (R2)"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Immunization",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Immunization",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Immunization",
+                "path": "Immunization",
+                "short": "Immunization event information",
+                "definition": "The US Core Immunization Profile is based upon the core FHIR Immunization Resource and created to meet the 2015 Edition Common Clinical Data Set 'Immunizations' requirements.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Immunization",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "VXU_V04"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "SubstanceAdministration"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Immunization"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.id",
+                "path": "Immunization.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Immunization.meta",
+                "path": "Immunization.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Immunization.implicitRules",
+                "path": "Immunization.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Immunization.language",
+                "path": "Immunization.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Immunization.text",
+                "path": "Immunization.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.contained",
+                "path": "Immunization.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.extension",
+                "path": "Immunization.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.modifierExtension",
+                "path": "Immunization.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.identifier",
+                "path": "Immunization.identifier",
+                "short": "Business identifier",
+                "definition": "A unique identifier assigned to this immunization record.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Immunization.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/component/StructuredBody/component/section/entry/substanceAdministration/id"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.status",
+                "path": "Immunization.status",
+                "short": "completed | entered-in-error | not-done",
+                "definition": "Indicates the current status of the immunization event.",
+                "comment": "Will generally be set to show that the immunization has been completed or not done.  This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains statuses entered-in-error and not-done which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/immunization-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "statusCode"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Immunization.status"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.statusReason",
+                "path": "Immunization.statusReason",
+                "short": "Reason not done",
+                "definition": "Indicates the reason the immunization event was not performed.",
+                "comment": "This is generally only used for the status of \"not-done\". The reason for performing the immunization event is captured in reasonCode, not here.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.statusReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "strength": "example",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/immunization-status-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.statusReason"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=SUBJ].source[classCode=CACT, moodCode=EVN].reasonCOde"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Immunization.wasNotGiven"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.vaccineCode",
+                "path": "Immunization.vaccineCode",
+                "short": "Vaccine Product Type (bind to CVX)",
+                "definition": "Vaccine that was administered or was to be administered.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.vaccineCode",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "us-core-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "key": "us-core-1",
+                        "severity": "warning",
+                        "human": "SHOULD have a translation to the NDC value set",
+                        "expression": "coding.where(system='http://hl7.org/fhir/sid/ndc').empty()",
+                        "xpath": "not(exists(f:coding/f:system[@value='http://hl7.org/fhir/sid/ndc']))"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.6"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXA-5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".code"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/component/StructuredBody/component/section/entry/substanceAdministration/consumable/manfacturedProduct/manufacturedMaterial/realmCode/code"
+                    },
+                    {
+                        "identity": "quick",
+                        "map": "vaccine"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Immunization.vaccineCode"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.patient",
+                "path": "Immunization.patient",
+                "short": "Who was immunized",
+                "definition": "The patient who either received or did not receive the immunization.",
+                "alias": [
+                    "Patient"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.patient",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".partipication[ttypeCode=].role"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    },
+                    {
+                        "identity": "quick",
+                        "map": "subject"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Immunization.patient"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.encounter",
+                "path": "Immunization.encounter",
+                "short": "Encounter immunization was part of",
+                "definition": "The visit or admission or other contact between patient and health care provider the immunization was performed as part of.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1-19"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "component->EncounterEvent"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.occurrence[x]",
+                "path": "Immunization.occurrence[x]",
+                "short": "Vaccine administration date",
+                "definition": "Date vaccine administered or was to be administered.",
+                "comment": "When immunizations are given a specific date and time should always be known.   When immunizations are patient reported, a specific date might not be known.  Although partial dates are allowed, an adult patient might not be able to recall the year a childhood immunization was given. An exact date is always preferable, but the use of the String data type is acceptable when an exact date is not known. A small number of vaccines (e.g. live oral typhoid vaccine) are given as a series of patient self-administered dose over a span of time. In cases like this, often, only the first dose (typically a provider supervised dose) is recorded with the occurrence indicating the date/time of the first dose.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.occurrence[x]",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXA-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/component/StructuredBody/component/section/entry/substanceAdministration/effectiveTime/value"
+                    },
+                    {
+                        "identity": "quick",
+                        "map": "performanceTime"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Immunization.date"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.recorded",
+                "path": "Immunization.recorded",
+                "short": "When the immunization was first captured in the subject's record",
+                "definition": "The date the occurrence of the immunization was first captured in the record - potentially significantly after the occurrence of the event.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.recorded",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.primarySource",
+                "path": "Immunization.primarySource",
+                "short": "Indicates context the data was recorded in",
+                "definition": "An indication that the content of the record is based on information from the person who administered the vaccine. This reflects the context under which the data was originally recorded.",
+                "comment": "Reflects the “reliability” of the content.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.primarySource",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.source"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXA-9"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "immunization.uncertaintycode (if primary source=false, uncertainty=U)"
+                    },
+                    {
+                        "identity": "quick",
+                        "map": "reported"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Immunization.reported"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.reportOrigin",
+                "path": "Immunization.reportOrigin",
+                "short": "Indicates the source of a secondarily reported record",
+                "definition": "The source of the data when the report of the immunization event is not based on information from the person who administered the vaccine.",
+                "comment": "Should not be populated if primarySource = True, not required even if primarySource = False.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.reportOrigin",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ImmunizationReportOrigin"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "The source of the data for a record which is not from a primary source.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/immunization-origin"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.source"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXA-9"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=INF].role[classCode=PAT] (this syntax for self-reported) .participation[typeCode=INF].role[classCode=LIC] (this syntax for health care professional) .participation[typeCode=INF].role[classCode=PRS] (this syntax for family member)"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.location",
+                "path": "Immunization.location",
+                "short": "Where immunization occurred",
+                "definition": "The service delivery location where the vaccine administration occurred.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.location",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Location"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.location"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.where[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXA-27  (or RXA-11, deprecated as of v2.7)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=LOC].COCT_MT240000UV"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.manufacturer",
+                "path": "Immunization.manufacturer",
+                "short": "Vaccine manufacturer",
+                "definition": "Name of vaccine manufacturer.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.manufacturer",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXA-17"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=CSM].role[classCode=INST].scopedRole.scoper[classCode=ORG]"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/component/StructuredBody/component/section/entry/substanceAdministration/consumable/manfacturedProduct/manufacuturerOrganization/name"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.lotNumber",
+                "path": "Immunization.lotNumber",
+                "short": "Vaccine lot number",
+                "definition": "Lot number of the  vaccine product.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.lotNumber",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXA-15"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=CSM].role[classCode=INST].scopedRole.scoper[classCode=MMAT].id"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/component/StructuredBody/component/section/entry/substanceAdministration/consumable/manfacturedProduct/manufacturedMaterial/lotNumberText"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.expirationDate",
+                "path": "Immunization.expirationDate",
+                "short": "Vaccine expiration date",
+                "definition": "Date vaccine batch expires.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.expirationDate",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "date"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXA-16"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=CSM].role[classCode=INST].scopedRole.scoper[classCode=MMAT].expirationTime"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.site",
+                "path": "Immunization.site",
+                "short": "Body site vaccine  was administered",
+                "definition": "Body site where vaccine was administered.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.site",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ImmunizationSite"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "The site at which the vaccine was administered.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/immunization-site"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXR-2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "observation.targetSiteCode"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/component/StructuredBody/component/section/entry/substanceAdministration/approachSiteCode/code"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.route",
+                "path": "Immunization.route",
+                "short": "How vaccine entered body",
+                "definition": "The path by which the vaccine product is taken into the body.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.route",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ImmunizationRoute"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "The route by which the vaccine was administered.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/immunization-route"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXR-1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".routeCode"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument/component/StructuredBody/component/section/entry/substanceAdministration/routeCode/code"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.doseQuantity",
+                "path": "Immunization.doseQuantity",
+                "short": "Amount of vaccine administered",
+                "definition": "The quantity of vaccine product that was administered.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.doseQuantity",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXA-6 / RXA-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".doseQuantity"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.performer",
+                "path": "Immunization.performer",
+                "short": "Who performed event",
+                "definition": "Indicates who performed the immunization event.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Immunization.performer",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC-12 / RXA-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=PRF].role[scoper.determinerCode=INSTANCE]"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.performer.id",
+                "path": "Immunization.performer.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.performer.extension",
+                "path": "Immunization.performer.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.performer.modifierExtension",
+                "path": "Immunization.performer.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.performer.function",
+                "path": "Immunization.performer.function",
+                "short": "What type of performance was done",
+                "definition": "Describes the type of performance (e.g. ordering provider, administering provider, etc.).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.performer.function",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ImmunizationFunction"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "The role a practitioner or organization plays in the immunization event.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/immunization-function"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.function"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation.functionCode"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.performer.actor",
+                "path": "Immunization.performer.actor",
+                "short": "Individual or organization who was performing",
+                "definition": "The practitioner or organization who performed the action.",
+                "comment": "When the individual practitioner who performed the action is known, it is best to send.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.performer.actor",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".player"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.note",
+                "path": "Immunization.note",
+                "short": "Additional immunization notes",
+                "definition": "Extra information about the immunization that is not conveyed by the other attributes.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Immunization.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.note"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-5 : OBX-3 = 48767-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "note"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.reasonCode",
+                "path": "Immunization.reasonCode",
+                "short": "Why immunization occurred",
+                "definition": "Reasons why the vaccine was administered.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Immunization.reasonCode",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ImmunizationReason"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "The reason why a vaccine was administered.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/immunization-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.reasonCode"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "[actionNegationInd=false].reasonCode"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.reasonReference",
+                "path": "Immunization.reasonReference",
+                "short": "Why immunization occurred",
+                "definition": "Condition, Observation or DiagnosticReport that supports why the immunization was administered.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Immunization.reasonReference",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Condition",
+                            "http://hl7.org/fhir/StructureDefinition/Observation",
+                            "http://hl7.org/fhir/StructureDefinition/DiagnosticReport"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.reasonReference"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.isSubpotent",
+                "path": "Immunization.isSubpotent",
+                "short": "Dose potency",
+                "definition": "Indication if a dose is considered to be subpotent. By default, a dose should be considered to be potent.",
+                "comment": "Typically, the recognition of the dose being sub-potent is retrospective, after the administration (ex. notification of a manufacturer recall after administration). However, in the case of a partial administration (the patient moves unexpectedly and only some of the dose is actually administered), subpotency may be recognized immediately, but it is still important to record the event.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.isSubpotent",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "meaningWhenMissing": "By default, a dose should be considered to be potent.",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because an immunization event with a subpotent vaccine doesn't protect the patient the same way as a potent dose.",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXA-20 = PA (partial administration)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.subpotentReason",
+                "path": "Immunization.subpotentReason",
+                "short": "Reason for being subpotent",
+                "definition": "Reason why a dose is considered to be subpotent.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Immunization.subpotentReason",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "SubpotentReason"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "The reason why a dose is considered to be subpotent.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/immunization-subpotent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.education",
+                "path": "Immunization.education",
+                "short": "Educational material presented to patient",
+                "definition": "Educational material presented to the patient (or guardian) at the time of vaccine administration.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Immunization.education",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "imm-1",
+                        "severity": "error",
+                        "human": "One of documentType or reference SHALL be present",
+                        "expression": "documentType.exists() or reference.exists()",
+                        "xpath": "exists(f:documentType) or exists(f:reference)"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.education.id",
+                "path": "Immunization.education.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.education.extension",
+                "path": "Immunization.education.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.education.modifierExtension",
+                "path": "Immunization.education.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.education.documentType",
+                "path": "Immunization.education.documentType",
+                "short": "Educational material document identifier",
+                "definition": "Identifier of the material presented to the patient.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.education.documentType",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-5 : OBX-3 = 69764-9"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.education.reference",
+                "path": "Immunization.education.reference",
+                "short": "Educational material reference pointer",
+                "definition": "Reference pointer to the educational material given to the patient if the information was on line.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.education.reference",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.education.publicationDate",
+                "path": "Immunization.education.publicationDate",
+                "short": "Educational material publication date",
+                "definition": "Date the educational material was published.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.education.publicationDate",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-5 : OBX-3 = 29768-9"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.education.presentationDate",
+                "path": "Immunization.education.presentationDate",
+                "short": "Educational material presentation date",
+                "definition": "Date the educational material was given to the patient.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.education.presentationDate",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-5 : OBX-3 = 29769-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.programEligibility",
+                "path": "Immunization.programEligibility",
+                "short": "Patient eligibility for a vaccination program",
+                "definition": "Indicates a patient's eligibility for a funding program.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Immunization.programEligibility",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProgramEligibility"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "The patient's eligibility for a vaccation program.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/immunization-program-eligibility"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-5 : OBX-3 = 64994-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.fundingSource",
+                "path": "Immunization.fundingSource",
+                "short": "Funding source for the vaccine",
+                "definition": "Indicates the source of the vaccine actually administered. This may be different than the patient eligibility (e.g. the patient may be eligible for a publically purchased vaccine but due to inventory issues, vaccine purchased with private funds was actually administered).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.fundingSource",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "FundingSource"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "The source of funding used to purchase the vaccine administered.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/immunization-funding-source"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.reaction",
+                "path": "Immunization.reaction",
+                "short": "Details of a reaction that follows immunization",
+                "definition": "Categorical data indicating that an adverse event is associated in time to an immunization.",
+                "comment": "A reaction may be an indication of an allergy or intolerance and, if this is determined to be the case, it should be recorded as a new AllergyIntolerance resource instance as most systems will not query against past Immunization.reaction elements.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Immunization.reaction",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation[classCode=obs].code"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.reaction.id",
+                "path": "Immunization.reaction.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.reaction.extension",
+                "path": "Immunization.reaction.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.reaction.modifierExtension",
+                "path": "Immunization.reaction.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.reaction.date",
+                "path": "Immunization.reaction.date",
+                "short": "When reaction started",
+                "definition": "Date of reaction to the immunization.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.reaction.date",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-14 (ideally this would be reported in an IAM segment, but IAM is not part of the HL7 v2 VXU message - most likely would appear in OBX segments if at all)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.reaction.detail",
+                "path": "Immunization.reaction.detail",
+                "short": "Additional information on reaction",
+                "definition": "Details of the reaction.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.reaction.detail",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Observation"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".value"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.reaction.reported",
+                "path": "Immunization.reaction.reported",
+                "short": "Indicates self-reported reaction",
+                "definition": "Self-reported indicator.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.reaction.reported",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(HL7 v2 doesn't seem to provide for this)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=INF].role[classCode=PAT] (this syntax for self-reported=true)"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.protocolApplied",
+                "path": "Immunization.protocolApplied",
+                "short": "Protocol followed by the provider",
+                "definition": "The protocol (set of recommendations) being followed by the provider who administered the dose.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Immunization.protocolApplied",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.protocolApplied.id",
+                "path": "Immunization.protocolApplied.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.protocolApplied.extension",
+                "path": "Immunization.protocolApplied.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.protocolApplied.modifierExtension",
+                "path": "Immunization.protocolApplied.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.protocolApplied.series",
+                "path": "Immunization.protocolApplied.series",
+                "short": "Name of vaccine series",
+                "definition": "One possible path to achieve presumed immunity against a disease - within the context of an authority.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.protocolApplied.series",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.protocolApplied.authority",
+                "path": "Immunization.protocolApplied.authority",
+                "short": "Who is responsible for publishing the recommendations",
+                "definition": "Indicates the authority who published the protocol (e.g. ACIP) that is being followed.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.protocolApplied.authority",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.protocolApplied.targetDisease",
+                "path": "Immunization.protocolApplied.targetDisease",
+                "short": "Vaccine preventatable disease being targetted",
+                "definition": "The vaccine preventable disease the dose is being administered against.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Immunization.protocolApplied.targetDisease",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "TargetDisease"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "The vaccine preventable disease the dose is being administered for.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/immunization-target-disease"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.protocolApplied.doseNumber[x]",
+                "path": "Immunization.protocolApplied.doseNumber[x]",
+                "short": "Dose number within series",
+                "definition": "Nominal position in a series.",
+                "comment": "The use of an integer is preferred if known. A string should only be used in cases where an integer is not available (such as when documenting a recurring booster dose).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.protocolApplied.doseNumber[x]",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "positiveInt"
+                    },
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.protocolApplied.seriesDoses[x]",
+                "path": "Immunization.protocolApplied.seriesDoses[x]",
+                "short": "Recommended number of doses for immunity",
+                "definition": "The recommended number of doses to achieve immunity.",
+                "comment": "The use of an integer is preferred if known. A string should only be used in cases where an integer is not available (such as when documenting a recurring booster dose).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Immunization.protocolApplied.seriesDoses[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "positiveInt"
+                    },
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Immunization",
+                "path": "Immunization",
+                "definition": "The US Core Immunization Profile is based upon the core FHIR Immunization Resource and created to meet the 2015 Edition Common Clinical Data Set 'Immunizations' requirements.",
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Immunization"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.status",
+                "path": "Immunization.status",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/immunization-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Immunization.status"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.statusReason",
+                "path": "Immunization.statusReason",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "example",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/immunization-status-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Immunization.wasNotGiven"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.vaccineCode",
+                "path": "Immunization.vaccineCode",
+                "short": "Vaccine Product Type (bind to CVX)",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "us-core-1"
+                ],
+                "constraint": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "key": "us-core-1",
+                        "severity": "warning",
+                        "human": "SHOULD have a translation to the NDC value set",
+                        "expression": "coding.where(system='http://hl7.org/fhir/sid/ndc').empty()",
+                        "xpath": "not(exists(f:coding/f:system[@value='http://hl7.org/fhir/sid/ndc']))"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.6"
+                },
+                "mapping": [
+                    {
+                        "identity": "quick",
+                        "map": "vaccine"
+                    },
+                    {
+                        "identity": "quick",
+                        "map": "vaccine"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Immunization.vaccineCode"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.patient",
+                "path": "Immunization.patient",
+                "alias": [
+                    "Patient"
+                ],
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "quick",
+                        "map": "subject"
+                    },
+                    {
+                        "identity": "quick",
+                        "map": "subject"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Immunization.patient"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.occurrence[x]",
+                "path": "Immunization.occurrence[x]",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "quick",
+                        "map": "performanceTime"
+                    },
+                    {
+                        "identity": "quick",
+                        "map": "performanceTime"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Immunization.date"
+                    }
+                ]
+            },
+            {
+                "id": "Immunization.primarySource",
+                "path": "Immunization.primarySource",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "quick",
+                        "map": "reported"
+                    },
+                    {
+                        "identity": "quick",
+                        "map": "reported"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Immunization.reported"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-implantable-device.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-implantable-device.json
@@ -1,3015 +1,3015 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-implantable-device",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-implantable-device-definitions.html#Device\" title=\"The US Core Implantable Device Profile is based upon the core FHIR Device Resource and created to meet the 2015 Edition Common Clinical Data Set 'Unique device identifier(s) for a patient’s implantable device(s)' requirements.\">Device</a><a name=\"Device\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/device.html\">Device</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Item used in healthcare</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-implantable-device-definitions.html#Device.udiCarrier\">udiCarrier</a><a name=\"Device.udiCarrier\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Unique Device Identifier (UDI) Barcode string</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-implantable-device-definitions.html#Device.udiCarrier.deviceIdentifier\">deviceIdentifier</a><a name=\"Device.udiCarrier.deviceIdentifier\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Mandatory fixed portion of UDI</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-implantable-device-definitions.html#Device.udiCarrier.carrierHRF\">carrierHRF</a><a name=\"Device.udiCarrier.carrierHRF\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">UDI Human Readable Barcode String</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-implantable-device-definitions.html#Device.distinctIdentifier\">distinctIdentifier</a><a name=\"Device.distinctIdentifier\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The distinct identification string</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-implantable-device-definitions.html#Device.manufactureDate\">manufactureDate</a><a name=\"Device.manufactureDate\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#dateTime\">dateTime</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Date when the device was made</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-implantable-device-definitions.html#Device.expirationDate\">expirationDate</a><a name=\"Device.expirationDate\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#dateTime\">dateTime</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Date and time of expiry of this device (if applicable)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-implantable-device-definitions.html#Device.lotNumber\">lotNumber</a><a name=\"Device.lotNumber\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Lot number of manufacture</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-implantable-device-definitions.html#Device.serialNumber\">serialNumber</a><a name=\"Device.serialNumber\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Serial number assigned by the manufacturer</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-implantable-device-definitions.html#Device.type\">type</a><a name=\"Device.type\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The kind or type of device</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-device-kind.html\">FHIRDeviceTypes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>): Codes to identify medical devices<br/><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck00.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-implantable-device-definitions.html#Device.patient\">patient</a><a name=\"Device.patient\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Patient to whom Device is affixed</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device",
-	"version": "4.0.0",
-	"name": "USCoreImplantableDeviceProfile",
-	"title": "US Core Implantable Device Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2019-09-17",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the Device resource for the minimal set of data to query and retrieve a patient's implantable device(s).",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "udi",
-			"uri": "http://fda.gov/UDI",
-			"name": "UDI Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Device",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Device",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Device",
-				"path": "Device",
-				"short": "Item used in healthcare",
-				"definition": "The US Core Implantable Device Profile is based upon the core FHIR Device Resource and created to meet the 2015 Edition Common Clinical Data Set 'Unique device identifier(s) for a patient’s implantable device(s)' requirements.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Device",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "rim",
-						"map": "Device"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Device"
-					}
-				]
-			},
-			{
-				"id": "Device.id",
-				"path": "Device.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Device.meta",
-				"path": "Device.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Device.implicitRules",
-				"path": "Device.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Device.language",
-				"path": "Device.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Device.text",
-				"path": "Device.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Device.contained",
-				"path": "Device.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Device.extension",
-				"path": "Device.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Device.modifierExtension",
-				"path": "Device.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Device.identifier",
-				"path": "Device.identifier",
-				"short": "Instance identifier",
-				"definition": "Unique instance identifiers assigned to a device by manufacturers other organizations or owners.",
-				"comment": "The barcode string from a barcode present on a device label or package may identify the instance, include names given to the device in local usage, or may identify the type of device. If the identifier identifies the type of device, Device.type element should be used.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Device.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					},
-					{
-						"identity": "udi",
-						"map": "The serial number which is a component of the production identifier (PI), a conditional, variable portion of a UDI.   The identifier.type code should be set to “SNO”(Serial Number) and the system left empty."
-					}
-				]
-			},
-			{
-				"id": "Device.definition",
-				"path": "Device.definition",
-				"short": "The reference to the definition for the device",
-				"definition": "The reference to the definition for the device.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.definition",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/DeviceDefinition"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Device.udiCarrier",
-				"path": "Device.udiCarrier",
-				"short": "Unique Device Identifier (UDI) Barcode string",
-				"definition": "Unique device identifier (UDI) assigned to device label or package.  Note that the Device may include multiple udiCarriers as it either may include just the udiCarrier for the jurisdiction it is sold, or for multiple jurisdictions it could have been sold.",
-				"comment": "Some devices may not have UDI information (for example. historical data or patient reported data).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.udiCarrier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "rim",
-						"map": ".id and .code"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Device.udi"
-					}
-				]
-			},
-			{
-				"id": "Device.udiCarrier.id",
-				"path": "Device.udiCarrier.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Device.udiCarrier.extension",
-				"path": "Device.udiCarrier.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Device.udiCarrier.modifierExtension",
-				"path": "Device.udiCarrier.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Device.udiCarrier.deviceIdentifier",
-				"path": "Device.udiCarrier.deviceIdentifier",
-				"short": "Mandatory fixed portion of UDI",
-				"definition": "The device identifier (DI) is a mandatory, fixed portion of a UDI that identifies the labeler and the specific version or model of a device.",
-				"alias": [
-					"DI"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Device.udiCarrier.deviceIdentifier",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "rim",
-						"map": "Role.id.extension"
-					},
-					{
-						"identity": "udi",
-						"map": "The device identifier (DI), a mandatory, fixed portion of a UDI that identifies the labeler and the specific version or model of a device."
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA (not Supported)"
-					}
-				]
-			},
-			{
-				"id": "Device.udiCarrier.issuer",
-				"path": "Device.udiCarrier.issuer",
-				"short": "UDI Issuing Organization",
-				"definition": "Organization that is charged with issuing UDIs for devices.  For example, the US FDA issuers include :\n1) GS1: \nhttp://hl7.org/fhir/NamingSystem/gs1-di, \n2) HIBCC:\nhttp://hl7.org/fhir/NamingSystem/hibcc-dI, \n3) ICCBBA for blood containers:\nhttp://hl7.org/fhir/NamingSystem/iccbba-blood-di, \n4) ICCBA for other devices:\nhttp://hl7.org/fhir/NamingSystem/iccbba-other-di.",
-				"alias": [
-					"Barcode System"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.udiCarrier.issuer",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Role.id.root"
-					},
-					{
-						"identity": "udi",
-						"map": "All UDIs are to be issued under a system operated by an Jurisdiction-accredited issuing agency.\nGS1 DIs: \n http://hl7.org/fhir/NamingSystem/gs1\nHIBCC DIs:\n http://hl7.org/fhir/NamingSystem/hibcc\nICCBBA DIs for blood containers:\n http://hl7.org/fhir/NamingSystem/iccbba-blood\nICCBA DIs for other devices:\n http://hl7.org/fhir/NamingSystem/iccbba-other"
-					}
-				]
-			},
-			{
-				"id": "Device.udiCarrier.jurisdiction",
-				"path": "Device.udiCarrier.jurisdiction",
-				"short": "Regional UDI authority",
-				"definition": "The identity of the authoritative source for UDI generation within a  jurisdiction.  All UDIs are globally unique within a single namespace with the appropriate repository uri as the system.  For example,  UDIs of devices managed in the U.S. by the FDA, the value is  http://hl7.org/fhir/NamingSystem/fda-udi.",
-				"requirements": "Allows a recipient of a UDI to know which database will contain the UDI-associated metadata.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.udiCarrier.jurisdiction",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Role.scoper"
-					}
-				]
-			},
-			{
-				"id": "Device.udiCarrier.carrierAIDC",
-				"path": "Device.udiCarrier.carrierAIDC",
-				"short": "UDI Machine Readable Barcode String",
-				"definition": "The full UDI carrier of the Automatic Identification and Data Capture (AIDC) technology representation of the barcode string as printed on the packaging of the device - e.g., a barcode or RFID.   Because of limitations on character sets in XML and the need to round-trip JSON data through XML, AIDC Formats *SHALL* be base64 encoded.",
-				"comment": "The AIDC form of UDIs should be scanned or otherwise used for the identification of the device whenever possible to minimize errors in records resulting from manual transcriptions. If separate barcodes for DI and PI are present, concatenate the string with DI first and in order of human readable expression on label.",
-				"alias": [
-					"Automatic Identification and Data Capture"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.udiCarrier.carrierAIDC",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "base64Binary"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Role.id.extension"
-					},
-					{
-						"identity": "udi",
-						"map": "A unique device identifier (UDI) on a device label a form that uses automatic identification and data capture (AIDC) technology."
-					}
-				]
-			},
-			{
-				"id": "Device.udiCarrier.carrierHRF",
-				"path": "Device.udiCarrier.carrierHRF",
-				"short": "UDI Human Readable Barcode String",
-				"definition": "The full UDI carrier as the human readable form (HRF) representation of the barcode string as printed on the packaging of the device.",
-				"comment": "If separate barcodes for DI and PI are present, concatenate the string with DI first and in order of human readable expression on label.",
-				"alias": [
-					"Human Readable Form",
-					"UDI",
-					"Barcode String"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.udiCarrier.carrierHRF",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Role.id.extension"
-					},
-					{
-						"identity": "udi",
-						"map": "A unique device identifier (UDI) on a device label in plain text"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Device.udi"
-					}
-				]
-			},
-			{
-				"id": "Device.udiCarrier.entryType",
-				"path": "Device.udiCarrier.entryType",
-				"short": "barcode | rfid | manual +",
-				"definition": "A coded entry to indicate how the data was entered.",
-				"requirements": "Supports a way to distinguish hand entered from machine read data.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.udiCarrier.entryType",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "UDIEntryType"
-						}
-					],
-					"strength": "required",
-					"description": "Codes to identify how UDI data was entered.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/udi-entry-type|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Device.status",
-				"path": "Device.status",
-				"short": "active | inactive | entered-in-error | unknown",
-				"definition": "Status of the Device availability.",
-				"comment": "This element is labeled as a modifier because the status contains the codes inactive and entered-in-error that mark the device (record)as not currently valid.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.status",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labelled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "FHIRDeviceStatus"
-						}
-					],
-					"strength": "required",
-					"description": "The availability status of the device.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/device-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "rim",
-						"map": ".statusCode"
-					}
-				]
-			},
-			{
-				"id": "Device.statusReason",
-				"path": "Device.statusReason",
-				"short": "online | paused | standby | offline | not-ready | transduc-discon | hw-discon | off",
-				"definition": "Reason for the dtatus of the Device availability.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Device.statusReason",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "FHIRDeviceStatusReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "The availability status reason of the device.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/device-status-reason"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					}
-				]
-			},
-			{
-				"id": "Device.distinctIdentifier",
-				"path": "Device.distinctIdentifier",
-				"short": "The distinct identification string",
-				"definition": "The distinct identification string as required by regulation for a human cell, tissue, or cellular and tissue-based product.",
-				"comment": "For example, this applies to devices in the United States regulated under *Code of Federal Regulation 21CFR§1271.290(c)*.",
-				"alias": [
-					"Distinct Identification Code (DIC)"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.distinctIdentifier",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".lotNumberText"
-					},
-					{
-						"identity": "udi",
-						"map": "The lot or batch number within which a device was manufactured - which is a component of the production identifier (PI), a conditional, variable portion of a UDI."
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA (not Supported)"
-					}
-				]
-			},
-			{
-				"id": "Device.manufacturer",
-				"path": "Device.manufacturer",
-				"short": "Name of device manufacturer",
-				"definition": "A name of the manufacturer.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.manufacturer",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".playedRole[typeCode=MANU].scoper.name"
-					},
-					{
-						"identity": "udi",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Device.manufactureDate",
-				"path": "Device.manufactureDate",
-				"short": "Date when the device was made",
-				"definition": "The date and time when the device was manufactured.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.manufactureDate",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".existenceTime.low"
-					},
-					{
-						"identity": "udi",
-						"map": "The date a specific device was manufactured - which is a component of the production identifier (PI), a conditional, variable portion of a UDI.  For FHIR, The datetime syntax must converted to YYYY-MM-DD[THH:MM:SS].  If hour is present, the minutes and seconds should both be set to “00”."
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA (not Supported)"
-					}
-				]
-			},
-			{
-				"id": "Device.expirationDate",
-				"path": "Device.expirationDate",
-				"short": "Date and time of expiry of this device (if applicable)",
-				"definition": "The date and time beyond which this device is no longer valid or should not be used (if applicable).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.expirationDate",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".expirationTime"
-					},
-					{
-						"identity": "udi",
-						"map": "the expiration date of a specific device -  which is a component of the production identifier (PI), a conditional, variable portion of a UDI.  For FHIR, The datetime syntax must converted to YYYY-MM-DD[THH:MM:SS].  If hour is present, the minutes and seconds should both be set to “00”."
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA (not Supported)"
-					}
-				]
-			},
-			{
-				"id": "Device.lotNumber",
-				"path": "Device.lotNumber",
-				"short": "Lot number of manufacture",
-				"definition": "Lot number assigned by the manufacturer.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.lotNumber",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".lotNumberText"
-					},
-					{
-						"identity": "udi",
-						"map": "The lot or batch number within which a device was manufactured - which is a component of the production identifier (PI), a conditional, variable portion of a UDI."
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA (not Supported)"
-					}
-				]
-			},
-			{
-				"id": "Device.serialNumber",
-				"path": "Device.serialNumber",
-				"short": "Serial number assigned by the manufacturer",
-				"definition": "The serial number assigned by the organization when the device was manufactured.",
-				"comment": "Alphanumeric Maximum 20.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.serialNumber",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".playedRole[typeCode=MANU].id"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA (not Supported)"
-					}
-				]
-			},
-			{
-				"id": "Device.deviceName",
-				"path": "Device.deviceName",
-				"short": "The name of the device as given by the manufacturer",
-				"definition": "This represents the manufacturer's name of the device as provided by the device, from a UDI label, or by a person describing the Device.  This typically would be used when a person provides the name(s) or when the device represents one of the names available from DeviceDefinition.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Device.deviceName",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Device.deviceName.id",
-				"path": "Device.deviceName.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Device.deviceName.extension",
-				"path": "Device.deviceName.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Device.deviceName.modifierExtension",
-				"path": "Device.deviceName.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Device.deviceName.name",
-				"path": "Device.deviceName.name",
-				"short": "The name of the device",
-				"definition": "The name of the device.",
-				"alias": [
-					"Σ"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Device.deviceName.name",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Device.deviceName.type",
-				"path": "Device.deviceName.type",
-				"short": "udi-label-name | user-friendly-name | patient-reported-name | manufacturer-name | model-name | other",
-				"definition": "The type of deviceName.\nUDILabelName | UserFriendlyName | PatientReportedName | ManufactureDeviceName | ModelName.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Device.deviceName.type",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "DeviceNameType"
-						}
-					],
-					"strength": "required",
-					"description": "The type of name the device is referred by.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/device-nametype|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".playedRole[typeCode=MANU].code"
-					}
-				]
-			},
-			{
-				"id": "Device.modelNumber",
-				"path": "Device.modelNumber",
-				"short": "The model number for the device",
-				"definition": "The model number for the device.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.modelNumber",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".softwareName (included as part)"
-					}
-				]
-			},
-			{
-				"id": "Device.partNumber",
-				"path": "Device.partNumber",
-				"short": "The part number of the device",
-				"definition": "The part number of the device.",
-				"comment": "Alphanumeric Maximum 20.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.partNumber",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".playedRole[typeCode=MANU].id"
-					}
-				]
-			},
-			{
-				"id": "Device.type",
-				"path": "Device.type",
-				"short": "The kind or type of device",
-				"definition": "The kind or type of device.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Device.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"strength": "extensible",
-					"description": "Codes to identify medical devices",
-					"valueSet": "http://hl7.org/fhir/ValueSet/device-kind"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Device.type"
-					}
-				]
-			},
-			{
-				"id": "Device.specialization",
-				"path": "Device.specialization",
-				"short": "The capabilities supported on a  device, the standards to which the device conforms for a particular purpose, and used for the communication",
-				"definition": "The capabilities supported on a  device, the standards to which the device conforms for a particular purpose, and used for the communication.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Device.specialization",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Device.specialization.id",
-				"path": "Device.specialization.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Device.specialization.extension",
-				"path": "Device.specialization.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Device.specialization.modifierExtension",
-				"path": "Device.specialization.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Device.specialization.systemType",
-				"path": "Device.specialization.systemType",
-				"short": "The standard that is used to operate and communicate",
-				"definition": "The standard that is used to operate and communicate.",
-				"alias": [
-					"Σ"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Device.specialization.systemType",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Device.specialization.version",
-				"path": "Device.specialization.version",
-				"short": "The version of the standard that is used to operate and communicate",
-				"definition": "The version of the standard that is used to operate and communicate.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.specialization.version",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					}
-				]
-			},
-			{
-				"id": "Device.version",
-				"path": "Device.version",
-				"short": "The actual design of the device or software version running on the device",
-				"definition": "The actual design of the device or software version running on the device.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Device.version",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Device.version.id",
-				"path": "Device.version.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Device.version.extension",
-				"path": "Device.version.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Device.version.modifierExtension",
-				"path": "Device.version.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Device.version.type",
-				"path": "Device.version.type",
-				"short": "The type of the device version",
-				"definition": "The type of the device version.",
-				"alias": [
-					"Σ"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.version.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Device.version.component",
-				"path": "Device.version.component",
-				"short": "A single component of the device version",
-				"definition": "A single component of the device version.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.version.component",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					}
-				]
-			},
-			{
-				"id": "Device.version.value",
-				"path": "Device.version.value",
-				"short": "The version text",
-				"definition": "The version text.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Device.version.value",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Device.property",
-				"path": "Device.property",
-				"short": "The actual configuration settings of a device as it actually operates, e.g., regulation status, time properties",
-				"definition": "The actual configuration settings of a device as it actually operates, e.g., regulation status, time properties.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Device.property",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Device.property.id",
-				"path": "Device.property.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Device.property.extension",
-				"path": "Device.property.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Device.property.modifierExtension",
-				"path": "Device.property.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Device.property.type",
-				"path": "Device.property.type",
-				"short": "Code that specifies the property DeviceDefinitionPropetyCode (Extensible)",
-				"definition": "Code that specifies the property DeviceDefinitionPropetyCode (Extensible).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Device.property.type",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Device.property.valueQuantity",
-				"path": "Device.property.valueQuantity",
-				"short": "Property value as a quantity",
-				"definition": "Property value as a quantity.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Device.property.valueQuantity",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Device.property.valueCode",
-				"path": "Device.property.valueCode",
-				"short": "Property value as a code, e.g., NTP4 (synced to NTP)",
-				"definition": "Property value as a code, e.g., NTP4 (synced to NTP).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Device.property.valueCode",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Device.patient",
-				"path": "Device.patient",
-				"short": "Patient to whom Device is affixed",
-				"definition": "Patient information, If the device is affixed to a person.",
-				"requirements": "If the device is implanted in a patient, then need to associate the device to the patient.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Device.patient",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".playedRole[typeCode=USED].scoper.playedRole[typeCode=PAT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Device.patient"
-					}
-				]
-			},
-			{
-				"id": "Device.owner",
-				"path": "Device.owner",
-				"short": "Organization responsible for device",
-				"definition": "An organization that is responsible for the provision and ongoing maintenance of the device.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.owner",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.source"
-					},
-					{
-						"identity": "rim",
-						"map": ".playedRole[typeCode=OWN].scoper"
-					}
-				]
-			},
-			{
-				"id": "Device.contact",
-				"path": "Device.contact",
-				"short": "Details for human/organization for support",
-				"definition": "Contact details for an organization or a particular human that is responsible for the device.",
-				"comment": "used for troubleshooting etc.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Device.contact",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "ContactPoint"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.source"
-					},
-					{
-						"identity": "rim",
-						"map": ".scopedRole[typeCode=CON].player"
-					}
-				]
-			},
-			{
-				"id": "Device.location",
-				"path": "Device.location",
-				"short": "Where the device is found",
-				"definition": "The place where the device can be found.",
-				"requirements": "Device.location can be used to track device location.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.location",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Location"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.where[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".playedRole[typeCode=LOCE].scoper"
-					}
-				]
-			},
-			{
-				"id": "Device.url",
-				"path": "Device.url",
-				"short": "Network address to contact device",
-				"definition": "A network address on which the device may be contacted directly.",
-				"comment": "If the device is running a FHIR server, the network address should  be the Base URL from which a conformance statement may be retrieved.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.url",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.where[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".telecom"
-					}
-				]
-			},
-			{
-				"id": "Device.note",
-				"path": "Device.note",
-				"short": "Device notes and comments",
-				"definition": "Descriptive information, usage information or implantation information that is not captured in an existing element.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Device.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".text"
-					}
-				]
-			},
-			{
-				"id": "Device.safety",
-				"path": "Device.safety",
-				"short": "Safety Characteristics of Device",
-				"definition": "Provides additional safety characteristics about a medical device.  For example devices containing latex.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Device.safety",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Device.parent",
-				"path": "Device.parent",
-				"short": "The parent device",
-				"definition": "The parent device.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Device.parent",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Device"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Device",
-				"path": "Device",
-				"definition": "The US Core Implantable Device Profile is based upon the core FHIR Device Resource and created to meet the 2015 Edition Common Clinical Data Set 'Unique device identifier(s) for a patient’s implantable device(s)' requirements.",
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Device"
-					}
-				]
-			},
-			{
-				"id": "Device.udiCarrier",
-				"path": "Device.udiCarrier",
-				"comment": "Some devices may not have UDI information (for example. historical data or patient reported data).",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Device.udi"
-					}
-				]
-			},
-			{
-				"id": "Device.udiCarrier.deviceIdentifier",
-				"path": "Device.udiCarrier.deviceIdentifier",
-				"alias": [
-					"DI"
-				],
-				"min": 1,
-				"max": "1",
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA (not Supported)"
-					}
-				]
-			},
-			{
-				"id": "Device.udiCarrier.carrierHRF",
-				"path": "Device.udiCarrier.carrierHRF",
-				"alias": [
-					"UDI",
-					"Barcode String"
-				],
-				"min": 0,
-				"max": "1",
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Device.udi"
-					}
-				]
-			},
-			{
-				"id": "Device.distinctIdentifier",
-				"path": "Device.distinctIdentifier",
-				"min": 0,
-				"max": "1",
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA (not Supported)"
-					}
-				]
-			},
-			{
-				"id": "Device.manufactureDate",
-				"path": "Device.manufactureDate",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA (not Supported)"
-					}
-				]
-			},
-			{
-				"id": "Device.expirationDate",
-				"path": "Device.expirationDate",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA (not Supported)"
-					}
-				]
-			},
-			{
-				"id": "Device.lotNumber",
-				"path": "Device.lotNumber",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA (not Supported)"
-					}
-				]
-			},
-			{
-				"id": "Device.serialNumber",
-				"path": "Device.serialNumber",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA (not Supported)"
-					}
-				]
-			},
-			{
-				"id": "Device.type",
-				"path": "Device.type",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Codes to identify medical devices",
-					"valueSet": "http://hl7.org/fhir/ValueSet/device-kind"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Device.type"
-					}
-				]
-			},
-			{
-				"id": "Device.patient",
-				"path": "Device.patient",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Device.patient"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-implantable-device",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device",
+    "version": "4.0.0",
+    "name": "USCoreImplantableDeviceProfile",
+    "title": "US Core Implantable Device Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2019-09-17",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the Device resource for the minimal set of data to query and retrieve a patient's implantable device(s).",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "udi",
+            "uri": "http://fda.gov/UDI",
+            "name": "UDI Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Device",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Device",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Device",
+                "path": "Device",
+                "short": "Item used in healthcare",
+                "definition": "The US Core Implantable Device Profile is based upon the core FHIR Device Resource and created to meet the 2015 Edition Common Clinical Data Set 'Unique device identifier(s) for a patient’s implantable device(s)' requirements.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Device",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Device"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Device"
+                    }
+                ]
+            },
+            {
+                "id": "Device.id",
+                "path": "Device.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Device.meta",
+                "path": "Device.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Device.implicitRules",
+                "path": "Device.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Device.language",
+                "path": "Device.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Device.text",
+                "path": "Device.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Device.contained",
+                "path": "Device.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Device.extension",
+                "path": "Device.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Device.modifierExtension",
+                "path": "Device.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Device.identifier",
+                "path": "Device.identifier",
+                "short": "Instance identifier",
+                "definition": "Unique instance identifiers assigned to a device by manufacturers other organizations or owners.",
+                "comment": "The barcode string from a barcode present on a device label or package may identify the instance, include names given to the device in local usage, or may identify the type of device. If the identifier identifies the type of device, Device.type element should be used.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Device.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    },
+                    {
+                        "identity": "udi",
+                        "map": "The serial number which is a component of the production identifier (PI), a conditional, variable portion of a UDI.   The identifier.type code should be set to “SNO”(Serial Number) and the system left empty."
+                    }
+                ]
+            },
+            {
+                "id": "Device.definition",
+                "path": "Device.definition",
+                "short": "The reference to the definition for the device",
+                "definition": "The reference to the definition for the device.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.definition",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/DeviceDefinition"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Device.udiCarrier",
+                "path": "Device.udiCarrier",
+                "short": "Unique Device Identifier (UDI) Barcode string",
+                "definition": "Unique device identifier (UDI) assigned to device label or package.  Note that the Device may include multiple udiCarriers as it either may include just the udiCarrier for the jurisdiction it is sold, or for multiple jurisdictions it could have been sold.",
+                "comment": "Some devices may not have UDI information (for example. historical data or patient reported data).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.udiCarrier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id and .code"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Device.udi"
+                    }
+                ]
+            },
+            {
+                "id": "Device.udiCarrier.id",
+                "path": "Device.udiCarrier.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Device.udiCarrier.extension",
+                "path": "Device.udiCarrier.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Device.udiCarrier.modifierExtension",
+                "path": "Device.udiCarrier.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Device.udiCarrier.deviceIdentifier",
+                "path": "Device.udiCarrier.deviceIdentifier",
+                "short": "Mandatory fixed portion of UDI",
+                "definition": "The device identifier (DI) is a mandatory, fixed portion of a UDI that identifies the labeler and the specific version or model of a device.",
+                "alias": [
+                    "DI"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Device.udiCarrier.deviceIdentifier",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Role.id.extension"
+                    },
+                    {
+                        "identity": "udi",
+                        "map": "The device identifier (DI), a mandatory, fixed portion of a UDI that identifies the labeler and the specific version or model of a device."
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA (not Supported)"
+                    }
+                ]
+            },
+            {
+                "id": "Device.udiCarrier.issuer",
+                "path": "Device.udiCarrier.issuer",
+                "short": "UDI Issuing Organization",
+                "definition": "Organization that is charged with issuing UDIs for devices.  For example, the US FDA issuers include :\n1) GS1: \nhttp://hl7.org/fhir/NamingSystem/gs1-di, \n2) HIBCC:\nhttp://hl7.org/fhir/NamingSystem/hibcc-dI, \n3) ICCBBA for blood containers:\nhttp://hl7.org/fhir/NamingSystem/iccbba-blood-di, \n4) ICCBA for other devices:\nhttp://hl7.org/fhir/NamingSystem/iccbba-other-di.",
+                "alias": [
+                    "Barcode System"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.udiCarrier.issuer",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Role.id.root"
+                    },
+                    {
+                        "identity": "udi",
+                        "map": "All UDIs are to be issued under a system operated by an Jurisdiction-accredited issuing agency.\nGS1 DIs: \n http://hl7.org/fhir/NamingSystem/gs1\nHIBCC DIs:\n http://hl7.org/fhir/NamingSystem/hibcc\nICCBBA DIs for blood containers:\n http://hl7.org/fhir/NamingSystem/iccbba-blood\nICCBA DIs for other devices:\n http://hl7.org/fhir/NamingSystem/iccbba-other"
+                    }
+                ]
+            },
+            {
+                "id": "Device.udiCarrier.jurisdiction",
+                "path": "Device.udiCarrier.jurisdiction",
+                "short": "Regional UDI authority",
+                "definition": "The identity of the authoritative source for UDI generation within a  jurisdiction.  All UDIs are globally unique within a single namespace with the appropriate repository uri as the system.  For example,  UDIs of devices managed in the U.S. by the FDA, the value is  http://hl7.org/fhir/NamingSystem/fda-udi.",
+                "requirements": "Allows a recipient of a UDI to know which database will contain the UDI-associated metadata.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.udiCarrier.jurisdiction",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Role.scoper"
+                    }
+                ]
+            },
+            {
+                "id": "Device.udiCarrier.carrierAIDC",
+                "path": "Device.udiCarrier.carrierAIDC",
+                "short": "UDI Machine Readable Barcode String",
+                "definition": "The full UDI carrier of the Automatic Identification and Data Capture (AIDC) technology representation of the barcode string as printed on the packaging of the device - e.g., a barcode or RFID.   Because of limitations on character sets in XML and the need to round-trip JSON data through XML, AIDC Formats *SHALL* be base64 encoded.",
+                "comment": "The AIDC form of UDIs should be scanned or otherwise used for the identification of the device whenever possible to minimize errors in records resulting from manual transcriptions. If separate barcodes for DI and PI are present, concatenate the string with DI first and in order of human readable expression on label.",
+                "alias": [
+                    "Automatic Identification and Data Capture"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.udiCarrier.carrierAIDC",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "base64Binary"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Role.id.extension"
+                    },
+                    {
+                        "identity": "udi",
+                        "map": "A unique device identifier (UDI) on a device label a form that uses automatic identification and data capture (AIDC) technology."
+                    }
+                ]
+            },
+            {
+                "id": "Device.udiCarrier.carrierHRF",
+                "path": "Device.udiCarrier.carrierHRF",
+                "short": "UDI Human Readable Barcode String",
+                "definition": "The full UDI carrier as the human readable form (HRF) representation of the barcode string as printed on the packaging of the device.",
+                "comment": "If separate barcodes for DI and PI are present, concatenate the string with DI first and in order of human readable expression on label.",
+                "alias": [
+                    "Human Readable Form",
+                    "UDI",
+                    "Barcode String"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.udiCarrier.carrierHRF",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Role.id.extension"
+                    },
+                    {
+                        "identity": "udi",
+                        "map": "A unique device identifier (UDI) on a device label in plain text"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Device.udi"
+                    }
+                ]
+            },
+            {
+                "id": "Device.udiCarrier.entryType",
+                "path": "Device.udiCarrier.entryType",
+                "short": "barcode | rfid | manual +",
+                "definition": "A coded entry to indicate how the data was entered.",
+                "requirements": "Supports a way to distinguish hand entered from machine read data.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.udiCarrier.entryType",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "UDIEntryType"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Codes to identify how UDI data was entered.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/udi-entry-type|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Device.status",
+                "path": "Device.status",
+                "short": "active | inactive | entered-in-error | unknown",
+                "definition": "Status of the Device availability.",
+                "comment": "This element is labeled as a modifier because the status contains the codes inactive and entered-in-error that mark the device (record)as not currently valid.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.status",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labelled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "FHIRDeviceStatus"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The availability status of the device.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/device-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".statusCode"
+                    }
+                ]
+            },
+            {
+                "id": "Device.statusReason",
+                "path": "Device.statusReason",
+                "short": "online | paused | standby | offline | not-ready | transduc-discon | hw-discon | off",
+                "definition": "Reason for the dtatus of the Device availability.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Device.statusReason",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "FHIRDeviceStatusReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "The availability status reason of the device.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/device-status-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    }
+                ]
+            },
+            {
+                "id": "Device.distinctIdentifier",
+                "path": "Device.distinctIdentifier",
+                "short": "The distinct identification string",
+                "definition": "The distinct identification string as required by regulation for a human cell, tissue, or cellular and tissue-based product.",
+                "comment": "For example, this applies to devices in the United States regulated under *Code of Federal Regulation 21CFR§1271.290(c)*.",
+                "alias": [
+                    "Distinct Identification Code (DIC)"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.distinctIdentifier",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".lotNumberText"
+                    },
+                    {
+                        "identity": "udi",
+                        "map": "The lot or batch number within which a device was manufactured - which is a component of the production identifier (PI), a conditional, variable portion of a UDI."
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA (not Supported)"
+                    }
+                ]
+            },
+            {
+                "id": "Device.manufacturer",
+                "path": "Device.manufacturer",
+                "short": "Name of device manufacturer",
+                "definition": "A name of the manufacturer.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.manufacturer",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".playedRole[typeCode=MANU].scoper.name"
+                    },
+                    {
+                        "identity": "udi",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Device.manufactureDate",
+                "path": "Device.manufactureDate",
+                "short": "Date when the device was made",
+                "definition": "The date and time when the device was manufactured.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.manufactureDate",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".existenceTime.low"
+                    },
+                    {
+                        "identity": "udi",
+                        "map": "The date a specific device was manufactured - which is a component of the production identifier (PI), a conditional, variable portion of a UDI.  For FHIR, The datetime syntax must converted to YYYY-MM-DD[THH:MM:SS].  If hour is present, the minutes and seconds should both be set to “00”."
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA (not Supported)"
+                    }
+                ]
+            },
+            {
+                "id": "Device.expirationDate",
+                "path": "Device.expirationDate",
+                "short": "Date and time of expiry of this device (if applicable)",
+                "definition": "The date and time beyond which this device is no longer valid or should not be used (if applicable).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.expirationDate",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".expirationTime"
+                    },
+                    {
+                        "identity": "udi",
+                        "map": "the expiration date of a specific device -  which is a component of the production identifier (PI), a conditional, variable portion of a UDI.  For FHIR, The datetime syntax must converted to YYYY-MM-DD[THH:MM:SS].  If hour is present, the minutes and seconds should both be set to “00”."
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA (not Supported)"
+                    }
+                ]
+            },
+            {
+                "id": "Device.lotNumber",
+                "path": "Device.lotNumber",
+                "short": "Lot number of manufacture",
+                "definition": "Lot number assigned by the manufacturer.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.lotNumber",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".lotNumberText"
+                    },
+                    {
+                        "identity": "udi",
+                        "map": "The lot or batch number within which a device was manufactured - which is a component of the production identifier (PI), a conditional, variable portion of a UDI."
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA (not Supported)"
+                    }
+                ]
+            },
+            {
+                "id": "Device.serialNumber",
+                "path": "Device.serialNumber",
+                "short": "Serial number assigned by the manufacturer",
+                "definition": "The serial number assigned by the organization when the device was manufactured.",
+                "comment": "Alphanumeric Maximum 20.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.serialNumber",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".playedRole[typeCode=MANU].id"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA (not Supported)"
+                    }
+                ]
+            },
+            {
+                "id": "Device.deviceName",
+                "path": "Device.deviceName",
+                "short": "The name of the device as given by the manufacturer",
+                "definition": "This represents the manufacturer's name of the device as provided by the device, from a UDI label, or by a person describing the Device.  This typically would be used when a person provides the name(s) or when the device represents one of the names available from DeviceDefinition.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Device.deviceName",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Device.deviceName.id",
+                "path": "Device.deviceName.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Device.deviceName.extension",
+                "path": "Device.deviceName.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Device.deviceName.modifierExtension",
+                "path": "Device.deviceName.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Device.deviceName.name",
+                "path": "Device.deviceName.name",
+                "short": "The name of the device",
+                "definition": "The name of the device.",
+                "alias": [
+                    "Σ"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Device.deviceName.name",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Device.deviceName.type",
+                "path": "Device.deviceName.type",
+                "short": "udi-label-name | user-friendly-name | patient-reported-name | manufacturer-name | model-name | other",
+                "definition": "The type of deviceName.\nUDILabelName | UserFriendlyName | PatientReportedName | ManufactureDeviceName | ModelName.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Device.deviceName.type",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "DeviceNameType"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The type of name the device is referred by.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/device-nametype|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".playedRole[typeCode=MANU].code"
+                    }
+                ]
+            },
+            {
+                "id": "Device.modelNumber",
+                "path": "Device.modelNumber",
+                "short": "The model number for the device",
+                "definition": "The model number for the device.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.modelNumber",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".softwareName (included as part)"
+                    }
+                ]
+            },
+            {
+                "id": "Device.partNumber",
+                "path": "Device.partNumber",
+                "short": "The part number of the device",
+                "definition": "The part number of the device.",
+                "comment": "Alphanumeric Maximum 20.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.partNumber",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".playedRole[typeCode=MANU].id"
+                    }
+                ]
+            },
+            {
+                "id": "Device.type",
+                "path": "Device.type",
+                "short": "The kind or type of device",
+                "definition": "The kind or type of device.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Device.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Codes to identify medical devices",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/device-kind"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Device.type"
+                    }
+                ]
+            },
+            {
+                "id": "Device.specialization",
+                "path": "Device.specialization",
+                "short": "The capabilities supported on a  device, the standards to which the device conforms for a particular purpose, and used for the communication",
+                "definition": "The capabilities supported on a  device, the standards to which the device conforms for a particular purpose, and used for the communication.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Device.specialization",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Device.specialization.id",
+                "path": "Device.specialization.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Device.specialization.extension",
+                "path": "Device.specialization.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Device.specialization.modifierExtension",
+                "path": "Device.specialization.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Device.specialization.systemType",
+                "path": "Device.specialization.systemType",
+                "short": "The standard that is used to operate and communicate",
+                "definition": "The standard that is used to operate and communicate.",
+                "alias": [
+                    "Σ"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Device.specialization.systemType",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Device.specialization.version",
+                "path": "Device.specialization.version",
+                "short": "The version of the standard that is used to operate and communicate",
+                "definition": "The version of the standard that is used to operate and communicate.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.specialization.version",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    }
+                ]
+            },
+            {
+                "id": "Device.version",
+                "path": "Device.version",
+                "short": "The actual design of the device or software version running on the device",
+                "definition": "The actual design of the device or software version running on the device.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Device.version",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Device.version.id",
+                "path": "Device.version.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Device.version.extension",
+                "path": "Device.version.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Device.version.modifierExtension",
+                "path": "Device.version.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Device.version.type",
+                "path": "Device.version.type",
+                "short": "The type of the device version",
+                "definition": "The type of the device version.",
+                "alias": [
+                    "Σ"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.version.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Device.version.component",
+                "path": "Device.version.component",
+                "short": "A single component of the device version",
+                "definition": "A single component of the device version.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.version.component",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    }
+                ]
+            },
+            {
+                "id": "Device.version.value",
+                "path": "Device.version.value",
+                "short": "The version text",
+                "definition": "The version text.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Device.version.value",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Device.property",
+                "path": "Device.property",
+                "short": "The actual configuration settings of a device as it actually operates, e.g., regulation status, time properties",
+                "definition": "The actual configuration settings of a device as it actually operates, e.g., regulation status, time properties.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Device.property",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Device.property.id",
+                "path": "Device.property.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Device.property.extension",
+                "path": "Device.property.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Device.property.modifierExtension",
+                "path": "Device.property.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Device.property.type",
+                "path": "Device.property.type",
+                "short": "Code that specifies the property DeviceDefinitionPropetyCode (Extensible)",
+                "definition": "Code that specifies the property DeviceDefinitionPropetyCode (Extensible).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Device.property.type",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Device.property.valueQuantity",
+                "path": "Device.property.valueQuantity",
+                "short": "Property value as a quantity",
+                "definition": "Property value as a quantity.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Device.property.valueQuantity",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Device.property.valueCode",
+                "path": "Device.property.valueCode",
+                "short": "Property value as a code, e.g., NTP4 (synced to NTP)",
+                "definition": "Property value as a code, e.g., NTP4 (synced to NTP).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Device.property.valueCode",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Device.patient",
+                "path": "Device.patient",
+                "short": "Patient to whom Device is affixed",
+                "definition": "Patient information, If the device is affixed to a person.",
+                "requirements": "If the device is implanted in a patient, then need to associate the device to the patient.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Device.patient",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".playedRole[typeCode=USED].scoper.playedRole[typeCode=PAT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Device.patient"
+                    }
+                ]
+            },
+            {
+                "id": "Device.owner",
+                "path": "Device.owner",
+                "short": "Organization responsible for device",
+                "definition": "An organization that is responsible for the provision and ongoing maintenance of the device.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.owner",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.source"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".playedRole[typeCode=OWN].scoper"
+                    }
+                ]
+            },
+            {
+                "id": "Device.contact",
+                "path": "Device.contact",
+                "short": "Details for human/organization for support",
+                "definition": "Contact details for an organization or a particular human that is responsible for the device.",
+                "comment": "used for troubleshooting etc.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Device.contact",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "ContactPoint"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.source"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".scopedRole[typeCode=CON].player"
+                    }
+                ]
+            },
+            {
+                "id": "Device.location",
+                "path": "Device.location",
+                "short": "Where the device is found",
+                "definition": "The place where the device can be found.",
+                "requirements": "Device.location can be used to track device location.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.location",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Location"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.where[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".playedRole[typeCode=LOCE].scoper"
+                    }
+                ]
+            },
+            {
+                "id": "Device.url",
+                "path": "Device.url",
+                "short": "Network address to contact device",
+                "definition": "A network address on which the device may be contacted directly.",
+                "comment": "If the device is running a FHIR server, the network address should  be the Base URL from which a conformance statement may be retrieved.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.url",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.where[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".telecom"
+                    }
+                ]
+            },
+            {
+                "id": "Device.note",
+                "path": "Device.note",
+                "short": "Device notes and comments",
+                "definition": "Descriptive information, usage information or implantation information that is not captured in an existing element.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Device.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".text"
+                    }
+                ]
+            },
+            {
+                "id": "Device.safety",
+                "path": "Device.safety",
+                "short": "Safety Characteristics of Device",
+                "definition": "Provides additional safety characteristics about a medical device.  For example devices containing latex.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Device.safety",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Device.parent",
+                "path": "Device.parent",
+                "short": "The parent device",
+                "definition": "The parent device.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Device.parent",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Device"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Device",
+                "path": "Device",
+                "definition": "The US Core Implantable Device Profile is based upon the core FHIR Device Resource and created to meet the 2015 Edition Common Clinical Data Set 'Unique device identifier(s) for a patient’s implantable device(s)' requirements.",
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Device"
+                    }
+                ]
+            },
+            {
+                "id": "Device.udiCarrier",
+                "path": "Device.udiCarrier",
+                "comment": "Some devices may not have UDI information (for example. historical data or patient reported data).",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Device.udi"
+                    }
+                ]
+            },
+            {
+                "id": "Device.udiCarrier.deviceIdentifier",
+                "path": "Device.udiCarrier.deviceIdentifier",
+                "alias": [
+                    "DI"
+                ],
+                "min": 1,
+                "max": "1",
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA (not Supported)"
+                    }
+                ]
+            },
+            {
+                "id": "Device.udiCarrier.carrierHRF",
+                "path": "Device.udiCarrier.carrierHRF",
+                "alias": [
+                    "UDI",
+                    "Barcode String"
+                ],
+                "min": 0,
+                "max": "1",
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Device.udi"
+                    }
+                ]
+            },
+            {
+                "id": "Device.distinctIdentifier",
+                "path": "Device.distinctIdentifier",
+                "min": 0,
+                "max": "1",
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA (not Supported)"
+                    }
+                ]
+            },
+            {
+                "id": "Device.manufactureDate",
+                "path": "Device.manufactureDate",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA (not Supported)"
+                    }
+                ]
+            },
+            {
+                "id": "Device.expirationDate",
+                "path": "Device.expirationDate",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA (not Supported)"
+                    }
+                ]
+            },
+            {
+                "id": "Device.lotNumber",
+                "path": "Device.lotNumber",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA (not Supported)"
+                    }
+                ]
+            },
+            {
+                "id": "Device.serialNumber",
+                "path": "Device.serialNumber",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA (not Supported)"
+                    }
+                ]
+            },
+            {
+                "id": "Device.type",
+                "path": "Device.type",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Codes to identify medical devices",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/device-kind"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Device.type"
+                    }
+                ]
+            },
+            {
+                "id": "Device.patient",
+                "path": "Device.patient",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Device.patient"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-location.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-location.json
@@ -1,2537 +1,2537 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-location",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-location-definitions.html#Location\">Location</a><a name=\"Location\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/location.html\">Location</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Details and position information for a physical place</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-location-definitions.html#Location.status\">status</a><a name=\"Location.status\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">active | suspended | inactive</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-location-definitions.html#Location.name\">name</a><a name=\"Location.name\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Name of the location as used by humans</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-location-definitions.html#Location.telecom\">telecom</a><a name=\"Location.telecom\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#ContactPoint\">ContactPoint</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Contact details of the location</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-location-definitions.html#Location.address\">address</a><a name=\"Location.address\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Address\">Address</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Physical location</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-location-definitions.html#Location.address.line\">line</a><a name=\"Location.address.line\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Street name, number, direction &amp; P.O. Box etc.</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-location-definitions.html#Location.address.city\">city</a><a name=\"Location.address.city\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Name of city, town etc.</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-location-definitions.html#Location.address.state\">state</a><a name=\"Location.address.state\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Sub-unit of country (abbreviations ok)</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-usps-state.html\">USPS Two Letter Alphabetic Codes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>): Two letter USPS alphabetic codes.<br/><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-location-definitions.html#Location.address.postalCode\">postalCode</a><a name=\"Location.address.postalCode\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">US Zip Codes</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck00.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-location-definitions.html#Location.managingOrganization\">managingOrganization</a><a name=\"Location.managingOrganization\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-organization.html\">US Core Organization Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Organization responsible for provisioning and upkeep</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-location",
-	"version": "4.0.0",
-	"name": "USCoreLocation",
-	"title": "US Core Location Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Defines basic constraints and extensions on the Location resource for use with other US Core resources",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Location",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Location",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Location",
-				"path": "Location",
-				"short": "Details and position information for a physical place",
-				"definition": "Details and position information for a physical place where services are provided and resources and participants may be stored, found, contained, or accommodated.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Location",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "rim",
-						"map": ".Role[classCode=SDLC]"
-					},
-					{
-						"identity": "servd",
-						"map": "Organization"
-					}
-				]
-			},
-			{
-				"id": "Location.id",
-				"path": "Location.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Location.meta",
-				"path": "Location.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Location.implicitRules",
-				"path": "Location.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Location.language",
-				"path": "Location.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Location.text",
-				"path": "Location.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Location.contained",
-				"path": "Location.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Location.extension",
-				"path": "Location.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Location.modifierExtension",
-				"path": "Location.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Location.identifier",
-				"path": "Location.identifier",
-				"short": "Unique code or number identifying the location to its users",
-				"definition": "Unique code or number identifying the location to its users.",
-				"requirements": "Organization label locations in registries, need to keep track of those.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Location.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					}
-				]
-			},
-			{
-				"id": "Location.status",
-				"path": "Location.status",
-				"short": "active | suspended | inactive",
-				"definition": "The status property covers the general availability of the resource, not the current value which may be covered by the operationStatus, or by a schedule/slots if they are configured for the location.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Location.status",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "LocationStatus"
-						}
-					],
-					"strength": "required",
-					"description": "Indicates whether the location is still in use.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/location-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "rim",
-						"map": ".statusCode"
-					}
-				]
-			},
-			{
-				"id": "Location.operationalStatus",
-				"path": "Location.operationalStatus",
-				"short": "The operational status of the location (typically only for a bed/room)",
-				"definition": "The operational status covers operation values most relevant to beds (but can also apply to rooms/units/chairs/etc. such as an isolation unit/dialysis chair). This typically covers concepts such as contamination, housekeeping, and other activities like maintenance.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Location.operationalStatus",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "OperationalStatus"
-						}
-					],
-					"strength": "preferred",
-					"description": "The operational status if the location (where typically a bed/room).",
-					"valueSet": "http://terminology.hl7.org/ValueSet/v2-0116"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Location.name",
-				"path": "Location.name",
-				"short": "Name of the location as used by humans",
-				"definition": "Name of the location as used by humans. Does not need to be unique.",
-				"comment": "If the name of a location changes, consider putting the old name in the alias column so that it can still be located through searches.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Location.name",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".name"
-					},
-					{
-						"identity": "servd",
-						"map": "./PrimaryAddress and ./OtherAddresses"
-					}
-				]
-			},
-			{
-				"id": "Location.alias",
-				"path": "Location.alias",
-				"short": "A list of alternate names that the location is known as, or was known as, in the past",
-				"definition": "A list of alternate names that the location is known as, or was known as, in the past.",
-				"comment": "There are no dates associated with the alias/historic names, as this is not intended to track when names were used, but to assist in searching so that older names can still result in identifying the location.",
-				"requirements": "Over time locations and organizations go through many changes and can be known by different names.\n\nFor searching knowing previous names that the location was known by can be very useful.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Location.alias",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".name"
-					}
-				]
-			},
-			{
-				"id": "Location.description",
-				"path": "Location.description",
-				"short": "Additional details about the location that could be displayed as further information to identify the location beyond its name",
-				"definition": "Description of the Location, which helps in finding or referencing the place.",
-				"requirements": "Humans need additional information to verify a correct location has been identified.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Location.description",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".playingEntity[classCode=PLC determinerCode=INSTANCE].desc"
-					}
-				]
-			},
-			{
-				"id": "Location.mode",
-				"path": "Location.mode",
-				"short": "instance | kind",
-				"definition": "Indicates whether a resource instance represents a specific location or a class of locations.",
-				"comment": "This is labeled as a modifier because whether or not the location is a class of locations changes how it can be used and understood.",
-				"requirements": "When using a Location resource for scheduling or orders, we need to be able to refer to a class of Locations instead of a specific Location.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Location.mode",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "LocationMode"
-						}
-					],
-					"strength": "required",
-					"description": "Indicates whether a resource instance represents a specific location or a class of locations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/location-mode|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".playingEntity[classCode=PLC].determinerCode"
-					}
-				]
-			},
-			{
-				"id": "Location.type",
-				"path": "Location.type",
-				"short": "Type of function performed",
-				"definition": "Indicates the type of function performed at the location.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Location.type",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "LocationType"
-						}
-					],
-					"strength": "extensible",
-					"description": "Indicates the type of function performed at the location.",
-					"valueSet": "http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".code"
-					}
-				]
-			},
-			{
-				"id": "Location.telecom",
-				"path": "Location.telecom",
-				"short": "Contact details of the location",
-				"definition": "The contact details of communication devices available at the location. This can include phone numbers, fax numbers, mobile numbers, email addresses and web sites.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Location.telecom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "ContactPoint"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".telecom"
-					}
-				]
-			},
-			{
-				"id": "Location.address",
-				"path": "Location.address",
-				"short": "Physical location",
-				"definition": "Physical location.",
-				"comment": "Additional addresses should be recorded using another instance of the Location resource, or via the Organization.",
-				"requirements": "If locations can be visited, we need to keep track of their address.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Location.address",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Address"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".addr"
-					},
-					{
-						"identity": "servd",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Location.address.id",
-				"path": "Location.address.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Location.address.extension",
-				"path": "Location.address.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Location.address.use",
-				"path": "Location.address.use",
-				"short": "home | work | temp | old | billing - purpose of this address",
-				"definition": "The purpose of this address.",
-				"comment": "Applications can assume that an address is current unless it explicitly says that it is temporary or old.",
-				"requirements": "Allows an appropriate address to be chosen from a list of many.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.use",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueCode": "home"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old address etc.for a current/permanent one",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AddressUse"
-						}
-					],
-					"strength": "required",
-					"description": "The use of an address.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/address-use|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.7"
-					},
-					{
-						"identity": "rim",
-						"map": "unique(./use)"
-					},
-					{
-						"identity": "servd",
-						"map": "./AddressPurpose"
-					}
-				]
-			},
-			{
-				"id": "Location.address.type",
-				"path": "Location.address.type",
-				"short": "postal | physical | both",
-				"definition": "Distinguishes between physical addresses (those you can visit) and mailing addresses (e.g. PO Boxes and care-of addresses). Most addresses are both.",
-				"comment": "The definition of Address states that \"address is intended to describe postal addresses, not physical locations\". However, many applications track whether an address has a dual purpose of being a location that can be visited as well as being a valid delivery destination, and Postal addresses are often used as proxies for physical locations (also see the [Location](http://hl7.org/fhir/R4/location.html#) resource).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueCode": "both"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AddressType"
-						}
-					],
-					"strength": "required",
-					"description": "The type of an address (physical / postal).",
-					"valueSet": "http://hl7.org/fhir/ValueSet/address-type|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.18"
-					},
-					{
-						"identity": "rim",
-						"map": "unique(./use)"
-					},
-					{
-						"identity": "vcard",
-						"map": "address type parameter"
-					}
-				]
-			},
-			{
-				"id": "Location.address.text",
-				"path": "Location.address.text",
-				"short": "Text representation of the address",
-				"definition": "Specifies the entire address as it should be displayed e.g. on a postal label. This may be provided instead of or as well as the specific parts.",
-				"comment": "Can provide both a text representation and parts. Applications updating an address SHALL ensure that  when both text and parts are present,  no content is included in the text that isn't found in a part.",
-				"requirements": "A renderable, unencoded form.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "137 Nowhere Street, Erewhon 9132"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.1 + XAD.2 + XAD.3 + XAD.4 + XAD.5 + XAD.6"
-					},
-					{
-						"identity": "rim",
-						"map": "./formatted"
-					},
-					{
-						"identity": "vcard",
-						"map": "address label parameter"
-					}
-				]
-			},
-			{
-				"id": "Location.address.line",
-				"path": "Location.address.line",
-				"short": "Street name, number, direction & P.O. Box etc.",
-				"definition": "This component contains the house number, apartment number, street name, street direction,  P.O. Box number, delivery hints, and similar address information.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Address.line",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"orderMeaning": "The order in which lines should appear in an address label",
-				"example": [
-					{
-						"label": "General",
-						"valueString": "137 Nowhere Street"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.1 + XAD.2 (note: XAD.1 and XAD.2 have different meanings for a company address than for a person address)"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = AL]"
-					},
-					{
-						"identity": "vcard",
-						"map": "street"
-					},
-					{
-						"identity": "servd",
-						"map": "./StreetAddress (newline delimitted)"
-					}
-				]
-			},
-			{
-				"id": "Location.address.city",
-				"path": "Location.address.city",
-				"short": "Name of city, town etc.",
-				"definition": "The name of the city, town, suburb, village or other community or delivery center.",
-				"alias": [
-					"Municpality"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.city",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "Erewhon"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.3"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = CTY]"
-					},
-					{
-						"identity": "vcard",
-						"map": "locality"
-					},
-					{
-						"identity": "servd",
-						"map": "./Jurisdiction"
-					}
-				]
-			},
-			{
-				"id": "Location.address.district",
-				"path": "Location.address.district",
-				"short": "District name (aka county)",
-				"definition": "The name of the administrative area (county).",
-				"comment": "District is sometimes known as county, but in some regions 'county' is used in place of city (municipality), so county name should be conveyed in city instead.",
-				"alias": [
-					"County"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.district",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "Madison"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.9"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = CNT | CPA]"
-					}
-				]
-			},
-			{
-				"id": "Location.address.state",
-				"path": "Location.address.state",
-				"short": "Sub-unit of country (abbreviations ok)",
-				"definition": "Sub-unit of a country with limited sovereignty in a federally organized country. A code may be used if codes are in common use (e.g. US 2 letter state codes).",
-				"alias": [
-					"Province",
-					"Territory"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.state",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Two letter USPS alphabetic codes.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.4"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = STA]"
-					},
-					{
-						"identity": "vcard",
-						"map": "region"
-					},
-					{
-						"identity": "servd",
-						"map": "./Region"
-					},
-					{
-						"identity": "servd",
-						"map": "./Sites"
-					}
-				]
-			},
-			{
-				"id": "Location.address.postalCode",
-				"path": "Location.address.postalCode",
-				"short": "US Zip Codes",
-				"definition": "A postal code designating a region defined by the postal service.",
-				"alias": [
-					"Zip"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.postalCode",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "9132"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.5"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = ZIP]"
-					},
-					{
-						"identity": "vcard",
-						"map": "code"
-					},
-					{
-						"identity": "servd",
-						"map": "./PostalIdentificationCode"
-					}
-				]
-			},
-			{
-				"id": "Location.address.country",
-				"path": "Location.address.country",
-				"short": "Country (e.g. can be ISO 3166 2 or 3 letter code)",
-				"definition": "Country - a nation as commonly understood or generally accepted.",
-				"comment": "ISO 3166 3 letter codes can be used in place of a human readable country name.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.country",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.6"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = CNT]"
-					},
-					{
-						"identity": "vcard",
-						"map": "country"
-					},
-					{
-						"identity": "servd",
-						"map": "./Country"
-					}
-				]
-			},
-			{
-				"id": "Location.address.period",
-				"path": "Location.address.period",
-				"short": "Time period when address was/is in use",
-				"definition": "Time period when address was/is in use.",
-				"requirements": "Allows addresses to be placed in historical context.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valuePeriod": {
-							"start": "2010-03-23",
-							"end": "2010-07-01"
-						}
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.12 / XAD.13 + XAD.14"
-					},
-					{
-						"identity": "rim",
-						"map": "./usablePeriod[type=\"IVL<TS>\"]"
-					},
-					{
-						"identity": "servd",
-						"map": "./StartDate and ./EndDate"
-					}
-				]
-			},
-			{
-				"id": "Location.physicalType",
-				"path": "Location.physicalType",
-				"short": "Physical form of the location",
-				"definition": "Physical form of the location, e.g. building, room, vehicle, road.",
-				"requirements": "For purposes of showing relevant locations in queries, we need to categorize locations.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Location.physicalType",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "PhysicalType"
-						}
-					],
-					"strength": "example",
-					"description": "Physical form of the location.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/location-physical-type"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".playingEntity [classCode=PLC].code"
-					}
-				]
-			},
-			{
-				"id": "Location.position",
-				"path": "Location.position",
-				"short": "The absolute geographic location",
-				"definition": "The absolute geographic location of the Location, expressed using the WGS84 datum (This is the same co-ordinate system used in KML).",
-				"requirements": "For mobile applications and automated route-finding knowing the exact location of the Location is required.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Location.position",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".playingEntity [classCode=PLC determinerCode=INSTANCE].positionText"
-					}
-				]
-			},
-			{
-				"id": "Location.position.id",
-				"path": "Location.position.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Location.position.extension",
-				"path": "Location.position.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Location.position.modifierExtension",
-				"path": "Location.position.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Location.position.longitude",
-				"path": "Location.position.longitude",
-				"short": "Longitude with WGS84 datum",
-				"definition": "Longitude. The value domain and the interpretation are the same as for the text of the longitude element in KML (see notes below).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Location.position.longitude",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "(RIM Opted not to map the sub-elements of GPS location, is now an OBS)"
-					}
-				]
-			},
-			{
-				"id": "Location.position.latitude",
-				"path": "Location.position.latitude",
-				"short": "Latitude with WGS84 datum",
-				"definition": "Latitude. The value domain and the interpretation are the same as for the text of the latitude element in KML (see notes below).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Location.position.latitude",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "(RIM Opted not to map the sub-elements of GPS location, is now an OBS)"
-					}
-				]
-			},
-			{
-				"id": "Location.position.altitude",
-				"path": "Location.position.altitude",
-				"short": "Altitude with WGS84 datum",
-				"definition": "Altitude. The value domain and the interpretation are the same as for the text of the altitude element in KML (see notes below).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Location.position.altitude",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "(RIM Opted not to map the sub-elements of GPS location, is now an OBS)"
-					}
-				]
-			},
-			{
-				"id": "Location.managingOrganization",
-				"path": "Location.managingOrganization",
-				"short": "Organization responsible for provisioning and upkeep",
-				"definition": "The organization responsible for the provisioning and upkeep of the location.",
-				"comment": "This can also be used as the part of the organization hierarchy where this location provides services. These services can be defined through the HealthcareService resource.",
-				"requirements": "Need to know who manages the location.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Location.managingOrganization",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".scopingEntity[classCode=ORG determinerKind=INSTANCE]"
-					}
-				]
-			},
-			{
-				"id": "Location.partOf",
-				"path": "Location.partOf",
-				"short": "Another Location this one is physically a part of",
-				"definition": "Another Location of which this Location is physically a part of.",
-				"requirements": "For purposes of location, display and identification, knowing which locations are located within other locations is important.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Location.partOf",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-hierarchy",
-								"valueBoolean": true
-							}
-						],
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Location"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".inboundLink[typeCode=PART].source[classCode=SDLC]"
-					}
-				]
-			},
-			{
-				"id": "Location.hoursOfOperation",
-				"path": "Location.hoursOfOperation",
-				"short": "What days/times during a week is this location usually open",
-				"definition": "What days/times during a week is this location usually open.",
-				"comment": "This type of information is commonly found published in directories and on websites informing customers when the facility is available.\n\nSpecific services within the location may have their own hours which could be shorter (or longer) than the locations hours.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Location.hoursOfOperation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "Location.hoursOfOperation.id",
-				"path": "Location.hoursOfOperation.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Location.hoursOfOperation.extension",
-				"path": "Location.hoursOfOperation.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Location.hoursOfOperation.modifierExtension",
-				"path": "Location.hoursOfOperation.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Location.hoursOfOperation.daysOfWeek",
-				"path": "Location.hoursOfOperation.daysOfWeek",
-				"short": "mon | tue | wed | thu | fri | sat | sun",
-				"definition": "Indicates which days of the week are available between the start and end Times.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Location.hoursOfOperation.daysOfWeek",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "DaysOfWeek"
-						}
-					],
-					"strength": "required",
-					"description": "The days of the week.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/days-of-week|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "Location.hoursOfOperation.allDay",
-				"path": "Location.hoursOfOperation.allDay",
-				"short": "The Location is open all day",
-				"definition": "The Location is open all day.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Location.hoursOfOperation.allDay",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "Location.hoursOfOperation.openingTime",
-				"path": "Location.hoursOfOperation.openingTime",
-				"short": "Time that the Location opens",
-				"definition": "Time that the Location opens.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Location.hoursOfOperation.openingTime",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "time"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "Location.hoursOfOperation.closingTime",
-				"path": "Location.hoursOfOperation.closingTime",
-				"short": "Time that the Location closes",
-				"definition": "Time that the Location closes.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Location.hoursOfOperation.closingTime",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "time"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "Location.availabilityExceptions",
-				"path": "Location.availabilityExceptions",
-				"short": "Description of availability exceptions",
-				"definition": "A description of when the locations opening ours are different to normal, e.g. public holiday availability. Succinctly describing all possible exceptions to normal site availability as detailed in the opening hours Times.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Location.availabilityExceptions",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Location.endpoint",
-				"path": "Location.endpoint",
-				"short": "Technical endpoints providing access to services operated for the location",
-				"definition": "Technical endpoints providing access to services operated for the location.",
-				"requirements": "Organizations may have different systems at different locations that provide various services and need to be able to define the technical connection details for how to connect to them, and for what purpose.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Location.endpoint",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Endpoint"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Location",
-				"path": "Location",
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "servd",
-						"map": "Organization"
-					}
-				]
-			},
-			{
-				"id": "Location.status",
-				"path": "Location.status",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Location.name",
-				"path": "Location.name",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "servd",
-						"map": "./PrimaryAddress and ./OtherAddresses"
-					}
-				]
-			},
-			{
-				"id": "Location.telecom",
-				"path": "Location.telecom",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "ContactPoint"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Location.address",
-				"path": "Location.address",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Address"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "servd",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Location.address.line",
-				"path": "Location.address.line",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Location.address.city",
-				"path": "Location.address.city",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Location.address.state",
-				"path": "Location.address.state",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Two letter USPS alphabetic codes.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state"
-				},
-				"mapping": [
-					{
-						"identity": "servd",
-						"map": "./Sites"
-					}
-				]
-			},
-			{
-				"id": "Location.address.postalCode",
-				"path": "Location.address.postalCode",
-				"short": "US Zip Codes",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Location.managingOrganization",
-				"path": "Location.managingOrganization",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
-						]
-					}
-				],
-				"mustSupport": true
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-location",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-location",
+    "version": "4.0.0",
+    "name": "USCoreLocation",
+    "title": "US Core Location Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Defines basic constraints and extensions on the Location resource for use with other US Core resources",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Location",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Location",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Location",
+                "path": "Location",
+                "short": "Details and position information for a physical place",
+                "definition": "Details and position information for a physical place where services are provided and resources and participants may be stored, found, contained, or accommodated.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Location",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".Role[classCode=SDLC]"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "Organization"
+                    }
+                ]
+            },
+            {
+                "id": "Location.id",
+                "path": "Location.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Location.meta",
+                "path": "Location.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Location.implicitRules",
+                "path": "Location.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Location.language",
+                "path": "Location.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Location.text",
+                "path": "Location.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Location.contained",
+                "path": "Location.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Location.extension",
+                "path": "Location.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Location.modifierExtension",
+                "path": "Location.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Location.identifier",
+                "path": "Location.identifier",
+                "short": "Unique code or number identifying the location to its users",
+                "definition": "Unique code or number identifying the location to its users.",
+                "requirements": "Organization label locations in registries, need to keep track of those.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Location.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    }
+                ]
+            },
+            {
+                "id": "Location.status",
+                "path": "Location.status",
+                "short": "active | suspended | inactive",
+                "definition": "The status property covers the general availability of the resource, not the current value which may be covered by the operationStatus, or by a schedule/slots if they are configured for the location.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Location.status",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "LocationStatus"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Indicates whether the location is still in use.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/location-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".statusCode"
+                    }
+                ]
+            },
+            {
+                "id": "Location.operationalStatus",
+                "path": "Location.operationalStatus",
+                "short": "The operational status of the location (typically only for a bed/room)",
+                "definition": "The operational status covers operation values most relevant to beds (but can also apply to rooms/units/chairs/etc. such as an isolation unit/dialysis chair). This typically covers concepts such as contamination, housekeeping, and other activities like maintenance.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Location.operationalStatus",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "OperationalStatus"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "The operational status if the location (where typically a bed/room).",
+                    "valueSet": "http://terminology.hl7.org/ValueSet/v2-0116"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Location.name",
+                "path": "Location.name",
+                "short": "Name of the location as used by humans",
+                "definition": "Name of the location as used by humans. Does not need to be unique.",
+                "comment": "If the name of a location changes, consider putting the old name in the alias column so that it can still be located through searches.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Location.name",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".name"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./PrimaryAddress and ./OtherAddresses"
+                    }
+                ]
+            },
+            {
+                "id": "Location.alias",
+                "path": "Location.alias",
+                "short": "A list of alternate names that the location is known as, or was known as, in the past",
+                "definition": "A list of alternate names that the location is known as, or was known as, in the past.",
+                "comment": "There are no dates associated with the alias/historic names, as this is not intended to track when names were used, but to assist in searching so that older names can still result in identifying the location.",
+                "requirements": "Over time locations and organizations go through many changes and can be known by different names.\n\nFor searching knowing previous names that the location was known by can be very useful.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Location.alias",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".name"
+                    }
+                ]
+            },
+            {
+                "id": "Location.description",
+                "path": "Location.description",
+                "short": "Additional details about the location that could be displayed as further information to identify the location beyond its name",
+                "definition": "Description of the Location, which helps in finding or referencing the place.",
+                "requirements": "Humans need additional information to verify a correct location has been identified.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Location.description",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".playingEntity[classCode=PLC determinerCode=INSTANCE].desc"
+                    }
+                ]
+            },
+            {
+                "id": "Location.mode",
+                "path": "Location.mode",
+                "short": "instance | kind",
+                "definition": "Indicates whether a resource instance represents a specific location or a class of locations.",
+                "comment": "This is labeled as a modifier because whether or not the location is a class of locations changes how it can be used and understood.",
+                "requirements": "When using a Location resource for scheduling or orders, we need to be able to refer to a class of Locations instead of a specific Location.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Location.mode",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "LocationMode"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Indicates whether a resource instance represents a specific location or a class of locations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/location-mode|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".playingEntity[classCode=PLC].determinerCode"
+                    }
+                ]
+            },
+            {
+                "id": "Location.type",
+                "path": "Location.type",
+                "short": "Type of function performed",
+                "definition": "Indicates the type of function performed at the location.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Location.type",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "LocationType"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Indicates the type of function performed at the location.",
+                    "valueSet": "http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".code"
+                    }
+                ]
+            },
+            {
+                "id": "Location.telecom",
+                "path": "Location.telecom",
+                "short": "Contact details of the location",
+                "definition": "The contact details of communication devices available at the location. This can include phone numbers, fax numbers, mobile numbers, email addresses and web sites.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Location.telecom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "ContactPoint"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".telecom"
+                    }
+                ]
+            },
+            {
+                "id": "Location.address",
+                "path": "Location.address",
+                "short": "Physical location",
+                "definition": "Physical location.",
+                "comment": "Additional addresses should be recorded using another instance of the Location resource, or via the Organization.",
+                "requirements": "If locations can be visited, we need to keep track of their address.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Location.address",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Address"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".addr"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Location.address.id",
+                "path": "Location.address.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Location.address.extension",
+                "path": "Location.address.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Location.address.use",
+                "path": "Location.address.use",
+                "short": "home | work | temp | old | billing - purpose of this address",
+                "definition": "The purpose of this address.",
+                "comment": "Applications can assume that an address is current unless it explicitly says that it is temporary or old.",
+                "requirements": "Allows an appropriate address to be chosen from a list of many.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.use",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueCode": "home"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old address etc.for a current/permanent one",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AddressUse"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The use of an address.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/address-use|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "unique(./use)"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./AddressPurpose"
+                    }
+                ]
+            },
+            {
+                "id": "Location.address.type",
+                "path": "Location.address.type",
+                "short": "postal | physical | both",
+                "definition": "Distinguishes between physical addresses (those you can visit) and mailing addresses (e.g. PO Boxes and care-of addresses). Most addresses are both.",
+                "comment": "The definition of Address states that \"address is intended to describe postal addresses, not physical locations\". However, many applications track whether an address has a dual purpose of being a location that can be visited as well as being a valid delivery destination, and Postal addresses are often used as proxies for physical locations (also see the [Location](http://hl7.org/fhir/R4/location.html#) resource).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueCode": "both"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AddressType"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The type of an address (physical / postal).",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/address-type|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.18"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "unique(./use)"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "address type parameter"
+                    }
+                ]
+            },
+            {
+                "id": "Location.address.text",
+                "path": "Location.address.text",
+                "short": "Text representation of the address",
+                "definition": "Specifies the entire address as it should be displayed e.g. on a postal label. This may be provided instead of or as well as the specific parts.",
+                "comment": "Can provide both a text representation and parts. Applications updating an address SHALL ensure that  when both text and parts are present,  no content is included in the text that isn't found in a part.",
+                "requirements": "A renderable, unencoded form.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "137 Nowhere Street, Erewhon 9132"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.1 + XAD.2 + XAD.3 + XAD.4 + XAD.5 + XAD.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./formatted"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "address label parameter"
+                    }
+                ]
+            },
+            {
+                "id": "Location.address.line",
+                "path": "Location.address.line",
+                "short": "Street name, number, direction & P.O. Box etc.",
+                "definition": "This component contains the house number, apartment number, street name, street direction,  P.O. Box number, delivery hints, and similar address information.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Address.line",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "orderMeaning": "The order in which lines should appear in an address label",
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "137 Nowhere Street"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.1 + XAD.2 (note: XAD.1 and XAD.2 have different meanings for a company address than for a person address)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = AL]"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "street"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./StreetAddress (newline delimitted)"
+                    }
+                ]
+            },
+            {
+                "id": "Location.address.city",
+                "path": "Location.address.city",
+                "short": "Name of city, town etc.",
+                "definition": "The name of the city, town, suburb, village or other community or delivery center.",
+                "alias": [
+                    "Municpality"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.city",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "Erewhon"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = CTY]"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "locality"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Jurisdiction"
+                    }
+                ]
+            },
+            {
+                "id": "Location.address.district",
+                "path": "Location.address.district",
+                "short": "District name (aka county)",
+                "definition": "The name of the administrative area (county).",
+                "comment": "District is sometimes known as county, but in some regions 'county' is used in place of city (municipality), so county name should be conveyed in city instead.",
+                "alias": [
+                    "County"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.district",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "Madison"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.9"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = CNT | CPA]"
+                    }
+                ]
+            },
+            {
+                "id": "Location.address.state",
+                "path": "Location.address.state",
+                "short": "Sub-unit of country (abbreviations ok)",
+                "definition": "Sub-unit of a country with limited sovereignty in a federally organized country. A code may be used if codes are in common use (e.g. US 2 letter state codes).",
+                "alias": [
+                    "Province",
+                    "Territory"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.state",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Two letter USPS alphabetic codes.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = STA]"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "region"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Region"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Sites"
+                    }
+                ]
+            },
+            {
+                "id": "Location.address.postalCode",
+                "path": "Location.address.postalCode",
+                "short": "US Zip Codes",
+                "definition": "A postal code designating a region defined by the postal service.",
+                "alias": [
+                    "Zip"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.postalCode",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "9132"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = ZIP]"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "code"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./PostalIdentificationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Location.address.country",
+                "path": "Location.address.country",
+                "short": "Country (e.g. can be ISO 3166 2 or 3 letter code)",
+                "definition": "Country - a nation as commonly understood or generally accepted.",
+                "comment": "ISO 3166 3 letter codes can be used in place of a human readable country name.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.country",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = CNT]"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "country"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Country"
+                    }
+                ]
+            },
+            {
+                "id": "Location.address.period",
+                "path": "Location.address.period",
+                "short": "Time period when address was/is in use",
+                "definition": "Time period when address was/is in use.",
+                "requirements": "Allows addresses to be placed in historical context.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valuePeriod": {
+                            "start": "2010-03-23",
+                            "end": "2010-07-01"
+                        }
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.12 / XAD.13 + XAD.14"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./usablePeriod[type=\"IVL<TS>\"]"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./StartDate and ./EndDate"
+                    }
+                ]
+            },
+            {
+                "id": "Location.physicalType",
+                "path": "Location.physicalType",
+                "short": "Physical form of the location",
+                "definition": "Physical form of the location, e.g. building, room, vehicle, road.",
+                "requirements": "For purposes of showing relevant locations in queries, we need to categorize locations.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Location.physicalType",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "PhysicalType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Physical form of the location.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/location-physical-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".playingEntity [classCode=PLC].code"
+                    }
+                ]
+            },
+            {
+                "id": "Location.position",
+                "path": "Location.position",
+                "short": "The absolute geographic location",
+                "definition": "The absolute geographic location of the Location, expressed using the WGS84 datum (This is the same co-ordinate system used in KML).",
+                "requirements": "For mobile applications and automated route-finding knowing the exact location of the Location is required.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Location.position",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".playingEntity [classCode=PLC determinerCode=INSTANCE].positionText"
+                    }
+                ]
+            },
+            {
+                "id": "Location.position.id",
+                "path": "Location.position.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Location.position.extension",
+                "path": "Location.position.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Location.position.modifierExtension",
+                "path": "Location.position.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Location.position.longitude",
+                "path": "Location.position.longitude",
+                "short": "Longitude with WGS84 datum",
+                "definition": "Longitude. The value domain and the interpretation are the same as for the text of the longitude element in KML (see notes below).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Location.position.longitude",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "(RIM Opted not to map the sub-elements of GPS location, is now an OBS)"
+                    }
+                ]
+            },
+            {
+                "id": "Location.position.latitude",
+                "path": "Location.position.latitude",
+                "short": "Latitude with WGS84 datum",
+                "definition": "Latitude. The value domain and the interpretation are the same as for the text of the latitude element in KML (see notes below).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Location.position.latitude",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "(RIM Opted not to map the sub-elements of GPS location, is now an OBS)"
+                    }
+                ]
+            },
+            {
+                "id": "Location.position.altitude",
+                "path": "Location.position.altitude",
+                "short": "Altitude with WGS84 datum",
+                "definition": "Altitude. The value domain and the interpretation are the same as for the text of the altitude element in KML (see notes below).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Location.position.altitude",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "(RIM Opted not to map the sub-elements of GPS location, is now an OBS)"
+                    }
+                ]
+            },
+            {
+                "id": "Location.managingOrganization",
+                "path": "Location.managingOrganization",
+                "short": "Organization responsible for provisioning and upkeep",
+                "definition": "The organization responsible for the provisioning and upkeep of the location.",
+                "comment": "This can also be used as the part of the organization hierarchy where this location provides services. These services can be defined through the HealthcareService resource.",
+                "requirements": "Need to know who manages the location.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Location.managingOrganization",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".scopingEntity[classCode=ORG determinerKind=INSTANCE]"
+                    }
+                ]
+            },
+            {
+                "id": "Location.partOf",
+                "path": "Location.partOf",
+                "short": "Another Location this one is physically a part of",
+                "definition": "Another Location of which this Location is physically a part of.",
+                "requirements": "For purposes of location, display and identification, knowing which locations are located within other locations is important.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Location.partOf",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-hierarchy",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Location"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".inboundLink[typeCode=PART].source[classCode=SDLC]"
+                    }
+                ]
+            },
+            {
+                "id": "Location.hoursOfOperation",
+                "path": "Location.hoursOfOperation",
+                "short": "What days/times during a week is this location usually open",
+                "definition": "What days/times during a week is this location usually open.",
+                "comment": "This type of information is commonly found published in directories and on websites informing customers when the facility is available.\n\nSpecific services within the location may have their own hours which could be shorter (or longer) than the locations hours.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Location.hoursOfOperation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "Location.hoursOfOperation.id",
+                "path": "Location.hoursOfOperation.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Location.hoursOfOperation.extension",
+                "path": "Location.hoursOfOperation.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Location.hoursOfOperation.modifierExtension",
+                "path": "Location.hoursOfOperation.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Location.hoursOfOperation.daysOfWeek",
+                "path": "Location.hoursOfOperation.daysOfWeek",
+                "short": "mon | tue | wed | thu | fri | sat | sun",
+                "definition": "Indicates which days of the week are available between the start and end Times.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Location.hoursOfOperation.daysOfWeek",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "DaysOfWeek"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The days of the week.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/days-of-week|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "Location.hoursOfOperation.allDay",
+                "path": "Location.hoursOfOperation.allDay",
+                "short": "The Location is open all day",
+                "definition": "The Location is open all day.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Location.hoursOfOperation.allDay",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "Location.hoursOfOperation.openingTime",
+                "path": "Location.hoursOfOperation.openingTime",
+                "short": "Time that the Location opens",
+                "definition": "Time that the Location opens.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Location.hoursOfOperation.openingTime",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "time"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "Location.hoursOfOperation.closingTime",
+                "path": "Location.hoursOfOperation.closingTime",
+                "short": "Time that the Location closes",
+                "definition": "Time that the Location closes.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Location.hoursOfOperation.closingTime",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "time"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "Location.availabilityExceptions",
+                "path": "Location.availabilityExceptions",
+                "short": "Description of availability exceptions",
+                "definition": "A description of when the locations opening ours are different to normal, e.g. public holiday availability. Succinctly describing all possible exceptions to normal site availability as detailed in the opening hours Times.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Location.availabilityExceptions",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Location.endpoint",
+                "path": "Location.endpoint",
+                "short": "Technical endpoints providing access to services operated for the location",
+                "definition": "Technical endpoints providing access to services operated for the location.",
+                "requirements": "Organizations may have different systems at different locations that provide various services and need to be able to define the technical connection details for how to connect to them, and for what purpose.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Location.endpoint",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Endpoint"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Location",
+                "path": "Location",
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "servd",
+                        "map": "Organization"
+                    }
+                ]
+            },
+            {
+                "id": "Location.status",
+                "path": "Location.status",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Location.name",
+                "path": "Location.name",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "servd",
+                        "map": "./PrimaryAddress and ./OtherAddresses"
+                    }
+                ]
+            },
+            {
+                "id": "Location.telecom",
+                "path": "Location.telecom",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "ContactPoint"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Location.address",
+                "path": "Location.address",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Address"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "servd",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Location.address.line",
+                "path": "Location.address.line",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Location.address.city",
+                "path": "Location.address.city",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Location.address.state",
+                "path": "Location.address.state",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Two letter USPS alphabetic codes.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state"
+                },
+                "mapping": [
+                    {
+                        "identity": "servd",
+                        "map": "./Sites"
+                    }
+                ]
+            },
+            {
+                "id": "Location.address.postalCode",
+                "path": "Location.address.postalCode",
+                "short": "US Zip Codes",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Location.managingOrganization",
+                "path": "Location.managingOrganization",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
+                        ]
+                    }
+                ],
+                "mustSupport": true
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-medication.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-medication.json
@@ -1,1365 +1,1365 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-medication",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-medication-definitions.html#Medication\" title=\"The US Core Medication Profile is based upon the core FHIR Medication Resource and created to meet the 2015 Edition Common Clinical Data Set 'Medications' requirements.\">Medication</a><a name=\"Medication\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/medication.html\">Medication</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Definition of a Medication</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck00.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-medication-definitions.html#Medication.code\">code</a><a name=\"Medication.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Codes that identify this medication</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1010.4/expansion\">Medication Clinical Drug</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)</td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication",
-	"version": "4.0.0",
-	"name": "USCoreMedicationProfile",
-	"title": "US Core Medication Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the Medication resource for the minimal set of data to query and retrieve patient retrieving patient's medication information.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "script10.6",
-			"uri": "http://ncpdp.org/SCRIPT10_6",
-			"name": "Mapping to NCPDP SCRIPT 10.6"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Medication",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Medication",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Medication",
-				"path": "Medication",
-				"short": "Definition of a Medication",
-				"definition": "The US Core Medication Profile is based upon the core FHIR Medication Resource and created to meet the 2015 Edition Common Clinical Data Set 'Medications' requirements.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Medication",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "script10.6",
-						"map": "NewRx/MedicationPrescribed\r-or-\rRxFill/MedicationDispensed\r-or-\rRxHistoryResponse/MedicationDispensed\r-or-\rRxHistoryResponse/MedicationPrescribed"
-					},
-					{
-						"identity": "rim",
-						"map": "ManufacturedProduct[classCode=ADMM]"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Medication"
-					}
-				]
-			},
-			{
-				"id": "Medication.id",
-				"path": "Medication.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Medication.meta",
-				"path": "Medication.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Medication.implicitRules",
-				"path": "Medication.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Medication.language",
-				"path": "Medication.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Medication.text",
-				"path": "Medication.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Medication.contained",
-				"path": "Medication.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Medication.extension",
-				"path": "Medication.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Medication.modifierExtension",
-				"path": "Medication.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Medication.identifier",
-				"path": "Medication.identifier",
-				"short": "Business identifier for this medication",
-				"definition": "Business identifier for this medication.",
-				"comment": "The serial number could be included as an identifier.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Medication.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					}
-				]
-			},
-			{
-				"id": "Medication.code",
-				"path": "Medication.code",
-				"short": "Codes that identify this medication",
-				"definition": "A code (or set of codes) that specify this medication, or a textual description if no code is available. Usage note: This could be a standard medication code such as a code from RxNorm, SNOMED CT, IDMP etc. It could also be a national or local formulary code, optionally with translations to other code systems.",
-				"comment": "Depending on the context of use, the code that was actually selected by the user (prescriber, dispenser, etc.) will have the coding.userSelected set to true.  As described in the coding datatype: \"A coding may be marked as a \"userSelected\" if a user selected the particular coded value in a user interface (e.g. the user selects an item in a pick-list). If a user selected coding exists, it is the preferred choice for performing translations etc. Other codes can only be literal translations to alternative code systems, or codes at a lower level of granularity (e.g. a generic code for a vendor-specific primary one).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Medication.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.4"
-				},
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "coding.code = //element(*,MedicationType)/DrugCoded/ProductCode\r\rcoding.system = //element(*,MedicationType)/DrugCoded/ProductCodeQualifier\r\rcoding.display = //element(*,MedicationType)/DrugDescription"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "v2",
-						"map": "RXO-1.1-Requested Give Code.code / RXE-2.1-Give Code.code / RXD-2.1-Dispense/Give Code.code / RXG-4.1-Give Code.code /RXA-5.1-Administered Code.code / RXC-2.1 Component Code"
-					},
-					{
-						"identity": "rim",
-						"map": ".code"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Medication.code"
-					}
-				]
-			},
-			{
-				"id": "Medication.status",
-				"path": "Medication.status",
-				"short": "active | inactive | entered-in-error",
-				"definition": "A code to indicate if the medication is in active use.",
-				"comment": "This status is intended to identify if the medication in a local system is in active use within a drug database or inventory.  For example, a pharmacy system may create a new drug file record for a compounded product \"ABC Hospital Special Cream\" with an active status.  At some point in the future, it may be determined that the drug record was created with an error and the status is changed to \"entered in error\".   This status is not intended to specify if a medication is part of a particular formulary.  It is possible that the drug record may be referenced by multiple formularies or catalogues and each of those entries would have a separate status.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Medication.status",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element changes the interpretation of all descriptive attributes.",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "MedicationStatus"
-						}
-					],
-					"strength": "required",
-					"description": "A coded concept defining if the medication is in active use.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/medication-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".statusCode"
-					}
-				]
-			},
-			{
-				"id": "Medication.manufacturer",
-				"path": "Medication.manufacturer",
-				"short": "Manufacturer of the item",
-				"definition": "Describes the details of the manufacturer of the medication product.  This is not intended to represent the distributor of a medication product.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Medication.manufacturer",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "no mapping"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "RXD-20-Substance Manufacturer Name / RXG-21-Substance Manufacturer Name / RXA-17-Substance Manufacturer Name"
-					},
-					{
-						"identity": "rim",
-						"map": ".player.scopingRole[typeCode=MANU].scoper"
-					}
-				]
-			},
-			{
-				"id": "Medication.form",
-				"path": "Medication.form",
-				"short": "powder | tablets | capsule +",
-				"definition": "Describes the form of the item.  Powder; tablets; capsule.",
-				"comment": "When Medication is referenced from MedicationRequest, this is the ordered form.  When Medication is referenced within MedicationDispense, this is the dispensed form.  When Medication is referenced within MedicationAdministration, this is administered form.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Medication.form",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "MedicationForm"
-						}
-					],
-					"strength": "example",
-					"description": "A coded concept defining the form of a medication.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/medication-form-codes"
-				},
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "coding.code =  //element(*,DrugCodedType)/FormCode\r\rcoding.system = //element(*,DrugCodedType)/FormSourceCode"
-					},
-					{
-						"identity": "v2",
-						"map": "RXO-5-Requested Dosage Form / RXE-6-Give Dosage Form / RXD-6-Actual Dosage Form / RXG-8-Give Dosage Form / RXA-8-Administered Dosage Form"
-					},
-					{
-						"identity": "rim",
-						"map": ".formCode"
-					}
-				]
-			},
-			{
-				"id": "Medication.amount",
-				"path": "Medication.amount",
-				"short": "Amount of drug in package",
-				"definition": "Specific amount of the drug in the packaged product.  For example, when specifying a product that has the same strength (For example, Insulin glargine 100 unit per mL solution for injection), this attribute provides additional clarification of the package amount (For example, 3 mL, 10mL, etc.).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Medication.amount",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Ratio"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".quantity"
-					}
-				]
-			},
-			{
-				"id": "Medication.ingredient",
-				"path": "Medication.ingredient",
-				"short": "Active or inactive ingredient",
-				"definition": "Identifies a particular constituent of interest in the product.",
-				"comment": "The ingredients need not be a complete list.  If an ingredient is not specified, this does not indicate whether an ingredient is present or absent.  If an ingredient is specified it does not mean that all ingredients are specified.  It is possible to specify both inactive and active ingredients.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Medication.ingredient",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".scopesRole[typeCode=INGR]"
-					}
-				]
-			},
-			{
-				"id": "Medication.ingredient.id",
-				"path": "Medication.ingredient.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Medication.ingredient.extension",
-				"path": "Medication.ingredient.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Medication.ingredient.modifierExtension",
-				"path": "Medication.ingredient.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Medication.ingredient.item[x]",
-				"path": "Medication.ingredient.item[x]",
-				"short": "The actual ingredient or content",
-				"definition": "The actual ingredient - either a substance (simple ingredient) or another medication of a medication.",
-				"requirements": "The ingredient may reference a substance (for example, amoxicillin) or another medication (for example in the case of a compounded product, Glaxal Base).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Medication.ingredient.item[x]",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Substance",
-							"http://hl7.org/fhir/StructureDefinition/Medication"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "coding.code = //element(*,MedicationType)/DrugCoded/ProductCode\r\rcoding.system = //element(*,MedicationType)/DrugCoded/ProductCodeQualifier\r\rcoding.display = //element(*,MedicationType)/DrugDescription"
-					},
-					{
-						"identity": "v2",
-						"map": "RXC-2-Component Code  if medication: RXO-1-Requested Give Code / RXE-2-Give Code / RXD-2-Dispense/Give Code / RXG-4-Give Code / RXA-5-Administered Code"
-					},
-					{
-						"identity": "rim",
-						"map": ".player"
-					}
-				]
-			},
-			{
-				"id": "Medication.ingredient.isActive",
-				"path": "Medication.ingredient.isActive",
-				"short": "Active ingredient indicator",
-				"definition": "Indication of whether this ingredient affects the therapeutic action of the drug.",
-				"requirements": "True indicates that the ingredient affects the therapeutic action of the drug (i.e. active). \rFalse indicates that the ingredient does not affect the therapeutic action of the drug (i.e. inactive).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Medication.ingredient.isActive",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Medication.ingredient.strength",
-				"path": "Medication.ingredient.strength",
-				"short": "Quantity of ingredient present",
-				"definition": "Specifies how many (or how much) of the items there are in this Medication.  For example, 250 mg per tablet.  This is expressed as a ratio where the numerator is 250mg and the denominator is 1 tablet.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Medication.ingredient.strength",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Ratio"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "//element(*,DrugCodedType)/Strength"
-					},
-					{
-						"identity": "v2",
-						"map": "RXC-3-Component Amount & RXC-4-Component Units  if medication: RXO-2-Requested Give Amount - Minimum & RXO-4-Requested Give Units / RXO-3-Requested Give Amount - Maximum & RXO-4-Requested Give Units / RXO-11-Requested Dispense Amount & RXO-12-Requested Dispense Units / RXE-3-Give Amount - Minimum & RXE-5-Give Units / RXE-4-Give Amount - Maximum & RXE-5-Give Units / RXE-10-Dispense Amount & RXE-10-Dispense Units"
-					},
-					{
-						"identity": "rim",
-						"map": ".quantity"
-					}
-				]
-			},
-			{
-				"id": "Medication.batch",
-				"path": "Medication.batch",
-				"short": "Details about packaged medications",
-				"definition": "Information that only applies to packages (not products).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Medication.batch",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "no mapping"
-					},
-					{
-						"identity": "rim",
-						"map": ".player[classCode=CONT]"
-					}
-				]
-			},
-			{
-				"id": "Medication.batch.id",
-				"path": "Medication.batch.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Medication.batch.extension",
-				"path": "Medication.batch.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Medication.batch.modifierExtension",
-				"path": "Medication.batch.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Medication.batch.lotNumber",
-				"path": "Medication.batch.lotNumber",
-				"short": "Identifier assigned to batch",
-				"definition": "The assigned lot number of a batch of the specified product.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Medication.batch.lotNumber",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "no mapping"
-					},
-					{
-						"identity": "v2",
-						"map": "RXA-15 Substance Lot Number / RXG-19 Substance Lot Number"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					}
-				]
-			},
-			{
-				"id": "Medication.batch.expirationDate",
-				"path": "Medication.batch.expirationDate",
-				"short": "When batch will expire",
-				"definition": "When this specific batch of product will expire.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Medication.batch.expirationDate",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "no mapping"
-					},
-					{
-						"identity": "v2",
-						"map": "RXA-16 Substance Expiration Date / RXG-20 Substance Expiration Date"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=CSM].role[classCode=INST].scopedRole.scoper[classCode=MMAT].expirationTime"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Medication",
-				"path": "Medication",
-				"definition": "The US Core Medication Profile is based upon the core FHIR Medication Resource and created to meet the 2015 Edition Common Clinical Data Set 'Medications' requirements.",
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Medication"
-					}
-				]
-			},
-			{
-				"id": "Medication.code",
-				"path": "Medication.code",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.4"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Medication.code"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-medication",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication",
+    "version": "4.0.0",
+    "name": "USCoreMedicationProfile",
+    "title": "US Core Medication Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the Medication resource for the minimal set of data to query and retrieve patient retrieving patient's medication information.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "script10.6",
+            "uri": "http://ncpdp.org/SCRIPT10_6",
+            "name": "Mapping to NCPDP SCRIPT 10.6"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Medication",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Medication",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Medication",
+                "path": "Medication",
+                "short": "Definition of a Medication",
+                "definition": "The US Core Medication Profile is based upon the core FHIR Medication Resource and created to meet the 2015 Edition Common Clinical Data Set 'Medications' requirements.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Medication",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "script10.6",
+                        "map": "NewRx/MedicationPrescribed\r-or-\rRxFill/MedicationDispensed\r-or-\rRxHistoryResponse/MedicationDispensed\r-or-\rRxHistoryResponse/MedicationPrescribed"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "ManufacturedProduct[classCode=ADMM]"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Medication"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.id",
+                "path": "Medication.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Medication.meta",
+                "path": "Medication.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Medication.implicitRules",
+                "path": "Medication.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Medication.language",
+                "path": "Medication.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Medication.text",
+                "path": "Medication.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.contained",
+                "path": "Medication.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.extension",
+                "path": "Medication.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.modifierExtension",
+                "path": "Medication.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.identifier",
+                "path": "Medication.identifier",
+                "short": "Business identifier for this medication",
+                "definition": "Business identifier for this medication.",
+                "comment": "The serial number could be included as an identifier.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Medication.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.code",
+                "path": "Medication.code",
+                "short": "Codes that identify this medication",
+                "definition": "A code (or set of codes) that specify this medication, or a textual description if no code is available. Usage note: This could be a standard medication code such as a code from RxNorm, SNOMED CT, IDMP etc. It could also be a national or local formulary code, optionally with translations to other code systems.",
+                "comment": "Depending on the context of use, the code that was actually selected by the user (prescriber, dispenser, etc.) will have the coding.userSelected set to true.  As described in the coding datatype: \"A coding may be marked as a \"userSelected\" if a user selected the particular coded value in a user interface (e.g. the user selects an item in a pick-list). If a user selected coding exists, it is the preferred choice for performing translations etc. Other codes can only be literal translations to alternative code systems, or codes at a lower level of granularity (e.g. a generic code for a vendor-specific primary one).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Medication.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.4"
+                },
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "coding.code = //element(*,MedicationType)/DrugCoded/ProductCode\r\rcoding.system = //element(*,MedicationType)/DrugCoded/ProductCodeQualifier\r\rcoding.display = //element(*,MedicationType)/DrugDescription"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXO-1.1-Requested Give Code.code / RXE-2.1-Give Code.code / RXD-2.1-Dispense/Give Code.code / RXG-4.1-Give Code.code /RXA-5.1-Administered Code.code / RXC-2.1 Component Code"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".code"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Medication.code"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.status",
+                "path": "Medication.status",
+                "short": "active | inactive | entered-in-error",
+                "definition": "A code to indicate if the medication is in active use.",
+                "comment": "This status is intended to identify if the medication in a local system is in active use within a drug database or inventory.  For example, a pharmacy system may create a new drug file record for a compounded product \"ABC Hospital Special Cream\" with an active status.  At some point in the future, it may be determined that the drug record was created with an error and the status is changed to \"entered in error\".   This status is not intended to specify if a medication is part of a particular formulary.  It is possible that the drug record may be referenced by multiple formularies or catalogues and each of those entries would have a separate status.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Medication.status",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element changes the interpretation of all descriptive attributes.",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "MedicationStatus"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "A coded concept defining if the medication is in active use.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/medication-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".statusCode"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.manufacturer",
+                "path": "Medication.manufacturer",
+                "short": "Manufacturer of the item",
+                "definition": "Describes the details of the manufacturer of the medication product.  This is not intended to represent the distributor of a medication product.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Medication.manufacturer",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "no mapping"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXD-20-Substance Manufacturer Name / RXG-21-Substance Manufacturer Name / RXA-17-Substance Manufacturer Name"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".player.scopingRole[typeCode=MANU].scoper"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.form",
+                "path": "Medication.form",
+                "short": "powder | tablets | capsule +",
+                "definition": "Describes the form of the item.  Powder; tablets; capsule.",
+                "comment": "When Medication is referenced from MedicationRequest, this is the ordered form.  When Medication is referenced within MedicationDispense, this is the dispensed form.  When Medication is referenced within MedicationAdministration, this is administered form.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Medication.form",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "MedicationForm"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "A coded concept defining the form of a medication.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/medication-form-codes"
+                },
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "coding.code =  //element(*,DrugCodedType)/FormCode\r\rcoding.system = //element(*,DrugCodedType)/FormSourceCode"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXO-5-Requested Dosage Form / RXE-6-Give Dosage Form / RXD-6-Actual Dosage Form / RXG-8-Give Dosage Form / RXA-8-Administered Dosage Form"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".formCode"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.amount",
+                "path": "Medication.amount",
+                "short": "Amount of drug in package",
+                "definition": "Specific amount of the drug in the packaged product.  For example, when specifying a product that has the same strength (For example, Insulin glargine 100 unit per mL solution for injection), this attribute provides additional clarification of the package amount (For example, 3 mL, 10mL, etc.).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Medication.amount",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Ratio"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".quantity"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.ingredient",
+                "path": "Medication.ingredient",
+                "short": "Active or inactive ingredient",
+                "definition": "Identifies a particular constituent of interest in the product.",
+                "comment": "The ingredients need not be a complete list.  If an ingredient is not specified, this does not indicate whether an ingredient is present or absent.  If an ingredient is specified it does not mean that all ingredients are specified.  It is possible to specify both inactive and active ingredients.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Medication.ingredient",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".scopesRole[typeCode=INGR]"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.ingredient.id",
+                "path": "Medication.ingredient.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.ingredient.extension",
+                "path": "Medication.ingredient.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.ingredient.modifierExtension",
+                "path": "Medication.ingredient.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.ingredient.item[x]",
+                "path": "Medication.ingredient.item[x]",
+                "short": "The actual ingredient or content",
+                "definition": "The actual ingredient - either a substance (simple ingredient) or another medication of a medication.",
+                "requirements": "The ingredient may reference a substance (for example, amoxicillin) or another medication (for example in the case of a compounded product, Glaxal Base).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Medication.ingredient.item[x]",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Substance",
+                            "http://hl7.org/fhir/StructureDefinition/Medication"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "coding.code = //element(*,MedicationType)/DrugCoded/ProductCode\r\rcoding.system = //element(*,MedicationType)/DrugCoded/ProductCodeQualifier\r\rcoding.display = //element(*,MedicationType)/DrugDescription"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXC-2-Component Code  if medication: RXO-1-Requested Give Code / RXE-2-Give Code / RXD-2-Dispense/Give Code / RXG-4-Give Code / RXA-5-Administered Code"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".player"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.ingredient.isActive",
+                "path": "Medication.ingredient.isActive",
+                "short": "Active ingredient indicator",
+                "definition": "Indication of whether this ingredient affects the therapeutic action of the drug.",
+                "requirements": "True indicates that the ingredient affects the therapeutic action of the drug (i.e. active). \rFalse indicates that the ingredient does not affect the therapeutic action of the drug (i.e. inactive).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Medication.ingredient.isActive",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.ingredient.strength",
+                "path": "Medication.ingredient.strength",
+                "short": "Quantity of ingredient present",
+                "definition": "Specifies how many (or how much) of the items there are in this Medication.  For example, 250 mg per tablet.  This is expressed as a ratio where the numerator is 250mg and the denominator is 1 tablet.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Medication.ingredient.strength",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Ratio"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "//element(*,DrugCodedType)/Strength"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXC-3-Component Amount & RXC-4-Component Units  if medication: RXO-2-Requested Give Amount - Minimum & RXO-4-Requested Give Units / RXO-3-Requested Give Amount - Maximum & RXO-4-Requested Give Units / RXO-11-Requested Dispense Amount & RXO-12-Requested Dispense Units / RXE-3-Give Amount - Minimum & RXE-5-Give Units / RXE-4-Give Amount - Maximum & RXE-5-Give Units / RXE-10-Dispense Amount & RXE-10-Dispense Units"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".quantity"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.batch",
+                "path": "Medication.batch",
+                "short": "Details about packaged medications",
+                "definition": "Information that only applies to packages (not products).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Medication.batch",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "no mapping"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".player[classCode=CONT]"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.batch.id",
+                "path": "Medication.batch.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.batch.extension",
+                "path": "Medication.batch.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.batch.modifierExtension",
+                "path": "Medication.batch.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.batch.lotNumber",
+                "path": "Medication.batch.lotNumber",
+                "short": "Identifier assigned to batch",
+                "definition": "The assigned lot number of a batch of the specified product.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Medication.batch.lotNumber",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "no mapping"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXA-15 Substance Lot Number / RXG-19 Substance Lot Number"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.batch.expirationDate",
+                "path": "Medication.batch.expirationDate",
+                "short": "When batch will expire",
+                "definition": "When this specific batch of product will expire.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Medication.batch.expirationDate",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "no mapping"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXA-16 Substance Expiration Date / RXG-20 Substance Expiration Date"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=CSM].role[classCode=INST].scopedRole.scoper[classCode=MMAT].expirationTime"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Medication",
+                "path": "Medication",
+                "definition": "The US Core Medication Profile is based upon the core FHIR Medication Resource and created to meet the 2015 Edition Common Clinical Data Set 'Medications' requirements.",
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Medication"
+                    }
+                ]
+            },
+            {
+                "id": "Medication.code",
+                "path": "Medication.code",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.4"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Medication.code"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-medicationrequest.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-medicationrequest.json
@@ -1,4363 +1,4363 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-medicationrequest",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-medicationrequest-definitions.html#MedicationRequest\" title=\"The US Core Medication Request (Order) Profile is based upon the core FHIR MedicationRequest Resource and created to meet the 2015 Edition Common Clinical Data Set 'Medications' requirements.\">MedicationRequest</a><a name=\"MedicationRequest\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/medicationrequest.html\">MedicationRequest</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Ordering of medication for patient or group</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-medicationrequest-definitions.html#MedicationRequest.status\">status</a><a name=\"MedicationRequest.status\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">active | on-hold | cancelled | completed | entered-in-error | stopped | draft | unknown</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-medicationrequest-status.html\">medicationrequest Status</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>): A code specifying the state of the prescribing event. Describes the lifecycle of the prescription.<br/><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-medicationrequest-definitions.html#MedicationRequest.intent\">intent</a><a name=\"MedicationRequest.intent\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">proposal | plan | order | original-order | reflex-order | filler-order | instance-order | option</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-medicationrequest-intent.html\">medicationRequest Intent</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>): The kind of medication order.<br/><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-medicationrequest-definitions.html#MedicationRequest.category\">category</a><a name=\"MedicationRequest.category\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Type of medication usage</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-medicationrequest-category.html\">medicationRequest Category Codes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#preferred\" title=\"Instances are encouraged to draw from the specified codes for interoperability purposes but are not required to do so to be considered conformant.\">preferred</a>): The type of medication order.<br/><br/><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_choice.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Choice of Types\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-medicationrequest-definitions.html#MedicationRequest.reported[x]\">reported[x]</a><a name=\"MedicationRequest.reported_x_\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Reported rather than primary record</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for boolean Type: Value of &quot;true&quot; or &quot;false&quot;\">reportedBoolean</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#boolean\">boolean</a> <span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This type must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> reportedReference</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html#Reference\">Reference</a> <span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This type must be supported\">S</span>(<a href=\"StructureDefinition-us-core-practitioner.html\">US Core Practitioner Profile</a> <span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This target must be supported\">S</span> | <a href=\"StructureDefinition-us-core-organization.html\">US Core Organization Profile</a> | <a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a> | <a href=\"StructureDefinition-us-core-practitionerrole.html\">US Core PractitionerRole Profile</a> | <a href=\"http://hl7.org/fhir/R4/relatedperson.html\">RelatedPerson</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_choice.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Choice of Types\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-medicationrequest-definitions.html#MedicationRequest.medication[x]\">medication[x]</a><a name=\"MedicationRequest.medication_x_\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Medication to be taken</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1010.4/expansion\">Medication Clinical Drug</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for CodeableConcept Type: A concept that may be defined by a formal reference to a terminology or ontology or may be provided by text.\">medicationCodeableConcept</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> medicationReference</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html#Reference\">Reference</a>(<a href=\"StructureDefinition-us-core-medication.html\">US Core Medication Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-medicationrequest-definitions.html#MedicationRequest.subject\">subject</a><a name=\"MedicationRequest.subject\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who or group medication request is for</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-medicationrequest-definitions.html#MedicationRequest.encounter\">encounter</a><a name=\"MedicationRequest.encounter\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-encounter.html\">US Core Encounter Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Encounter created as part of encounter/admission/stay</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-medicationrequest-definitions.html#MedicationRequest.authoredOn\">authoredOn</a><a name=\"MedicationRequest.authoredOn\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#dateTime\">dateTime</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">When request was initially authored</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-medicationrequest-definitions.html#MedicationRequest.requester\">requester</a><a name=\"MedicationRequest.requester\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-practitioner.html\">US Core Practitioner Profile</a> <span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This target must be supported\">S</span> | <a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a> | <a href=\"StructureDefinition-us-core-organization.html\">US Core Organization Profile</a> | <a href=\"StructureDefinition-us-core-practitionerrole.html\">US Core PractitionerRole Profile</a> | <a href=\"http://hl7.org/fhir/R4/relatedperson.html\">RelatedPerson</a> | <a href=\"http://hl7.org/fhir/R4/device.html\">Device</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who/What requested the Request</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-medicationrequest-definitions.html#MedicationRequest.dosageInstruction\">dosageInstruction</a><a name=\"MedicationRequest.dosageInstruction\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Dosage\">Dosage</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">How the medication should be taken</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-medicationrequest-definitions.html#MedicationRequest.dosageInstruction.text\">text</a><a name=\"MedicationRequest.dosageInstruction.text\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Free text dosage instructions e.g. SIG</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest",
-	"version": "4.0.0",
-	"name": "USCoreMedicationRequestProfile",
-	"title": "US Core MedicationRequest Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-06-26",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the MedicationRequest resource for the minimal set of data to query and retrieve prescription information.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "script10.6",
-			"uri": "http://ncpdp.org/SCRIPT10_6",
-			"name": "Mapping to NCPDP SCRIPT 10.6"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "MedicationRequest",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "MedicationRequest",
-				"path": "MedicationRequest",
-				"short": "Ordering of medication for patient or group",
-				"definition": "The US Core Medication Request (Order) Profile is based upon the core FHIR MedicationRequest Resource and created to meet the 2015 Edition Common Clinical Data Set 'Medications' requirements.",
-				"alias": [
-					"Prescription",
-					"Order"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "MedicationRequest",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Request"
-					},
-					{
-						"identity": "script10.6",
-						"map": "Message/Body/NewRx"
-					},
-					{
-						"identity": "rim",
-						"map": "CombinedMedicationRequest"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.id",
-				"path": "MedicationRequest.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "MedicationRequest.meta",
-				"path": "MedicationRequest.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "MedicationRequest.implicitRules",
-				"path": "MedicationRequest.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "MedicationRequest.language",
-				"path": "MedicationRequest.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "MedicationRequest.text",
-				"path": "MedicationRequest.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.contained",
-				"path": "MedicationRequest.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.extension",
-				"path": "MedicationRequest.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.modifierExtension",
-				"path": "MedicationRequest.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.identifier",
-				"path": "MedicationRequest.identifier",
-				"short": "External ids for this request",
-				"definition": "Identifiers associated with this medication request that are defined by business processes and/or used to refer to it when a direct URL reference to the resource itself is not appropriate. They are business identifiers assigned to this resource by the performer or other systems and remain constant as the resource is updated and propagates from server to server.",
-				"comment": "This is a business identifier, not a resource identifier.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "MedicationRequest.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.identifier"
-					},
-					{
-						"identity": "script10.6",
-						"map": "Message/Header/PrescriberOrderNumber"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC-2-Placer Order Number / ORC-3-Filler Order Number"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.status",
-				"path": "MedicationRequest.status",
-				"short": "active | on-hold | cancelled | completed | entered-in-error | stopped | draft | unknown",
-				"definition": "A code specifying the current state of the order.  Generally, this will be active or completed state.",
-				"comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"description": "A code specifying the state of the prescribing event. Describes the lifecycle of the prescription.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/medicationrequest-status"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.status"
-					},
-					{
-						"identity": "script10.6",
-						"map": "no mapping"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "rim",
-						"map": ".statusCode"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder.status"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.statusReason",
-				"path": "MedicationRequest.statusReason",
-				"short": "Reason for current status",
-				"definition": "Captures the reason for the current state of the MedicationRequest.",
-				"comment": "This is generally only used for \"exception\" statuses such as \"suspended\" or \"cancelled\". The reason why the MedicationRequest was created at all is captured in reasonCode, not here.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.statusReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "MedicationRequestStatusReason"
-						}
-					],
-					"strength": "example",
-					"description": "Identifies the reasons for a given status.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/medicationrequest-status-reason"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.statusReason"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=SUBJ].source[classCode=CACT, moodCode=EVN].reasonCOde"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.intent",
-				"path": "MedicationRequest.intent",
-				"short": "proposal | plan | order | original-order | reflex-order | filler-order | instance-order | option",
-				"definition": "Whether the request is a proposal, plan, or an original order.",
-				"comment": "It is expected that the type of requester will be restricted for different stages of a MedicationRequest.  For example, Proposals can be created by a patient, relatedPerson, Practitioner or Device.  Plans can be created by Practitioners, Patients, RelatedPersons and Devices.  Original orders can be created by a Practitioner only.\r\rAn instance-order is an instantiation of a request or order and may be used to populate Medication Administration Record.\r\rThis element is labeled as a modifier because the intent alters when and how the resource is actually applicable.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.intent",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element changes the interpretation of all descriptive attributes. For example \"the time the request is recommended to occur\" vs. \"the time the request is authorized to occur\" or \"who is recommended to perform the request\" vs. \"who is authorized to perform the request",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"description": "The kind of medication order.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/medicationrequest-intent"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.intent"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".moodCode (nuances beyond PRP/PLAN/RQO would need to be elsewhere)"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder.status"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.category",
-				"path": "MedicationRequest.category",
-				"short": "Type of medication usage",
-				"definition": "Indicates the type of medication request (for example, where the medication is expected to be consumed or administered (i.e. inpatient or outpatient)).",
-				"comment": "The category can be used to include where the medication is expected to be consumed or other types of requests.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "MedicationRequest.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"strength": "preferred",
-					"description": "The type of medication order.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/medicationrequest-category"
-				},
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "Message/Body/NewRx/MedicationPrescribed/Directions\r\ror \r\rMessage/Body/NewRx/MedicationPrescribed/StructuredSIG"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[classCode=OBS, moodCode=EVN, code=\"type of medication usage\"].value"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.priority",
-				"path": "MedicationRequest.priority",
-				"short": "routine | urgent | asap | stat",
-				"definition": "Indicates how quickly the Medication Request should be addressed with respect to other requests.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.priority",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "MedicationRequestPriority"
-						}
-					],
-					"strength": "required",
-					"description": "Identifies the level of importance to be assigned to actioning the request.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/request-priority|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.priority"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.grade"
-					},
-					{
-						"identity": "rim",
-						"map": ".priorityCode"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.doNotPerform",
-				"path": "MedicationRequest.doNotPerform",
-				"short": "True if request is prohibiting action",
-				"definition": "If true indicates that the provider is asking for the medication request not to occur.",
-				"comment": "If do not perform is not specified, the request is a positive request e.g. \"do perform\".",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.doNotPerform",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because this element negates the request to occur (ie, this is a request for the medication not to be ordered or prescribed, etc)",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "SubstanceAdministration.actionNegationInd"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.reported[x]",
-				"path": "MedicationRequest.reported[x]",
-				"short": "Reported rather than primary record",
-				"definition": "Indicates if this record was captured as a secondary 'reported' record rather than as an original primary source-of-truth record.  It may also indicate the source of the report.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.reported[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "boolean"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						],
-						"_targetProfile": [
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": true
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							}
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=INF].role"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder.status"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.medication[x]",
-				"path": "MedicationRequest.medication[x]",
-				"short": "Medication to be taken",
-				"definition": "Identifies the medication being requested. This is a link to a resource that represents the medication which may be the details of the medication or simply an attribute carrying a code that identifies the medication from a known list of medications.",
-				"comment": "If only a code is specified, then it needs to be a code for a specific product. If more information is required, then the use of the Medication resource is recommended.  For example, if you require form or lot number or if the medication is compounded or extemporaneously prepared, then you must reference the Medication resource.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.medication[x]",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.4"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.code"
-					},
-					{
-						"identity": "script10.6",
-						"map": "Message/Body/NewRx/MedicationPrescribed\r\rMedication.code.coding.code = Message/Body/NewRx/MedicationPrescribed/DrugCoded/ProductCode\r\rMedication.code.coding.system = Message/Body/NewRx/MedicationPrescribed/DrugCoded/ProductCodeQualifier\r\rMedication.code.coding.display = Message/Body/NewRx/MedicationPrescribed/DrugDescription"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "RXE-2-Give Code / RXO-1-Requested Give Code / RXC-2-Component Code"
-					},
-					{
-						"identity": "rim",
-						"map": "consumable.administrableMedication"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder.medication[x]"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.subject",
-				"path": "MedicationRequest.subject",
-				"short": "Who or group medication request is for",
-				"definition": "A link to a resource representing the person or set of individuals to whom the medication will be given.",
-				"comment": "The subject on a medication request is mandatory.  For the secondary use case where the actual subject is not provided, there still must be an anonymized subject specified.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.subject",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.subject"
-					},
-					{
-						"identity": "script10.6",
-						"map": "Message/Body/NewRx/Patient\r\r(need detail to link to specific patient … Patient.Identification in SCRIPT)"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3-Patient ID List"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=AUT].role"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder.patient"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.encounter",
-				"path": "MedicationRequest.encounter",
-				"short": "Encounter created as part of encounter/admission/stay",
-				"definition": "The Encounter during which this [x] was created or to which the creation of this record is tightly associated.",
-				"comment": "This will typically be the encounter the event occurred within, but some activities may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter.\"    If there is a need to link to episodes of care they will be handled with an extension.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.context"
-					},
-					{
-						"identity": "script10.6",
-						"map": "no mapping"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1-19-Visit Number"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN, code=\"type of encounter or episode\"]"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.supportingInformation",
-				"path": "MedicationRequest.supportingInformation",
-				"short": "Information to support ordering of the medication",
-				"definition": "Include additional information (for example, patient height and weight) that supports the ordering of the medication.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "MedicationRequest.supportingInformation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.supportingInfo"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=PERT].target[A_SupportingClinicalStatement CMET minimal with many different choices of classCodes(ORG, ENC, PROC, SPLY, SBADM, OBS) and each of the act class codes draws from one or more of the following moodCodes (EVN, DEF, INT PRMS, RQO, PRP, APT, ARQ, GOL)]"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.authoredOn",
-				"path": "MedicationRequest.authoredOn",
-				"short": "When request was initially authored",
-				"definition": "The date (and perhaps time) when the prescription was initially written or authored on.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.authoredOn",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.authoredOn"
-					},
-					{
-						"identity": "script10.6",
-						"map": "Message/Body/NewRx/MedicationPrescribed/WrittenDate"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "v2",
-						"map": "RXE-32-Original Order Date/Time / ORC-9-Date/Time of Transaction"
-					},
-					{
-						"identity": "rim",
-						"map": "author.time"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder.dateWritten"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.requester",
-				"path": "MedicationRequest.requester",
-				"short": "Who/What requested the Request",
-				"definition": "The individual, organization, or device that initiated the request and has responsibility for its activation.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.requester",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson",
-							"http://hl7.org/fhir/StructureDefinition/Device"
-						],
-						"_targetProfile": [
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": true
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							}
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.requester"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.author"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=AUT].role"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder.prescriber"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.performer",
-				"path": "MedicationRequest.performer",
-				"short": "Intended performer of administration",
-				"definition": "The specified desired performer of the medication treatment (e.g. the performer of the medication administration).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.performer",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.performer"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=PRF].role[scoper.determinerCode=INSTANCE]"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.performerType",
-				"path": "MedicationRequest.performerType",
-				"short": "Desired kind of performer of the medication administration",
-				"definition": "Indicates the type of performer of the administration of the medication.",
-				"comment": "If specified without indicating a performer, this indicates that the performer must be of the specified type. If specified with a performer then it indicates the requirements of the performer if the designated performer is not available.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.performerType",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "MedicationRequestPerformerType"
-						}
-					],
-					"strength": "example",
-					"description": "Identifies the type of individual that is desired to administer the medication.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/performer-role"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.performerType"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=PRF].role[scoper.determinerCode=KIND].code"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.recorder",
-				"path": "MedicationRequest.recorder",
-				"short": "Person who entered the request",
-				"definition": "The person who entered the order on behalf of another individual for example in the case of a verbal or a telephone order.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.recorder",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.who"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=TRANS].role[classCode=ASSIGNED].code (HealthcareProviderType)"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.reasonCode",
-				"path": "MedicationRequest.reasonCode",
-				"short": "Reason or indication for ordering or not ordering the medication",
-				"definition": "The reason or the indication for ordering or not ordering the medication.",
-				"comment": "This could be a diagnosis code. If a full condition record exists or additional detail is needed, use reasonReference.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "MedicationRequest.reasonCode",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "MedicationRequestReason"
-						}
-					],
-					"strength": "example",
-					"description": "A coded concept indicating why the medication was ordered.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/condition-code"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.reasonCode"
-					},
-					{
-						"identity": "script10.6",
-						"map": "Message/Body/NewRx/MedicationPrescribed/Diagnosis/Primary/Value"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.why[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC-16-Order Control Code Reason /RXE-27-Give Indication/RXO-20-Indication / RXD-21-Indication / RXG-22-Indication / RXA-19-Indication"
-					},
-					{
-						"identity": "rim",
-						"map": "reason.observation.reasonCode"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.reasonReference",
-				"path": "MedicationRequest.reasonReference",
-				"short": "Condition or observation that supports why the prescription is being written",
-				"definition": "Condition or observation that supports why the medication was ordered.",
-				"comment": "This is a reference to a condition or observation that is the reason for the medication order.  If only a code exists, use reasonCode.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "MedicationRequest.reasonReference",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Condition",
-							"http://hl7.org/fhir/StructureDefinition/Observation"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.reasonReference"
-					},
-					{
-						"identity": "script10.6",
-						"map": "no mapping"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.why[x]"
-					},
-					{
-						"identity": "rim",
-						"map": "reason.observation[code=ASSERTION].value"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.instantiatesCanonical",
-				"path": "MedicationRequest.instantiatesCanonical",
-				"short": "Instantiates FHIR protocol or definition",
-				"definition": "The URL pointing to a protocol, guideline, orderset, or other definition that is adhered to in whole or in part by this MedicationRequest.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "MedicationRequest.instantiatesCanonical",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "canonical"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.instantiates"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=DEFN].target"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.instantiatesUri",
-				"path": "MedicationRequest.instantiatesUri",
-				"short": "Instantiates external protocol or definition",
-				"definition": "The URL pointing to an externally maintained protocol, guideline, orderset or other definition that is adhered to in whole or in part by this MedicationRequest.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "MedicationRequest.instantiatesUri",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=DEFN].target"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.basedOn",
-				"path": "MedicationRequest.basedOn",
-				"short": "What request fulfills",
-				"definition": "A plan or request that is fulfilled in whole or in part by this medication request.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "MedicationRequest.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan",
-							"http://hl7.org/fhir/StructureDefinition/MedicationRequest",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest",
-							"http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.basedOn"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=FLFS].target[classCode=SBADM or PROC or PCPR or OBS, moodCode=RQO orPLAN or PRP]"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.groupIdentifier",
-				"path": "MedicationRequest.groupIdentifier",
-				"short": "Composite request this is part of",
-				"definition": "A shared identifier common to all requests that were authorized more or less simultaneously by a single author, representing the identifier of the requisition or prescription.",
-				"requirements": "Requests are linked either by a \"basedOn\" relationship (i.e. one request is fulfilling another) or by having a common requisition. Requests that are part of the same requisition are generally treated independently from the perspective of changing their state or maintaining them after initial creation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.groupIdentifier",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.groupIdentifier"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship(typeCode=COMP].target[classCode=SBADM, moodCode=INT].id"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.courseOfTherapyType",
-				"path": "MedicationRequest.courseOfTherapyType",
-				"short": "Overall pattern of medication administration",
-				"definition": "The description of the overall patte3rn of the administration of the medication to the patient.",
-				"comment": "This attribute should not be confused with the protocol of the medication.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.courseOfTherapyType",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "MedicationRequestCourseOfTherapy"
-						}
-					],
-					"strength": "example",
-					"description": "Identifies the overall pattern of medication administratio.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/medicationrequest-course-of-therapy"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.code where classCode = LIST and moodCode = EVN"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.insurance",
-				"path": "MedicationRequest.insurance",
-				"short": "Associated insurance coverage",
-				"definition": "Insurance plans, coverage extensions, pre-authorizations and/or pre-determinations that may be required for delivering the requested service.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "MedicationRequest.insurance",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Coverage",
-							"http://hl7.org/fhir/StructureDefinition/ClaimResponse"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.insurance"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=COVBY].target"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.note",
-				"path": "MedicationRequest.note",
-				"short": "Information about the prescription",
-				"definition": "Extra information about the prescription that could not be conveyed by the other attributes.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "MedicationRequest.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.note"
-					},
-					{
-						"identity": "script10.6",
-						"map": "Message/Body/NewRx/MedicationPrescribed/Note"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=SUBJ]/source[classCode=OBS,moodCode=EVN,code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction",
-				"path": "MedicationRequest.dosageInstruction",
-				"short": "How the medication should be taken",
-				"definition": "Indicates how the medication is to be used by the patient.",
-				"comment": "There are examples where a medication request may include the option of an oral dose or an Intravenous or Intramuscular dose.  For example, \"Ondansetron 8mg orally or IV twice a day as needed for nausea\" or \"Compazine® (prochlorperazine) 5-10mg PO or 25mg PR bid prn nausea or vomiting\".  In these cases, two medication requests would be created that could be grouped together.  The decision on which dose and route of administration to use is based on the patient's condition at the time the dose is needed.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "MedicationRequest.dosageInstruction",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Dosage"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.occurrence[x]"
-					},
-					{
-						"identity": "rim",
-						"map": "see dosageInstruction mapping"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.id",
-				"path": "MedicationRequest.dosageInstruction.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.extension",
-				"path": "MedicationRequest.dosageInstruction.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.modifierExtension",
-				"path": "MedicationRequest.dosageInstruction.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.sequence",
-				"path": "MedicationRequest.dosageInstruction.sequence",
-				"short": "The order of the dosage instructions",
-				"definition": "Indicates the order in which the dosage instructions should be applied or interpreted.",
-				"requirements": "If the sequence number of multiple Dosages is the same, then it is implied that the instructions are to be treated as concurrent.  If the sequence number is different, then the Dosages are intended to be sequential.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Dosage.sequence",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "integer"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "TQ1-1"
-					},
-					{
-						"identity": "rim",
-						"map": ".text"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.text",
-				"path": "MedicationRequest.dosageInstruction.text",
-				"short": "Free text dosage instructions e.g. SIG",
-				"definition": "Free text dosage instructions e.g. SIG.",
-				"requirements": "Free text dosage instructions can be used for cases where the instructions are too complex to code.  The content of this attribute does not include the name or description of the medication. When coded instructions are present, the free text instructions may still be present for display to humans taking or administering the medication. It is expected that the text instructions will always be populated.  If the dosage.timing attribute is also populated, then the dosage.text should reflect the same information as the timing.  Additional information about administration or preparation of the medication should be included as text.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Dosage.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXO-6; RXE-21"
-					},
-					{
-						"identity": "rim",
-						"map": ".text"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.additionalInstruction",
-				"path": "MedicationRequest.dosageInstruction.additionalInstruction",
-				"short": "Supplemental instruction or warnings to the patient - e.g. \"with meals\", \"may cause drowsiness\"",
-				"definition": "Supplemental instructions to the patient on how to take the medication  (e.g. \"with meals\" or\"take half to one hour before food\") or warnings for the patient about the medication (e.g. \"may cause drowsiness\" or \"avoid exposure of skin to direct sunlight or sunlamps\").",
-				"comment": "Information about administration or preparation of the medication (e.g. \"infuse as rapidly as possibly via intraperitoneal port\" or \"immediately following drug x\") should be populated in dosage.text.",
-				"requirements": "Additional instruction is intended to be coded, but where no code exists, the element could include text.  For example, \"Swallow with plenty of water\" which might or might not be coded.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Dosage.additionalInstruction",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AdditionalInstruction"
-						}
-					],
-					"strength": "example",
-					"description": "A coded concept identifying additional instructions such as \"take with water\" or \"avoid operating heavy machinery\".",
-					"valueSet": "http://hl7.org/fhir/ValueSet/additional-instruction-codes"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXO-7"
-					},
-					{
-						"identity": "rim",
-						"map": ".text"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.patientInstruction",
-				"path": "MedicationRequest.dosageInstruction.patientInstruction",
-				"short": "Patient or consumer oriented instructions",
-				"definition": "Instructions in terms that are understood by the patient or consumer.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Dosage.patientInstruction",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXO-7"
-					},
-					{
-						"identity": "rim",
-						"map": ".text"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.timing",
-				"path": "MedicationRequest.dosageInstruction.timing",
-				"short": "When medication should be administered",
-				"definition": "When medication should be administered.",
-				"comment": "This attribute might not always be populated while the Dosage.text is expected to be populated.  If both are populated, then the Dosage.text should reflect the content of the Dosage.timing.",
-				"requirements": "The timing schedule for giving the medication to the patient. This  data type allows many different expressions. For example: \"Every 8 hours\"; \"Three times a day\"; \"1/2 an hour before breakfast for 10 days from 23-Dec 2011:\"; \"15 Oct 2013, 17 Oct 2013 and 1 Nov 2013\".  Sometimes, a rate can imply duration when expressed as total volume / duration (e.g.  500mL/2 hours implies a duration of 2 hours).  However, when rate doesn't imply duration (e.g. 250mL/hour), then the timing.repeat.duration is needed to convey the infuse over time period.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Dosage.timing",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Timing"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.asNeeded[x]",
-				"path": "MedicationRequest.dosageInstruction.asNeeded[x]",
-				"short": "Take \"as needed\" (for x)",
-				"definition": "Indicates whether the Medication is only taken when needed within a specific dosing schedule (Boolean option), or it indicates the precondition for taking the Medication (CodeableConcept).",
-				"comment": "Can express \"as needed\" without a reason by setting the Boolean = True.  In this case the CodeableConcept is not populated.  Or you can express \"as needed\" with a reason by including the CodeableConcept.  In this case the Boolean is assumed to be True.  If you set the Boolean to False, then the dose is given according to the schedule and is not \"prn\" or \"as needed\".",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Dosage.asNeeded[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "MedicationAsNeededReason"
-						}
-					],
-					"strength": "example",
-					"description": "A coded concept identifying the precondition that should be met or evaluated prior to consuming or administering a medication dose.  For example \"pain\", \"30 minutes prior to sexual intercourse\", \"on flare-up\" etc.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/medication-as-needed-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "TQ1-9"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=PRCN].target[classCode=OBS, moodCode=EVN, code=\"as needed\"].value=boolean or codable concept"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.site",
-				"path": "MedicationRequest.dosageInstruction.site",
-				"short": "Body site to administer to",
-				"definition": "Body site to administer to.",
-				"comment": "If the use case requires attributes from the BodySite resource (e.g. to identify and track separately) then use the standard extension [bodySite](http://hl7.org/fhir/R4/extension-bodysite.html).  May be a summary code, or a reference to a very precise definition of the location, or both.",
-				"requirements": "A coded specification of the anatomic site where the medication first enters the body.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Dosage.site",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "MedicationAdministrationSite"
-						}
-					],
-					"strength": "example",
-					"description": "A coded concept describing the site location the medicine enters into or onto the body.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/approach-site-codes"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXR-2"
-					},
-					{
-						"identity": "rim",
-						"map": ".approachSiteCode"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.route",
-				"path": "MedicationRequest.dosageInstruction.route",
-				"short": "How drug should enter body",
-				"definition": "How drug should enter body.",
-				"requirements": "A code specifying the route or physiological path of administration of a therapeutic agent into or onto a patient's body.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Dosage.route",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "RouteOfAdministration"
-						}
-					],
-					"strength": "example",
-					"description": "A coded concept describing the route or physiological path of administration of a therapeutic agent into or onto the body of a subject.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/route-codes"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXR-1"
-					},
-					{
-						"identity": "rim",
-						"map": ".routeCode"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.method",
-				"path": "MedicationRequest.dosageInstruction.method",
-				"short": "Technique for administering medication",
-				"definition": "Technique for administering medication.",
-				"comment": "Terminologies used often pre-coordinate this term with the route and or form of administration.",
-				"requirements": "A coded value indicating the method by which the medication is introduced into or onto the body. Most commonly used for injections.  For examples, Slow Push; Deep IV.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Dosage.method",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "MedicationAdministrationMethod"
-						}
-					],
-					"strength": "example",
-					"description": "A coded concept describing the technique by which the medicine is administered.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/administration-method-codes"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXR-4"
-					},
-					{
-						"identity": "rim",
-						"map": ".doseQuantity"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.doseAndRate",
-				"path": "MedicationRequest.dosageInstruction.doseAndRate",
-				"short": "Amount of medication administered",
-				"definition": "The amount of medication administered.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Dosage.doseAndRate",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Element"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "TQ1-2"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.doseAndRate.id",
-				"path": "MedicationRequest.dosageInstruction.doseAndRate.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.doseAndRate.extension",
-				"path": "MedicationRequest.dosageInstruction.doseAndRate.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.doseAndRate.type",
-				"path": "MedicationRequest.dosageInstruction.doseAndRate.type",
-				"short": "The kind of dose or rate specified",
-				"definition": "The kind of dose or rate specified, for example, ordered or calculated.",
-				"requirements": "If the type is not populated, assume to be \"ordered\".",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Dosage.doseAndRate.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "DoseAndRateType"
-						}
-					],
-					"strength": "example",
-					"description": "The kind of dose or rate specified.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/dose-rate-type"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXO-21; RXE-23"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.doseAndRate.dose[x]",
-				"path": "MedicationRequest.dosageInstruction.doseAndRate.dose[x]",
-				"short": "Amount of medication per dose",
-				"definition": "Amount of medication per dose.",
-				"comment": "Note that this specifies the quantity of the specified medication, not the quantity for each active ingredient(s). Each ingredient amount can be communicated in the Medication resource. For example, if one wants to communicate that a tablet was 375 mg, where the dose was one tablet, you can use the Medication resource to document that the tablet was comprised of 375 mg of drug XYZ. Alternatively if the dose was 375 mg, then you may only need to use the Medication resource to indicate this was a tablet. If the example were an IV such as dopamine and you wanted to communicate that 400mg of dopamine was mixed in 500 ml of some IV solution, then this would all be communicated in the Medication resource. If the administration is not intended to be instantaneous (rate is present or timing has a duration), this can be specified to convey the total amount to be administered over the period of time as indicated by the schedule e.g. 500 ml in dose, with timing used to convey that this should be done over 4 hours.",
-				"requirements": "The amount of therapeutic or other substance given at one administration event.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Dosage.doseAndRate.dose[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXO-2, RXE-3"
-					},
-					{
-						"identity": "rim",
-						"map": ".doseQuantity"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.doseAndRate.rate[x]",
-				"path": "MedicationRequest.dosageInstruction.doseAndRate.rate[x]",
-				"short": "Amount of medication per unit of time",
-				"definition": "Amount of medication per unit of time.",
-				"comment": "It is possible to supply both a rate and a doseQuantity to provide full details about how the medication is to be administered and supplied. If the rate is intended to change over time, depending on local rules/regulations, each change should be captured as a new version of the MedicationRequest with an updated rate, or captured with a new MedicationRequest with the new rate.\r\rIt is possible to specify a rate over time (for example, 100 ml/hour) using either the rateRatio and rateQuantity.  The rateQuantity approach requires systems to have the capability to parse UCUM grammer where ml/hour is included rather than a specific ratio where the time is specified as the denominator.  Where a rate such as 500ml over 2 hours is specified, the use of rateRatio may be more semantically correct than specifying using a rateQuantity of 250 mg/hour.",
-				"requirements": "Identifies the speed with which the medication was or will be introduced into the patient. Typically the rate for an infusion e.g. 100 ml per 1 hour or 100 ml/hr.  May also be expressed as a rate per unit of time e.g. 500 ml per 2 hours.   Other examples: 200 mcg/min or 200 mcg/1 minute; 1 liter/8 hours.  Sometimes, a rate can imply duration when expressed as total volume / duration (e.g.  500mL/2 hours implies a duration of 2 hours).  However, when rate doesn't imply duration (e.g. 250mL/hour), then the timing.repeat.duration is needed to convey the infuse over time period.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Dosage.doseAndRate.rate[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXE22, RXE23, RXE-24"
-					},
-					{
-						"identity": "rim",
-						"map": ".rateQuantity"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.maxDosePerPeriod",
-				"path": "MedicationRequest.dosageInstruction.maxDosePerPeriod",
-				"short": "Upper limit on medication per unit of time",
-				"definition": "Upper limit on medication per unit of time.",
-				"comment": "This is intended for use as an adjunct to the dosage when there is an upper cap.  For example \"2 tablets every 4 hours to a maximum of 8/day\".",
-				"requirements": "The maximum total quantity of a therapeutic substance that may be administered to a subject over the period of time.  For example, 1000mg in 24 hours.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Dosage.maxDosePerPeriod",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Ratio"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "RXO-23, RXE-19"
-					},
-					{
-						"identity": "rim",
-						"map": ".maxDoseQuantity"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.maxDosePerAdministration",
-				"path": "MedicationRequest.dosageInstruction.maxDosePerAdministration",
-				"short": "Upper limit on medication per administration",
-				"definition": "Upper limit on medication per administration.",
-				"comment": "This is intended for use as an adjunct to the dosage when there is an upper cap.  For example, a body surface area related dose with a maximum amount, such as 1.5 mg/m2 (maximum 2 mg) IV over 5 – 10 minutes would have doseQuantity of 1.5 mg/m2 and maxDosePerAdministration of 2 mg.",
-				"requirements": "The maximum total quantity of a therapeutic substance that may be administered to a subject per administration.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Dosage.maxDosePerAdministration",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "not supported"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.maxDosePerLifetime",
-				"path": "MedicationRequest.dosageInstruction.maxDosePerLifetime",
-				"short": "Upper limit on medication per lifetime of the patient",
-				"definition": "Upper limit on medication per lifetime of the patient.",
-				"requirements": "The maximum total quantity of a therapeutic substance that may be administered per lifetime of the subject.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Dosage.maxDosePerLifetime",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "not supported"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest",
-				"path": "MedicationRequest.dispenseRequest",
-				"short": "Medication supply authorization",
-				"definition": "Indicates the specific details for the dispense or medication supply part of a medication request (also known as a Medication Prescription or Medication Order).  Note that this information is not always sent with the order.  There may be in some settings (e.g. hospitals) institutional or system support for completing the dispense details in the pharmacy department.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.dispenseRequest",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "Message/Body/NewRx/MedicationPrescribed/ExpirationDate"
-					},
-					{
-						"identity": "rim",
-						"map": "component.supplyEvent"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest.id",
-				"path": "MedicationRequest.dispenseRequest.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest.extension",
-				"path": "MedicationRequest.dispenseRequest.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest.modifierExtension",
-				"path": "MedicationRequest.dispenseRequest.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest.initialFill",
-				"path": "MedicationRequest.dispenseRequest.initialFill",
-				"short": "First fill details",
-				"definition": "Indicates the quantity or duration for the first dispense of the medication.",
-				"comment": "If populating this element, either the quantity or the duration must be included.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.dispenseRequest.initialFill",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "SubstanceAdministration -> ActRelationship[sequenceNumber = '1'] -> Supply"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest.initialFill.id",
-				"path": "MedicationRequest.dispenseRequest.initialFill.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest.initialFill.extension",
-				"path": "MedicationRequest.dispenseRequest.initialFill.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest.initialFill.modifierExtension",
-				"path": "MedicationRequest.dispenseRequest.initialFill.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest.initialFill.quantity",
-				"path": "MedicationRequest.dispenseRequest.initialFill.quantity",
-				"short": "First fill quantity",
-				"definition": "The amount or quantity to provide as part of the first dispense.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.dispenseRequest.initialFill.quantity",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Supply.quantity[moodCode=RQO]"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest.initialFill.duration",
-				"path": "MedicationRequest.dispenseRequest.initialFill.duration",
-				"short": "First fill duration",
-				"definition": "The length of time that the first dispense is expected to last.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.dispenseRequest.initialFill.duration",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Duration"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Supply.effectivetime[moodCode=RQO]"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest.dispenseInterval",
-				"path": "MedicationRequest.dispenseRequest.dispenseInterval",
-				"short": "Minimum period of time between dispenses",
-				"definition": "The minimum period of time that must occur between dispenses of the medication.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.dispenseRequest.dispenseInterval",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Duration"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Supply.effectivetime[moodCode=RQO]"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest.validityPeriod",
-				"path": "MedicationRequest.dispenseRequest.validityPeriod",
-				"short": "Time period supply is authorized for",
-				"definition": "This indicates the validity period of a prescription (stale dating the Prescription).",
-				"comment": "It reflects the prescribers' perspective for the validity of the prescription. Dispenses must not be made against the prescription outside of this period. The lower-bound of the Dispensing Window signifies the earliest date that the prescription can be filled for the first time. If an upper-bound is not specified then the Prescription is open-ended or will default to a stale-date based on regulations.",
-				"requirements": "Indicates when the Prescription becomes valid, and when it ceases to be a dispensable Prescription.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.dispenseRequest.validityPeriod",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "Message/Body/NewRx/MedicationPrescribed/Refills"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest.numberOfRepeatsAllowed",
-				"path": "MedicationRequest.dispenseRequest.numberOfRepeatsAllowed",
-				"short": "Number of refills authorized",
-				"definition": "An integer indicating the number of times, in addition to the original dispense, (aka refills or repeats) that the patient can receive the prescribed medication. Usage Notes: This integer does not include the original order dispense. This means that if an order indicates dispense 30 tablets plus \"3 repeats\", then the order can be dispensed a total of 4 times and the patient can receive a total of 120 tablets.  A prescriber may explicitly say that zero refills are permitted after the initial dispense.",
-				"comment": "If displaying \"number of authorized fills\", add 1 to this number.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.dispenseRequest.numberOfRepeatsAllowed",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "unsignedInt"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "Message/Body/NewRx/MedicationPrescribed/Quantity"
-					},
-					{
-						"identity": "v2",
-						"map": "RXE-12-Number of Refills"
-					},
-					{
-						"identity": "rim",
-						"map": "repeatNumber"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest.quantity",
-				"path": "MedicationRequest.dispenseRequest.quantity",
-				"short": "Amount of medication to supply per dispense",
-				"definition": "The amount that is to be dispensed for one fill.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.dispenseRequest.quantity",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "Message/Body/NewRx/MedicationPrescribed/DaysSupply"
-					},
-					{
-						"identity": "v2",
-						"map": "RXD-4-Actual Dispense Amount / RXD-5.1-Actual Dispense Units.code / RXD-5.3-Actual Dispense Units.name of coding system"
-					},
-					{
-						"identity": "rim",
-						"map": "quantity"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest.expectedSupplyDuration",
-				"path": "MedicationRequest.dispenseRequest.expectedSupplyDuration",
-				"short": "Number of days supply per dispense",
-				"definition": "Identifies the period time over which the supplied product is expected to be used, or the length of time the dispense is expected to last.",
-				"comment": "In some situations, this attribute may be used instead of quantity to identify the amount supplied by how long it is expected to last, rather than the physical quantity issued, e.g. 90 days supply of medication (based on an ordered dosage). When possible, it is always better to specify quantity, as this tends to be more precise. expectedSupplyDuration will always be an estimate that can be influenced by external factors.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.dispenseRequest.expectedSupplyDuration",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Duration"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "Message/Body/NewRx/MedicationPrescribed/Substitutions"
-					},
-					{
-						"identity": "rim",
-						"map": "expectedUseTime"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dispenseRequest.performer",
-				"path": "MedicationRequest.dispenseRequest.performer",
-				"short": "Intended dispenser",
-				"definition": "Indicates the intended dispensing Organization specified by the prescriber.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.dispenseRequest.performer",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.who"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=COMP].target[classCode=SPLY, moodCode=RQO] .participation[typeCode=PRF].role[scoper.determinerCode=INSTANCE]"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.substitution",
-				"path": "MedicationRequest.substitution",
-				"short": "Any restrictions on medication substitution",
-				"definition": "Indicates whether or not substitution can or should be part of the dispense. In some cases, substitution must happen, in other cases substitution must not happen. This block explains the prescriber's intent. If nothing is specified substitution may be done.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.substitution",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "specific values within Message/Body/NewRx/MedicationPrescribed/Substitutions"
-					},
-					{
-						"identity": "rim",
-						"map": "subjectOf.substitutionPersmission"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.substitution.id",
-				"path": "MedicationRequest.substitution.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.substitution.extension",
-				"path": "MedicationRequest.substitution.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.substitution.modifierExtension",
-				"path": "MedicationRequest.substitution.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.substitution.allowed[x]",
-				"path": "MedicationRequest.substitution.allowed[x]",
-				"short": "Whether substitution is allowed or not",
-				"definition": "True if the prescriber allows a different drug to be dispensed from what was prescribed.",
-				"comment": "This element is labeled as a modifier because whether substitution is allow or not, it cannot be ignored.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.substitution.allowed[x]",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "MedicationRequestSubstitution"
-						}
-					],
-					"strength": "example",
-					"description": "Identifies the type of substitution allowed.",
-					"valueSet": "http://terminology.hl7.org/ValueSet/v3-ActSubstanceAdminSubstitutionCode"
-				},
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "specific values within Message/Body/NewRx/MedicationPrescribed/Substitutions"
-					},
-					{
-						"identity": "v2",
-						"map": "RXO-9-Allow Substitutions / RXE-9-Substitution Status"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.substitution.reason",
-				"path": "MedicationRequest.substitution.reason",
-				"short": "Why should (not) substitution be made",
-				"definition": "Indicates the reason for the substitution, or why substitution must or must not be performed.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.substitution.reason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "MedicationIntendedSubstitutionReason"
-						}
-					],
-					"strength": "example",
-					"description": "A coded concept describing the reason that a different medication should (or should not) be substituted from what was prescribed.",
-					"valueSet": "http://terminology.hl7.org/ValueSet/v3-SubstanceAdminSubstitutionReason"
-				},
-				"mapping": [
-					{
-						"identity": "script10.6",
-						"map": "not mapped"
-					},
-					{
-						"identity": "v2",
-						"map": "RXE-9 Substition status"
-					},
-					{
-						"identity": "rim",
-						"map": "reasonCode"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.priorPrescription",
-				"path": "MedicationRequest.priorPrescription",
-				"short": "An order/prescription that is being replaced",
-				"definition": "A link to a resource representing an earlier order related order or prescription.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "MedicationRequest.priorPrescription",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/MedicationRequest"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.replaces"
-					},
-					{
-						"identity": "script10.6",
-						"map": "not mapped"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=?RPLC or ?SUCC]/target[classCode=SBADM,moodCode=RQO]"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.detectedIssue",
-				"path": "MedicationRequest.detectedIssue",
-				"short": "Clinical Issue with action",
-				"definition": "Indicates an actual or potential clinical issue with or between one or more active or proposed clinical actions for a patient; e.g. Drug-drug interaction, duplicate therapy, dosage alert etc.",
-				"comment": "This element can include a detected issue that has been identified either by a decision support system or by a clinician and may include information on the steps that were taken to address the issue.",
-				"alias": [
-					"Contraindication",
-					"Drug Utilization Review (DUR)",
-					"Alert"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "MedicationRequest.detectedIssue",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/DetectedIssue"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=SUBJ]/source[classCode=ALRT,moodCode=EVN].value"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.eventHistory",
-				"path": "MedicationRequest.eventHistory",
-				"short": "A list of events of interest in the lifecycle",
-				"definition": "Links to Provenance records for past versions of this resource or fulfilling request or event resources that identify key state transitions or updates that are likely to be relevant to a user looking at the current version of the resource.",
-				"comment": "This might not include provenances for all versions of the request – only those deemed “relevant” or important. This SHALL NOT include the provenance associated with this current version of the resource. (If that provenance is deemed to be a “relevant” change, it will need to be added as part of a later update. Until then, it can be queried directly as the provenance that points to this version using _revinclude All Provenances should have some historical version of this Request as their subject.).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "MedicationRequest.eventHistory",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Provenance"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Request.relevantHistory"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship(typeCode=SUBJ].source[classCode=CACT, moodCode=EVN]"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "MedicationRequest",
-				"path": "MedicationRequest",
-				"definition": "The US Core Medication Request (Order) Profile is based upon the core FHIR MedicationRequest Resource and created to meet the 2015 Edition Common Clinical Data Set 'Medications' requirements.",
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.status",
-				"path": "MedicationRequest.status",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"description": "A code specifying the state of the prescribing event. Describes the lifecycle of the prescription.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/medicationrequest-status"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder.status"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.intent",
-				"path": "MedicationRequest.intent",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"description": "The kind of medication order.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/medicationrequest-intent"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder.status"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.category",
-				"path": "MedicationRequest.category",
-				"min": 0,
-				"max": "*",
-				"mustSupport": true,
-				"binding": {
-					"strength": "preferred",
-					"description": "The type of medication order.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/medicationrequest-category"
-				}
-			},
-			{
-				"id": "MedicationRequest.reported[x]",
-				"path": "MedicationRequest.reported[x]",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "boolean"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						],
-						"_targetProfile": [
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": true
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							}
-						]
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder.status"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.medication[x]",
-				"path": "MedicationRequest.medication[x]",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication"
-						]
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.4"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder.medication[x]"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.subject",
-				"path": "MedicationRequest.subject",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder.patient"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.encounter",
-				"path": "MedicationRequest.encounter",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
-						]
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.authoredOn",
-				"path": "MedicationRequest.authoredOn",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder.dateWritten"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.requester",
-				"path": "MedicationRequest.requester",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson",
-							"http://hl7.org/fhir/StructureDefinition/Device"
-						],
-						"_targetProfile": [
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": true
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							}
-						]
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "MedicationOrder.prescriber"
-					}
-				]
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction",
-				"path": "MedicationRequest.dosageInstruction",
-				"mustSupport": true
-			},
-			{
-				"id": "MedicationRequest.dosageInstruction.text",
-				"path": "MedicationRequest.dosageInstruction.text",
-				"mustSupport": true
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-medicationrequest",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest",
+    "version": "4.0.0",
+    "name": "USCoreMedicationRequestProfile",
+    "title": "US Core MedicationRequest Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-06-26",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the MedicationRequest resource for the minimal set of data to query and retrieve prescription information.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "script10.6",
+            "uri": "http://ncpdp.org/SCRIPT10_6",
+            "name": "Mapping to NCPDP SCRIPT 10.6"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "MedicationRequest",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "MedicationRequest",
+                "path": "MedicationRequest",
+                "short": "Ordering of medication for patient or group",
+                "definition": "The US Core Medication Request (Order) Profile is based upon the core FHIR MedicationRequest Resource and created to meet the 2015 Edition Common Clinical Data Set 'Medications' requirements.",
+                "alias": [
+                    "Prescription",
+                    "Order"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "MedicationRequest",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Request"
+                    },
+                    {
+                        "identity": "script10.6",
+                        "map": "Message/Body/NewRx"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CombinedMedicationRequest"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.id",
+                "path": "MedicationRequest.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "MedicationRequest.meta",
+                "path": "MedicationRequest.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "MedicationRequest.implicitRules",
+                "path": "MedicationRequest.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "MedicationRequest.language",
+                "path": "MedicationRequest.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "MedicationRequest.text",
+                "path": "MedicationRequest.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.contained",
+                "path": "MedicationRequest.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.extension",
+                "path": "MedicationRequest.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.modifierExtension",
+                "path": "MedicationRequest.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.identifier",
+                "path": "MedicationRequest.identifier",
+                "short": "External ids for this request",
+                "definition": "Identifiers associated with this medication request that are defined by business processes and/or used to refer to it when a direct URL reference to the resource itself is not appropriate. They are business identifiers assigned to this resource by the performer or other systems and remain constant as the resource is updated and propagates from server to server.",
+                "comment": "This is a business identifier, not a resource identifier.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "MedicationRequest.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.identifier"
+                    },
+                    {
+                        "identity": "script10.6",
+                        "map": "Message/Header/PrescriberOrderNumber"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC-2-Placer Order Number / ORC-3-Filler Order Number"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.status",
+                "path": "MedicationRequest.status",
+                "short": "active | on-hold | cancelled | completed | entered-in-error | stopped | draft | unknown",
+                "definition": "A code specifying the current state of the order.  Generally, this will be active or completed state.",
+                "comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "description": "A code specifying the state of the prescribing event. Describes the lifecycle of the prescription.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/medicationrequest-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.status"
+                    },
+                    {
+                        "identity": "script10.6",
+                        "map": "no mapping"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".statusCode"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder.status"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.statusReason",
+                "path": "MedicationRequest.statusReason",
+                "short": "Reason for current status",
+                "definition": "Captures the reason for the current state of the MedicationRequest.",
+                "comment": "This is generally only used for \"exception\" statuses such as \"suspended\" or \"cancelled\". The reason why the MedicationRequest was created at all is captured in reasonCode, not here.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.statusReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "MedicationRequestStatusReason"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Identifies the reasons for a given status.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/medicationrequest-status-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.statusReason"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=SUBJ].source[classCode=CACT, moodCode=EVN].reasonCOde"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.intent",
+                "path": "MedicationRequest.intent",
+                "short": "proposal | plan | order | original-order | reflex-order | filler-order | instance-order | option",
+                "definition": "Whether the request is a proposal, plan, or an original order.",
+                "comment": "It is expected that the type of requester will be restricted for different stages of a MedicationRequest.  For example, Proposals can be created by a patient, relatedPerson, Practitioner or Device.  Plans can be created by Practitioners, Patients, RelatedPersons and Devices.  Original orders can be created by a Practitioner only.\r\rAn instance-order is an instantiation of a request or order and may be used to populate Medication Administration Record.\r\rThis element is labeled as a modifier because the intent alters when and how the resource is actually applicable.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.intent",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element changes the interpretation of all descriptive attributes. For example \"the time the request is recommended to occur\" vs. \"the time the request is authorized to occur\" or \"who is recommended to perform the request\" vs. \"who is authorized to perform the request",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "description": "The kind of medication order.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/medicationrequest-intent"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.intent"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".moodCode (nuances beyond PRP/PLAN/RQO would need to be elsewhere)"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder.status"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.category",
+                "path": "MedicationRequest.category",
+                "short": "Type of medication usage",
+                "definition": "Indicates the type of medication request (for example, where the medication is expected to be consumed or administered (i.e. inpatient or outpatient)).",
+                "comment": "The category can be used to include where the medication is expected to be consumed or other types of requests.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "MedicationRequest.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "strength": "preferred",
+                    "description": "The type of medication order.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/medicationrequest-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "Message/Body/NewRx/MedicationPrescribed/Directions\r\ror \r\rMessage/Body/NewRx/MedicationPrescribed/StructuredSIG"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[classCode=OBS, moodCode=EVN, code=\"type of medication usage\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.priority",
+                "path": "MedicationRequest.priority",
+                "short": "routine | urgent | asap | stat",
+                "definition": "Indicates how quickly the Medication Request should be addressed with respect to other requests.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.priority",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "MedicationRequestPriority"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Identifies the level of importance to be assigned to actioning the request.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/request-priority|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.priority"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.grade"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".priorityCode"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.doNotPerform",
+                "path": "MedicationRequest.doNotPerform",
+                "short": "True if request is prohibiting action",
+                "definition": "If true indicates that the provider is asking for the medication request not to occur.",
+                "comment": "If do not perform is not specified, the request is a positive request e.g. \"do perform\".",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.doNotPerform",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because this element negates the request to occur (ie, this is a request for the medication not to be ordered or prescribed, etc)",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "SubstanceAdministration.actionNegationInd"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.reported[x]",
+                "path": "MedicationRequest.reported[x]",
+                "short": "Reported rather than primary record",
+                "definition": "Indicates if this record was captured as a secondary 'reported' record rather than as an original primary source-of-truth record.  It may also indicate the source of the report.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.reported[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "boolean"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ],
+                        "_targetProfile": [
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": true
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=INF].role"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder.status"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.medication[x]",
+                "path": "MedicationRequest.medication[x]",
+                "short": "Medication to be taken",
+                "definition": "Identifies the medication being requested. This is a link to a resource that represents the medication which may be the details of the medication or simply an attribute carrying a code that identifies the medication from a known list of medications.",
+                "comment": "If only a code is specified, then it needs to be a code for a specific product. If more information is required, then the use of the Medication resource is recommended.  For example, if you require form or lot number or if the medication is compounded or extemporaneously prepared, then you must reference the Medication resource.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.medication[x]",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.4"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.code"
+                    },
+                    {
+                        "identity": "script10.6",
+                        "map": "Message/Body/NewRx/MedicationPrescribed\r\rMedication.code.coding.code = Message/Body/NewRx/MedicationPrescribed/DrugCoded/ProductCode\r\rMedication.code.coding.system = Message/Body/NewRx/MedicationPrescribed/DrugCoded/ProductCodeQualifier\r\rMedication.code.coding.display = Message/Body/NewRx/MedicationPrescribed/DrugDescription"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXE-2-Give Code / RXO-1-Requested Give Code / RXC-2-Component Code"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "consumable.administrableMedication"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder.medication[x]"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.subject",
+                "path": "MedicationRequest.subject",
+                "short": "Who or group medication request is for",
+                "definition": "A link to a resource representing the person or set of individuals to whom the medication will be given.",
+                "comment": "The subject on a medication request is mandatory.  For the secondary use case where the actual subject is not provided, there still must be an anonymized subject specified.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.subject",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.subject"
+                    },
+                    {
+                        "identity": "script10.6",
+                        "map": "Message/Body/NewRx/Patient\r\r(need detail to link to specific patient … Patient.Identification in SCRIPT)"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3-Patient ID List"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=AUT].role"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder.patient"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.encounter",
+                "path": "MedicationRequest.encounter",
+                "short": "Encounter created as part of encounter/admission/stay",
+                "definition": "The Encounter during which this [x] was created or to which the creation of this record is tightly associated.",
+                "comment": "This will typically be the encounter the event occurred within, but some activities may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter.\"    If there is a need to link to episodes of care they will be handled with an extension.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.context"
+                    },
+                    {
+                        "identity": "script10.6",
+                        "map": "no mapping"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1-19-Visit Number"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN, code=\"type of encounter or episode\"]"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.supportingInformation",
+                "path": "MedicationRequest.supportingInformation",
+                "short": "Information to support ordering of the medication",
+                "definition": "Include additional information (for example, patient height and weight) that supports the ordering of the medication.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "MedicationRequest.supportingInformation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.supportingInfo"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=PERT].target[A_SupportingClinicalStatement CMET minimal with many different choices of classCodes(ORG, ENC, PROC, SPLY, SBADM, OBS) and each of the act class codes draws from one or more of the following moodCodes (EVN, DEF, INT PRMS, RQO, PRP, APT, ARQ, GOL)]"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.authoredOn",
+                "path": "MedicationRequest.authoredOn",
+                "short": "When request was initially authored",
+                "definition": "The date (and perhaps time) when the prescription was initially written or authored on.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.authoredOn",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.authoredOn"
+                    },
+                    {
+                        "identity": "script10.6",
+                        "map": "Message/Body/NewRx/MedicationPrescribed/WrittenDate"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXE-32-Original Order Date/Time / ORC-9-Date/Time of Transaction"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "author.time"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder.dateWritten"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.requester",
+                "path": "MedicationRequest.requester",
+                "short": "Who/What requested the Request",
+                "definition": "The individual, organization, or device that initiated the request and has responsibility for its activation.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.requester",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+                            "http://hl7.org/fhir/StructureDefinition/Device"
+                        ],
+                        "_targetProfile": [
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": true
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.requester"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.author"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=AUT].role"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder.prescriber"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.performer",
+                "path": "MedicationRequest.performer",
+                "short": "Intended performer of administration",
+                "definition": "The specified desired performer of the medication treatment (e.g. the performer of the medication administration).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.performer",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.performer"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=PRF].role[scoper.determinerCode=INSTANCE]"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.performerType",
+                "path": "MedicationRequest.performerType",
+                "short": "Desired kind of performer of the medication administration",
+                "definition": "Indicates the type of performer of the administration of the medication.",
+                "comment": "If specified without indicating a performer, this indicates that the performer must be of the specified type. If specified with a performer then it indicates the requirements of the performer if the designated performer is not available.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.performerType",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "MedicationRequestPerformerType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Identifies the type of individual that is desired to administer the medication.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/performer-role"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.performerType"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=PRF].role[scoper.determinerCode=KIND].code"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.recorder",
+                "path": "MedicationRequest.recorder",
+                "short": "Person who entered the request",
+                "definition": "The person who entered the order on behalf of another individual for example in the case of a verbal or a telephone order.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.recorder",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.who"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=TRANS].role[classCode=ASSIGNED].code (HealthcareProviderType)"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.reasonCode",
+                "path": "MedicationRequest.reasonCode",
+                "short": "Reason or indication for ordering or not ordering the medication",
+                "definition": "The reason or the indication for ordering or not ordering the medication.",
+                "comment": "This could be a diagnosis code. If a full condition record exists or additional detail is needed, use reasonReference.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "MedicationRequest.reasonCode",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "MedicationRequestReason"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "A coded concept indicating why the medication was ordered.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/condition-code"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.reasonCode"
+                    },
+                    {
+                        "identity": "script10.6",
+                        "map": "Message/Body/NewRx/MedicationPrescribed/Diagnosis/Primary/Value"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.why[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC-16-Order Control Code Reason /RXE-27-Give Indication/RXO-20-Indication / RXD-21-Indication / RXG-22-Indication / RXA-19-Indication"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "reason.observation.reasonCode"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.reasonReference",
+                "path": "MedicationRequest.reasonReference",
+                "short": "Condition or observation that supports why the prescription is being written",
+                "definition": "Condition or observation that supports why the medication was ordered.",
+                "comment": "This is a reference to a condition or observation that is the reason for the medication order.  If only a code exists, use reasonCode.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "MedicationRequest.reasonReference",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Condition",
+                            "http://hl7.org/fhir/StructureDefinition/Observation"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.reasonReference"
+                    },
+                    {
+                        "identity": "script10.6",
+                        "map": "no mapping"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.why[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "reason.observation[code=ASSERTION].value"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.instantiatesCanonical",
+                "path": "MedicationRequest.instantiatesCanonical",
+                "short": "Instantiates FHIR protocol or definition",
+                "definition": "The URL pointing to a protocol, guideline, orderset, or other definition that is adhered to in whole or in part by this MedicationRequest.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "MedicationRequest.instantiatesCanonical",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "canonical"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.instantiates"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=DEFN].target"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.instantiatesUri",
+                "path": "MedicationRequest.instantiatesUri",
+                "short": "Instantiates external protocol or definition",
+                "definition": "The URL pointing to an externally maintained protocol, guideline, orderset or other definition that is adhered to in whole or in part by this MedicationRequest.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "MedicationRequest.instantiatesUri",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=DEFN].target"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.basedOn",
+                "path": "MedicationRequest.basedOn",
+                "short": "What request fulfills",
+                "definition": "A plan or request that is fulfilled in whole or in part by this medication request.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "MedicationRequest.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest",
+                            "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.basedOn"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=FLFS].target[classCode=SBADM or PROC or PCPR or OBS, moodCode=RQO orPLAN or PRP]"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.groupIdentifier",
+                "path": "MedicationRequest.groupIdentifier",
+                "short": "Composite request this is part of",
+                "definition": "A shared identifier common to all requests that were authorized more or less simultaneously by a single author, representing the identifier of the requisition or prescription.",
+                "requirements": "Requests are linked either by a \"basedOn\" relationship (i.e. one request is fulfilling another) or by having a common requisition. Requests that are part of the same requisition are generally treated independently from the perspective of changing their state or maintaining them after initial creation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.groupIdentifier",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.groupIdentifier"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship(typeCode=COMP].target[classCode=SBADM, moodCode=INT].id"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.courseOfTherapyType",
+                "path": "MedicationRequest.courseOfTherapyType",
+                "short": "Overall pattern of medication administration",
+                "definition": "The description of the overall patte3rn of the administration of the medication to the patient.",
+                "comment": "This attribute should not be confused with the protocol of the medication.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.courseOfTherapyType",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "MedicationRequestCourseOfTherapy"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Identifies the overall pattern of medication administratio.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/medicationrequest-course-of-therapy"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.code where classCode = LIST and moodCode = EVN"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.insurance",
+                "path": "MedicationRequest.insurance",
+                "short": "Associated insurance coverage",
+                "definition": "Insurance plans, coverage extensions, pre-authorizations and/or pre-determinations that may be required for delivering the requested service.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "MedicationRequest.insurance",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Coverage",
+                            "http://hl7.org/fhir/StructureDefinition/ClaimResponse"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.insurance"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=COVBY].target"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.note",
+                "path": "MedicationRequest.note",
+                "short": "Information about the prescription",
+                "definition": "Extra information about the prescription that could not be conveyed by the other attributes.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "MedicationRequest.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.note"
+                    },
+                    {
+                        "identity": "script10.6",
+                        "map": "Message/Body/NewRx/MedicationPrescribed/Note"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=SUBJ]/source[classCode=OBS,moodCode=EVN,code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction",
+                "path": "MedicationRequest.dosageInstruction",
+                "short": "How the medication should be taken",
+                "definition": "Indicates how the medication is to be used by the patient.",
+                "comment": "There are examples where a medication request may include the option of an oral dose or an Intravenous or Intramuscular dose.  For example, \"Ondansetron 8mg orally or IV twice a day as needed for nausea\" or \"Compazine® (prochlorperazine) 5-10mg PO or 25mg PR bid prn nausea or vomiting\".  In these cases, two medication requests would be created that could be grouped together.  The decision on which dose and route of administration to use is based on the patient's condition at the time the dose is needed.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "MedicationRequest.dosageInstruction",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Dosage"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.occurrence[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "see dosageInstruction mapping"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.id",
+                "path": "MedicationRequest.dosageInstruction.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.extension",
+                "path": "MedicationRequest.dosageInstruction.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.modifierExtension",
+                "path": "MedicationRequest.dosageInstruction.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.sequence",
+                "path": "MedicationRequest.dosageInstruction.sequence",
+                "short": "The order of the dosage instructions",
+                "definition": "Indicates the order in which the dosage instructions should be applied or interpreted.",
+                "requirements": "If the sequence number of multiple Dosages is the same, then it is implied that the instructions are to be treated as concurrent.  If the sequence number is different, then the Dosages are intended to be sequential.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Dosage.sequence",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "integer"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "TQ1-1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".text"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.text",
+                "path": "MedicationRequest.dosageInstruction.text",
+                "short": "Free text dosage instructions e.g. SIG",
+                "definition": "Free text dosage instructions e.g. SIG.",
+                "requirements": "Free text dosage instructions can be used for cases where the instructions are too complex to code.  The content of this attribute does not include the name or description of the medication. When coded instructions are present, the free text instructions may still be present for display to humans taking or administering the medication. It is expected that the text instructions will always be populated.  If the dosage.timing attribute is also populated, then the dosage.text should reflect the same information as the timing.  Additional information about administration or preparation of the medication should be included as text.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Dosage.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXO-6; RXE-21"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".text"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.additionalInstruction",
+                "path": "MedicationRequest.dosageInstruction.additionalInstruction",
+                "short": "Supplemental instruction or warnings to the patient - e.g. \"with meals\", \"may cause drowsiness\"",
+                "definition": "Supplemental instructions to the patient on how to take the medication  (e.g. \"with meals\" or\"take half to one hour before food\") or warnings for the patient about the medication (e.g. \"may cause drowsiness\" or \"avoid exposure of skin to direct sunlight or sunlamps\").",
+                "comment": "Information about administration or preparation of the medication (e.g. \"infuse as rapidly as possibly via intraperitoneal port\" or \"immediately following drug x\") should be populated in dosage.text.",
+                "requirements": "Additional instruction is intended to be coded, but where no code exists, the element could include text.  For example, \"Swallow with plenty of water\" which might or might not be coded.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Dosage.additionalInstruction",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AdditionalInstruction"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "A coded concept identifying additional instructions such as \"take with water\" or \"avoid operating heavy machinery\".",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/additional-instruction-codes"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXO-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".text"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.patientInstruction",
+                "path": "MedicationRequest.dosageInstruction.patientInstruction",
+                "short": "Patient or consumer oriented instructions",
+                "definition": "Instructions in terms that are understood by the patient or consumer.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Dosage.patientInstruction",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXO-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".text"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.timing",
+                "path": "MedicationRequest.dosageInstruction.timing",
+                "short": "When medication should be administered",
+                "definition": "When medication should be administered.",
+                "comment": "This attribute might not always be populated while the Dosage.text is expected to be populated.  If both are populated, then the Dosage.text should reflect the content of the Dosage.timing.",
+                "requirements": "The timing schedule for giving the medication to the patient. This  data type allows many different expressions. For example: \"Every 8 hours\"; \"Three times a day\"; \"1/2 an hour before breakfast for 10 days from 23-Dec 2011:\"; \"15 Oct 2013, 17 Oct 2013 and 1 Nov 2013\".  Sometimes, a rate can imply duration when expressed as total volume / duration (e.g.  500mL/2 hours implies a duration of 2 hours).  However, when rate doesn't imply duration (e.g. 250mL/hour), then the timing.repeat.duration is needed to convey the infuse over time period.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Dosage.timing",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Timing"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.asNeeded[x]",
+                "path": "MedicationRequest.dosageInstruction.asNeeded[x]",
+                "short": "Take \"as needed\" (for x)",
+                "definition": "Indicates whether the Medication is only taken when needed within a specific dosing schedule (Boolean option), or it indicates the precondition for taking the Medication (CodeableConcept).",
+                "comment": "Can express \"as needed\" without a reason by setting the Boolean = True.  In this case the CodeableConcept is not populated.  Or you can express \"as needed\" with a reason by including the CodeableConcept.  In this case the Boolean is assumed to be True.  If you set the Boolean to False, then the dose is given according to the schedule and is not \"prn\" or \"as needed\".",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Dosage.asNeeded[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "MedicationAsNeededReason"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "A coded concept identifying the precondition that should be met or evaluated prior to consuming or administering a medication dose.  For example \"pain\", \"30 minutes prior to sexual intercourse\", \"on flare-up\" etc.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/medication-as-needed-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "TQ1-9"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=PRCN].target[classCode=OBS, moodCode=EVN, code=\"as needed\"].value=boolean or codable concept"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.site",
+                "path": "MedicationRequest.dosageInstruction.site",
+                "short": "Body site to administer to",
+                "definition": "Body site to administer to.",
+                "comment": "If the use case requires attributes from the BodySite resource (e.g. to identify and track separately) then use the standard extension [bodySite](http://hl7.org/fhir/R4/extension-bodysite.html).  May be a summary code, or a reference to a very precise definition of the location, or both.",
+                "requirements": "A coded specification of the anatomic site where the medication first enters the body.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Dosage.site",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "MedicationAdministrationSite"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "A coded concept describing the site location the medicine enters into or onto the body.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/approach-site-codes"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXR-2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".approachSiteCode"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.route",
+                "path": "MedicationRequest.dosageInstruction.route",
+                "short": "How drug should enter body",
+                "definition": "How drug should enter body.",
+                "requirements": "A code specifying the route or physiological path of administration of a therapeutic agent into or onto a patient's body.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Dosage.route",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "RouteOfAdministration"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "A coded concept describing the route or physiological path of administration of a therapeutic agent into or onto the body of a subject.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/route-codes"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXR-1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".routeCode"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.method",
+                "path": "MedicationRequest.dosageInstruction.method",
+                "short": "Technique for administering medication",
+                "definition": "Technique for administering medication.",
+                "comment": "Terminologies used often pre-coordinate this term with the route and or form of administration.",
+                "requirements": "A coded value indicating the method by which the medication is introduced into or onto the body. Most commonly used for injections.  For examples, Slow Push; Deep IV.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Dosage.method",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "MedicationAdministrationMethod"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "A coded concept describing the technique by which the medicine is administered.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/administration-method-codes"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXR-4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".doseQuantity"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.doseAndRate",
+                "path": "MedicationRequest.dosageInstruction.doseAndRate",
+                "short": "Amount of medication administered",
+                "definition": "The amount of medication administered.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Dosage.doseAndRate",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Element"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "TQ1-2"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.doseAndRate.id",
+                "path": "MedicationRequest.dosageInstruction.doseAndRate.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.doseAndRate.extension",
+                "path": "MedicationRequest.dosageInstruction.doseAndRate.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.doseAndRate.type",
+                "path": "MedicationRequest.dosageInstruction.doseAndRate.type",
+                "short": "The kind of dose or rate specified",
+                "definition": "The kind of dose or rate specified, for example, ordered or calculated.",
+                "requirements": "If the type is not populated, assume to be \"ordered\".",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Dosage.doseAndRate.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "DoseAndRateType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "The kind of dose or rate specified.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/dose-rate-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXO-21; RXE-23"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.doseAndRate.dose[x]",
+                "path": "MedicationRequest.dosageInstruction.doseAndRate.dose[x]",
+                "short": "Amount of medication per dose",
+                "definition": "Amount of medication per dose.",
+                "comment": "Note that this specifies the quantity of the specified medication, not the quantity for each active ingredient(s). Each ingredient amount can be communicated in the Medication resource. For example, if one wants to communicate that a tablet was 375 mg, where the dose was one tablet, you can use the Medication resource to document that the tablet was comprised of 375 mg of drug XYZ. Alternatively if the dose was 375 mg, then you may only need to use the Medication resource to indicate this was a tablet. If the example were an IV such as dopamine and you wanted to communicate that 400mg of dopamine was mixed in 500 ml of some IV solution, then this would all be communicated in the Medication resource. If the administration is not intended to be instantaneous (rate is present or timing has a duration), this can be specified to convey the total amount to be administered over the period of time as indicated by the schedule e.g. 500 ml in dose, with timing used to convey that this should be done over 4 hours.",
+                "requirements": "The amount of therapeutic or other substance given at one administration event.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Dosage.doseAndRate.dose[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXO-2, RXE-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".doseQuantity"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.doseAndRate.rate[x]",
+                "path": "MedicationRequest.dosageInstruction.doseAndRate.rate[x]",
+                "short": "Amount of medication per unit of time",
+                "definition": "Amount of medication per unit of time.",
+                "comment": "It is possible to supply both a rate and a doseQuantity to provide full details about how the medication is to be administered and supplied. If the rate is intended to change over time, depending on local rules/regulations, each change should be captured as a new version of the MedicationRequest with an updated rate, or captured with a new MedicationRequest with the new rate.\r\rIt is possible to specify a rate over time (for example, 100 ml/hour) using either the rateRatio and rateQuantity.  The rateQuantity approach requires systems to have the capability to parse UCUM grammer where ml/hour is included rather than a specific ratio where the time is specified as the denominator.  Where a rate such as 500ml over 2 hours is specified, the use of rateRatio may be more semantically correct than specifying using a rateQuantity of 250 mg/hour.",
+                "requirements": "Identifies the speed with which the medication was or will be introduced into the patient. Typically the rate for an infusion e.g. 100 ml per 1 hour or 100 ml/hr.  May also be expressed as a rate per unit of time e.g. 500 ml per 2 hours.   Other examples: 200 mcg/min or 200 mcg/1 minute; 1 liter/8 hours.  Sometimes, a rate can imply duration when expressed as total volume / duration (e.g.  500mL/2 hours implies a duration of 2 hours).  However, when rate doesn't imply duration (e.g. 250mL/hour), then the timing.repeat.duration is needed to convey the infuse over time period.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Dosage.doseAndRate.rate[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXE22, RXE23, RXE-24"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".rateQuantity"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.maxDosePerPeriod",
+                "path": "MedicationRequest.dosageInstruction.maxDosePerPeriod",
+                "short": "Upper limit on medication per unit of time",
+                "definition": "Upper limit on medication per unit of time.",
+                "comment": "This is intended for use as an adjunct to the dosage when there is an upper cap.  For example \"2 tablets every 4 hours to a maximum of 8/day\".",
+                "requirements": "The maximum total quantity of a therapeutic substance that may be administered to a subject over the period of time.  For example, 1000mg in 24 hours.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Dosage.maxDosePerPeriod",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Ratio"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "RXO-23, RXE-19"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".maxDoseQuantity"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.maxDosePerAdministration",
+                "path": "MedicationRequest.dosageInstruction.maxDosePerAdministration",
+                "short": "Upper limit on medication per administration",
+                "definition": "Upper limit on medication per administration.",
+                "comment": "This is intended for use as an adjunct to the dosage when there is an upper cap.  For example, a body surface area related dose with a maximum amount, such as 1.5 mg/m2 (maximum 2 mg) IV over 5 – 10 minutes would have doseQuantity of 1.5 mg/m2 and maxDosePerAdministration of 2 mg.",
+                "requirements": "The maximum total quantity of a therapeutic substance that may be administered to a subject per administration.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Dosage.maxDosePerAdministration",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "not supported"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.maxDosePerLifetime",
+                "path": "MedicationRequest.dosageInstruction.maxDosePerLifetime",
+                "short": "Upper limit on medication per lifetime of the patient",
+                "definition": "Upper limit on medication per lifetime of the patient.",
+                "requirements": "The maximum total quantity of a therapeutic substance that may be administered per lifetime of the subject.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Dosage.maxDosePerLifetime",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "not supported"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest",
+                "path": "MedicationRequest.dispenseRequest",
+                "short": "Medication supply authorization",
+                "definition": "Indicates the specific details for the dispense or medication supply part of a medication request (also known as a Medication Prescription or Medication Order).  Note that this information is not always sent with the order.  There may be in some settings (e.g. hospitals) institutional or system support for completing the dispense details in the pharmacy department.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.dispenseRequest",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "Message/Body/NewRx/MedicationPrescribed/ExpirationDate"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "component.supplyEvent"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest.id",
+                "path": "MedicationRequest.dispenseRequest.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest.extension",
+                "path": "MedicationRequest.dispenseRequest.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest.modifierExtension",
+                "path": "MedicationRequest.dispenseRequest.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest.initialFill",
+                "path": "MedicationRequest.dispenseRequest.initialFill",
+                "short": "First fill details",
+                "definition": "Indicates the quantity or duration for the first dispense of the medication.",
+                "comment": "If populating this element, either the quantity or the duration must be included.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.dispenseRequest.initialFill",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "SubstanceAdministration -> ActRelationship[sequenceNumber = '1'] -> Supply"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest.initialFill.id",
+                "path": "MedicationRequest.dispenseRequest.initialFill.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest.initialFill.extension",
+                "path": "MedicationRequest.dispenseRequest.initialFill.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest.initialFill.modifierExtension",
+                "path": "MedicationRequest.dispenseRequest.initialFill.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest.initialFill.quantity",
+                "path": "MedicationRequest.dispenseRequest.initialFill.quantity",
+                "short": "First fill quantity",
+                "definition": "The amount or quantity to provide as part of the first dispense.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.dispenseRequest.initialFill.quantity",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Supply.quantity[moodCode=RQO]"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest.initialFill.duration",
+                "path": "MedicationRequest.dispenseRequest.initialFill.duration",
+                "short": "First fill duration",
+                "definition": "The length of time that the first dispense is expected to last.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.dispenseRequest.initialFill.duration",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Duration"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Supply.effectivetime[moodCode=RQO]"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest.dispenseInterval",
+                "path": "MedicationRequest.dispenseRequest.dispenseInterval",
+                "short": "Minimum period of time between dispenses",
+                "definition": "The minimum period of time that must occur between dispenses of the medication.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.dispenseRequest.dispenseInterval",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Duration"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Supply.effectivetime[moodCode=RQO]"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest.validityPeriod",
+                "path": "MedicationRequest.dispenseRequest.validityPeriod",
+                "short": "Time period supply is authorized for",
+                "definition": "This indicates the validity period of a prescription (stale dating the Prescription).",
+                "comment": "It reflects the prescribers' perspective for the validity of the prescription. Dispenses must not be made against the prescription outside of this period. The lower-bound of the Dispensing Window signifies the earliest date that the prescription can be filled for the first time. If an upper-bound is not specified then the Prescription is open-ended or will default to a stale-date based on regulations.",
+                "requirements": "Indicates when the Prescription becomes valid, and when it ceases to be a dispensable Prescription.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.dispenseRequest.validityPeriod",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "Message/Body/NewRx/MedicationPrescribed/Refills"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest.numberOfRepeatsAllowed",
+                "path": "MedicationRequest.dispenseRequest.numberOfRepeatsAllowed",
+                "short": "Number of refills authorized",
+                "definition": "An integer indicating the number of times, in addition to the original dispense, (aka refills or repeats) that the patient can receive the prescribed medication. Usage Notes: This integer does not include the original order dispense. This means that if an order indicates dispense 30 tablets plus \"3 repeats\", then the order can be dispensed a total of 4 times and the patient can receive a total of 120 tablets.  A prescriber may explicitly say that zero refills are permitted after the initial dispense.",
+                "comment": "If displaying \"number of authorized fills\", add 1 to this number.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.dispenseRequest.numberOfRepeatsAllowed",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "unsignedInt"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "Message/Body/NewRx/MedicationPrescribed/Quantity"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXE-12-Number of Refills"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "repeatNumber"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest.quantity",
+                "path": "MedicationRequest.dispenseRequest.quantity",
+                "short": "Amount of medication to supply per dispense",
+                "definition": "The amount that is to be dispensed for one fill.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.dispenseRequest.quantity",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "Message/Body/NewRx/MedicationPrescribed/DaysSupply"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXD-4-Actual Dispense Amount / RXD-5.1-Actual Dispense Units.code / RXD-5.3-Actual Dispense Units.name of coding system"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "quantity"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest.expectedSupplyDuration",
+                "path": "MedicationRequest.dispenseRequest.expectedSupplyDuration",
+                "short": "Number of days supply per dispense",
+                "definition": "Identifies the period time over which the supplied product is expected to be used, or the length of time the dispense is expected to last.",
+                "comment": "In some situations, this attribute may be used instead of quantity to identify the amount supplied by how long it is expected to last, rather than the physical quantity issued, e.g. 90 days supply of medication (based on an ordered dosage). When possible, it is always better to specify quantity, as this tends to be more precise. expectedSupplyDuration will always be an estimate that can be influenced by external factors.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.dispenseRequest.expectedSupplyDuration",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Duration"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "Message/Body/NewRx/MedicationPrescribed/Substitutions"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "expectedUseTime"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dispenseRequest.performer",
+                "path": "MedicationRequest.dispenseRequest.performer",
+                "short": "Intended dispenser",
+                "definition": "Indicates the intended dispensing Organization specified by the prescriber.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.dispenseRequest.performer",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.who"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=COMP].target[classCode=SPLY, moodCode=RQO] .participation[typeCode=PRF].role[scoper.determinerCode=INSTANCE]"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.substitution",
+                "path": "MedicationRequest.substitution",
+                "short": "Any restrictions on medication substitution",
+                "definition": "Indicates whether or not substitution can or should be part of the dispense. In some cases, substitution must happen, in other cases substitution must not happen. This block explains the prescriber's intent. If nothing is specified substitution may be done.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.substitution",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "specific values within Message/Body/NewRx/MedicationPrescribed/Substitutions"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "subjectOf.substitutionPersmission"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.substitution.id",
+                "path": "MedicationRequest.substitution.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.substitution.extension",
+                "path": "MedicationRequest.substitution.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.substitution.modifierExtension",
+                "path": "MedicationRequest.substitution.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.substitution.allowed[x]",
+                "path": "MedicationRequest.substitution.allowed[x]",
+                "short": "Whether substitution is allowed or not",
+                "definition": "True if the prescriber allows a different drug to be dispensed from what was prescribed.",
+                "comment": "This element is labeled as a modifier because whether substitution is allow or not, it cannot be ignored.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.substitution.allowed[x]",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "MedicationRequestSubstitution"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Identifies the type of substitution allowed.",
+                    "valueSet": "http://terminology.hl7.org/ValueSet/v3-ActSubstanceAdminSubstitutionCode"
+                },
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "specific values within Message/Body/NewRx/MedicationPrescribed/Substitutions"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXO-9-Allow Substitutions / RXE-9-Substitution Status"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.substitution.reason",
+                "path": "MedicationRequest.substitution.reason",
+                "short": "Why should (not) substitution be made",
+                "definition": "Indicates the reason for the substitution, or why substitution must or must not be performed.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.substitution.reason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "MedicationIntendedSubstitutionReason"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "A coded concept describing the reason that a different medication should (or should not) be substituted from what was prescribed.",
+                    "valueSet": "http://terminology.hl7.org/ValueSet/v3-SubstanceAdminSubstitutionReason"
+                },
+                "mapping": [
+                    {
+                        "identity": "script10.6",
+                        "map": "not mapped"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "RXE-9 Substition status"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "reasonCode"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.priorPrescription",
+                "path": "MedicationRequest.priorPrescription",
+                "short": "An order/prescription that is being replaced",
+                "definition": "A link to a resource representing an earlier order related order or prescription.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "MedicationRequest.priorPrescription",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/MedicationRequest"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.replaces"
+                    },
+                    {
+                        "identity": "script10.6",
+                        "map": "not mapped"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=?RPLC or ?SUCC]/target[classCode=SBADM,moodCode=RQO]"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.detectedIssue",
+                "path": "MedicationRequest.detectedIssue",
+                "short": "Clinical Issue with action",
+                "definition": "Indicates an actual or potential clinical issue with or between one or more active or proposed clinical actions for a patient; e.g. Drug-drug interaction, duplicate therapy, dosage alert etc.",
+                "comment": "This element can include a detected issue that has been identified either by a decision support system or by a clinician and may include information on the steps that were taken to address the issue.",
+                "alias": [
+                    "Contraindication",
+                    "Drug Utilization Review (DUR)",
+                    "Alert"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "MedicationRequest.detectedIssue",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/DetectedIssue"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=SUBJ]/source[classCode=ALRT,moodCode=EVN].value"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.eventHistory",
+                "path": "MedicationRequest.eventHistory",
+                "short": "A list of events of interest in the lifecycle",
+                "definition": "Links to Provenance records for past versions of this resource or fulfilling request or event resources that identify key state transitions or updates that are likely to be relevant to a user looking at the current version of the resource.",
+                "comment": "This might not include provenances for all versions of the request – only those deemed “relevant” or important. This SHALL NOT include the provenance associated with this current version of the resource. (If that provenance is deemed to be a “relevant” change, it will need to be added as part of a later update. Until then, it can be queried directly as the provenance that points to this version using _revinclude All Provenances should have some historical version of this Request as their subject.).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "MedicationRequest.eventHistory",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Provenance"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Request.relevantHistory"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship(typeCode=SUBJ].source[classCode=CACT, moodCode=EVN]"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "MedicationRequest",
+                "path": "MedicationRequest",
+                "definition": "The US Core Medication Request (Order) Profile is based upon the core FHIR MedicationRequest Resource and created to meet the 2015 Edition Common Clinical Data Set 'Medications' requirements.",
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.status",
+                "path": "MedicationRequest.status",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "description": "A code specifying the state of the prescribing event. Describes the lifecycle of the prescription.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/medicationrequest-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder.status"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.intent",
+                "path": "MedicationRequest.intent",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "description": "The kind of medication order.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/medicationrequest-intent"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder.status"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.category",
+                "path": "MedicationRequest.category",
+                "min": 0,
+                "max": "*",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "preferred",
+                    "description": "The type of medication order.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/medicationrequest-category"
+                }
+            },
+            {
+                "id": "MedicationRequest.reported[x]",
+                "path": "MedicationRequest.reported[x]",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "boolean"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ],
+                        "_targetProfile": [
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": true
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder.status"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.medication[x]",
+                "path": "MedicationRequest.medication[x]",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1010.4"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder.medication[x]"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.subject",
+                "path": "MedicationRequest.subject",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder.patient"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.encounter",
+                "path": "MedicationRequest.encounter",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.authoredOn",
+                "path": "MedicationRequest.authoredOn",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder.dateWritten"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.requester",
+                "path": "MedicationRequest.requester",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+                            "http://hl7.org/fhir/StructureDefinition/Device"
+                        ],
+                        "_targetProfile": [
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": true
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "MedicationOrder.prescriber"
+                    }
+                ]
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction",
+                "path": "MedicationRequest.dosageInstruction",
+                "mustSupport": true
+            },
+            {
+                "id": "MedicationRequest.dosageInstruction.text",
+                "path": "MedicationRequest.dosageInstruction.text",
+                "mustSupport": true
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-observation-lab.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-observation-lab.json
@@ -1,3184 +1,3184 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-observation-lab",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-observation-lab-definitions.html#Observation\" title=\"This profile is  created to meet the 2015 Edition Common Clinical Data Set 'Laboratory test(s) and Laboratory value(s)/result(s)' requirements.\">Observation</a><a name=\"Observation\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-2)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/observation.html\">Observation</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Measurements and simple assertions</span><br/><span style=\"font-weight:bold\">us-core-2: </span>If there is no component or hasMember element then either a value[x] or a data absent reason must be present</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-observation-lab-definitions.html#Observation.status\">status</a><a name=\"Observation.status\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">registered | preliminary | final | amended +</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-observation-status.html\">ObservationStatus</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck13.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Slice Definition\" class=\"hierarchy\"/> <a style=\"font-style: italic\" href=\"StructureDefinition-us-core-observation-lab-definitions.html#Observation.category\">Slices for category</a><a name=\"Observation.category\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red; font-style: italic\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"font-style: italic\"/><span style=\"font-style: italic\">1</span><span style=\"font-style: italic\">..</span><span style=\"font-style: italic\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"font-style: italic\" href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5; font-style: italic\">Classification of  type of observation</span><br style=\"font-style: italic\"/><span style=\"font-weight:bold; font-style: italic\">Slice: </span><span style=\"font-style: italic\">Unordered, Open by pattern:$this</span><br style=\"font-style: italic\"/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck125.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-observation-lab-definitions.html#Observation.category:Laboratory\" title=\"Slice Laboratory\">category:Laboratory</a><a name=\"Observation.category\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Classification of  type of observation</span><br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1241.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#CodeableConcept.coding\">coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Code defined by a terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">(complex)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck12410.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"https://terminology.hl7.org/1.0.0//CodeSystem-observation-category.html\">http://terminology.hl7.org/CodeSystem/observation-category</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck12400.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">laboratory</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-observation-lab-definitions.html#Observation.code\" title=\"The test that was performed.  A LOINC **SHALL** be used if the concept is present in LOINC.\">code</a><a name=\"Observation.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Laboratory Test Name<br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-observation-codes.html\">LOINCCodes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>): LOINC codes<br/><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-observation-lab-definitions.html#Observation.subject\">subject</a><a name=\"Observation.subject\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who and/or what the observation is about</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_choice.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Choice of Types\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-observation-lab-definitions.html#Observation.effective[x]\" title=\"For lab tests this is the specimen collection date.  For Ask at Order Entry Questions (AOE)'s this is the date the question was asked.\">effective[x]</a><a name=\"Observation.effective_x_\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-1, us-core-1)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Clinically relevant time/time-period for observation</span><br/><span style=\"font-weight:bold\">us-core-1: </span>Datetime must be at least to day.</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for dateTime Type: A date, date-time or partial date (e.g. just year or year + month).  If hours and minutes are specified, a time zone SHALL be populated. The format is a union of the schema types gYear, gYearMonth, date and dateTime. Seconds must be provided due to schema type constraints but may be zero-filled and may be ignored.                 Dates SHALL be valid dates.\">effectiveDateTime</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#dateTime\">dateTime</a> <span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This type must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for Period Type: A time period defined by a start and end date and optionally time.\">effectivePeriod</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Period\">Period</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for Timing Type: Specifies an event that may occur multiple times. Timing schedules are used to record when things are planned, expected or requested to occur. The most common usage is in dosage instructions for medications. They are also used when planning care of various kinds, and may be used for reporting the schedule to which past regular activities were carried out.\">effectiveTiming</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Timing\">Timing</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for instant Type: An instant in time - known at least to the second\">effectiveInstant</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#instant\">instant</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_choice.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Choice of Types\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-observation-lab-definitions.html#Observation.value[x]\" title=\"The Laboratory result value.  If a coded value,  the valueCodeableConcept.code **SHOULD** be selected from [SNOMED CT](http://hl7.org/fhir/ValueSet/uslab-obs-codedresults) if the concept exists. If a numeric value, valueQuantity.code **SHALL** be selected from [UCUM](http://unitsofmeasure.org).  A FHIR [UCUM Codes value set](http://hl7.org/fhir/STU3/valueset-ucum-units.html) that defines all UCUM codes is in the FHIR specification.\">value[x]</a><a name=\"Observation.value_x_\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-4, us-core-3, us-core-2, us-core-3, us-core-4)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Result Value<br/><span style=\"font-weight:bold\">us-core-4: </span>SHOULD use Snomed CT for coded Results<br/><span style=\"font-weight:bold\">us-core-3: </span>SHALL use UCUM for coded quantity units.</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for Quantity Type: A measured amount (or an amount that can potentially be measured). Note that measured amounts include amounts that are not precisely quantified, including amounts involving arbitrary units and floating currencies.\">valueQuantity</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Quantity\">Quantity</a> <span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This type must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for CodeableConcept Type: A concept that may be defined by a formal reference to a terminology or ontology or may be provided by text.\">valueCodeableConcept</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a> <span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This type must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for string Type: A sequence of Unicode characters\">valueString</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a> <span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This type must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for boolean Type: Value of &quot;true&quot; or &quot;false&quot;\">valueBoolean</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#boolean\">boolean</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for integer Type: A whole number\">valueInteger</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#integer\">integer</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for Range Type: A set of ordered Quantities defined by a low and high limit.\">valueRange</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Range\">Range</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for Ratio Type: A relationship of two Quantity values - expressed as a numerator and a denominator.\">valueRatio</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Ratio\">Ratio</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for SampledData Type: A series of measurements taken by a device, with upper and lower limits. There may be more than one dimension in the data.\">valueSampledData</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#SampledData\">SampledData</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for time Type: A time during the day, with no date specified\">valueTime</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#time\">time</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for dateTime Type: A date, date-time or partial date (e.g. just year or year + month).  If hours and minutes are specified, a time zone SHALL be populated. The format is a union of the schema types gYear, gYearMonth, date and dateTime. Seconds must be provided due to schema type constraints but may be zero-filled and may be ignored.                 Dates SHALL be valid dates.\">valueDateTime</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#dateTime\">dateTime</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for Period Type: A time period defined by a start and end date and optionally time.\">valuePeriod</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Period\">Period</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck00.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-observation-lab-definitions.html#Observation.dataAbsentReason\">dataAbsentReason</a><a name=\"Observation.dataAbsentReason\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-2)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Why the result is missing</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-data-absent-reason.html\">DataAbsentReason</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)</td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab",
-	"version": "4.0.0",
-	"name": "USCoreLaboratoryResultObservationProfile",
-	"title": "US Core Laboratory Result Observation Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-06-27",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the Observation resource for the minimal set of data to query and retrieve laboratory test results",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "sct-concept",
-			"uri": "http://snomed.info/conceptdomain",
-			"name": "SNOMED CT Concept Domain Binding"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "sct-attr",
-			"uri": "http://snomed.org/attributebinding",
-			"name": "SNOMED CT Attribute Binding"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Observation",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Observation",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "Measurements and simple assertions",
-				"definition": "This profile is  created to meet the 2015 Edition Common Clinical Data Set 'Laboratory test(s) and Laboratory value(s)/result(s)' requirements.",
-				"comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
-				"alias": [
-					"Vital Signs",
-					"Measurement",
-					"Results",
-					"Tests"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "obs-6",
-						"severity": "error",
-						"human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
-						"expression": "dataAbsentReason.empty() or value.empty()",
-						"xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "obs-7",
-						"severity": "error",
-						"human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
-						"expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
-						"xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "us-core-2",
-						"severity": "error",
-						"human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present",
-						"expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
-						"xpath": "exists(f:component) or exists(f:hasMember) or exists(f:*[starts-with(local-name(.), 'value')]) or exists(f:dataAbsentReason)"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation[classCode=OBS, moodCode=EVN]"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation"
-					}
-				]
-			},
-			{
-				"id": "Observation.id",
-				"path": "Observation.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.meta",
-				"path": "Observation.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.implicitRules",
-				"path": "Observation.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Observation.language",
-				"path": "Observation.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Observation.text",
-				"path": "Observation.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Observation.contained",
-				"path": "Observation.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.extension",
-				"path": "Observation.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.modifierExtension",
-				"path": "Observation.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.identifier",
-				"path": "Observation.identifier",
-				"short": "Business Identifier for observation",
-				"definition": "A unique identifier assigned to this observation.",
-				"requirements": "Allows observations to be distinguished and referenced.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
-					},
-					{
-						"identity": "rim",
-						"map": "id"
-					}
-				]
-			},
-			{
-				"id": "Observation.basedOn",
-				"path": "Observation.basedOn",
-				"short": "Fulfills plan, proposal or order",
-				"definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
-				"requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
-				"alias": [
-					"Fulfills"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan",
-							"http://hl7.org/fhir/StructureDefinition/DeviceRequest",
-							"http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
-							"http://hl7.org/fhir/StructureDefinition/MedicationRequest",
-							"http://hl7.org/fhir/StructureDefinition/NutritionOrder",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.basedOn"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.partOf",
-				"path": "Observation.partOf",
-				"short": "Part of referenced event",
-				"definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
-				"comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/R4/observation.html#obsgrouping) below for guidance on referencing another Observation.",
-				"alias": [
-					"Container"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.partOf",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
-							"http://hl7.org/fhir/StructureDefinition/MedicationDispense",
-							"http://hl7.org/fhir/StructureDefinition/MedicationStatement",
-							"http://hl7.org/fhir/StructureDefinition/Procedure",
-							"http://hl7.org/fhir/StructureDefinition/Immunization",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.partOf"
-					},
-					{
-						"identity": "v2",
-						"map": "Varies by domain"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=FLFS].target"
-					}
-				]
-			},
-			{
-				"id": "Observation.status",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
-						"valueString": "default: final"
-					}
-				],
-				"path": "Observation.status",
-				"short": "registered | preliminary | final | amended +",
-				"definition": "The status of the result value.",
-				"comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
-				"requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-status"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 445584004 |Report by finality status|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-11"
-					},
-					{
-						"identity": "rim",
-						"map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.status"
-					}
-				]
-			},
-			{
-				"id": "Observation.category",
-				"path": "Observation.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "$this"
-						}
-					],
-					"rules": "open"
-				},
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.category"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:Laboratory",
-				"path": "Observation.category",
-				"sliceName": "Laboratory",
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://terminology.hl7.org/CodeSystem/observation-category",
-							"code": "laboratory"
-						}
-					]
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.category"
-					}
-				]
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Laboratory Test Name",
-				"definition": "The test that was performed.  A LOINC **SHALL** be used if the concept is present in LOINC.",
-				"comment": "The typical patterns for codes are:  1)  a LOINC code either as a  translation from a \"local\" code or as a primary code, or 2)  a local code only if no suitable LOINC exists,  or 3)  both the local and the LOINC translation.   Systems SHALL be capable of sending the local code if one exists.  When using LOINC , Use either the SHORTNAME or LONG_COMMON_NAME field for the display.",
-				"requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
-				"alias": [
-					"Name",
-					"Test Name",
-					"Observation Identifer"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "LOINC codes",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-codes"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "116680003 |Is a|"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.subject",
-				"path": "Observation.subject",
-				"short": "Who and/or what the observation is about",
-				"definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
-				"comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
-				"requirements": "Observations have no value if you don't know who or what they're about.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=RTGT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.focus",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
-						"valueCode": "trial-use"
-					}
-				],
-				"path": "Observation.focus",
-				"short": "What the observation is about, when it is not about the subject of record",
-				"definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
-				"comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/R4/extension-observation-focuscode.html).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.focus",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SBJ]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.encounter",
-				"path": "Observation.encounter",
-				"short": "Healthcare event during which this observation is made",
-				"definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
-				"comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
-				"requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
-				"alias": [
-					"Context"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.effective[x]",
-				"path": "Observation.effective[x]",
-				"short": "Clinically relevant time/time-period for observation",
-				"definition": "For lab tests this is the specimen collection date.  For Ask at Order Entry Questions (AOE)'s this is the date the question was asked.",
-				"comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/R4/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
-				"requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
-				"alias": [
-					"Occurrence"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.effective[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					},
-					{
-						"code": "Timing"
-					},
-					{
-						"code": "instant"
-					}
-				],
-				"condition": [
-					"us-core-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "us-core-1",
-						"severity": "error",
-						"human": "Datetime must be at least to day.",
-						"expression": "Observation.effectiveDateTime.exists() implies Observation.effectiveDateTime.toString().length() >= 8",
-						"xpath": "f:matches(effectiveDateTime,/\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z)/)"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.effective[x]"
-					}
-				]
-			},
-			{
-				"id": "Observation.issued",
-				"path": "Observation.issued",
-				"short": "Date/Time this version was made available",
-				"definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
-				"comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/R4/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.issued",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=AUT].time"
-					}
-				]
-			},
-			{
-				"id": "Observation.performer",
-				"path": "Observation.performer",
-				"short": "Who is responsible for the observation",
-				"definition": "Who was responsible for asserting the observed value as \"true\".",
-				"requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.performer",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=PRF]"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]",
-				"path": "Observation.value[x]",
-				"short": "Result Value",
-				"definition": "The Laboratory result value.  If a coded value,  the valueCodeableConcept.code **SHOULD** be selected from [SNOMED CT](http://hl7.org/fhir/ValueSet/uslab-obs-codedresults) if the concept exists. If a numeric value, valueQuantity.code **SHALL** be selected from [UCUM](http://unitsofmeasure.org).  A FHIR [UCUM Codes value set](http://hl7.org/fhir/STU3/valueset-ucum-units.html) that defines all UCUM codes is in the FHIR specification.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/R4/observation.html#notes) below.",
-				"requirements": "An observation exists to have a value, though it might not if it is in error, or if it represents a group of observations.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "Quantity"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "CodeableConcept"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "string"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"us-core-2",
-					"us-core-3",
-					"us-core-4"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							}
-						],
-						"key": "us-core-4",
-						"severity": "warning",
-						"human": "SHOULD use Snomed CT for coded Results",
-						"expression": "valueCodeableConcept.coding.system.empty() or valueCodeableConcept.coding.system = 'http://snomed.info/sct'",
-						"xpath": "not(exists(f:valueCodeableConcept/f:coding/f:system) ) or  f:valueCodeableConcept/f:coding/f:system[@value='http://snomed.info/sct']"
-					},
-					{
-						"key": "us-core-3",
-						"severity": "error",
-						"human": "SHALL use UCUM for coded quantity units.",
-						"expression": "valueQuantity.system.empty() or valueQuantity.system = 'http://unitsofmeasure.org'",
-						"xpath": "not(exists(f:valueQuantity/f:system) ) or  f:valueQuantity/f:system[@value='http://unitsofmeasure.org']"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.value[x]"
-					}
-				]
-			},
-			{
-				"id": "Observation.dataAbsentReason",
-				"path": "Observation.dataAbsentReason",
-				"short": "Why the result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
-				"comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"us-core-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.dataAbsentReason"
-					}
-				]
-			},
-			{
-				"id": "Observation.interpretation",
-				"path": "Observation.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.note",
-				"path": "Observation.note",
-				"short": "Comments about the observation",
-				"definition": "Comments about the observation or the results.",
-				"comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
-				"requirements": "Need to be able to provide free text additional information.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
-					},
-					{
-						"identity": "rim",
-						"map": "subjectOf.observationEvent[code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.bodySite",
-				"path": "Observation.bodySite",
-				"short": "Observed body part",
-				"definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
-				"comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/R4/extension-bodysite.html).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.bodySite",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "BodySite"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing anatomical locations. May include laterality.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/body-site"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123037004 |Body structure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-20"
-					},
-					{
-						"identity": "rim",
-						"map": "targetSiteCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "718497002 |Inherent location|"
-					}
-				]
-			},
-			{
-				"id": "Observation.method",
-				"path": "Observation.method",
-				"short": "How it was done",
-				"definition": "Indicates the mechanism used to perform the observation.",
-				"comment": "Only used if not implicit in code for Observation.code.",
-				"requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.method",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationMethod"
-						}
-					],
-					"strength": "example",
-					"description": "Methods for simple observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-17"
-					},
-					{
-						"identity": "rim",
-						"map": "methodCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.specimen",
-				"path": "Observation.specimen",
-				"short": "Specimen used for this observation",
-				"definition": "The specimen that was used when this observation was made.",
-				"comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.specimen",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Specimen"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123038009 |Specimen|"
-					},
-					{
-						"identity": "v2",
-						"map": "SPM segment"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SPC].specimen"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "704319004 |Inherent in|"
-					}
-				]
-			},
-			{
-				"id": "Observation.device",
-				"path": "Observation.device",
-				"short": "(Measurement) Device",
-				"definition": "The device used to generate the observation data.",
-				"comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.device",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/DeviceMetric"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 49062001 |Device|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-17 / PRT -10"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=DEV]"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "424226004 |Using device|"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange",
-				"path": "Observation.referenceRange",
-				"short": "Provides guide for interpretation",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "obs-3",
-						"severity": "error",
-						"human": "Must have at least a low or a high or text",
-						"expression": "low.exists() or high.exists() or text.exists()",
-						"xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.id",
-				"path": "Observation.referenceRange.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.extension",
-				"path": "Observation.referenceRange.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.modifierExtension",
-				"path": "Observation.referenceRange.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.low",
-				"path": "Observation.referenceRange.low",
-				"short": "Low Range, if relevant",
-				"definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.low",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.low"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.high",
-				"path": "Observation.referenceRange.high",
-				"short": "High Range, if relevant",
-				"definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.high",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.high"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.type",
-				"path": "Observation.referenceRange.type",
-				"short": "Reference range qualifier",
-				"definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
-				"requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeMeaning"
-						}
-					],
-					"strength": "preferred",
-					"description": "Code for the meaning of a reference range.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.appliesTo",
-				"path": "Observation.referenceRange.appliesTo",
-				"short": "Reference range population",
-				"definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
-				"requirements": "Need to be able to identify the target population for proper interpretation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange.appliesTo",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeType"
-						}
-					],
-					"strength": "example",
-					"description": "Codes identifying the population the reference range applies to.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.age",
-				"path": "Observation.referenceRange.age",
-				"short": "Applicable age range, if relevant",
-				"definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
-				"requirements": "Some analytes vary greatly over age.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.age",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Range"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.text",
-				"path": "Observation.referenceRange.text",
-				"short": "Text based reference range in an observation",
-				"definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:ST"
-					}
-				]
-			},
-			{
-				"id": "Observation.hasMember",
-				"path": "Observation.hasMember",
-				"short": "Related resource that belongs to the Observation group",
-				"definition": "This observation is a group observation (e.g. a battery, a panel of tests, a set of vital sign measurements) that includes the target as a member of the group.",
-				"comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/R4/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/R4/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.hasMember",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Observation",
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship"
-					}
-				]
-			},
-			{
-				"id": "Observation.derivedFrom",
-				"path": "Observation.derivedFrom",
-				"short": "Related measurements the observation is made from",
-				"definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
-				"comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/R4/observation.html#obsgrouping) below.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.derivedFrom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/DocumentReference",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy",
-							"http://hl7.org/fhir/StructureDefinition/Media",
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/Observation",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": ".targetObservation"
-					}
-				]
-			},
-			{
-				"id": "Observation.component",
-				"path": "Observation.component",
-				"short": "Component results",
-				"definition": "Some observations have multiple component observations.  These component observations are expressed as separate code value pairs that share the same attributes.  Examples include systolic and diastolic component observations for blood pressure measurement and multiple component observations for genetics observations.",
-				"comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/R4/observation.html#notes) below.",
-				"requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "containment by OBX-4?"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=COMP]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.id",
-				"path": "Observation.component.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.extension",
-				"path": "Observation.component.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.modifierExtension",
-				"path": "Observation.component.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.code",
-				"path": "Observation.component.code",
-				"short": "Type of component observation (code / type)",
-				"definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
-				"comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCode"
-						}
-					],
-					"strength": "example",
-					"description": "Codes identifying names of simple observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-codes"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.value[x]",
-				"path": "Observation.component.value[x]",
-				"short": "Actual component result",
-				"definition": "The information determined as a result of making the observation, if the information has a simple value.",
-				"comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/R4/observation.html#notes) below.",
-				"requirements": "An observation exists to have a value, though it might not if it is in error, or if it represents a group of observations.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.dataAbsentReason",
-				"path": "Observation.component.dataAbsentReason",
-				"short": "Why the component result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
-				"comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.interpretation",
-				"path": "Observation.component.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.referenceRange",
-				"path": "Observation.component.referenceRange",
-				"short": "Provides guide for interpretation of component result",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"definition": "This profile is  created to meet the 2015 Edition Common Clinical Data Set 'Laboratory test(s) and Laboratory value(s)/result(s)' requirements.",
-				"constraint": [
-					{
-						"key": "us-core-2",
-						"severity": "error",
-						"human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present",
-						"expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
-						"xpath": "exists(f:component) or exists(f:hasMember) or exists(f:*[starts-with(local-name(.), 'value')]) or exists(f:dataAbsentReason)"
-					}
-				],
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation"
-					}
-				]
-			},
-			{
-				"id": "Observation.status",
-				"path": "Observation.status",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-status"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.status"
-					}
-				]
-			},
-			{
-				"id": "Observation.category",
-				"path": "Observation.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "$this"
-						}
-					],
-					"rules": "open"
-				},
-				"min": 1,
-				"max": "*",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.category"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:Laboratory",
-				"path": "Observation.category",
-				"sliceName": "Laboratory",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://terminology.hl7.org/CodeSystem/observation-category",
-							"code": "laboratory"
-						}
-					]
-				},
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.category"
-					}
-				]
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Laboratory Test Name",
-				"definition": "The test that was performed.  A LOINC **SHALL** be used if the concept is present in LOINC.",
-				"comment": "The typical patterns for codes are:  1)  a LOINC code either as a  translation from a \"local\" code or as a primary code, or 2)  a local code only if no suitable LOINC exists,  or 3)  both the local and the LOINC translation.   Systems SHALL be capable of sending the local code if one exists.  When using LOINC , Use either the SHORTNAME or LONG_COMMON_NAME field for the display.",
-				"alias": [
-					"Test Name",
-					"Observation Identifer"
-				],
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "LOINC codes",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-codes"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.subject",
-				"path": "Observation.subject",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.effective[x]",
-				"path": "Observation.effective[x]",
-				"definition": "For lab tests this is the specimen collection date.  For Ask at Order Entry Questions (AOE)'s this is the date the question was asked.",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					},
-					{
-						"code": "Timing"
-					},
-					{
-						"code": "instant"
-					}
-				],
-				"condition": [
-					"us-core-1"
-				],
-				"constraint": [
-					{
-						"key": "us-core-1",
-						"severity": "error",
-						"human": "Datetime must be at least to day.",
-						"expression": "Observation.effectiveDateTime.exists() implies Observation.effectiveDateTime.toString().length() >= 8",
-						"xpath": "f:matches(effectiveDateTime,/\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z)/)"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.effective[x]"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]",
-				"path": "Observation.value[x]",
-				"short": "Result Value",
-				"definition": "The Laboratory result value.  If a coded value,  the valueCodeableConcept.code **SHOULD** be selected from [SNOMED CT](http://hl7.org/fhir/ValueSet/uslab-obs-codedresults) if the concept exists. If a numeric value, valueQuantity.code **SHALL** be selected from [UCUM](http://unitsofmeasure.org).  A FHIR [UCUM Codes value set](http://hl7.org/fhir/STU3/valueset-ucum-units.html) that defines all UCUM codes is in the FHIR specification.",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "Quantity"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "CodeableConcept"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "string"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"us-core-2",
-					"us-core-3",
-					"us-core-4"
-				],
-				"constraint": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							}
-						],
-						"key": "us-core-4",
-						"severity": "warning",
-						"human": "SHOULD use Snomed CT for coded Results",
-						"expression": "valueCodeableConcept.coding.system.empty() or valueCodeableConcept.coding.system = 'http://snomed.info/sct'",
-						"xpath": "not(exists(f:valueCodeableConcept/f:coding/f:system) ) or  f:valueCodeableConcept/f:coding/f:system[@value='http://snomed.info/sct']"
-					},
-					{
-						"key": "us-core-3",
-						"severity": "error",
-						"human": "SHALL use UCUM for coded quantity units.",
-						"expression": "valueQuantity.system.empty() or valueQuantity.system = 'http://unitsofmeasure.org'",
-						"xpath": "not(exists(f:valueQuantity/f:system) ) or  f:valueQuantity/f:system[@value='http://unitsofmeasure.org']"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.value[x]"
-					}
-				]
-			},
-			{
-				"id": "Observation.dataAbsentReason",
-				"path": "Observation.dataAbsentReason",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"us-core-2"
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.dataAbsentReason"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-observation-lab",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab",
+    "version": "4.0.0",
+    "name": "USCoreLaboratoryResultObservationProfile",
+    "title": "US Core Laboratory Result Observation Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-06-27",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the Observation resource for the minimal set of data to query and retrieve laboratory test results",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "sct-concept",
+            "uri": "http://snomed.info/conceptdomain",
+            "name": "SNOMED CT Concept Domain Binding"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "sct-attr",
+            "uri": "http://snomed.org/attributebinding",
+            "name": "SNOMED CT Attribute Binding"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Observation",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Observation",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "Measurements and simple assertions",
+                "definition": "This profile is  created to meet the 2015 Edition Common Clinical Data Set 'Laboratory test(s) and Laboratory value(s)/result(s)' requirements.",
+                "comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
+                "alias": [
+                    "Vital Signs",
+                    "Measurement",
+                    "Results",
+                    "Tests"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "obs-6",
+                        "severity": "error",
+                        "human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
+                        "expression": "dataAbsentReason.empty() or value.empty()",
+                        "xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "obs-7",
+                        "severity": "error",
+                        "human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
+                        "expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
+                        "xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "us-core-2",
+                        "severity": "error",
+                        "human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present",
+                        "expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
+                        "xpath": "exists(f:component) or exists(f:hasMember) or exists(f:*[starts-with(local-name(.), 'value')]) or exists(f:dataAbsentReason)"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation[classCode=OBS, moodCode=EVN]"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.id",
+                "path": "Observation.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.meta",
+                "path": "Observation.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.implicitRules",
+                "path": "Observation.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Observation.language",
+                "path": "Observation.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Observation.text",
+                "path": "Observation.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.contained",
+                "path": "Observation.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.extension",
+                "path": "Observation.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.modifierExtension",
+                "path": "Observation.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.identifier",
+                "path": "Observation.identifier",
+                "short": "Business Identifier for observation",
+                "definition": "A unique identifier assigned to this observation.",
+                "requirements": "Allows observations to be distinguished and referenced.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "id"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.basedOn",
+                "path": "Observation.basedOn",
+                "short": "Fulfills plan, proposal or order",
+                "definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
+                "requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
+                "alias": [
+                    "Fulfills"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceRequest",
+                            "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+                            "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.basedOn"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.partOf",
+                "path": "Observation.partOf",
+                "short": "Part of referenced event",
+                "definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
+                "comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/R4/observation.html#obsgrouping) below for guidance on referencing another Observation.",
+                "alias": [
+                    "Container"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.partOf",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationDispense",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationStatement",
+                            "http://hl7.org/fhir/StructureDefinition/Procedure",
+                            "http://hl7.org/fhir/StructureDefinition/Immunization",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.partOf"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "Varies by domain"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=FLFS].target"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.status",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
+                        "valueString": "default: final"
+                    }
+                ],
+                "path": "Observation.status",
+                "short": "registered | preliminary | final | amended +",
+                "definition": "The status of the result value.",
+                "comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
+                "requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 445584004 |Report by finality status|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-11"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.status"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category",
+                "path": "Observation.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "$this"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.category"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:Laboratory",
+                "path": "Observation.category",
+                "sliceName": "Laboratory",
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.category"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Laboratory Test Name",
+                "definition": "The test that was performed.  A LOINC **SHALL** be used if the concept is present in LOINC.",
+                "comment": "The typical patterns for codes are:  1)  a LOINC code either as a  translation from a \"local\" code or as a primary code, or 2)  a local code only if no suitable LOINC exists,  or 3)  both the local and the LOINC translation.   Systems SHALL be capable of sending the local code if one exists.  When using LOINC , Use either the SHORTNAME or LONG_COMMON_NAME field for the display.",
+                "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+                "alias": [
+                    "Name",
+                    "Test Name",
+                    "Observation Identifer"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "LOINC codes",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-codes"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "116680003 |Is a|"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.subject",
+                "path": "Observation.subject",
+                "short": "Who and/or what the observation is about",
+                "definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
+                "comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
+                "requirements": "Observations have no value if you don't know who or what they're about.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=RTGT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.focus",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+                        "valueCode": "trial-use"
+                    }
+                ],
+                "path": "Observation.focus",
+                "short": "What the observation is about, when it is not about the subject of record",
+                "definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
+                "comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/R4/extension-observation-focuscode.html).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.focus",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SBJ]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.encounter",
+                "path": "Observation.encounter",
+                "short": "Healthcare event during which this observation is made",
+                "definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
+                "comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
+                "requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
+                "alias": [
+                    "Context"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.effective[x]",
+                "path": "Observation.effective[x]",
+                "short": "Clinically relevant time/time-period for observation",
+                "definition": "For lab tests this is the specimen collection date.  For Ask at Order Entry Questions (AOE)'s this is the date the question was asked.",
+                "comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/R4/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
+                "requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
+                "alias": [
+                    "Occurrence"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.effective[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    },
+                    {
+                        "code": "Timing"
+                    },
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "condition": [
+                    "us-core-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "us-core-1",
+                        "severity": "error",
+                        "human": "Datetime must be at least to day.",
+                        "expression": "Observation.effectiveDateTime.exists() implies Observation.effectiveDateTime.toString().length() >= 8",
+                        "xpath": "f:matches(effectiveDateTime,/\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z)/)"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.effective[x]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.issued",
+                "path": "Observation.issued",
+                "short": "Date/Time this version was made available",
+                "definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
+                "comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/R4/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.issued",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.performer",
+                "path": "Observation.performer",
+                "short": "Who is responsible for the observation",
+                "definition": "Who was responsible for asserting the observed value as \"true\".",
+                "requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.performer",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=PRF]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]",
+                "path": "Observation.value[x]",
+                "short": "Result Value",
+                "definition": "The Laboratory result value.  If a coded value,  the valueCodeableConcept.code **SHOULD** be selected from [SNOMED CT](http://hl7.org/fhir/ValueSet/uslab-obs-codedresults) if the concept exists. If a numeric value, valueQuantity.code **SHALL** be selected from [UCUM](http://unitsofmeasure.org).  A FHIR [UCUM Codes value set](http://hl7.org/fhir/STU3/valueset-ucum-units.html) that defines all UCUM codes is in the FHIR specification.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/R4/observation.html#notes) below.",
+                "requirements": "An observation exists to have a value, though it might not if it is in error, or if it represents a group of observations.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Quantity"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "string"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "us-core-2",
+                    "us-core-3",
+                    "us-core-4"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "key": "us-core-4",
+                        "severity": "warning",
+                        "human": "SHOULD use Snomed CT for coded Results",
+                        "expression": "valueCodeableConcept.coding.system.empty() or valueCodeableConcept.coding.system = 'http://snomed.info/sct'",
+                        "xpath": "not(exists(f:valueCodeableConcept/f:coding/f:system) ) or  f:valueCodeableConcept/f:coding/f:system[@value='http://snomed.info/sct']"
+                    },
+                    {
+                        "key": "us-core-3",
+                        "severity": "error",
+                        "human": "SHALL use UCUM for coded quantity units.",
+                        "expression": "valueQuantity.system.empty() or valueQuantity.system = 'http://unitsofmeasure.org'",
+                        "xpath": "not(exists(f:valueQuantity/f:system) ) or  f:valueQuantity/f:system[@value='http://unitsofmeasure.org']"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.value[x]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.dataAbsentReason",
+                "path": "Observation.dataAbsentReason",
+                "short": "Why the result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
+                "comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "us-core-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.dataAbsentReason"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.interpretation",
+                "path": "Observation.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.note",
+                "path": "Observation.note",
+                "short": "Comments about the observation",
+                "definition": "Comments about the observation or the results.",
+                "comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
+                "requirements": "Need to be able to provide free text additional information.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "subjectOf.observationEvent[code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.bodySite",
+                "path": "Observation.bodySite",
+                "short": "Observed body part",
+                "definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
+                "comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/R4/extension-bodysite.html).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.bodySite",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "BodySite"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing anatomical locations. May include laterality.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/body-site"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123037004 |Body structure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-20"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "targetSiteCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "718497002 |Inherent location|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.method",
+                "path": "Observation.method",
+                "short": "How it was done",
+                "definition": "Indicates the mechanism used to perform the observation.",
+                "comment": "Only used if not implicit in code for Observation.code.",
+                "requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.method",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationMethod"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Methods for simple observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "methodCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.specimen",
+                "path": "Observation.specimen",
+                "short": "Specimen used for this observation",
+                "definition": "The specimen that was used when this observation was made.",
+                "comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.specimen",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Specimen"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123038009 |Specimen|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "SPM segment"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SPC].specimen"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "704319004 |Inherent in|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.device",
+                "path": "Observation.device",
+                "short": "(Measurement) Device",
+                "definition": "The device used to generate the observation data.",
+                "comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.device",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceMetric"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 49062001 |Device|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17 / PRT -10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=DEV]"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "424226004 |Using device|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange",
+                "path": "Observation.referenceRange",
+                "short": "Provides guide for interpretation",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "obs-3",
+                        "severity": "error",
+                        "human": "Must have at least a low or a high or text",
+                        "expression": "low.exists() or high.exists() or text.exists()",
+                        "xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.id",
+                "path": "Observation.referenceRange.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.extension",
+                "path": "Observation.referenceRange.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.modifierExtension",
+                "path": "Observation.referenceRange.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.low",
+                "path": "Observation.referenceRange.low",
+                "short": "Low Range, if relevant",
+                "definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.low",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.low"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.high",
+                "path": "Observation.referenceRange.high",
+                "short": "High Range, if relevant",
+                "definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.high",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.high"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.type",
+                "path": "Observation.referenceRange.type",
+                "short": "Reference range qualifier",
+                "definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
+                "requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeMeaning"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Code for the meaning of a reference range.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.appliesTo",
+                "path": "Observation.referenceRange.appliesTo",
+                "short": "Reference range population",
+                "definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
+                "requirements": "Need to be able to identify the target population for proper interpretation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange.appliesTo",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes identifying the population the reference range applies to.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.age",
+                "path": "Observation.referenceRange.age",
+                "short": "Applicable age range, if relevant",
+                "definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
+                "requirements": "Some analytes vary greatly over age.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.age",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Range"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.text",
+                "path": "Observation.referenceRange.text",
+                "short": "Text based reference range in an observation",
+                "definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:ST"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.hasMember",
+                "path": "Observation.hasMember",
+                "short": "Related resource that belongs to the Observation group",
+                "definition": "This observation is a group observation (e.g. a battery, a panel of tests, a set of vital sign measurements) that includes the target as a member of the group.",
+                "comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/R4/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/R4/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.hasMember",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Observation",
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.derivedFrom",
+                "path": "Observation.derivedFrom",
+                "short": "Related measurements the observation is made from",
+                "definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
+                "comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/R4/observation.html#obsgrouping) below.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.derivedFrom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/DocumentReference",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy",
+                            "http://hl7.org/fhir/StructureDefinition/Media",
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/Observation",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".targetObservation"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component",
+                "path": "Observation.component",
+                "short": "Component results",
+                "definition": "Some observations have multiple component observations.  These component observations are expressed as separate code value pairs that share the same attributes.  Examples include systolic and diastolic component observations for blood pressure measurement and multiple component observations for genetics observations.",
+                "comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/R4/observation.html#notes) below.",
+                "requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "containment by OBX-4?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=COMP]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.id",
+                "path": "Observation.component.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.extension",
+                "path": "Observation.component.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.modifierExtension",
+                "path": "Observation.component.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.code",
+                "path": "Observation.component.code",
+                "short": "Type of component observation (code / type)",
+                "definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
+                "comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCode"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes identifying names of simple observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-codes"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.value[x]",
+                "path": "Observation.component.value[x]",
+                "short": "Actual component result",
+                "definition": "The information determined as a result of making the observation, if the information has a simple value.",
+                "comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/R4/observation.html#notes) below.",
+                "requirements": "An observation exists to have a value, though it might not if it is in error, or if it represents a group of observations.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.dataAbsentReason",
+                "path": "Observation.component.dataAbsentReason",
+                "short": "Why the component result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
+                "comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.interpretation",
+                "path": "Observation.component.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.referenceRange",
+                "path": "Observation.component.referenceRange",
+                "short": "Provides guide for interpretation of component result",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "definition": "This profile is  created to meet the 2015 Edition Common Clinical Data Set 'Laboratory test(s) and Laboratory value(s)/result(s)' requirements.",
+                "constraint": [
+                    {
+                        "key": "us-core-2",
+                        "severity": "error",
+                        "human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present",
+                        "expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
+                        "xpath": "exists(f:component) or exists(f:hasMember) or exists(f:*[starts-with(local-name(.), 'value')]) or exists(f:dataAbsentReason)"
+                    }
+                ],
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.status",
+                "path": "Observation.status",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.status"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category",
+                "path": "Observation.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "$this"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "min": 1,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.category"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:Laboratory",
+                "path": "Observation.category",
+                "sliceName": "Laboratory",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "laboratory"
+                        }
+                    ]
+                },
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.category"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Laboratory Test Name",
+                "definition": "The test that was performed.  A LOINC **SHALL** be used if the concept is present in LOINC.",
+                "comment": "The typical patterns for codes are:  1)  a LOINC code either as a  translation from a \"local\" code or as a primary code, or 2)  a local code only if no suitable LOINC exists,  or 3)  both the local and the LOINC translation.   Systems SHALL be capable of sending the local code if one exists.  When using LOINC , Use either the SHORTNAME or LONG_COMMON_NAME field for the display.",
+                "alias": [
+                    "Test Name",
+                    "Observation Identifer"
+                ],
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "LOINC codes",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-codes"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.subject",
+                "path": "Observation.subject",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.effective[x]",
+                "path": "Observation.effective[x]",
+                "definition": "For lab tests this is the specimen collection date.  For Ask at Order Entry Questions (AOE)'s this is the date the question was asked.",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    },
+                    {
+                        "code": "Timing"
+                    },
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "condition": [
+                    "us-core-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "us-core-1",
+                        "severity": "error",
+                        "human": "Datetime must be at least to day.",
+                        "expression": "Observation.effectiveDateTime.exists() implies Observation.effectiveDateTime.toString().length() >= 8",
+                        "xpath": "f:matches(effectiveDateTime,/\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z)/)"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.effective[x]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]",
+                "path": "Observation.value[x]",
+                "short": "Result Value",
+                "definition": "The Laboratory result value.  If a coded value,  the valueCodeableConcept.code **SHOULD** be selected from [SNOMED CT](http://hl7.org/fhir/ValueSet/uslab-obs-codedresults) if the concept exists. If a numeric value, valueQuantity.code **SHALL** be selected from [UCUM](http://unitsofmeasure.org).  A FHIR [UCUM Codes value set](http://hl7.org/fhir/STU3/valueset-ucum-units.html) that defines all UCUM codes is in the FHIR specification.",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Quantity"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "string"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "us-core-2",
+                    "us-core-3",
+                    "us-core-4"
+                ],
+                "constraint": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "key": "us-core-4",
+                        "severity": "warning",
+                        "human": "SHOULD use Snomed CT for coded Results",
+                        "expression": "valueCodeableConcept.coding.system.empty() or valueCodeableConcept.coding.system = 'http://snomed.info/sct'",
+                        "xpath": "not(exists(f:valueCodeableConcept/f:coding/f:system) ) or  f:valueCodeableConcept/f:coding/f:system[@value='http://snomed.info/sct']"
+                    },
+                    {
+                        "key": "us-core-3",
+                        "severity": "error",
+                        "human": "SHALL use UCUM for coded quantity units.",
+                        "expression": "valueQuantity.system.empty() or valueQuantity.system = 'http://unitsofmeasure.org'",
+                        "xpath": "not(exists(f:valueQuantity/f:system) ) or  f:valueQuantity/f:system[@value='http://unitsofmeasure.org']"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.value[x]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.dataAbsentReason",
+                "path": "Observation.dataAbsentReason",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "us-core-2"
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.dataAbsentReason"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-organization.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-organization.json
@@ -1,3093 +1,3093 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-organization",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-organization-definitions.html#Organization\">Organization</a><a name=\"Organization\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/organization.html\">Organization</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">A grouping of people or organizations with a common purpose</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck13.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Definition\" class=\"hierarchy\"/> <a style=\"font-style: italic\" href=\"StructureDefinition-us-core-organization-definitions.html#Organization.identifier\">Slices for identifier</a><a name=\"Organization.identifier\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red; font-style: italic\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"font-style: italic\"/><span style=\"font-style: italic\">0</span><span style=\"font-style: italic\">..</span><span style=\"font-style: italic\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"font-style: italic\" href=\"http://hl7.org/fhir/R4/datatypes.html#Identifier\">Identifier</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5; font-style: italic\">Identifies this organization  across multiple systems</span><br style=\"font-style: italic\"/><span style=\"font-weight:bold; font-style: italic\">Slice: </span><span style=\"font-style: italic\">Unordered, Open by pattern:$this</span><br style=\"font-style: italic\"/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck133.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> identifier:All Slices<a name=\"Organization.identifier\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Content/Rules for all slices</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1330.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-organization-definitions.html#Organization.identifier.system\">system</a><a name=\"Organization.identifier.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The namespace for the identifier value</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1320.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-organization-definitions.html#Organization.identifier.value\">value</a><a name=\"Organization.identifier.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The value that is unique</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck135.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-organization-definitions.html#Organization.identifier:NPI\" title=\"Slice NPI\">identifier:NPI</a><a name=\"Organization.identifier\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Identifier\">Identifier</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">National Provider Identifier (NPI)<br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1340.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Identifier.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">The namespace for the identifier value<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">http://hl7.org/fhir/sid/us-npi</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck125.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-organization-definitions.html#Organization.identifier:CLIA\" title=\"Slice CLIA\">identifier:CLIA</a><a name=\"Organization.identifier\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Identifier\">Identifier</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Clinical Laboratory Improvement Amendments (CLIA) Number for laboratories<br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1240.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Identifier.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">The namespace for the identifier value<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">urn:oid:2.16.840.1.113883.4.7</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-organization-definitions.html#Organization.active\">active</a><a name=\"Organization.active\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#boolean\">boolean</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Whether the organization's record is still in active use</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-organization-definitions.html#Organization.name\">name</a><a name=\"Organization.name\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Name used for the organization</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-organization-definitions.html#Organization.telecom\">telecom</a><a name=\"Organization.telecom\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#ContactPoint\">ContactPoint</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">A contact detail for the organization</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-organization-definitions.html#Organization.telecom.system\">system</a><a name=\"Organization.telecom.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">phone | fax | email | pager | url | sms | other</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-organization-definitions.html#Organization.telecom.value\">value</a><a name=\"Organization.telecom.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The actual contact point details</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-organization-definitions.html#Organization.address\">address</a><a name=\"Organization.address\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Address\">Address</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">An address for the organization</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-organization-definitions.html#Organization.address.line\">line</a><a name=\"Organization.address.line\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..4</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Street name, number, direction &amp; P.O. Box etc.</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-organization-definitions.html#Organization.address.city\">city</a><a name=\"Organization.address.city\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Name of city, town etc.</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-organization-definitions.html#Organization.address.state\">state</a><a name=\"Organization.address.state\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Sub-unit of country (abbreviations ok)</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-usps-state.html\">USPS Two Letter Alphabetic Codes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>): Two letter USPS alphabetic codes.<br/><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-organization-definitions.html#Organization.address.postalCode\">postalCode</a><a name=\"Organization.address.postalCode\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">US Zip Codes</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-organization-definitions.html#Organization.address.country\">country</a><a name=\"Organization.address.country\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Country (e.g. can be ISO 3166 2 or 3 letter code)</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
-	"version": "4.0.0",
-	"name": "USCoreOrganizationProfile",
-	"title": "US Core Organization Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-06-29",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Defines basic constraints and extensions on the Organization resource for use with other US Core resources",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "servd",
-			"uri": "http://www.omg.org/spec/ServD/1.0/",
-			"name": "ServD"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Organization",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Organization",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Organization",
-				"path": "Organization",
-				"short": "A grouping of people or organizations with a common purpose",
-				"definition": "A formally or informally recognized grouping of people or organizations formed for the purpose of achieving some form of collective action.  Includes companies, institutions, corporations, departments, community groups, healthcare practice groups, payer/insurer, etc.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Organization",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "org-1",
-						"severity": "error",
-						"human": "The organization SHALL at least have a name or an identifier, and possibly more than one",
-						"expression": "(identifier.count() + name.count()) > 0",
-						"xpath": "count(f:identifier | f:name) > 0",
-						"source": "http://hl7.org/fhir/StructureDefinition/Organization"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "v2",
-						"map": "(also see master files messages)"
-					},
-					{
-						"identity": "rim",
-						"map": "Organization(classCode=ORG, determinerCode=INST)"
-					},
-					{
-						"identity": "servd",
-						"map": "Organization"
-					}
-				]
-			},
-			{
-				"id": "Organization.id",
-				"path": "Organization.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Organization.meta",
-				"path": "Organization.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Organization.implicitRules",
-				"path": "Organization.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Organization.language",
-				"path": "Organization.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Organization.text",
-				"path": "Organization.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Organization.contained",
-				"path": "Organization.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Organization.extension",
-				"path": "Organization.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Organization.modifierExtension",
-				"path": "Organization.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Organization.identifier",
-				"path": "Organization.identifier",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "$this"
-						}
-					],
-					"rules": "open"
-				},
-				"short": "Identifies this organization  across multiple systems",
-				"definition": "Identifier for the organization that is used to identify the organization across multiple disparate systems.",
-				"comment": "NPI preferred.",
-				"requirements": "Organizations are known by a variety of ids. Some institutions maintain several, and most collect identifiers for exchange with other organizations concerning the organization.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Organization.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"condition": [
-					"org-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "XON.10 / XON.3"
-					},
-					{
-						"identity": "rim",
-						"map": ".scopes[Role](classCode=IDENT)"
-					},
-					{
-						"identity": "servd",
-						"map": "./Identifiers"
-					},
-					{
-						"identity": "servd",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.identifier.id",
-				"path": "Organization.identifier.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.identifier.extension",
-				"path": "Organization.identifier.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.identifier.use",
-				"path": "Organization.identifier.use",
-				"short": "usual | official | temp | secondary | old (If known)",
-				"definition": "The purpose of this identifier.",
-				"comment": "Applications can assume that an identifier is permanent unless it explicitly says that it is temporary.",
-				"requirements": "Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.use",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary id for a permanent one.",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "IdentifierUse"
-						}
-					],
-					"strength": "required",
-					"description": "Identifies the purpose for this identifier, if known .",
-					"valueSet": "http://hl7.org/fhir/ValueSet/identifier-use|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "Role.code or implied by context"
-					}
-				]
-			},
-			{
-				"id": "Organization.identifier.type",
-				"path": "Organization.identifier.type",
-				"short": "Description of identifier",
-				"definition": "A coded type for the identifier that can be used to determine which identifier to use for a specific purpose.",
-				"comment": "This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage.   Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type.",
-				"requirements": "Allows users to make use of identifiers when the identifier system is not known.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "IdentifierType"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "extensible",
-					"description": "A coded type for an identifier that can be used to determine which identifier to use for a specific purpose.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/identifier-type"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.5"
-					},
-					{
-						"identity": "rim",
-						"map": "Role.code or implied by context"
-					}
-				]
-			},
-			{
-				"id": "Organization.identifier.system",
-				"path": "Organization.identifier.system",
-				"short": "The namespace for the identifier value",
-				"definition": "Establishes the namespace for the value - that is, a URL that describes a set values that are unique.",
-				"comment": "Identifier.system is always case sensitive.",
-				"requirements": "There are many sets  of identifiers.  To perform matching of two identifiers, we need to know what set we're dealing with. The system identifies a particular set of unique identifiers.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueUri": "http://www.acme.com/identifiers/patient"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.4 / EI-2-4"
-					},
-					{
-						"identity": "rim",
-						"map": "II.root or Role.id.root"
-					},
-					{
-						"identity": "servd",
-						"map": "./IdentifierType"
-					}
-				]
-			},
-			{
-				"id": "Organization.identifier.value",
-				"path": "Organization.identifier.value",
-				"short": "The value that is unique",
-				"definition": "The portion of the identifier typically relevant to the user and which is unique within the context of the system.",
-				"comment": "If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986.  The value's primary purpose is computational mapping.  As a result, it may be normalized for comparison purposes (e.g. removing non-significant whitespace, dashes, etc.)  A value formatted for human display can be conveyed using the [Rendered Value extension](http://hl7.org/fhir/R4/extension-rendered-value.html). Identifier.value is to be treated as case sensitive unless knowledge of the Identifier.system allows the processer to be confident that non-case-sensitive processing is safe.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "123456"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.1 / EI.1"
-					},
-					{
-						"identity": "rim",
-						"map": "II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)"
-					},
-					{
-						"identity": "servd",
-						"map": "./Value"
-					}
-				]
-			},
-			{
-				"id": "Organization.identifier.period",
-				"path": "Organization.identifier.period",
-				"short": "Time period when id is/was valid for use",
-				"definition": "Time period during which identifier is/was valid for use.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.7 + CX.8"
-					},
-					{
-						"identity": "rim",
-						"map": "Role.effectiveTime or implied by context"
-					},
-					{
-						"identity": "servd",
-						"map": "./StartDate and ./EndDate"
-					}
-				]
-			},
-			{
-				"id": "Organization.identifier.assigner",
-				"path": "Organization.identifier.assigner",
-				"short": "Organization that issued id (may be just text)",
-				"definition": "Organization that issued/manages the identifier.",
-				"comment": "The Identifier.assigner may omit the .reference element and only contain a .display element reflecting the name or other textual information about the assigning organization.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.assigner",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.4 / (CX.4,CX.9,CX.10)"
-					},
-					{
-						"identity": "rim",
-						"map": "II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper"
-					},
-					{
-						"identity": "servd",
-						"map": "./IdentifierIssuingAuthority"
-					}
-				]
-			},
-			{
-				"id": "Organization.identifier:NPI",
-				"path": "Organization.identifier",
-				"sliceName": "NPI",
-				"short": "National Provider Identifier (NPI)",
-				"definition": "Identifier for the organization that is used to identify the organization across multiple disparate systems.",
-				"requirements": "Organizations are known by a variety of ids. Some institutions maintain several, and most collect identifiers for exchange with other organizations concerning the organization.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Organization.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"patternIdentifier": {
-					"system": "http://hl7.org/fhir/sid/us-npi"
-				},
-				"condition": [
-					"org-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "XON.10 / XON.3"
-					},
-					{
-						"identity": "rim",
-						"map": ".scopes[Role](classCode=IDENT)"
-					},
-					{
-						"identity": "servd",
-						"map": "./Identifiers"
-					},
-					{
-						"identity": "servd",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.identifier:CLIA",
-				"path": "Organization.identifier",
-				"sliceName": "CLIA",
-				"short": "Clinical Laboratory Improvement Amendments (CLIA) Number for laboratories",
-				"definition": "Identifier for the organization that is used to identify the organization across multiple disparate systems.",
-				"requirements": "Organizations are known by a variety of ids. Some institutions maintain several, and most collect identifiers for exchange with other organizations concerning the organization.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Organization.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"patternIdentifier": {
-					"system": "urn:oid:2.16.840.1.113883.4.7"
-				},
-				"condition": [
-					"org-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "XON.10 / XON.3"
-					},
-					{
-						"identity": "rim",
-						"map": ".scopes[Role](classCode=IDENT)"
-					},
-					{
-						"identity": "servd",
-						"map": "./Identifiers"
-					},
-					{
-						"identity": "servd",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.active",
-				"path": "Organization.active",
-				"short": "Whether the organization's record is still in active use",
-				"definition": "Whether the organization's record is still in active use.",
-				"comment": "This active flag is not intended to be used to mark an organization as temporarily closed or under construction. Instead the Location(s) within the Organization should have the suspended status. If further details of the reason for the suspension are required, then an extension on this element should be used.\n\nThis element is labeled as a modifier because it may be used to mark that the resource was created in error.",
-				"requirements": "Need a flag to indicate a record is no longer to be used and should generally be hidden for the user in the UI.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Organization.active",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"meaningWhenMissing": "This resource is generally assumed to be active if no value is provided for the active element",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labelled as a modifier because it is a status element that can indicate that a record should not be treated as valid",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "v2",
-						"map": "No equivalent in HL7 v2"
-					},
-					{
-						"identity": "rim",
-						"map": ".status"
-					},
-					{
-						"identity": "servd",
-						"map": "./Status (however this concept in ServD more covers why the organization is active or not, could be delisted, deregistered, not operational yet) this could alternatively be derived from ./StartDate and ./EndDate and given a context date."
-					}
-				]
-			},
-			{
-				"id": "Organization.type",
-				"path": "Organization.type",
-				"short": "Kind of organization",
-				"definition": "The kind(s) of organization that this is.",
-				"comment": "Organizations can be corporations, wards, sections, clinical teams, government departments, etc. Note that code is generally a classifier of the type of organization; in many applications, codes are used to identity a particular organization (say, ward) as opposed to another of the same type - these are identifiers, not codes\n\nWhen considering if multiple types are appropriate, you should evaluate if child organizations would be a more appropriate use of the concept, as different types likely are in different sub-areas of the organization. This is most likely to be used where type values have orthogonal values, such as a religious, academic and medical center.\n\nWe expect that some jurisdictions will profile this optionality to be a single cardinality.",
-				"requirements": "Need to be able to track the kind of organization that this is - different organization types have different uses.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Organization.type",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "OrganizationType"
-						}
-					],
-					"strength": "example",
-					"description": "Used to categorize the organization.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/organization-type"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "v2",
-						"map": "No equivalent in v2"
-					},
-					{
-						"identity": "rim",
-						"map": ".code"
-					},
-					{
-						"identity": "servd",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.name",
-				"path": "Organization.name",
-				"short": "Name used for the organization",
-				"definition": "A name associated with the organization.",
-				"comment": "If the name of an organization changes, consider putting the old name in the alias column so that it can still be located through searches.",
-				"requirements": "Need to use the name as the label of the organization.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Organization.name",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"condition": [
-					"org-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XON.1"
-					},
-					{
-						"identity": "rim",
-						"map": ".name"
-					},
-					{
-						"identity": "servd",
-						"map": ".PreferredName/Name"
-					},
-					{
-						"identity": "servd",
-						"map": "./PrimaryAddress and ./OtherAddresses"
-					}
-				]
-			},
-			{
-				"id": "Organization.alias",
-				"path": "Organization.alias",
-				"short": "A list of alternate names that the organization is known as, or was known as in the past",
-				"definition": "A list of alternate names that the organization is known as, or was known as in the past.",
-				"comment": "There are no dates associated with the alias/historic names, as this is not intended to track when names were used, but to assist in searching so that older names can still result in identifying the organization.",
-				"requirements": "Over time locations and organizations go through many changes and can be known by different names.\n\nFor searching knowing previous names that the organization was known by can be very useful.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Organization.alias",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".name"
-					}
-				]
-			},
-			{
-				"id": "Organization.telecom",
-				"path": "Organization.telecom",
-				"short": "A contact detail for the organization",
-				"definition": "A contact detail for the organization.",
-				"comment": "The use code 'home' is not to be used. Note that these contacts are not the contact details of people who are employed by or represent the organization, but official contacts for the organization itself.",
-				"requirements": "Human contact for the organization.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Organization.telecom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "ContactPoint"
-					}
-				],
-				"condition": [
-					"org-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "org-3",
-						"severity": "error",
-						"human": "The telecom of an organization can never be of use 'home'",
-						"expression": "where(use = 'home').empty()",
-						"xpath": "count(f:use[@value='home']) = 0",
-						"source": "http://hl7.org/fhir/StructureDefinition/Organization"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "ORC-22?"
-					},
-					{
-						"identity": "rim",
-						"map": ".telecom"
-					},
-					{
-						"identity": "servd",
-						"map": "./ContactPoints"
-					}
-				]
-			},
-			{
-				"id": "Organization.telecom.id",
-				"path": "Organization.telecom.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.telecom.extension",
-				"path": "Organization.telecom.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.telecom.system",
-				"path": "Organization.telecom.system",
-				"short": "phone | fax | email | pager | url | sms | other",
-				"definition": "Telecommunications form for contact point - what communications system is required to make use of the contact.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "ContactPoint.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"condition": [
-					"cpt-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ContactPointSystem"
-						}
-					],
-					"strength": "required",
-					"description": "Telecommunications form for contact point.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/contact-point-system|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XTN.3"
-					},
-					{
-						"identity": "rim",
-						"map": "./scheme"
-					},
-					{
-						"identity": "servd",
-						"map": "./ContactPointType"
-					}
-				]
-			},
-			{
-				"id": "Organization.telecom.value",
-				"path": "Organization.telecom.value",
-				"short": "The actual contact point details",
-				"definition": "The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address).",
-				"comment": "Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value.",
-				"requirements": "Need to support legacy numbers that are not in a tightly controlled format.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "ContactPoint.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XTN.1 (or XTN.12)"
-					},
-					{
-						"identity": "rim",
-						"map": "./url"
-					},
-					{
-						"identity": "servd",
-						"map": "./Value"
-					}
-				]
-			},
-			{
-				"id": "Organization.telecom.use",
-				"path": "Organization.telecom.use",
-				"short": "home | work | temp | old | mobile - purpose of this contact point",
-				"definition": "Identifies the purpose for the contact point.",
-				"comment": "Applications can assume that a contact is current unless it explicitly says that it is temporary or old.",
-				"requirements": "Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "ContactPoint.use",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old contact etc.for a current/permanent one",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ContactPointUse"
-						}
-					],
-					"strength": "required",
-					"description": "Use of contact point.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/contact-point-use|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XTN.2 - but often indicated by field"
-					},
-					{
-						"identity": "rim",
-						"map": "unique(./use)"
-					},
-					{
-						"identity": "servd",
-						"map": "./ContactPointPurpose"
-					}
-				]
-			},
-			{
-				"id": "Organization.telecom.rank",
-				"path": "Organization.telecom.rank",
-				"short": "Specify preferred order of use (1 = highest)",
-				"definition": "Specifies a preferred order in which to use a set of contacts. ContactPoints with lower rank values are more preferred than those with higher rank values.",
-				"comment": "Note that rank does not necessarily follow the order in which the contacts are represented in the instance.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "ContactPoint.rank",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "positiveInt"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "n/a"
-					},
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.telecom.period",
-				"path": "Organization.telecom.period",
-				"short": "Time period when the contact point was/is in use",
-				"definition": "Time period when the contact point was/is in use.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "ContactPoint.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "./usablePeriod[type=\"IVL<TS>\"]"
-					},
-					{
-						"identity": "servd",
-						"map": "./StartDate and ./EndDate"
-					}
-				]
-			},
-			{
-				"id": "Organization.address",
-				"path": "Organization.address",
-				"short": "An address for the organization",
-				"definition": "An address for the organization.",
-				"comment": "Organization may have multiple addresses with different uses or applicable periods. The use code 'home' is not to be used.",
-				"requirements": "May need to keep track of the organization's addresses for contacting, billing or reporting requirements.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Organization.address",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Address"
-					}
-				],
-				"condition": [
-					"org-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "org-2",
-						"severity": "error",
-						"human": "An address of an organization can never be of use 'home'",
-						"expression": "where(use = 'home').empty()",
-						"xpath": "count(f:use[@value='home']) = 0",
-						"source": "http://hl7.org/fhir/StructureDefinition/Organization"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "ORC-23?"
-					},
-					{
-						"identity": "rim",
-						"map": ".address"
-					},
-					{
-						"identity": "servd",
-						"map": "./PrimaryAddress and ./OtherAddresses"
-					},
-					{
-						"identity": "servd",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.address.id",
-				"path": "Organization.address.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.address.extension",
-				"path": "Organization.address.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.address.use",
-				"path": "Organization.address.use",
-				"short": "home | work | temp | old | billing - purpose of this address",
-				"definition": "The purpose of this address.",
-				"comment": "Applications can assume that an address is current unless it explicitly says that it is temporary or old.",
-				"requirements": "Allows an appropriate address to be chosen from a list of many.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.use",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueCode": "home"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old address etc.for a current/permanent one",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AddressUse"
-						}
-					],
-					"strength": "required",
-					"description": "The use of an address.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/address-use|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.7"
-					},
-					{
-						"identity": "rim",
-						"map": "unique(./use)"
-					},
-					{
-						"identity": "servd",
-						"map": "./AddressPurpose"
-					}
-				]
-			},
-			{
-				"id": "Organization.address.type",
-				"path": "Organization.address.type",
-				"short": "postal | physical | both",
-				"definition": "Distinguishes between physical addresses (those you can visit) and mailing addresses (e.g. PO Boxes and care-of addresses). Most addresses are both.",
-				"comment": "The definition of Address states that \"address is intended to describe postal addresses, not physical locations\". However, many applications track whether an address has a dual purpose of being a location that can be visited as well as being a valid delivery destination, and Postal addresses are often used as proxies for physical locations (also see the [Location](http://hl7.org/fhir/R4/location.html#) resource).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueCode": "both"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AddressType"
-						}
-					],
-					"strength": "required",
-					"description": "The type of an address (physical / postal).",
-					"valueSet": "http://hl7.org/fhir/ValueSet/address-type|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.18"
-					},
-					{
-						"identity": "rim",
-						"map": "unique(./use)"
-					},
-					{
-						"identity": "vcard",
-						"map": "address type parameter"
-					}
-				]
-			},
-			{
-				"id": "Organization.address.text",
-				"path": "Organization.address.text",
-				"short": "Text representation of the address",
-				"definition": "Specifies the entire address as it should be displayed e.g. on a postal label. This may be provided instead of or as well as the specific parts.",
-				"comment": "Can provide both a text representation and parts. Applications updating an address SHALL ensure that  when both text and parts are present,  no content is included in the text that isn't found in a part.",
-				"requirements": "A renderable, unencoded form.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "137 Nowhere Street, Erewhon 9132"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.1 + XAD.2 + XAD.3 + XAD.4 + XAD.5 + XAD.6"
-					},
-					{
-						"identity": "rim",
-						"map": "./formatted"
-					},
-					{
-						"identity": "vcard",
-						"map": "address label parameter"
-					}
-				]
-			},
-			{
-				"id": "Organization.address.line",
-				"path": "Organization.address.line",
-				"short": "Street name, number, direction & P.O. Box etc.",
-				"definition": "This component contains the house number, apartment number, street name, street direction,  P.O. Box number, delivery hints, and similar address information.",
-				"min": 0,
-				"max": "4",
-				"base": {
-					"path": "Address.line",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"orderMeaning": "The order in which lines should appear in an address label",
-				"example": [
-					{
-						"label": "General",
-						"valueString": "137 Nowhere Street"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.1 + XAD.2 (note: XAD.1 and XAD.2 have different meanings for a company address than for a person address)"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = AL]"
-					},
-					{
-						"identity": "vcard",
-						"map": "street"
-					},
-					{
-						"identity": "servd",
-						"map": "./StreetAddress (newline delimitted)"
-					}
-				]
-			},
-			{
-				"id": "Organization.address.city",
-				"path": "Organization.address.city",
-				"short": "Name of city, town etc.",
-				"definition": "The name of the city, town, suburb, village or other community or delivery center.",
-				"alias": [
-					"Municpality"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.city",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "Erewhon"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.3"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = CTY]"
-					},
-					{
-						"identity": "vcard",
-						"map": "locality"
-					},
-					{
-						"identity": "servd",
-						"map": "./Jurisdiction"
-					}
-				]
-			},
-			{
-				"id": "Organization.address.district",
-				"path": "Organization.address.district",
-				"short": "District name (aka county)",
-				"definition": "The name of the administrative area (county).",
-				"comment": "District is sometimes known as county, but in some regions 'county' is used in place of city (municipality), so county name should be conveyed in city instead.",
-				"alias": [
-					"County"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.district",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "Madison"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.9"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = CNT | CPA]"
-					}
-				]
-			},
-			{
-				"id": "Organization.address.state",
-				"path": "Organization.address.state",
-				"short": "Sub-unit of country (abbreviations ok)",
-				"definition": "Sub-unit of a country with limited sovereignty in a federally organized country. A code may be used if codes are in common use (e.g. US 2 letter state codes).",
-				"alias": [
-					"Province",
-					"Territory"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.state",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Two letter USPS alphabetic codes.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.4"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = STA]"
-					},
-					{
-						"identity": "vcard",
-						"map": "region"
-					},
-					{
-						"identity": "servd",
-						"map": "./Region"
-					},
-					{
-						"identity": "servd",
-						"map": "./Sites"
-					}
-				]
-			},
-			{
-				"id": "Organization.address.postalCode",
-				"path": "Organization.address.postalCode",
-				"short": "US Zip Codes",
-				"definition": "A postal code designating a region defined by the postal service.",
-				"alias": [
-					"Zip"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.postalCode",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "9132"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.5"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = ZIP]"
-					},
-					{
-						"identity": "vcard",
-						"map": "code"
-					},
-					{
-						"identity": "servd",
-						"map": "./PostalIdentificationCode"
-					}
-				]
-			},
-			{
-				"id": "Organization.address.country",
-				"path": "Organization.address.country",
-				"short": "Country (e.g. can be ISO 3166 2 or 3 letter code)",
-				"definition": "Country - a nation as commonly understood or generally accepted.",
-				"comment": "ISO 3166 3 letter codes can be used in place of a human readable country name.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.country",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.6"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = CNT]"
-					},
-					{
-						"identity": "vcard",
-						"map": "country"
-					},
-					{
-						"identity": "servd",
-						"map": "./Country"
-					}
-				]
-			},
-			{
-				"id": "Organization.address.period",
-				"path": "Organization.address.period",
-				"short": "Time period when address was/is in use",
-				"definition": "Time period when address was/is in use.",
-				"requirements": "Allows addresses to be placed in historical context.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valuePeriod": {
-							"start": "2010-03-23",
-							"end": "2010-07-01"
-						}
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.12 / XAD.13 + XAD.14"
-					},
-					{
-						"identity": "rim",
-						"map": "./usablePeriod[type=\"IVL<TS>\"]"
-					},
-					{
-						"identity": "servd",
-						"map": "./StartDate and ./EndDate"
-					}
-				]
-			},
-			{
-				"id": "Organization.partOf",
-				"path": "Organization.partOf",
-				"short": "The organization of which this organization forms a part",
-				"definition": "The organization of which this organization forms a part.",
-				"requirements": "Need to be able to track the hierarchy of organizations within an organization.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Organization.partOf",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-hierarchy",
-								"valueBoolean": true
-							}
-						],
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "No equivalent in HL7 v2"
-					},
-					{
-						"identity": "rim",
-						"map": ".playedBy[classCode=Part].scoper"
-					},
-					{
-						"identity": "servd",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.contact",
-				"path": "Organization.contact",
-				"short": "Contact for the organization for a certain purpose",
-				"definition": "Contact for the organization for a certain purpose.",
-				"comment": "Where multiple contacts for the same purpose are provided there is a standard extension that can be used to determine which one is the preferred contact to use.",
-				"requirements": "Need to keep track of assigned contact points within bigger organization.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Organization.contact",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".contactParty"
-					}
-				]
-			},
-			{
-				"id": "Organization.contact.id",
-				"path": "Organization.contact.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.contact.extension",
-				"path": "Organization.contact.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.contact.modifierExtension",
-				"path": "Organization.contact.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Organization.contact.purpose",
-				"path": "Organization.contact.purpose",
-				"short": "The type of contact",
-				"definition": "Indicates a purpose for which the contact can be reached.",
-				"requirements": "Need to distinguish between multiple contact persons.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Organization.contact.purpose",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ContactPartyType"
-						}
-					],
-					"strength": "extensible",
-					"description": "The purpose for which you would contact a contact party.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/contactentity-type"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "./type"
-					}
-				]
-			},
-			{
-				"id": "Organization.contact.name",
-				"path": "Organization.contact.name",
-				"short": "A name associated with the contact",
-				"definition": "A name associated with the contact.",
-				"requirements": "Need to be able to track the person by name.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Organization.contact.name",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "HumanName"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PID-5, PID-9"
-					},
-					{
-						"identity": "rim",
-						"map": "./name"
-					}
-				]
-			},
-			{
-				"id": "Organization.contact.telecom",
-				"path": "Organization.contact.telecom",
-				"short": "Contact details (telephone, email, etc.)  for a contact",
-				"definition": "A contact detail (e.g. a telephone number or an email address) by which the party may be contacted.",
-				"requirements": "People have (primary) ways to contact them in some way such as phone, email.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Organization.contact.telecom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "ContactPoint"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PID-13, PID-14"
-					},
-					{
-						"identity": "rim",
-						"map": "./telecom"
-					}
-				]
-			},
-			{
-				"id": "Organization.contact.address",
-				"path": "Organization.contact.address",
-				"short": "Visiting or postal addresses for the contact",
-				"definition": "Visiting or postal addresses for the contact.",
-				"requirements": "May need to keep track of a contact party's address for contacting, billing or reporting requirements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Organization.contact.address",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Address"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PID-11"
-					},
-					{
-						"identity": "rim",
-						"map": "./addr"
-					}
-				]
-			},
-			{
-				"id": "Organization.endpoint",
-				"path": "Organization.endpoint",
-				"short": "Technical endpoints providing access to services operated for the organization",
-				"definition": "Technical endpoints providing access to services operated for the organization.",
-				"requirements": "Organizations have multiple systems that provide various services and need to be able to define the technical connection details for how to connect to them, and for what purpose.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Organization.endpoint",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Endpoint"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Organization",
-				"path": "Organization",
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "servd",
-						"map": "Organization"
-					}
-				]
-			},
-			{
-				"id": "Organization.identifier",
-				"path": "Organization.identifier",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "$this"
-						}
-					],
-					"rules": "open"
-				},
-				"comment": "NPI preferred.",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "servd",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.identifier.system",
-				"path": "Organization.identifier.system",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Organization.identifier.value",
-				"path": "Organization.identifier.value",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Organization.identifier:NPI",
-				"path": "Organization.identifier",
-				"sliceName": "NPI",
-				"short": "National Provider Identifier (NPI)",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"patternIdentifier": {
-					"system": "http://hl7.org/fhir/sid/us-npi"
-				},
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "servd",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.identifier:CLIA",
-				"path": "Organization.identifier",
-				"sliceName": "CLIA",
-				"short": "Clinical Laboratory Improvement Amendments (CLIA) Number for laboratories",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"patternIdentifier": {
-					"system": "urn:oid:2.16.840.1.113883.4.7"
-				},
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "servd",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.active",
-				"path": "Organization.active",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Organization.name",
-				"path": "Organization.name",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "servd",
-						"map": "./PrimaryAddress and ./OtherAddresses"
-					}
-				]
-			},
-			{
-				"id": "Organization.telecom",
-				"path": "Organization.telecom",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "ContactPoint"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Organization.telecom.system",
-				"path": "Organization.telecom.system",
-				"mustSupport": true
-			},
-			{
-				"id": "Organization.telecom.value",
-				"path": "Organization.telecom.value",
-				"mustSupport": true
-			},
-			{
-				"id": "Organization.address",
-				"path": "Organization.address",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "Address"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "servd",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Organization.address.line",
-				"path": "Organization.address.line",
-				"min": 0,
-				"max": "4",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Organization.address.city",
-				"path": "Organization.address.city",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Organization.address.state",
-				"path": "Organization.address.state",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Two letter USPS alphabetic codes.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state"
-				},
-				"mapping": [
-					{
-						"identity": "servd",
-						"map": "./Sites"
-					}
-				]
-			},
-			{
-				"id": "Organization.address.postalCode",
-				"path": "Organization.address.postalCode",
-				"short": "US Zip Codes",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Organization.address.country",
-				"path": "Organization.address.country",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-organization",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
+    "version": "4.0.0",
+    "name": "USCoreOrganizationProfile",
+    "title": "US Core Organization Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-06-29",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Defines basic constraints and extensions on the Organization resource for use with other US Core resources",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "servd",
+            "uri": "http://www.omg.org/spec/ServD/1.0/",
+            "name": "ServD"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Organization",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Organization",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Organization",
+                "path": "Organization",
+                "short": "A grouping of people or organizations with a common purpose",
+                "definition": "A formally or informally recognized grouping of people or organizations formed for the purpose of achieving some form of collective action.  Includes companies, institutions, corporations, departments, community groups, healthcare practice groups, payer/insurer, etc.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Organization",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "org-1",
+                        "severity": "error",
+                        "human": "The organization SHALL at least have a name or an identifier, and possibly more than one",
+                        "expression": "(identifier.count() + name.count()) > 0",
+                        "xpath": "count(f:identifier | f:name) > 0",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Organization"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "(also see master files messages)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Organization(classCode=ORG, determinerCode=INST)"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "Organization"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.id",
+                "path": "Organization.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Organization.meta",
+                "path": "Organization.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Organization.implicitRules",
+                "path": "Organization.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Organization.language",
+                "path": "Organization.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Organization.text",
+                "path": "Organization.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.contained",
+                "path": "Organization.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.extension",
+                "path": "Organization.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.modifierExtension",
+                "path": "Organization.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.identifier",
+                "path": "Organization.identifier",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "$this"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "short": "Identifies this organization  across multiple systems",
+                "definition": "Identifier for the organization that is used to identify the organization across multiple disparate systems.",
+                "comment": "NPI preferred.",
+                "requirements": "Organizations are known by a variety of ids. Some institutions maintain several, and most collect identifiers for exchange with other organizations concerning the organization.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Organization.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "condition": [
+                    "org-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "XON.10 / XON.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".scopes[Role](classCode=IDENT)"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Identifiers"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.identifier.id",
+                "path": "Organization.identifier.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.identifier.extension",
+                "path": "Organization.identifier.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.identifier.use",
+                "path": "Organization.identifier.use",
+                "short": "usual | official | temp | secondary | old (If known)",
+                "definition": "The purpose of this identifier.",
+                "comment": "Applications can assume that an identifier is permanent unless it explicitly says that it is temporary.",
+                "requirements": "Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.use",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary id for a permanent one.",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "IdentifierUse"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Identifies the purpose for this identifier, if known .",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/identifier-use|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Role.code or implied by context"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.identifier.type",
+                "path": "Organization.identifier.type",
+                "short": "Description of identifier",
+                "definition": "A coded type for the identifier that can be used to determine which identifier to use for a specific purpose.",
+                "comment": "This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage.   Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type.",
+                "requirements": "Allows users to make use of identifiers when the identifier system is not known.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "IdentifierType"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "A coded type for an identifier that can be used to determine which identifier to use for a specific purpose.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/identifier-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Role.code or implied by context"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.identifier.system",
+                "path": "Organization.identifier.system",
+                "short": "The namespace for the identifier value",
+                "definition": "Establishes the namespace for the value - that is, a URL that describes a set values that are unique.",
+                "comment": "Identifier.system is always case sensitive.",
+                "requirements": "There are many sets  of identifiers.  To perform matching of two identifiers, we need to know what set we're dealing with. The system identifies a particular set of unique identifiers.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueUri": "http://www.acme.com/identifiers/patient"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.4 / EI-2-4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "II.root or Role.id.root"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./IdentifierType"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.identifier.value",
+                "path": "Organization.identifier.value",
+                "short": "The value that is unique",
+                "definition": "The portion of the identifier typically relevant to the user and which is unique within the context of the system.",
+                "comment": "If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986.  The value's primary purpose is computational mapping.  As a result, it may be normalized for comparison purposes (e.g. removing non-significant whitespace, dashes, etc.)  A value formatted for human display can be conveyed using the [Rendered Value extension](http://hl7.org/fhir/R4/extension-rendered-value.html). Identifier.value is to be treated as case sensitive unless knowledge of the Identifier.system allows the processer to be confident that non-case-sensitive processing is safe.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "123456"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.1 / EI.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Value"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.identifier.period",
+                "path": "Organization.identifier.period",
+                "short": "Time period when id is/was valid for use",
+                "definition": "Time period during which identifier is/was valid for use.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.7 + CX.8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Role.effectiveTime or implied by context"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./StartDate and ./EndDate"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.identifier.assigner",
+                "path": "Organization.identifier.assigner",
+                "short": "Organization that issued id (may be just text)",
+                "definition": "Organization that issued/manages the identifier.",
+                "comment": "The Identifier.assigner may omit the .reference element and only contain a .display element reflecting the name or other textual information about the assigning organization.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.assigner",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.4 / (CX.4,CX.9,CX.10)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./IdentifierIssuingAuthority"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.identifier:NPI",
+                "path": "Organization.identifier",
+                "sliceName": "NPI",
+                "short": "National Provider Identifier (NPI)",
+                "definition": "Identifier for the organization that is used to identify the organization across multiple disparate systems.",
+                "requirements": "Organizations are known by a variety of ids. Some institutions maintain several, and most collect identifiers for exchange with other organizations concerning the organization.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Organization.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "patternIdentifier": {
+                    "system": "http://hl7.org/fhir/sid/us-npi"
+                },
+                "condition": [
+                    "org-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "XON.10 / XON.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".scopes[Role](classCode=IDENT)"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Identifiers"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.identifier:CLIA",
+                "path": "Organization.identifier",
+                "sliceName": "CLIA",
+                "short": "Clinical Laboratory Improvement Amendments (CLIA) Number for laboratories",
+                "definition": "Identifier for the organization that is used to identify the organization across multiple disparate systems.",
+                "requirements": "Organizations are known by a variety of ids. Some institutions maintain several, and most collect identifiers for exchange with other organizations concerning the organization.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Organization.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "patternIdentifier": {
+                    "system": "urn:oid:2.16.840.1.113883.4.7"
+                },
+                "condition": [
+                    "org-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "XON.10 / XON.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".scopes[Role](classCode=IDENT)"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Identifiers"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.active",
+                "path": "Organization.active",
+                "short": "Whether the organization's record is still in active use",
+                "definition": "Whether the organization's record is still in active use.",
+                "comment": "This active flag is not intended to be used to mark an organization as temporarily closed or under construction. Instead the Location(s) within the Organization should have the suspended status. If further details of the reason for the suspension are required, then an extension on this element should be used.\n\nThis element is labeled as a modifier because it may be used to mark that the resource was created in error.",
+                "requirements": "Need a flag to indicate a record is no longer to be used and should generally be hidden for the user in the UI.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Organization.active",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "meaningWhenMissing": "This resource is generally assumed to be active if no value is provided for the active element",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labelled as a modifier because it is a status element that can indicate that a record should not be treated as valid",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "No equivalent in HL7 v2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".status"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Status (however this concept in ServD more covers why the organization is active or not, could be delisted, deregistered, not operational yet) this could alternatively be derived from ./StartDate and ./EndDate and given a context date."
+                    }
+                ]
+            },
+            {
+                "id": "Organization.type",
+                "path": "Organization.type",
+                "short": "Kind of organization",
+                "definition": "The kind(s) of organization that this is.",
+                "comment": "Organizations can be corporations, wards, sections, clinical teams, government departments, etc. Note that code is generally a classifier of the type of organization; in many applications, codes are used to identity a particular organization (say, ward) as opposed to another of the same type - these are identifiers, not codes\n\nWhen considering if multiple types are appropriate, you should evaluate if child organizations would be a more appropriate use of the concept, as different types likely are in different sub-areas of the organization. This is most likely to be used where type values have orthogonal values, such as a religious, academic and medical center.\n\nWe expect that some jurisdictions will profile this optionality to be a single cardinality.",
+                "requirements": "Need to be able to track the kind of organization that this is - different organization types have different uses.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Organization.type",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "OrganizationType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Used to categorize the organization.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/organization-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "No equivalent in v2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".code"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.name",
+                "path": "Organization.name",
+                "short": "Name used for the organization",
+                "definition": "A name associated with the organization.",
+                "comment": "If the name of an organization changes, consider putting the old name in the alias column so that it can still be located through searches.",
+                "requirements": "Need to use the name as the label of the organization.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Organization.name",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "condition": [
+                    "org-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XON.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".name"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": ".PreferredName/Name"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./PrimaryAddress and ./OtherAddresses"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.alias",
+                "path": "Organization.alias",
+                "short": "A list of alternate names that the organization is known as, or was known as in the past",
+                "definition": "A list of alternate names that the organization is known as, or was known as in the past.",
+                "comment": "There are no dates associated with the alias/historic names, as this is not intended to track when names were used, but to assist in searching so that older names can still result in identifying the organization.",
+                "requirements": "Over time locations and organizations go through many changes and can be known by different names.\n\nFor searching knowing previous names that the organization was known by can be very useful.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Organization.alias",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".name"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.telecom",
+                "path": "Organization.telecom",
+                "short": "A contact detail for the organization",
+                "definition": "A contact detail for the organization.",
+                "comment": "The use code 'home' is not to be used. Note that these contacts are not the contact details of people who are employed by or represent the organization, but official contacts for the organization itself.",
+                "requirements": "Human contact for the organization.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Organization.telecom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "ContactPoint"
+                    }
+                ],
+                "condition": [
+                    "org-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "org-3",
+                        "severity": "error",
+                        "human": "The telecom of an organization can never be of use 'home'",
+                        "expression": "where(use = 'home').empty()",
+                        "xpath": "count(f:use[@value='home']) = 0",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Organization"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "ORC-22?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".telecom"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./ContactPoints"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.telecom.id",
+                "path": "Organization.telecom.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.telecom.extension",
+                "path": "Organization.telecom.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.telecom.system",
+                "path": "Organization.telecom.system",
+                "short": "phone | fax | email | pager | url | sms | other",
+                "definition": "Telecommunications form for contact point - what communications system is required to make use of the contact.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "ContactPoint.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "condition": [
+                    "cpt-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ContactPointSystem"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Telecommunications form for contact point.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/contact-point-system|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XTN.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./scheme"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./ContactPointType"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.telecom.value",
+                "path": "Organization.telecom.value",
+                "short": "The actual contact point details",
+                "definition": "The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address).",
+                "comment": "Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value.",
+                "requirements": "Need to support legacy numbers that are not in a tightly controlled format.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "ContactPoint.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XTN.1 (or XTN.12)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./url"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Value"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.telecom.use",
+                "path": "Organization.telecom.use",
+                "short": "home | work | temp | old | mobile - purpose of this contact point",
+                "definition": "Identifies the purpose for the contact point.",
+                "comment": "Applications can assume that a contact is current unless it explicitly says that it is temporary or old.",
+                "requirements": "Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "ContactPoint.use",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old contact etc.for a current/permanent one",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ContactPointUse"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Use of contact point.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/contact-point-use|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XTN.2 - but often indicated by field"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "unique(./use)"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./ContactPointPurpose"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.telecom.rank",
+                "path": "Organization.telecom.rank",
+                "short": "Specify preferred order of use (1 = highest)",
+                "definition": "Specifies a preferred order in which to use a set of contacts. ContactPoints with lower rank values are more preferred than those with higher rank values.",
+                "comment": "Note that rank does not necessarily follow the order in which the contacts are represented in the instance.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "ContactPoint.rank",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "positiveInt"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "n/a"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.telecom.period",
+                "path": "Organization.telecom.period",
+                "short": "Time period when the contact point was/is in use",
+                "definition": "Time period when the contact point was/is in use.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "ContactPoint.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./usablePeriod[type=\"IVL<TS>\"]"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./StartDate and ./EndDate"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.address",
+                "path": "Organization.address",
+                "short": "An address for the organization",
+                "definition": "An address for the organization.",
+                "comment": "Organization may have multiple addresses with different uses or applicable periods. The use code 'home' is not to be used.",
+                "requirements": "May need to keep track of the organization's addresses for contacting, billing or reporting requirements.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Organization.address",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Address"
+                    }
+                ],
+                "condition": [
+                    "org-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "org-2",
+                        "severity": "error",
+                        "human": "An address of an organization can never be of use 'home'",
+                        "expression": "where(use = 'home').empty()",
+                        "xpath": "count(f:use[@value='home']) = 0",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Organization"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "ORC-23?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".address"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./PrimaryAddress and ./OtherAddresses"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.address.id",
+                "path": "Organization.address.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.address.extension",
+                "path": "Organization.address.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.address.use",
+                "path": "Organization.address.use",
+                "short": "home | work | temp | old | billing - purpose of this address",
+                "definition": "The purpose of this address.",
+                "comment": "Applications can assume that an address is current unless it explicitly says that it is temporary or old.",
+                "requirements": "Allows an appropriate address to be chosen from a list of many.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.use",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueCode": "home"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old address etc.for a current/permanent one",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AddressUse"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The use of an address.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/address-use|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "unique(./use)"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./AddressPurpose"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.address.type",
+                "path": "Organization.address.type",
+                "short": "postal | physical | both",
+                "definition": "Distinguishes between physical addresses (those you can visit) and mailing addresses (e.g. PO Boxes and care-of addresses). Most addresses are both.",
+                "comment": "The definition of Address states that \"address is intended to describe postal addresses, not physical locations\". However, many applications track whether an address has a dual purpose of being a location that can be visited as well as being a valid delivery destination, and Postal addresses are often used as proxies for physical locations (also see the [Location](http://hl7.org/fhir/R4/location.html#) resource).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueCode": "both"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AddressType"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The type of an address (physical / postal).",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/address-type|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.18"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "unique(./use)"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "address type parameter"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.address.text",
+                "path": "Organization.address.text",
+                "short": "Text representation of the address",
+                "definition": "Specifies the entire address as it should be displayed e.g. on a postal label. This may be provided instead of or as well as the specific parts.",
+                "comment": "Can provide both a text representation and parts. Applications updating an address SHALL ensure that  when both text and parts are present,  no content is included in the text that isn't found in a part.",
+                "requirements": "A renderable, unencoded form.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "137 Nowhere Street, Erewhon 9132"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.1 + XAD.2 + XAD.3 + XAD.4 + XAD.5 + XAD.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./formatted"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "address label parameter"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.address.line",
+                "path": "Organization.address.line",
+                "short": "Street name, number, direction & P.O. Box etc.",
+                "definition": "This component contains the house number, apartment number, street name, street direction,  P.O. Box number, delivery hints, and similar address information.",
+                "min": 0,
+                "max": "4",
+                "base": {
+                    "path": "Address.line",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "orderMeaning": "The order in which lines should appear in an address label",
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "137 Nowhere Street"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.1 + XAD.2 (note: XAD.1 and XAD.2 have different meanings for a company address than for a person address)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = AL]"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "street"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./StreetAddress (newline delimitted)"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.address.city",
+                "path": "Organization.address.city",
+                "short": "Name of city, town etc.",
+                "definition": "The name of the city, town, suburb, village or other community or delivery center.",
+                "alias": [
+                    "Municpality"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.city",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "Erewhon"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = CTY]"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "locality"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Jurisdiction"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.address.district",
+                "path": "Organization.address.district",
+                "short": "District name (aka county)",
+                "definition": "The name of the administrative area (county).",
+                "comment": "District is sometimes known as county, but in some regions 'county' is used in place of city (municipality), so county name should be conveyed in city instead.",
+                "alias": [
+                    "County"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.district",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "Madison"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.9"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = CNT | CPA]"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.address.state",
+                "path": "Organization.address.state",
+                "short": "Sub-unit of country (abbreviations ok)",
+                "definition": "Sub-unit of a country with limited sovereignty in a federally organized country. A code may be used if codes are in common use (e.g. US 2 letter state codes).",
+                "alias": [
+                    "Province",
+                    "Territory"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.state",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Two letter USPS alphabetic codes.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = STA]"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "region"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Region"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Sites"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.address.postalCode",
+                "path": "Organization.address.postalCode",
+                "short": "US Zip Codes",
+                "definition": "A postal code designating a region defined by the postal service.",
+                "alias": [
+                    "Zip"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.postalCode",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "9132"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = ZIP]"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "code"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./PostalIdentificationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.address.country",
+                "path": "Organization.address.country",
+                "short": "Country (e.g. can be ISO 3166 2 or 3 letter code)",
+                "definition": "Country - a nation as commonly understood or generally accepted.",
+                "comment": "ISO 3166 3 letter codes can be used in place of a human readable country name.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.country",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = CNT]"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "country"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Country"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.address.period",
+                "path": "Organization.address.period",
+                "short": "Time period when address was/is in use",
+                "definition": "Time period when address was/is in use.",
+                "requirements": "Allows addresses to be placed in historical context.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valuePeriod": {
+                            "start": "2010-03-23",
+                            "end": "2010-07-01"
+                        }
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.12 / XAD.13 + XAD.14"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./usablePeriod[type=\"IVL<TS>\"]"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./StartDate and ./EndDate"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.partOf",
+                "path": "Organization.partOf",
+                "short": "The organization of which this organization forms a part",
+                "definition": "The organization of which this organization forms a part.",
+                "requirements": "Need to be able to track the hierarchy of organizations within an organization.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Organization.partOf",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-hierarchy",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "No equivalent in HL7 v2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".playedBy[classCode=Part].scoper"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.contact",
+                "path": "Organization.contact",
+                "short": "Contact for the organization for a certain purpose",
+                "definition": "Contact for the organization for a certain purpose.",
+                "comment": "Where multiple contacts for the same purpose are provided there is a standard extension that can be used to determine which one is the preferred contact to use.",
+                "requirements": "Need to keep track of assigned contact points within bigger organization.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Organization.contact",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".contactParty"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.contact.id",
+                "path": "Organization.contact.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.contact.extension",
+                "path": "Organization.contact.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.contact.modifierExtension",
+                "path": "Organization.contact.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.contact.purpose",
+                "path": "Organization.contact.purpose",
+                "short": "The type of contact",
+                "definition": "Indicates a purpose for which the contact can be reached.",
+                "requirements": "Need to distinguish between multiple contact persons.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Organization.contact.purpose",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ContactPartyType"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "The purpose for which you would contact a contact party.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/contactentity-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "./type"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.contact.name",
+                "path": "Organization.contact.name",
+                "short": "A name associated with the contact",
+                "definition": "A name associated with the contact.",
+                "requirements": "Need to be able to track the person by name.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Organization.contact.name",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "HumanName"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PID-5, PID-9"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./name"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.contact.telecom",
+                "path": "Organization.contact.telecom",
+                "short": "Contact details (telephone, email, etc.)  for a contact",
+                "definition": "A contact detail (e.g. a telephone number or an email address) by which the party may be contacted.",
+                "requirements": "People have (primary) ways to contact them in some way such as phone, email.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Organization.contact.telecom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "ContactPoint"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PID-13, PID-14"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./telecom"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.contact.address",
+                "path": "Organization.contact.address",
+                "short": "Visiting or postal addresses for the contact",
+                "definition": "Visiting or postal addresses for the contact.",
+                "requirements": "May need to keep track of a contact party's address for contacting, billing or reporting requirements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Organization.contact.address",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Address"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PID-11"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./addr"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.endpoint",
+                "path": "Organization.endpoint",
+                "short": "Technical endpoints providing access to services operated for the organization",
+                "definition": "Technical endpoints providing access to services operated for the organization.",
+                "requirements": "Organizations have multiple systems that provide various services and need to be able to define the technical connection details for how to connect to them, and for what purpose.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Organization.endpoint",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Endpoint"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Organization",
+                "path": "Organization",
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "servd",
+                        "map": "Organization"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.identifier",
+                "path": "Organization.identifier",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "$this"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "comment": "NPI preferred.",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "servd",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.identifier.system",
+                "path": "Organization.identifier.system",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Organization.identifier.value",
+                "path": "Organization.identifier.value",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Organization.identifier:NPI",
+                "path": "Organization.identifier",
+                "sliceName": "NPI",
+                "short": "National Provider Identifier (NPI)",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "patternIdentifier": {
+                    "system": "http://hl7.org/fhir/sid/us-npi"
+                },
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "servd",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.identifier:CLIA",
+                "path": "Organization.identifier",
+                "sliceName": "CLIA",
+                "short": "Clinical Laboratory Improvement Amendments (CLIA) Number for laboratories",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "patternIdentifier": {
+                    "system": "urn:oid:2.16.840.1.113883.4.7"
+                },
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "servd",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.active",
+                "path": "Organization.active",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Organization.name",
+                "path": "Organization.name",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "servd",
+                        "map": "./PrimaryAddress and ./OtherAddresses"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.telecom",
+                "path": "Organization.telecom",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "ContactPoint"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Organization.telecom.system",
+                "path": "Organization.telecom.system",
+                "mustSupport": true
+            },
+            {
+                "id": "Organization.telecom.value",
+                "path": "Organization.telecom.value",
+                "mustSupport": true
+            },
+            {
+                "id": "Organization.address",
+                "path": "Organization.address",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "Address"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "servd",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.address.line",
+                "path": "Organization.address.line",
+                "min": 0,
+                "max": "4",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Organization.address.city",
+                "path": "Organization.address.city",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Organization.address.state",
+                "path": "Organization.address.state",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Two letter USPS alphabetic codes.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state"
+                },
+                "mapping": [
+                    {
+                        "identity": "servd",
+                        "map": "./Sites"
+                    }
+                ]
+            },
+            {
+                "id": "Organization.address.postalCode",
+                "path": "Organization.address.postalCode",
+                "short": "US Zip Codes",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Organization.address.country",
+                "path": "Organization.address.country",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-patient.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-patient.json
@@ -1,4748 +1,4748 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-patient",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient\" title=\"The US Core Patient Profile is based upon the core FHIR Patient Resource and designed to meet the applicable patient demographic data elements from the 2015 Edition Common Clinical Data Set.\">Patient</a><a name=\"Patient\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/patient.html\">Patient</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Information about an individual or animal receiving health care services</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck14.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.extension:race\" title=\"Extension URL = http://hl7.org/fhir/us/core/StructureDefinition/us-core-race\">us-core-race</a><a name=\"Patient.extension\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">(Complex)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">US Core Race Extension</span><br/><span style=\"font-weight:bold\">URL: </span><a href=\"http://hl7.org/fhir/R4/StructureDefinition-us-core-race.html\">http://hl7.org/fhir/us/core/StructureDefinition/us-core-race</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck14.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.extension:ethnicity\" title=\"Extension URL = http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity\">us-core-ethnicity</a><a name=\"Patient.extension\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">(Complex)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">US Core ethnicity Extension</span><br/><span style=\"font-weight:bold\">URL: </span><a href=\"http://hl7.org/fhir/R4/StructureDefinition-us-core-ethnicity.html\">http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck14.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.extension:birthsex\" title=\"Extension URL = http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex\">us-core-birthsex</a><a name=\"Patient.extension\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Extension</span><br/><span style=\"font-weight:bold\">URL: </span><a href=\"http://hl7.org/fhir/R4/StructureDefinition-us-core-birthsex.html\">http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex</a><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-birthsex.html\">Birth Sex</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>): Code for sex assigned at birth<br/><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.identifier\">identifier</a><a name=\"Patient.identifier\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Identifier\">Identifier</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">An identifier for this patient</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.identifier.system\">system</a><a name=\"Patient.identifier.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The namespace for the identifier value</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.identifier.value\">value</a><a name=\"Patient.identifier.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">The value that is unique within the system.</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.name\">name</a><a name=\"Patient.name\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-8)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#HumanName\">HumanName</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">A name associated with the patient</span><br/><span style=\"font-weight:bold\">us-core-8: </span>Either Patient.name.given and/or Patient.name.family SHALL be present or a Data Absent Reason Extension SHALL be present.<br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.name.family\">family</a><a name=\"Patient.name.family\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-8)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Family name (often called 'Surname')</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.name.given\">given</a><a name=\"Patient.name.given\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-8)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Given names (not always 'first'). Includes middle names</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.name.suffix\">suffix</a><a name=\"Patient.name.suffix\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Parts that come after the name</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.name.period\">period</a><a name=\"Patient.name.period\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Period\">Period</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Time period when name was/is in use</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.telecom\">telecom</a><a name=\"Patient.telecom\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#ContactPoint\">ContactPoint</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">A contact detail for the individual</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.telecom.system\">system</a><a name=\"Patient.telecom.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">phone | fax | email | pager | url | sms | other</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-contact-point-system.html\">ContactPointSystem</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>): Telecommunications form for contact point.<br/><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.telecom.value\">value</a><a name=\"Patient.telecom.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The actual contact point details</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.telecom.use\">use</a><a name=\"Patient.telecom.use\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">home | work | temp | old | mobile - purpose of this contact point</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-contact-point-use.html\">ContactPointUse</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.gender\">gender</a><a name=\"Patient.gender\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">male | female | other | unknown</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-administrative-gender.html\">AdministrativeGender</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.birthDate\">birthDate</a><a name=\"Patient.birthDate\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#date\">date</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The date of birth for the individual</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.address\">address</a><a name=\"Patient.address\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Address\">Address</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">An address for the individual</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.address.line\">line</a><a name=\"Patient.address.line\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Street name, number, direction &amp; P.O. Box etc.</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.address.city\">city</a><a name=\"Patient.address.city\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Name of city, town etc.</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.address.state\">state</a><a name=\"Patient.address.state\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Sub-unit of country (abbreviations ok)</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-usps-state.html\">USPS Two Letter Alphabetic Codes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>): Two Letter USPS alphabetic codes.<br/><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.address.postalCode\">postalCode</a><a name=\"Patient.address.postalCode\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">US Zip Codes</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.address.period\">period</a><a name=\"Patient.address.period\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Period\">Period</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Time period when address was/is in use</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.communication\">communication</a><a name=\"Patient.communication\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">A language which may be used to communicate with the patient about his or her health</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-patient-definitions.html#Patient.communication.language\">language</a><a name=\"Patient.communication.language\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The language which can be used to communicate with the patient about his or her health</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-simple-language.html\">Language codes with language and optionally a region modifier</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)</td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
-	"version": "4.0.0",
-	"name": "USCorePatientProfile",
-	"title": "US Core Patient Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-06-27",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the patient resource for the minimal set of data to query and retrieve patient demographic information.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "cda",
-			"uri": "http://hl7.org/v3/cda",
-			"name": "CDA (R2)"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "loinc",
-			"uri": "http://loinc.org",
-			"name": "LOINC code for the element"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Patient",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Patient",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Patient",
-				"path": "Patient",
-				"short": "Information about an individual or animal receiving health care services",
-				"definition": "The US Core Patient Profile is based upon the core FHIR Patient Resource and designed to meet the applicable patient demographic data elements from the 2015 Edition Common Clinical Data Set.",
-				"alias": [
-					"SubjectOfCare Client Resident"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Patient",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "rim",
-						"map": "Patient[classCode=PAT]"
-					},
-					{
-						"identity": "cda",
-						"map": "ClinicalDocument.recordTarget.patientRole"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient"
-					}
-				]
-			},
-			{
-				"id": "Patient.id",
-				"path": "Patient.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Patient.meta",
-				"path": "Patient.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Patient.implicitRules",
-				"path": "Patient.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Patient.language",
-				"path": "Patient.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Patient.text",
-				"path": "Patient.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Patient.contained",
-				"path": "Patient.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Patient.extension",
-				"path": "Patient.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"ordered": false,
-					"rules": "open"
-				},
-				"short": "Extension",
-				"definition": "An Extension",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Patient.extension:race",
-				"path": "Patient.extension",
-				"sliceName": "race",
-				"short": "US Core Race Extension",
-				"definition": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\n   - American Indian or Alaska Native\n   - Asian\n   - Black or African American\n   - Native Hawaiian or Other Pacific Islander\n   - White.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension",
-						"profile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
-						]
-					}
-				],
-				"condition": [
-					"ele-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.extension"
-					}
-				]
-			},
-			{
-				"id": "Patient.extension:ethnicity",
-				"path": "Patient.extension",
-				"sliceName": "ethnicity",
-				"short": "US Core ethnicity Extension",
-				"definition": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension",
-						"profile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
-						]
-					}
-				],
-				"condition": [
-					"ele-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.extension"
-					}
-				]
-			},
-			{
-				"id": "Patient.extension:birthsex",
-				"path": "Patient.extension",
-				"sliceName": "birthsex",
-				"short": "Extension",
-				"definition": "A code classifying the person's sex assigned at birth  as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc).",
-				"comment": "The codes required are intended to present birth sex (i.e., the sex recorded on the patient’s birth certificate) and not gender identity or reassigned sex.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension",
-						"profile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex"
-						]
-					}
-				],
-				"condition": [
-					"ele-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender"
-					},
-					{
-						"identity": "iso11179",
-						"map": ".patient.administrativeGenderCode"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.extension"
-					}
-				]
-			},
-			{
-				"id": "Patient.modifierExtension",
-				"path": "Patient.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Patient.identifier",
-				"path": "Patient.identifier",
-				"short": "An identifier for this patient",
-				"definition": "An identifier for this patient.",
-				"requirements": "Patients are almost always assigned specific numerical identifiers.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Patient.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": "id"
-					},
-					{
-						"identity": "cda",
-						"map": ".id"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.identifier"
-					}
-				]
-			},
-			{
-				"id": "Patient.identifier.id",
-				"path": "Patient.identifier.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.identifier.extension",
-				"path": "Patient.identifier.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.identifier.use",
-				"path": "Patient.identifier.use",
-				"short": "usual | official | temp | secondary | old (If known)",
-				"definition": "The purpose of this identifier.",
-				"comment": "Applications can assume that an identifier is permanent unless it explicitly says that it is temporary.",
-				"requirements": "Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.use",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary id for a permanent one.",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "IdentifierUse"
-						}
-					],
-					"strength": "required",
-					"description": "Identifies the purpose for this identifier, if known .",
-					"valueSet": "http://hl7.org/fhir/ValueSet/identifier-use|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "Role.code or implied by context"
-					}
-				]
-			},
-			{
-				"id": "Patient.identifier.type",
-				"path": "Patient.identifier.type",
-				"short": "Description of identifier",
-				"definition": "A coded type for the identifier that can be used to determine which identifier to use for a specific purpose.",
-				"comment": "This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage.   Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type.",
-				"requirements": "Allows users to make use of identifiers when the identifier system is not known.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "IdentifierType"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "extensible",
-					"description": "A coded type for an identifier that can be used to determine which identifier to use for a specific purpose.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/identifier-type"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.5"
-					},
-					{
-						"identity": "rim",
-						"map": "Role.code or implied by context"
-					}
-				]
-			},
-			{
-				"id": "Patient.identifier.system",
-				"path": "Patient.identifier.system",
-				"short": "The namespace for the identifier value",
-				"definition": "Establishes the namespace for the value - that is, a URL that describes a set values that are unique.",
-				"comment": "Identifier.system is always case sensitive.",
-				"requirements": "There are many sets  of identifiers.  To perform matching of two identifiers, we need to know what set we're dealing with. The system identifies a particular set of unique identifiers.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Identifier.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueUri": "http://www.acme.com/identifiers/patient"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.4 / EI-2-4"
-					},
-					{
-						"identity": "rim",
-						"map": "II.root or Role.id.root"
-					},
-					{
-						"identity": "servd",
-						"map": "./IdentifierType"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.identifier.system"
-					}
-				]
-			},
-			{
-				"id": "Patient.identifier.value",
-				"path": "Patient.identifier.value",
-				"short": "The value that is unique within the system.",
-				"definition": "The portion of the identifier typically relevant to the user and which is unique within the context of the system.",
-				"comment": "If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986.  The value's primary purpose is computational mapping.  As a result, it may be normalized for comparison purposes (e.g. removing non-significant whitespace, dashes, etc.)  A value formatted for human display can be conveyed using the [Rendered Value extension](http://hl7.org/fhir/R4/extension-rendered-value.html). Identifier.value is to be treated as case sensitive unless knowledge of the Identifier.system allows the processer to be confident that non-case-sensitive processing is safe.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Identifier.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "123456"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.1 / EI.1"
-					},
-					{
-						"identity": "rim",
-						"map": "II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)"
-					},
-					{
-						"identity": "servd",
-						"map": "./Value"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.identifier.value"
-					}
-				]
-			},
-			{
-				"id": "Patient.identifier.period",
-				"path": "Patient.identifier.period",
-				"short": "Time period when id is/was valid for use",
-				"definition": "Time period during which identifier is/was valid for use.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.7 + CX.8"
-					},
-					{
-						"identity": "rim",
-						"map": "Role.effectiveTime or implied by context"
-					},
-					{
-						"identity": "servd",
-						"map": "./StartDate and ./EndDate"
-					}
-				]
-			},
-			{
-				"id": "Patient.identifier.assigner",
-				"path": "Patient.identifier.assigner",
-				"short": "Organization that issued id (may be just text)",
-				"definition": "Organization that issued/manages the identifier.",
-				"comment": "The Identifier.assigner may omit the .reference element and only contain a .display element reflecting the name or other textual information about the assigning organization.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.assigner",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.4 / (CX.4,CX.9,CX.10)"
-					},
-					{
-						"identity": "rim",
-						"map": "II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper"
-					},
-					{
-						"identity": "servd",
-						"map": "./IdentifierIssuingAuthority"
-					}
-				]
-			},
-			{
-				"id": "Patient.active",
-				"path": "Patient.active",
-				"short": "Whether this patient's record is in active use",
-				"definition": "Whether this patient record is in active use. \nMany systems use this property to mark as non-current patients, such as those that have not been seen for a period of time based on an organization's business rules.\n\nIt is often used to filter patient lists to exclude inactive patients\n\nDeceased patients may also be marked as inactive for the same reasons, but may be active for some time after death.",
-				"comment": "If a record is inactive, and linked to an active record, then future patient/record updates should occur on the other patient.",
-				"requirements": "Need to be able to mark a patient record as not to be used because it was created in error.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Patient.active",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"meaningWhenMissing": "This resource is generally assumed to be active if no value is provided for the active element",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labelled as a modifier because it is a status element that can indicate that a record should not be treated as valid",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "rim",
-						"map": "statusCode"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.name",
-				"path": "Patient.name",
-				"short": "A name associated with the patient",
-				"definition": "A name associated with the individual.",
-				"comment": "A patient may have multiple names with different uses or applicable periods. For animals, the name is a \"HumanName\" in the sense that is assigned and used by humans and has the same patterns.",
-				"requirements": "Need to be able to track the patient by multiple names. Examples are your official name and a partner name.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Patient.name",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "HumanName"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "us-core-8",
-						"severity": "error",
-						"human": "Either Patient.name.given and/or Patient.name.family SHALL be present or a Data Absent Reason Extension SHALL be present.",
-						"expression": "(family.exists() or given.exists()) xor extension.where(url='http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()",
-						"xpath": "(/f:extension/@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason' and not(/f:family or /f:given)) or (not(/f:extension/@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason') and (/f:family or /f:given))"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PID-5, PID-9"
-					},
-					{
-						"identity": "rim",
-						"map": "name"
-					},
-					{
-						"identity": "cda",
-						"map": ".patient.name"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.name"
-					}
-				]
-			},
-			{
-				"id": "Patient.name.id",
-				"path": "Patient.name.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.name.extension",
-				"path": "Patient.name.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.name.use",
-				"path": "Patient.name.use",
-				"short": "usual | official | temp | nickname | anonymous | old | maiden",
-				"definition": "Identifies the purpose for this name.",
-				"comment": "Applications can assume that a name is current unless it explicitly says that it is temporary or old.",
-				"requirements": "Allows the appropriate name for a particular context of use to be selected from among a set of names.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "HumanName.use",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old name etc.for a current/permanent one",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "NameUse"
-						}
-					],
-					"strength": "required",
-					"description": "The use of a human name.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/name-use|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XPN.7, but often indicated by which field contains the name"
-					},
-					{
-						"identity": "rim",
-						"map": "unique(./use)"
-					},
-					{
-						"identity": "servd",
-						"map": "./NamePurpose"
-					}
-				]
-			},
-			{
-				"id": "Patient.name.text",
-				"path": "Patient.name.text",
-				"short": "Text representation of the full name",
-				"definition": "Specifies the entire name as it should be displayed e.g. on an application UI. This may be provided instead of or as well as the specific parts.",
-				"comment": "Can provide both a text representation and parts. Applications updating a name SHALL ensure that when both text and parts are present,  no content is included in the text that isn't found in a part.",
-				"requirements": "A renderable, unencoded form.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "HumanName.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "implied by XPN.11"
-					},
-					{
-						"identity": "rim",
-						"map": "./formatted"
-					}
-				]
-			},
-			{
-				"id": "Patient.name.family",
-				"path": "Patient.name.family",
-				"short": "Family name (often called 'Surname')",
-				"definition": "The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father.",
-				"comment": "Family Name may be decomposed into specific parts using extensions (de, nl, es related cultures).",
-				"alias": [
-					"surname"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "HumanName.family",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"condition": [
-					"us-core-8"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XPN.1/FN.1"
-					},
-					{
-						"identity": "rim",
-						"map": "./part[partType = FAM]"
-					},
-					{
-						"identity": "servd",
-						"map": "./FamilyName"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.name.family"
-					}
-				]
-			},
-			{
-				"id": "Patient.name.given",
-				"path": "Patient.name.given",
-				"short": "Given names (not always 'first'). Includes middle names",
-				"definition": "Given name.",
-				"comment": "If only initials are recorded, they may be used in place of the full name parts. Initials may be separated into multiple given names but often aren't due to paractical limitations.  This element is not called \"first name\" since given names do not always come first.",
-				"alias": [
-					"first name",
-					"middle name"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "HumanName.given",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"orderMeaning": "Given Names appear in the correct order for presenting the name",
-				"condition": [
-					"us-core-8"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XPN.2 + XPN.3"
-					},
-					{
-						"identity": "rim",
-						"map": "./part[partType = GIV]"
-					},
-					{
-						"identity": "servd",
-						"map": "./GivenNames"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.name.given"
-					}
-				]
-			},
-			{
-				"id": "Patient.name.prefix",
-				"path": "Patient.name.prefix",
-				"short": "Parts that come before the name",
-				"definition": "Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "HumanName.prefix",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"orderMeaning": "Prefixes appear in the correct order for presenting the name",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XPN.5"
-					},
-					{
-						"identity": "rim",
-						"map": "./part[partType = PFX]"
-					},
-					{
-						"identity": "servd",
-						"map": "./TitleCode"
-					}
-				]
-			},
-			{
-				"id": "Patient.name.suffix",
-				"path": "Patient.name.suffix",
-				"short": "Parts that come after the name",
-				"definition": "Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "HumanName.suffix",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"orderMeaning": "Suffixes appear in the correct order for presenting the name",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XPN/4"
-					},
-					{
-						"identity": "rim",
-						"map": "./part[partType = SFX]"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.name.period",
-				"path": "Patient.name.period",
-				"short": "Time period when name was/is in use",
-				"definition": "Indicates the period of time when this name was valid for the named person.",
-				"requirements": "Allows names to be placed in historical context.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "HumanName.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XPN.13 + XPN.14"
-					},
-					{
-						"identity": "rim",
-						"map": "./usablePeriod[type=\"IVL<TS>\"]"
-					},
-					{
-						"identity": "servd",
-						"map": "./StartDate and ./EndDate"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.telecom",
-				"path": "Patient.telecom",
-				"short": "A contact detail for the individual",
-				"definition": "A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted.",
-				"comment": "A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address might not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner's phone).",
-				"requirements": "People have (primary) ways to contact them in some way such as phone, email.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Patient.telecom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "ContactPoint"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PID-13, PID-14, PID-40"
-					},
-					{
-						"identity": "rim",
-						"map": "telecom"
-					},
-					{
-						"identity": "cda",
-						"map": ".telecom"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.telecom.id",
-				"path": "Patient.telecom.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.telecom.extension",
-				"path": "Patient.telecom.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.telecom.system",
-				"path": "Patient.telecom.system",
-				"short": "phone | fax | email | pager | url | sms | other",
-				"definition": "Telecommunications form for contact point - what communications system is required to make use of the contact.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "ContactPoint.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"condition": [
-					"cpt-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"description": "Telecommunications form for contact point.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/contact-point-system"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XTN.3"
-					},
-					{
-						"identity": "rim",
-						"map": "./scheme"
-					},
-					{
-						"identity": "servd",
-						"map": "./ContactPointType"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.telecom.value",
-				"path": "Patient.telecom.value",
-				"short": "The actual contact point details",
-				"definition": "The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address).",
-				"comment": "Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value.",
-				"requirements": "Need to support legacy numbers that are not in a tightly controlled format.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "ContactPoint.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XTN.1 (or XTN.12)"
-					},
-					{
-						"identity": "rim",
-						"map": "./url"
-					},
-					{
-						"identity": "servd",
-						"map": "./Value"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.telecom.use",
-				"path": "Patient.telecom.use",
-				"short": "home | work | temp | old | mobile - purpose of this contact point",
-				"definition": "Identifies the purpose for the contact point.",
-				"comment": "Applications can assume that a contact is current unless it explicitly says that it is temporary or old.",
-				"requirements": "Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "ContactPoint.use",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old contact etc.for a current/permanent one",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/contact-point-use"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XTN.2 - but often indicated by field"
-					},
-					{
-						"identity": "rim",
-						"map": "unique(./use)"
-					},
-					{
-						"identity": "servd",
-						"map": "./ContactPointPurpose"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.telecom.rank",
-				"path": "Patient.telecom.rank",
-				"short": "Specify preferred order of use (1 = highest)",
-				"definition": "Specifies a preferred order in which to use a set of contacts. ContactPoints with lower rank values are more preferred than those with higher rank values.",
-				"comment": "Note that rank does not necessarily follow the order in which the contacts are represented in the instance.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "ContactPoint.rank",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "positiveInt"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "n/a"
-					},
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.telecom.period",
-				"path": "Patient.telecom.period",
-				"short": "Time period when the contact point was/is in use",
-				"definition": "Time period when the contact point was/is in use.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "ContactPoint.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "./usablePeriod[type=\"IVL<TS>\"]"
-					},
-					{
-						"identity": "servd",
-						"map": "./StartDate and ./EndDate"
-					}
-				]
-			},
-			{
-				"id": "Patient.gender",
-				"path": "Patient.gender",
-				"short": "male | female | other | unknown",
-				"definition": "Administrative Gender - the gender that the patient is considered to have for administration and record keeping purposes.",
-				"comment": "The gender might not match the biological sex as determined by genetics or the individual's preferred identification. Note that for both humans and particularly animals, there are other legitimate possibilities than male and female, though the vast majority of systems and contexts only support male and female.  Systems providing decision support or enforcing business rules should ideally do this on the basis of Observations dealing with the specific sex or gender aspect of interest (anatomical, chromosomal, social, etc.)  However, because these observations are infrequently recorded, defaulting to the administrative gender is common practice.  Where such defaulting occurs, rule enforcement should allow for the variation between administrative and biological, chromosomal and other gender aspects.  For example, an alert about a hysterectomy on a male should be handled as a warning or overridable error, not a \"hard\" error.  See the Patient Gender and Sex section for additional information about communicating patient gender and sex.",
-				"requirements": "Needed for identification of the individual, in combination with (at least) name and birth date.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Patient.gender",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/administrative-gender"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PID-8"
-					},
-					{
-						"identity": "rim",
-						"map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender"
-					},
-					{
-						"identity": "cda",
-						"map": ".patient.administrativeGenderCode"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.gender"
-					}
-				]
-			},
-			{
-				"id": "Patient.birthDate",
-				"path": "Patient.birthDate",
-				"short": "The date of birth for the individual",
-				"definition": "The date of birth for the individual.",
-				"comment": "At least an estimated year should be provided as a guess if the real DOB is unknown  There is a standard extension \"patient-birthTime\" available that should be used where Time is required (such as in maternity/infant care systems).",
-				"requirements": "Age of the individual drives many clinical processes.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Patient.birthDate",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "date"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PID-7"
-					},
-					{
-						"identity": "rim",
-						"map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/birthTime"
-					},
-					{
-						"identity": "cda",
-						"map": ".patient.birthTime"
-					},
-					{
-						"identity": "loinc",
-						"map": "21112-8"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.birthDate"
-					}
-				]
-			},
-			{
-				"id": "Patient.deceased[x]",
-				"path": "Patient.deceased[x]",
-				"short": "Indicates if the individual is deceased or not",
-				"definition": "Indicates if the individual is deceased or not.",
-				"comment": "If there's no value in the instance, it means there is no statement on whether or not the individual is deceased. Most systems will interpret the absence of a value as a sign of the person being alive.",
-				"requirements": "The fact that a patient is deceased influences the clinical process. Also, in human communication and relation management it is necessary to know whether the person is alive.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Patient.deceased[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because once a patient is marked as deceased, the actions that are appropriate to perform on the patient may be significantly different.",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PID-30  (bool) and PID-29 (datetime)"
-					},
-					{
-						"identity": "rim",
-						"map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedInd, player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedTime"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.address",
-				"path": "Patient.address",
-				"short": "An address for the individual",
-				"definition": "An address for the individual.",
-				"comment": "Patient may have multiple addresses with different uses or applicable periods.",
-				"requirements": "May need to keep track of patient addresses for contacting, billing or reporting requirements and also to help with identification.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Patient.address",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Address"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PID-11"
-					},
-					{
-						"identity": "rim",
-						"map": "addr"
-					},
-					{
-						"identity": "cda",
-						"map": ".addr"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.birthDate"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.id",
-				"path": "Patient.address.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.extension",
-				"path": "Patient.address.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.use",
-				"path": "Patient.address.use",
-				"short": "home | work | temp | old | billing - purpose of this address",
-				"definition": "The purpose of this address.",
-				"comment": "Applications can assume that an address is current unless it explicitly says that it is temporary or old.",
-				"requirements": "Allows an appropriate address to be chosen from a list of many.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.use",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueCode": "home"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old address etc.for a current/permanent one",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AddressUse"
-						}
-					],
-					"strength": "required",
-					"description": "The use of an address.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/address-use|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.7"
-					},
-					{
-						"identity": "rim",
-						"map": "unique(./use)"
-					},
-					{
-						"identity": "servd",
-						"map": "./AddressPurpose"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.type",
-				"path": "Patient.address.type",
-				"short": "postal | physical | both",
-				"definition": "Distinguishes between physical addresses (those you can visit) and mailing addresses (e.g. PO Boxes and care-of addresses). Most addresses are both.",
-				"comment": "The definition of Address states that \"address is intended to describe postal addresses, not physical locations\". However, many applications track whether an address has a dual purpose of being a location that can be visited as well as being a valid delivery destination, and Postal addresses are often used as proxies for physical locations (also see the [Location](http://hl7.org/fhir/R4/location.html#) resource).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueCode": "both"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AddressType"
-						}
-					],
-					"strength": "required",
-					"description": "The type of an address (physical / postal).",
-					"valueSet": "http://hl7.org/fhir/ValueSet/address-type|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.18"
-					},
-					{
-						"identity": "rim",
-						"map": "unique(./use)"
-					},
-					{
-						"identity": "vcard",
-						"map": "address type parameter"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.text",
-				"path": "Patient.address.text",
-				"short": "Text representation of the address",
-				"definition": "Specifies the entire address as it should be displayed e.g. on a postal label. This may be provided instead of or as well as the specific parts.",
-				"comment": "Can provide both a text representation and parts. Applications updating an address SHALL ensure that  when both text and parts are present,  no content is included in the text that isn't found in a part.",
-				"requirements": "A renderable, unencoded form.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "137 Nowhere Street, Erewhon 9132"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.1 + XAD.2 + XAD.3 + XAD.4 + XAD.5 + XAD.6"
-					},
-					{
-						"identity": "rim",
-						"map": "./formatted"
-					},
-					{
-						"identity": "vcard",
-						"map": "address label parameter"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.line",
-				"path": "Patient.address.line",
-				"short": "Street name, number, direction & P.O. Box etc.",
-				"definition": "This component contains the house number, apartment number, street name, street direction,  P.O. Box number, delivery hints, and similar address information.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Address.line",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"orderMeaning": "The order in which lines should appear in an address label",
-				"example": [
-					{
-						"label": "General",
-						"valueString": "137 Nowhere Street"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.1 + XAD.2 (note: XAD.1 and XAD.2 have different meanings for a company address than for a person address)"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = AL]"
-					},
-					{
-						"identity": "vcard",
-						"map": "street"
-					},
-					{
-						"identity": "servd",
-						"map": "./StreetAddress (newline delimitted)"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.city",
-				"path": "Patient.address.city",
-				"short": "Name of city, town etc.",
-				"definition": "The name of the city, town, suburb, village or other community or delivery center.",
-				"alias": [
-					"Municpality"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.city",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "Erewhon"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.3"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = CTY]"
-					},
-					{
-						"identity": "vcard",
-						"map": "locality"
-					},
-					{
-						"identity": "servd",
-						"map": "./Jurisdiction"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.district",
-				"path": "Patient.address.district",
-				"short": "District name (aka county)",
-				"definition": "The name of the administrative area (county).",
-				"comment": "District is sometimes known as county, but in some regions 'county' is used in place of city (municipality), so county name should be conveyed in city instead.",
-				"alias": [
-					"County"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.district",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "Madison"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.9"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = CNT | CPA]"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.state",
-				"path": "Patient.address.state",
-				"short": "Sub-unit of country (abbreviations ok)",
-				"definition": "Sub-unit of a country with limited sovereignty in a federally organized country. A code may be used if codes are in common use (e.g. US 2 letter state codes).",
-				"alias": [
-					"Province",
-					"Territory"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.state",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Two Letter USPS alphabetic codes.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.4"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = STA]"
-					},
-					{
-						"identity": "vcard",
-						"map": "region"
-					},
-					{
-						"identity": "servd",
-						"map": "./Region"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.postalCode",
-				"path": "Patient.address.postalCode",
-				"short": "US Zip Codes",
-				"definition": "A postal code designating a region defined by the postal service.",
-				"alias": [
-					"Zip",
-					"Zip Code"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.postalCode",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "9132"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.5"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = ZIP]"
-					},
-					{
-						"identity": "vcard",
-						"map": "code"
-					},
-					{
-						"identity": "servd",
-						"map": "./PostalIdentificationCode"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.country",
-				"path": "Patient.address.country",
-				"short": "Country (e.g. can be ISO 3166 2 or 3 letter code)",
-				"definition": "Country - a nation as commonly understood or generally accepted.",
-				"comment": "ISO 3166 3 letter codes can be used in place of a human readable country name.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.country",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.6"
-					},
-					{
-						"identity": "rim",
-						"map": "AD.part[parttype = CNT]"
-					},
-					{
-						"identity": "vcard",
-						"map": "country"
-					},
-					{
-						"identity": "servd",
-						"map": "./Country"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.period",
-				"path": "Patient.address.period",
-				"short": "Time period when address was/is in use",
-				"definition": "Time period when address was/is in use.",
-				"requirements": "Allows addresses to be placed in historical context.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Address.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valuePeriod": {
-							"start": "2010-03-23",
-							"end": "2010-07-01"
-						}
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XAD.12 / XAD.13 + XAD.14"
-					},
-					{
-						"identity": "rim",
-						"map": "./usablePeriod[type=\"IVL<TS>\"]"
-					},
-					{
-						"identity": "servd",
-						"map": "./StartDate and ./EndDate"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.maritalStatus",
-				"path": "Patient.maritalStatus",
-				"short": "Marital (civil) status of a patient",
-				"definition": "This field contains a patient's most recent marital (civil) status.",
-				"requirements": "Most, if not all systems capture it.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Patient.maritalStatus",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "MaritalStatus"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "extensible",
-					"description": "The domestic partnership status of a person.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/marital-status"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PID-16"
-					},
-					{
-						"identity": "rim",
-						"map": "player[classCode=PSN]/maritalStatusCode"
-					},
-					{
-						"identity": "cda",
-						"map": ".patient.maritalStatusCode"
-					}
-				]
-			},
-			{
-				"id": "Patient.multipleBirth[x]",
-				"path": "Patient.multipleBirth[x]",
-				"short": "Whether patient is part of a multiple birth",
-				"definition": "Indicates whether the patient is part of a multiple (boolean) or indicates the actual birth order (integer).",
-				"comment": "Where the valueInteger is provided, the number is the birth number in the sequence. E.g. The middle birth in triplets would be valueInteger=2 and the third born would have valueInteger=3 If a boolean value was provided for this triplets example, then all 3 patient records would have valueBoolean=true (the ordering is not indicated).",
-				"requirements": "For disambiguation of multiple-birth children, especially relevant where the care provider doesn't meet the patient, such as labs.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Patient.multipleBirth[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PID-24 (bool), PID-25 (integer)"
-					},
-					{
-						"identity": "rim",
-						"map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/multipleBirthInd,  player[classCode=PSN|ANM and determinerCode=INSTANCE]/multipleBirthOrderNumber"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.photo",
-				"path": "Patient.photo",
-				"short": "Image of the patient",
-				"definition": "Image of the patient.",
-				"comment": "Guidelines:\n* Use id photos, not clinical photos.\n* Limit dimensions to thumbnail.\n* Keep byte count low to ease resource updates.",
-				"requirements": "Many EHR systems have the capability to capture an image of the patient. Fits with newer social media usage too.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Patient.photo",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Attachment"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-5 - needs a profile"
-					},
-					{
-						"identity": "rim",
-						"map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/desc"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.contact",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name",
-						"valueString": "Contact"
-					}
-				],
-				"path": "Patient.contact",
-				"short": "A contact party (e.g. guardian, partner, friend) for the patient",
-				"definition": "A contact party (e.g. guardian, partner, friend) for the patient.",
-				"comment": "Contact covers all kinds of contact parties: family members, business contacts, guardians, caregivers. Not applicable to register pedigree and family ties beyond use of having contact.",
-				"requirements": "Need to track people you can contact about the patient.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Patient.contact",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "pat-1",
-						"severity": "error",
-						"human": "SHALL at least contain a contact's details or a reference to an organization",
-						"expression": "name.exists() or telecom.exists() or address.exists() or organization.exists()",
-						"xpath": "exists(f:name) or exists(f:telecom) or exists(f:address) or exists(f:organization)"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/scopedRole[classCode=CON]"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.contact.id",
-				"path": "Patient.contact.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.contact.extension",
-				"path": "Patient.contact.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.contact.modifierExtension",
-				"path": "Patient.contact.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Patient.contact.relationship",
-				"path": "Patient.contact.relationship",
-				"short": "The kind of relationship",
-				"definition": "The nature of the relationship between the patient and the contact person.",
-				"requirements": "Used to determine which contact person is the most relevant to approach, depending on circumstances.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Patient.contact.relationship",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ContactRelationship"
-						}
-					],
-					"strength": "extensible",
-					"description": "The nature of the relationship between a patient and a contact person for that patient.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/patient-contactrelationship"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NK1-7, NK1-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.contact.name",
-				"path": "Patient.contact.name",
-				"short": "A name associated with the contact person",
-				"definition": "A name associated with the contact person.",
-				"requirements": "Contact persons need to be identified by name, but it is uncommon to need details about multiple other names for that contact person.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Patient.contact.name",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "HumanName"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NK1-2"
-					},
-					{
-						"identity": "rim",
-						"map": "name"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.contact.telecom",
-				"path": "Patient.contact.telecom",
-				"short": "A contact detail for the person",
-				"definition": "A contact detail for the person, e.g. a telephone number or an email address.",
-				"comment": "Contact may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently, and also to help with identification.",
-				"requirements": "People have (primary) ways to contact them in some way such as phone, email.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Patient.contact.telecom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "ContactPoint"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NK1-5, NK1-6, NK1-40"
-					},
-					{
-						"identity": "rim",
-						"map": "telecom"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.contact.address",
-				"path": "Patient.contact.address",
-				"short": "Address for the contact person",
-				"definition": "Address for the contact person.",
-				"requirements": "Need to keep track where the contact person can be contacted per postal mail or visited.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Patient.contact.address",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Address"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NK1-4"
-					},
-					{
-						"identity": "rim",
-						"map": "addr"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.contact.gender",
-				"path": "Patient.contact.gender",
-				"short": "male | female | other | unknown",
-				"definition": "Administrative Gender - the gender that the contact person is considered to have for administration and record keeping purposes.",
-				"requirements": "Needed to address the person correctly.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Patient.contact.gender",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AdministrativeGender"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "required",
-					"description": "The gender of a person used for administrative purposes.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/administrative-gender|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NK1-15"
-					},
-					{
-						"identity": "rim",
-						"map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.contact.organization",
-				"path": "Patient.contact.organization",
-				"short": "Organization that is associated with the contact",
-				"definition": "Organization on behalf of which the contact is acting or for which the contact is working.",
-				"requirements": "For guardians or business related contacts, the organization is relevant.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Patient.contact.organization",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"condition": [
-					"pat-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NK1-13, NK1-30, NK1-31, NK1-32, NK1-41"
-					},
-					{
-						"identity": "rim",
-						"map": "scoper"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.contact.period",
-				"path": "Patient.contact.period",
-				"short": "The period during which this contact person or organization is valid to be contacted relating to this patient",
-				"definition": "The period during which this contact person or organization is valid to be contacted relating to this patient.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Patient.contact.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "effectiveTime"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.communication",
-				"path": "Patient.communication",
-				"short": "A language which may be used to communicate with the patient about his or her health",
-				"definition": "A language which may be used to communicate with the patient about his or her health.",
-				"comment": "If no language is specified, this *implies* that the default local language is spoken.  If you need to convey proficiency for multiple modes, then you need multiple Patient.Communication associations.   For animals, language is not a relevant field, and should be absent from the instance. If the Patient does not speak the default local language, then the Interpreter Required Standard can be used to explicitly declare that an interpreter is required.",
-				"requirements": "If a patient does not speak the local language, interpreters may be required, so languages spoken and proficiency are important things to keep track of both for patient and other persons of interest.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Patient.communication",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "LanguageCommunication"
-					},
-					{
-						"identity": "cda",
-						"map": "patient.languageCommunication"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.communication"
-					}
-				]
-			},
-			{
-				"id": "Patient.communication.id",
-				"path": "Patient.communication.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.communication.extension",
-				"path": "Patient.communication.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.communication.modifierExtension",
-				"path": "Patient.communication.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Patient.communication.language",
-				"path": "Patient.communication.language",
-				"short": "The language which can be used to communicate with the patient about his or her health",
-				"definition": "The ISO-639-1 alpha 2 code in lower case for the language, optionally followed by a hyphen and the ISO-3166-1 alpha 2 code for the region in upper case; e.g. \"en\" for English, or \"en-US\" for American English versus \"en-EN\" for England English.",
-				"comment": "The structure aa-BB with this exact casing is one the most widely used notations for locale. However not all systems actually code this but instead have it as free text. Hence CodeableConcept instead of code as the data type.",
-				"requirements": "Most systems in multilingual countries will want to convey language. Not all systems actually need the regional dialect.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Patient.communication.language",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/simple-language"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PID-15, LAN-2"
-					},
-					{
-						"identity": "rim",
-						"map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/languageCommunication/code"
-					},
-					{
-						"identity": "cda",
-						"map": ".languageCode"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.communication.language"
-					}
-				]
-			},
-			{
-				"id": "Patient.communication.preferred",
-				"path": "Patient.communication.preferred",
-				"short": "Language preference indicator",
-				"definition": "Indicates whether or not the patient prefers this language (over other languages he masters up a certain level).",
-				"comment": "This language is specifically identified for communicating healthcare information.",
-				"requirements": "People that master multiple languages up to certain level may prefer one or more, i.e. feel more confident in communicating in a particular language making other languages sort of a fall back method.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Patient.communication.preferred",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PID-15"
-					},
-					{
-						"identity": "rim",
-						"map": "preferenceInd"
-					},
-					{
-						"identity": "cda",
-						"map": ".preferenceInd"
-					}
-				]
-			},
-			{
-				"id": "Patient.generalPractitioner",
-				"path": "Patient.generalPractitioner",
-				"short": "Patient's nominated primary care provider",
-				"definition": "Patient's nominated care provider.",
-				"comment": "This may be the primary care provider (in a GP context), or it may be a patient nominated care manager in a community/disability setting, or even organization that will provide people to perform the care provider roles.  It is not to be used to record Care Teams, these should be in a CareTeam resource that may be linked to the CarePlan or EpisodeOfCare resources.\nMultiple GPs may be recorded against the patient for various reasons, such as a student that has his home GP listed along with the GP at university during the school semesters, or a \"fly-in/fly-out\" worker that has the onsite GP also included with his home GP to remain aware of medical issues.\n\nJurisdictions may decide that they can profile this down to 1 if desired, or 1 per type.",
-				"alias": [
-					"careProvider"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Patient.generalPractitioner",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PD1-4"
-					},
-					{
-						"identity": "rim",
-						"map": "subjectOf.CareEvent.performer.AssignedEntity"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.managingOrganization",
-				"path": "Patient.managingOrganization",
-				"short": "Organization that is the custodian of the patient record",
-				"definition": "Organization that is the custodian of the patient record.",
-				"comment": "There is only one managing organization for a specific patient record. Other organizations will have their own Patient record, and may use the Link property to join the records together (or a Person resource which can include confidence ratings for the association).",
-				"requirements": "Need to know who recognizes this patient record, manages and updates it.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Patient.managingOrganization",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "scoper"
-					},
-					{
-						"identity": "cda",
-						"map": ".providerOrganization"
-					}
-				]
-			},
-			{
-				"id": "Patient.link",
-				"path": "Patient.link",
-				"short": "Link to another patient resource that concerns the same actual person",
-				"definition": "Link to another patient resource that concerns the same actual patient.",
-				"comment": "There is no assumption that linked patient records have mutual links.",
-				"requirements": "There are multiple use cases:   \n\n* Duplicate patient records due to the clerical errors associated with the difficulties of identifying humans consistently, and \n* Distribution of patient information across multiple servers.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Patient.link",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it might not be the main Patient resource, and the referenced patient should be used instead of this Patient record. This is when the link.type value is 'replaced-by'",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outboundLink"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.link.id",
-				"path": "Patient.link.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.link.extension",
-				"path": "Patient.link.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.link.modifierExtension",
-				"path": "Patient.link.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Patient.link.other",
-				"path": "Patient.link.other",
-				"short": "The other patient or related person resource that the link refers to",
-				"definition": "The other patient resource that the link refers to.",
-				"comment": "Referencing a RelatedPerson here removes the need to use a Person record to associate a Patient and RelatedPerson as the same individual.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Patient.link.other",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-hierarchy",
-								"valueBoolean": false
-							}
-						],
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PID-3, MRG-1"
-					},
-					{
-						"identity": "rim",
-						"map": "id"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Patient.link.type",
-				"path": "Patient.link.type",
-				"short": "replaced-by | replaces | refer | seealso",
-				"definition": "The type of link between this patient resource and another patient resource.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Patient.link.type",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "LinkType"
-						}
-					],
-					"strength": "required",
-					"description": "The type of link between this patient resource and another patient resource.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/link-type|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "typeCode"
-					},
-					{
-						"identity": "cda",
-						"map": "n/a"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Patient",
-				"path": "Patient",
-				"definition": "The US Core Patient Profile is based upon the core FHIR Patient Resource and designed to meet the applicable patient demographic data elements from the 2015 Edition Common Clinical Data Set.",
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient"
-					}
-				]
-			},
-			{
-				"id": "Patient.extension:race",
-				"path": "Patient.extension",
-				"sliceName": "race",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Extension",
-						"profile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
-						]
-					}
-				],
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.extension"
-					}
-				]
-			},
-			{
-				"id": "Patient.extension:ethnicity",
-				"path": "Patient.extension",
-				"sliceName": "ethnicity",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Extension",
-						"profile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
-						]
-					}
-				],
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.extension"
-					}
-				]
-			},
-			{
-				"id": "Patient.extension:birthsex",
-				"path": "Patient.extension",
-				"sliceName": "birthsex",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Extension",
-						"profile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex"
-						]
-					}
-				],
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.extension"
-					}
-				]
-			},
-			{
-				"id": "Patient.identifier",
-				"path": "Patient.identifier",
-				"min": 1,
-				"max": "*",
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.identifier"
-					}
-				]
-			},
-			{
-				"id": "Patient.identifier.system",
-				"path": "Patient.identifier.system",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.identifier.system"
-					}
-				]
-			},
-			{
-				"id": "Patient.identifier.value",
-				"path": "Patient.identifier.value",
-				"short": "The value that is unique within the system.",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.identifier.value"
-					}
-				]
-			},
-			{
-				"id": "Patient.name",
-				"path": "Patient.name",
-				"min": 1,
-				"max": "*",
-				"type": [
-					{
-						"code": "HumanName"
-					}
-				],
-				"constraint": [
-					{
-						"key": "us-core-8",
-						"severity": "error",
-						"human": "Either Patient.name.given and/or Patient.name.family SHALL be present or a Data Absent Reason Extension SHALL be present.",
-						"expression": "(family.exists() or given.exists()) xor extension.where(url='http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()",
-						"xpath": "(/f:extension/@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason' and not(/f:family or /f:given)) or (not(/f:extension/@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason') and (/f:family or /f:given))"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.name"
-					}
-				]
-			},
-			{
-				"id": "Patient.name.family",
-				"path": "Patient.name.family",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"condition": [
-					"us-core-8"
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.name.family"
-					}
-				]
-			},
-			{
-				"id": "Patient.name.given",
-				"path": "Patient.name.given",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"condition": [
-					"us-core-8"
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.name.given"
-					}
-				]
-			},
-			{
-				"id": "Patient.name.suffix",
-				"path": "Patient.name.suffix",
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.name.period",
-				"path": "Patient.name.period",
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.telecom",
-				"path": "Patient.telecom",
-				"min": 0,
-				"max": "*",
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.telecom.system",
-				"path": "Patient.telecom.system",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"description": "Telecommunications form for contact point.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/contact-point-system"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.telecom.value",
-				"path": "Patient.telecom.value",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.telecom.use",
-				"path": "Patient.telecom.use",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/contact-point-use"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.gender",
-				"path": "Patient.gender",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/administrative-gender"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.gender"
-					}
-				]
-			},
-			{
-				"id": "Patient.birthDate",
-				"path": "Patient.birthDate",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "date"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.birthDate"
-					}
-				]
-			},
-			{
-				"id": "Patient.address",
-				"path": "Patient.address",
-				"min": 0,
-				"max": "*",
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.birthDate"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.line",
-				"path": "Patient.address.line",
-				"min": 0,
-				"max": "*",
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.city",
-				"path": "Patient.address.city",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.state",
-				"path": "Patient.address.state",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Two Letter USPS alphabetic codes.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.postalCode",
-				"path": "Patient.address.postalCode",
-				"short": "US Zip Codes",
-				"alias": [
-					"Zip Code"
-				],
-				"min": 0,
-				"max": "1",
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.address.period",
-				"path": "Patient.address.period",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "NA"
-					}
-				]
-			},
-			{
-				"id": "Patient.communication",
-				"path": "Patient.communication",
-				"min": 0,
-				"max": "*",
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.communication"
-					}
-				]
-			},
-			{
-				"id": "Patient.communication.language",
-				"path": "Patient.communication.language",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/simple-language"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Patient.communication.language"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-patient",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
+    "version": "4.0.0",
+    "name": "USCorePatientProfile",
+    "title": "US Core Patient Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-06-27",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the patient resource for the minimal set of data to query and retrieve patient demographic information.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "cda",
+            "uri": "http://hl7.org/v3/cda",
+            "name": "CDA (R2)"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "loinc",
+            "uri": "http://loinc.org",
+            "name": "LOINC code for the element"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Patient",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Patient",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Patient",
+                "path": "Patient",
+                "short": "Information about an individual or animal receiving health care services",
+                "definition": "The US Core Patient Profile is based upon the core FHIR Patient Resource and designed to meet the applicable patient demographic data elements from the 2015 Edition Common Clinical Data Set.",
+                "alias": [
+                    "SubjectOfCare Client Resident"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Patient",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Patient[classCode=PAT]"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "ClinicalDocument.recordTarget.patientRole"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.id",
+                "path": "Patient.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Patient.meta",
+                "path": "Patient.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Patient.implicitRules",
+                "path": "Patient.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Patient.language",
+                "path": "Patient.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Patient.text",
+                "path": "Patient.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.contained",
+                "path": "Patient.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.extension",
+                "path": "Patient.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "open"
+                },
+                "short": "Extension",
+                "definition": "An Extension",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Patient.extension:race",
+                "path": "Patient.extension",
+                "sliceName": "race",
+                "short": "US Core Race Extension",
+                "definition": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\n   - American Indian or Alaska Native\n   - Asian\n   - Black or African American\n   - Native Hawaiian or Other Pacific Islander\n   - White.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension",
+                        "profile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "ele-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.extension"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.extension:ethnicity",
+                "path": "Patient.extension",
+                "sliceName": "ethnicity",
+                "short": "US Core ethnicity Extension",
+                "definition": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension",
+                        "profile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "ele-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.extension"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.extension:birthsex",
+                "path": "Patient.extension",
+                "sliceName": "birthsex",
+                "short": "Extension",
+                "definition": "A code classifying the person's sex assigned at birth  as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc).",
+                "comment": "The codes required are intended to present birth sex (i.e., the sex recorded on the patient’s birth certificate) and not gender identity or reassigned sex.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension",
+                        "profile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "ele-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender"
+                    },
+                    {
+                        "identity": "iso11179",
+                        "map": ".patient.administrativeGenderCode"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.extension"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.modifierExtension",
+                "path": "Patient.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.identifier",
+                "path": "Patient.identifier",
+                "short": "An identifier for this patient",
+                "definition": "An identifier for this patient.",
+                "requirements": "Patients are almost always assigned specific numerical identifiers.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Patient.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "id"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": ".id"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.identifier"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.identifier.id",
+                "path": "Patient.identifier.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.identifier.extension",
+                "path": "Patient.identifier.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.identifier.use",
+                "path": "Patient.identifier.use",
+                "short": "usual | official | temp | secondary | old (If known)",
+                "definition": "The purpose of this identifier.",
+                "comment": "Applications can assume that an identifier is permanent unless it explicitly says that it is temporary.",
+                "requirements": "Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.use",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary id for a permanent one.",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "IdentifierUse"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Identifies the purpose for this identifier, if known .",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/identifier-use|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Role.code or implied by context"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.identifier.type",
+                "path": "Patient.identifier.type",
+                "short": "Description of identifier",
+                "definition": "A coded type for the identifier that can be used to determine which identifier to use for a specific purpose.",
+                "comment": "This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage.   Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type.",
+                "requirements": "Allows users to make use of identifiers when the identifier system is not known.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "IdentifierType"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "A coded type for an identifier that can be used to determine which identifier to use for a specific purpose.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/identifier-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Role.code or implied by context"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.identifier.system",
+                "path": "Patient.identifier.system",
+                "short": "The namespace for the identifier value",
+                "definition": "Establishes the namespace for the value - that is, a URL that describes a set values that are unique.",
+                "comment": "Identifier.system is always case sensitive.",
+                "requirements": "There are many sets  of identifiers.  To perform matching of two identifiers, we need to know what set we're dealing with. The system identifies a particular set of unique identifiers.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueUri": "http://www.acme.com/identifiers/patient"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.4 / EI-2-4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "II.root or Role.id.root"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./IdentifierType"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.identifier.system"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.identifier.value",
+                "path": "Patient.identifier.value",
+                "short": "The value that is unique within the system.",
+                "definition": "The portion of the identifier typically relevant to the user and which is unique within the context of the system.",
+                "comment": "If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986.  The value's primary purpose is computational mapping.  As a result, it may be normalized for comparison purposes (e.g. removing non-significant whitespace, dashes, etc.)  A value formatted for human display can be conveyed using the [Rendered Value extension](http://hl7.org/fhir/R4/extension-rendered-value.html). Identifier.value is to be treated as case sensitive unless knowledge of the Identifier.system allows the processer to be confident that non-case-sensitive processing is safe.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "123456"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.1 / EI.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Value"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.identifier.value"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.identifier.period",
+                "path": "Patient.identifier.period",
+                "short": "Time period when id is/was valid for use",
+                "definition": "Time period during which identifier is/was valid for use.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.7 + CX.8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Role.effectiveTime or implied by context"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./StartDate and ./EndDate"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.identifier.assigner",
+                "path": "Patient.identifier.assigner",
+                "short": "Organization that issued id (may be just text)",
+                "definition": "Organization that issued/manages the identifier.",
+                "comment": "The Identifier.assigner may omit the .reference element and only contain a .display element reflecting the name or other textual information about the assigning organization.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.assigner",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.4 / (CX.4,CX.9,CX.10)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./IdentifierIssuingAuthority"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.active",
+                "path": "Patient.active",
+                "short": "Whether this patient's record is in active use",
+                "definition": "Whether this patient record is in active use. \nMany systems use this property to mark as non-current patients, such as those that have not been seen for a period of time based on an organization's business rules.\n\nIt is often used to filter patient lists to exclude inactive patients\n\nDeceased patients may also be marked as inactive for the same reasons, but may be active for some time after death.",
+                "comment": "If a record is inactive, and linked to an active record, then future patient/record updates should occur on the other patient.",
+                "requirements": "Need to be able to mark a patient record as not to be used because it was created in error.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Patient.active",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "meaningWhenMissing": "This resource is generally assumed to be active if no value is provided for the active element",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labelled as a modifier because it is a status element that can indicate that a record should not be treated as valid",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "statusCode"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.name",
+                "path": "Patient.name",
+                "short": "A name associated with the patient",
+                "definition": "A name associated with the individual.",
+                "comment": "A patient may have multiple names with different uses or applicable periods. For animals, the name is a \"HumanName\" in the sense that is assigned and used by humans and has the same patterns.",
+                "requirements": "Need to be able to track the patient by multiple names. Examples are your official name and a partner name.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Patient.name",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "HumanName"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "us-core-8",
+                        "severity": "error",
+                        "human": "Either Patient.name.given and/or Patient.name.family SHALL be present or a Data Absent Reason Extension SHALL be present.",
+                        "expression": "(family.exists() or given.exists()) xor extension.where(url='http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()",
+                        "xpath": "(/f:extension/@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason' and not(/f:family or /f:given)) or (not(/f:extension/@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason') and (/f:family or /f:given))"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PID-5, PID-9"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "name"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": ".patient.name"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.name"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.name.id",
+                "path": "Patient.name.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.name.extension",
+                "path": "Patient.name.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.name.use",
+                "path": "Patient.name.use",
+                "short": "usual | official | temp | nickname | anonymous | old | maiden",
+                "definition": "Identifies the purpose for this name.",
+                "comment": "Applications can assume that a name is current unless it explicitly says that it is temporary or old.",
+                "requirements": "Allows the appropriate name for a particular context of use to be selected from among a set of names.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "HumanName.use",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old name etc.for a current/permanent one",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "NameUse"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The use of a human name.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/name-use|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XPN.7, but often indicated by which field contains the name"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "unique(./use)"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./NamePurpose"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.name.text",
+                "path": "Patient.name.text",
+                "short": "Text representation of the full name",
+                "definition": "Specifies the entire name as it should be displayed e.g. on an application UI. This may be provided instead of or as well as the specific parts.",
+                "comment": "Can provide both a text representation and parts. Applications updating a name SHALL ensure that when both text and parts are present,  no content is included in the text that isn't found in a part.",
+                "requirements": "A renderable, unencoded form.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "HumanName.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "implied by XPN.11"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./formatted"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.name.family",
+                "path": "Patient.name.family",
+                "short": "Family name (often called 'Surname')",
+                "definition": "The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father.",
+                "comment": "Family Name may be decomposed into specific parts using extensions (de, nl, es related cultures).",
+                "alias": [
+                    "surname"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "HumanName.family",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "condition": [
+                    "us-core-8"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XPN.1/FN.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./part[partType = FAM]"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./FamilyName"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.name.family"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.name.given",
+                "path": "Patient.name.given",
+                "short": "Given names (not always 'first'). Includes middle names",
+                "definition": "Given name.",
+                "comment": "If only initials are recorded, they may be used in place of the full name parts. Initials may be separated into multiple given names but often aren't due to paractical limitations.  This element is not called \"first name\" since given names do not always come first.",
+                "alias": [
+                    "first name",
+                    "middle name"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "HumanName.given",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "orderMeaning": "Given Names appear in the correct order for presenting the name",
+                "condition": [
+                    "us-core-8"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XPN.2 + XPN.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./part[partType = GIV]"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./GivenNames"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.name.given"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.name.prefix",
+                "path": "Patient.name.prefix",
+                "short": "Parts that come before the name",
+                "definition": "Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "HumanName.prefix",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "orderMeaning": "Prefixes appear in the correct order for presenting the name",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XPN.5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./part[partType = PFX]"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./TitleCode"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.name.suffix",
+                "path": "Patient.name.suffix",
+                "short": "Parts that come after the name",
+                "definition": "Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "HumanName.suffix",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "orderMeaning": "Suffixes appear in the correct order for presenting the name",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XPN/4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./part[partType = SFX]"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.name.period",
+                "path": "Patient.name.period",
+                "short": "Time period when name was/is in use",
+                "definition": "Indicates the period of time when this name was valid for the named person.",
+                "requirements": "Allows names to be placed in historical context.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "HumanName.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XPN.13 + XPN.14"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./usablePeriod[type=\"IVL<TS>\"]"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./StartDate and ./EndDate"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.telecom",
+                "path": "Patient.telecom",
+                "short": "A contact detail for the individual",
+                "definition": "A contact detail (e.g. a telephone number or an email address) by which the individual may be contacted.",
+                "comment": "A Patient may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and also to help with identification. The address might not go directly to the individual, but may reach another party that is able to proxy for the patient (i.e. home phone, or pet owner's phone).",
+                "requirements": "People have (primary) ways to contact them in some way such as phone, email.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Patient.telecom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "ContactPoint"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PID-13, PID-14, PID-40"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "telecom"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": ".telecom"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.telecom.id",
+                "path": "Patient.telecom.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.telecom.extension",
+                "path": "Patient.telecom.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.telecom.system",
+                "path": "Patient.telecom.system",
+                "short": "phone | fax | email | pager | url | sms | other",
+                "definition": "Telecommunications form for contact point - what communications system is required to make use of the contact.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "ContactPoint.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "condition": [
+                    "cpt-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "description": "Telecommunications form for contact point.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/contact-point-system"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XTN.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./scheme"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./ContactPointType"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.telecom.value",
+                "path": "Patient.telecom.value",
+                "short": "The actual contact point details",
+                "definition": "The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address).",
+                "comment": "Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value.",
+                "requirements": "Need to support legacy numbers that are not in a tightly controlled format.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "ContactPoint.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XTN.1 (or XTN.12)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./url"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Value"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.telecom.use",
+                "path": "Patient.telecom.use",
+                "short": "home | work | temp | old | mobile - purpose of this contact point",
+                "definition": "Identifies the purpose for the contact point.",
+                "comment": "Applications can assume that a contact is current unless it explicitly says that it is temporary or old.",
+                "requirements": "Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "ContactPoint.use",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old contact etc.for a current/permanent one",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/contact-point-use"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XTN.2 - but often indicated by field"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "unique(./use)"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./ContactPointPurpose"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.telecom.rank",
+                "path": "Patient.telecom.rank",
+                "short": "Specify preferred order of use (1 = highest)",
+                "definition": "Specifies a preferred order in which to use a set of contacts. ContactPoints with lower rank values are more preferred than those with higher rank values.",
+                "comment": "Note that rank does not necessarily follow the order in which the contacts are represented in the instance.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "ContactPoint.rank",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "positiveInt"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "n/a"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.telecom.period",
+                "path": "Patient.telecom.period",
+                "short": "Time period when the contact point was/is in use",
+                "definition": "Time period when the contact point was/is in use.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "ContactPoint.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./usablePeriod[type=\"IVL<TS>\"]"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./StartDate and ./EndDate"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.gender",
+                "path": "Patient.gender",
+                "short": "male | female | other | unknown",
+                "definition": "Administrative Gender - the gender that the patient is considered to have for administration and record keeping purposes.",
+                "comment": "The gender might not match the biological sex as determined by genetics or the individual's preferred identification. Note that for both humans and particularly animals, there are other legitimate possibilities than male and female, though the vast majority of systems and contexts only support male and female.  Systems providing decision support or enforcing business rules should ideally do this on the basis of Observations dealing with the specific sex or gender aspect of interest (anatomical, chromosomal, social, etc.)  However, because these observations are infrequently recorded, defaulting to the administrative gender is common practice.  Where such defaulting occurs, rule enforcement should allow for the variation between administrative and biological, chromosomal and other gender aspects.  For example, an alert about a hysterectomy on a male should be handled as a warning or overridable error, not a \"hard\" error.  See the Patient Gender and Sex section for additional information about communicating patient gender and sex.",
+                "requirements": "Needed for identification of the individual, in combination with (at least) name and birth date.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Patient.gender",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/administrative-gender"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PID-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": ".patient.administrativeGenderCode"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.gender"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.birthDate",
+                "path": "Patient.birthDate",
+                "short": "The date of birth for the individual",
+                "definition": "The date of birth for the individual.",
+                "comment": "At least an estimated year should be provided as a guess if the real DOB is unknown  There is a standard extension \"patient-birthTime\" available that should be used where Time is required (such as in maternity/infant care systems).",
+                "requirements": "Age of the individual drives many clinical processes.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Patient.birthDate",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "date"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PID-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/birthTime"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": ".patient.birthTime"
+                    },
+                    {
+                        "identity": "loinc",
+                        "map": "21112-8"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.birthDate"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.deceased[x]",
+                "path": "Patient.deceased[x]",
+                "short": "Indicates if the individual is deceased or not",
+                "definition": "Indicates if the individual is deceased or not.",
+                "comment": "If there's no value in the instance, it means there is no statement on whether or not the individual is deceased. Most systems will interpret the absence of a value as a sign of the person being alive.",
+                "requirements": "The fact that a patient is deceased influences the clinical process. Also, in human communication and relation management it is necessary to know whether the person is alive.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Patient.deceased[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because once a patient is marked as deceased, the actions that are appropriate to perform on the patient may be significantly different.",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PID-30  (bool) and PID-29 (datetime)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedInd, player[classCode=PSN|ANM and determinerCode=INSTANCE]/deceasedTime"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address",
+                "path": "Patient.address",
+                "short": "An address for the individual",
+                "definition": "An address for the individual.",
+                "comment": "Patient may have multiple addresses with different uses or applicable periods.",
+                "requirements": "May need to keep track of patient addresses for contacting, billing or reporting requirements and also to help with identification.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Patient.address",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Address"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PID-11"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "addr"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": ".addr"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.birthDate"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.id",
+                "path": "Patient.address.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.extension",
+                "path": "Patient.address.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.use",
+                "path": "Patient.address.use",
+                "short": "home | work | temp | old | billing - purpose of this address",
+                "definition": "The purpose of this address.",
+                "comment": "Applications can assume that an address is current unless it explicitly says that it is temporary or old.",
+                "requirements": "Allows an appropriate address to be chosen from a list of many.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.use",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueCode": "home"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old address etc.for a current/permanent one",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AddressUse"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The use of an address.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/address-use|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "unique(./use)"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./AddressPurpose"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.type",
+                "path": "Patient.address.type",
+                "short": "postal | physical | both",
+                "definition": "Distinguishes between physical addresses (those you can visit) and mailing addresses (e.g. PO Boxes and care-of addresses). Most addresses are both.",
+                "comment": "The definition of Address states that \"address is intended to describe postal addresses, not physical locations\". However, many applications track whether an address has a dual purpose of being a location that can be visited as well as being a valid delivery destination, and Postal addresses are often used as proxies for physical locations (also see the [Location](http://hl7.org/fhir/R4/location.html#) resource).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueCode": "both"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AddressType"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The type of an address (physical / postal).",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/address-type|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.18"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "unique(./use)"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "address type parameter"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.text",
+                "path": "Patient.address.text",
+                "short": "Text representation of the address",
+                "definition": "Specifies the entire address as it should be displayed e.g. on a postal label. This may be provided instead of or as well as the specific parts.",
+                "comment": "Can provide both a text representation and parts. Applications updating an address SHALL ensure that  when both text and parts are present,  no content is included in the text that isn't found in a part.",
+                "requirements": "A renderable, unencoded form.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "137 Nowhere Street, Erewhon 9132"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.1 + XAD.2 + XAD.3 + XAD.4 + XAD.5 + XAD.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./formatted"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "address label parameter"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.line",
+                "path": "Patient.address.line",
+                "short": "Street name, number, direction & P.O. Box etc.",
+                "definition": "This component contains the house number, apartment number, street name, street direction,  P.O. Box number, delivery hints, and similar address information.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Address.line",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "orderMeaning": "The order in which lines should appear in an address label",
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "137 Nowhere Street"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.1 + XAD.2 (note: XAD.1 and XAD.2 have different meanings for a company address than for a person address)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = AL]"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "street"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./StreetAddress (newline delimitted)"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.city",
+                "path": "Patient.address.city",
+                "short": "Name of city, town etc.",
+                "definition": "The name of the city, town, suburb, village or other community or delivery center.",
+                "alias": [
+                    "Municpality"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.city",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "Erewhon"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = CTY]"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "locality"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Jurisdiction"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.district",
+                "path": "Patient.address.district",
+                "short": "District name (aka county)",
+                "definition": "The name of the administrative area (county).",
+                "comment": "District is sometimes known as county, but in some regions 'county' is used in place of city (municipality), so county name should be conveyed in city instead.",
+                "alias": [
+                    "County"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.district",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "Madison"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.9"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = CNT | CPA]"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.state",
+                "path": "Patient.address.state",
+                "short": "Sub-unit of country (abbreviations ok)",
+                "definition": "Sub-unit of a country with limited sovereignty in a federally organized country. A code may be used if codes are in common use (e.g. US 2 letter state codes).",
+                "alias": [
+                    "Province",
+                    "Territory"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.state",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Two Letter USPS alphabetic codes.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = STA]"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "region"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Region"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.postalCode",
+                "path": "Patient.address.postalCode",
+                "short": "US Zip Codes",
+                "definition": "A postal code designating a region defined by the postal service.",
+                "alias": [
+                    "Zip",
+                    "Zip Code"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.postalCode",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "9132"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = ZIP]"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "code"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./PostalIdentificationCode"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.country",
+                "path": "Patient.address.country",
+                "short": "Country (e.g. can be ISO 3166 2 or 3 letter code)",
+                "definition": "Country - a nation as commonly understood or generally accepted.",
+                "comment": "ISO 3166 3 letter codes can be used in place of a human readable country name.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.country",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "AD.part[parttype = CNT]"
+                    },
+                    {
+                        "identity": "vcard",
+                        "map": "country"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Country"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.period",
+                "path": "Patient.address.period",
+                "short": "Time period when address was/is in use",
+                "definition": "Time period when address was/is in use.",
+                "requirements": "Allows addresses to be placed in historical context.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Address.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valuePeriod": {
+                            "start": "2010-03-23",
+                            "end": "2010-07-01"
+                        }
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XAD.12 / XAD.13 + XAD.14"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./usablePeriod[type=\"IVL<TS>\"]"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./StartDate and ./EndDate"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.maritalStatus",
+                "path": "Patient.maritalStatus",
+                "short": "Marital (civil) status of a patient",
+                "definition": "This field contains a patient's most recent marital (civil) status.",
+                "requirements": "Most, if not all systems capture it.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Patient.maritalStatus",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "MaritalStatus"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "The domestic partnership status of a person.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/marital-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PID-16"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "player[classCode=PSN]/maritalStatusCode"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": ".patient.maritalStatusCode"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.multipleBirth[x]",
+                "path": "Patient.multipleBirth[x]",
+                "short": "Whether patient is part of a multiple birth",
+                "definition": "Indicates whether the patient is part of a multiple (boolean) or indicates the actual birth order (integer).",
+                "comment": "Where the valueInteger is provided, the number is the birth number in the sequence. E.g. The middle birth in triplets would be valueInteger=2 and the third born would have valueInteger=3 If a boolean value was provided for this triplets example, then all 3 patient records would have valueBoolean=true (the ordering is not indicated).",
+                "requirements": "For disambiguation of multiple-birth children, especially relevant where the care provider doesn't meet the patient, such as labs.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Patient.multipleBirth[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PID-24 (bool), PID-25 (integer)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/multipleBirthInd,  player[classCode=PSN|ANM and determinerCode=INSTANCE]/multipleBirthOrderNumber"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.photo",
+                "path": "Patient.photo",
+                "short": "Image of the patient",
+                "definition": "Image of the patient.",
+                "comment": "Guidelines:\n* Use id photos, not clinical photos.\n* Limit dimensions to thumbnail.\n* Keep byte count low to ease resource updates.",
+                "requirements": "Many EHR systems have the capability to capture an image of the patient. Fits with newer social media usage too.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Patient.photo",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Attachment"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-5 - needs a profile"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/desc"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.contact",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-explicit-type-name",
+                        "valueString": "Contact"
+                    }
+                ],
+                "path": "Patient.contact",
+                "short": "A contact party (e.g. guardian, partner, friend) for the patient",
+                "definition": "A contact party (e.g. guardian, partner, friend) for the patient.",
+                "comment": "Contact covers all kinds of contact parties: family members, business contacts, guardians, caregivers. Not applicable to register pedigree and family ties beyond use of having contact.",
+                "requirements": "Need to track people you can contact about the patient.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Patient.contact",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "pat-1",
+                        "severity": "error",
+                        "human": "SHALL at least contain a contact's details or a reference to an organization",
+                        "expression": "name.exists() or telecom.exists() or address.exists() or organization.exists()",
+                        "xpath": "exists(f:name) or exists(f:telecom) or exists(f:address) or exists(f:organization)"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/scopedRole[classCode=CON]"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.contact.id",
+                "path": "Patient.contact.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.contact.extension",
+                "path": "Patient.contact.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.contact.modifierExtension",
+                "path": "Patient.contact.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.contact.relationship",
+                "path": "Patient.contact.relationship",
+                "short": "The kind of relationship",
+                "definition": "The nature of the relationship between the patient and the contact person.",
+                "requirements": "Used to determine which contact person is the most relevant to approach, depending on circumstances.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Patient.contact.relationship",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ContactRelationship"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "The nature of the relationship between a patient and a contact person for that patient.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/patient-contactrelationship"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NK1-7, NK1-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.contact.name",
+                "path": "Patient.contact.name",
+                "short": "A name associated with the contact person",
+                "definition": "A name associated with the contact person.",
+                "requirements": "Contact persons need to be identified by name, but it is uncommon to need details about multiple other names for that contact person.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Patient.contact.name",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "HumanName"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NK1-2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "name"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.contact.telecom",
+                "path": "Patient.contact.telecom",
+                "short": "A contact detail for the person",
+                "definition": "A contact detail for the person, e.g. a telephone number or an email address.",
+                "comment": "Contact may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently, and also to help with identification.",
+                "requirements": "People have (primary) ways to contact them in some way such as phone, email.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Patient.contact.telecom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "ContactPoint"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NK1-5, NK1-6, NK1-40"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "telecom"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.contact.address",
+                "path": "Patient.contact.address",
+                "short": "Address for the contact person",
+                "definition": "Address for the contact person.",
+                "requirements": "Need to keep track where the contact person can be contacted per postal mail or visited.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Patient.contact.address",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Address"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NK1-4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "addr"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.contact.gender",
+                "path": "Patient.contact.gender",
+                "short": "male | female | other | unknown",
+                "definition": "Administrative Gender - the gender that the contact person is considered to have for administration and record keeping purposes.",
+                "requirements": "Needed to address the person correctly.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Patient.contact.gender",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AdministrativeGender"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The gender of a person used for administrative purposes.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/administrative-gender|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NK1-15"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/administrativeGender"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.contact.organization",
+                "path": "Patient.contact.organization",
+                "short": "Organization that is associated with the contact",
+                "definition": "Organization on behalf of which the contact is acting or for which the contact is working.",
+                "requirements": "For guardians or business related contacts, the organization is relevant.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Patient.contact.organization",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "pat-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NK1-13, NK1-30, NK1-31, NK1-32, NK1-41"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "scoper"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.contact.period",
+                "path": "Patient.contact.period",
+                "short": "The period during which this contact person or organization is valid to be contacted relating to this patient",
+                "definition": "The period during which this contact person or organization is valid to be contacted relating to this patient.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Patient.contact.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.communication",
+                "path": "Patient.communication",
+                "short": "A language which may be used to communicate with the patient about his or her health",
+                "definition": "A language which may be used to communicate with the patient about his or her health.",
+                "comment": "If no language is specified, this *implies* that the default local language is spoken.  If you need to convey proficiency for multiple modes, then you need multiple Patient.Communication associations.   For animals, language is not a relevant field, and should be absent from the instance. If the Patient does not speak the default local language, then the Interpreter Required Standard can be used to explicitly declare that an interpreter is required.",
+                "requirements": "If a patient does not speak the local language, interpreters may be required, so languages spoken and proficiency are important things to keep track of both for patient and other persons of interest.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Patient.communication",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "LanguageCommunication"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "patient.languageCommunication"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.communication"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.communication.id",
+                "path": "Patient.communication.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.communication.extension",
+                "path": "Patient.communication.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.communication.modifierExtension",
+                "path": "Patient.communication.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.communication.language",
+                "path": "Patient.communication.language",
+                "short": "The language which can be used to communicate with the patient about his or her health",
+                "definition": "The ISO-639-1 alpha 2 code in lower case for the language, optionally followed by a hyphen and the ISO-3166-1 alpha 2 code for the region in upper case; e.g. \"en\" for English, or \"en-US\" for American English versus \"en-EN\" for England English.",
+                "comment": "The structure aa-BB with this exact casing is one the most widely used notations for locale. However not all systems actually code this but instead have it as free text. Hence CodeableConcept instead of code as the data type.",
+                "requirements": "Most systems in multilingual countries will want to convey language. Not all systems actually need the regional dialect.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Patient.communication.language",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/simple-language"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PID-15, LAN-2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "player[classCode=PSN|ANM and determinerCode=INSTANCE]/languageCommunication/code"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": ".languageCode"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.communication.language"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.communication.preferred",
+                "path": "Patient.communication.preferred",
+                "short": "Language preference indicator",
+                "definition": "Indicates whether or not the patient prefers this language (over other languages he masters up a certain level).",
+                "comment": "This language is specifically identified for communicating healthcare information.",
+                "requirements": "People that master multiple languages up to certain level may prefer one or more, i.e. feel more confident in communicating in a particular language making other languages sort of a fall back method.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Patient.communication.preferred",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PID-15"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "preferenceInd"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": ".preferenceInd"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.generalPractitioner",
+                "path": "Patient.generalPractitioner",
+                "short": "Patient's nominated primary care provider",
+                "definition": "Patient's nominated care provider.",
+                "comment": "This may be the primary care provider (in a GP context), or it may be a patient nominated care manager in a community/disability setting, or even organization that will provide people to perform the care provider roles.  It is not to be used to record Care Teams, these should be in a CareTeam resource that may be linked to the CarePlan or EpisodeOfCare resources.\nMultiple GPs may be recorded against the patient for various reasons, such as a student that has his home GP listed along with the GP at university during the school semesters, or a \"fly-in/fly-out\" worker that has the onsite GP also included with his home GP to remain aware of medical issues.\n\nJurisdictions may decide that they can profile this down to 1 if desired, or 1 per type.",
+                "alias": [
+                    "careProvider"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Patient.generalPractitioner",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PD1-4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "subjectOf.CareEvent.performer.AssignedEntity"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.managingOrganization",
+                "path": "Patient.managingOrganization",
+                "short": "Organization that is the custodian of the patient record",
+                "definition": "Organization that is the custodian of the patient record.",
+                "comment": "There is only one managing organization for a specific patient record. Other organizations will have their own Patient record, and may use the Link property to join the records together (or a Person resource which can include confidence ratings for the association).",
+                "requirements": "Need to know who recognizes this patient record, manages and updates it.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Patient.managingOrganization",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "scoper"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": ".providerOrganization"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.link",
+                "path": "Patient.link",
+                "short": "Link to another patient resource that concerns the same actual person",
+                "definition": "Link to another patient resource that concerns the same actual patient.",
+                "comment": "There is no assumption that linked patient records have mutual links.",
+                "requirements": "There are multiple use cases:   \n\n* Duplicate patient records due to the clerical errors associated with the difficulties of identifying humans consistently, and \n* Distribution of patient information across multiple servers.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Patient.link",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it might not be the main Patient resource, and the referenced patient should be used instead of this Patient record. This is when the link.type value is 'replaced-by'",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outboundLink"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.link.id",
+                "path": "Patient.link.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.link.extension",
+                "path": "Patient.link.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.link.modifierExtension",
+                "path": "Patient.link.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.link.other",
+                "path": "Patient.link.other",
+                "short": "The other patient or related person resource that the link refers to",
+                "definition": "The other patient resource that the link refers to.",
+                "comment": "Referencing a RelatedPerson here removes the need to use a Person record to associate a Patient and RelatedPerson as the same individual.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Patient.link.other",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-hierarchy",
+                                "valueBoolean": false
+                            }
+                        ],
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PID-3, MRG-1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "id"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.link.type",
+                "path": "Patient.link.type",
+                "short": "replaced-by | replaces | refer | seealso",
+                "definition": "The type of link between this patient resource and another patient resource.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Patient.link.type",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "LinkType"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The type of link between this patient resource and another patient resource.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/link-type|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "typeCode"
+                    },
+                    {
+                        "identity": "cda",
+                        "map": "n/a"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Patient",
+                "path": "Patient",
+                "definition": "The US Core Patient Profile is based upon the core FHIR Patient Resource and designed to meet the applicable patient demographic data elements from the 2015 Edition Common Clinical Data Set.",
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.extension:race",
+                "path": "Patient.extension",
+                "sliceName": "race",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Extension",
+                        "profile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
+                        ]
+                    }
+                ],
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.extension"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.extension:ethnicity",
+                "path": "Patient.extension",
+                "sliceName": "ethnicity",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Extension",
+                        "profile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
+                        ]
+                    }
+                ],
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.extension"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.extension:birthsex",
+                "path": "Patient.extension",
+                "sliceName": "birthsex",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Extension",
+                        "profile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex"
+                        ]
+                    }
+                ],
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.extension"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.identifier",
+                "path": "Patient.identifier",
+                "min": 1,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.identifier"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.identifier.system",
+                "path": "Patient.identifier.system",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.identifier.system"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.identifier.value",
+                "path": "Patient.identifier.value",
+                "short": "The value that is unique within the system.",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.identifier.value"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.name",
+                "path": "Patient.name",
+                "min": 1,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "HumanName"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "us-core-8",
+                        "severity": "error",
+                        "human": "Either Patient.name.given and/or Patient.name.family SHALL be present or a Data Absent Reason Extension SHALL be present.",
+                        "expression": "(family.exists() or given.exists()) xor extension.where(url='http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()",
+                        "xpath": "(/f:extension/@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason' and not(/f:family or /f:given)) or (not(/f:extension/@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason') and (/f:family or /f:given))"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.name"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.name.family",
+                "path": "Patient.name.family",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "condition": [
+                    "us-core-8"
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.name.family"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.name.given",
+                "path": "Patient.name.given",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "condition": [
+                    "us-core-8"
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.name.given"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.name.suffix",
+                "path": "Patient.name.suffix",
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.name.period",
+                "path": "Patient.name.period",
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.telecom",
+                "path": "Patient.telecom",
+                "min": 0,
+                "max": "*",
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.telecom.system",
+                "path": "Patient.telecom.system",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "description": "Telecommunications form for contact point.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/contact-point-system"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.telecom.value",
+                "path": "Patient.telecom.value",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.telecom.use",
+                "path": "Patient.telecom.use",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/contact-point-use"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.gender",
+                "path": "Patient.gender",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/administrative-gender"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.gender"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.birthDate",
+                "path": "Patient.birthDate",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "date"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.birthDate"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address",
+                "path": "Patient.address",
+                "min": 0,
+                "max": "*",
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.birthDate"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.line",
+                "path": "Patient.address.line",
+                "min": 0,
+                "max": "*",
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.city",
+                "path": "Patient.address.city",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.state",
+                "path": "Patient.address.state",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Two Letter USPS alphabetic codes.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.postalCode",
+                "path": "Patient.address.postalCode",
+                "short": "US Zip Codes",
+                "alias": [
+                    "Zip Code"
+                ],
+                "min": 0,
+                "max": "1",
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.address.period",
+                "path": "Patient.address.period",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "NA"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.communication",
+                "path": "Patient.communication",
+                "min": 0,
+                "max": "*",
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.communication"
+                    }
+                ]
+            },
+            {
+                "id": "Patient.communication.language",
+                "path": "Patient.communication.language",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/simple-language"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Patient.communication.language"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-practitioner.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-practitioner.json
@@ -1,2254 +1,2254 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-practitioner",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitioner-definitions.html#Practitioner\" title=\"This is basic constraint on provider for use in US Core resources.\">Practitioner</a><a name=\"Practitioner\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/practitioner.html\">Practitioner</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">A person with a  formal responsibility in the provisioning of healthcare or related services</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck13.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Definition\" class=\"hierarchy\"/> <a style=\"font-style: italic\" href=\"StructureDefinition-us-core-practitioner-definitions.html#Practitioner.identifier\">Slices for identifier</a><a name=\"Practitioner.identifier\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red; font-style: italic\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"font-style: italic\"/><span style=\"font-style: italic\">1</span><span style=\"font-style: italic\">..</span><span style=\"font-style: italic\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"font-style: italic\" href=\"http://hl7.org/fhir/R4/datatypes.html#Identifier\">Identifier</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5; font-style: italic\">An identifier for the person as this agent</span><br style=\"font-style: italic\"/><span style=\"font-weight:bold; font-style: italic\">Slice: </span><span style=\"font-style: italic\">Unordered, Open by pattern:$this</span><br style=\"font-style: italic\"/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck133.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> identifier:All Slices<a name=\"Practitioner.identifier\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Content/Rules for all slices</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1330.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitioner-definitions.html#Practitioner.identifier.system\">system</a><a name=\"Practitioner.identifier.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The namespace for the identifier value</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1320.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitioner-definitions.html#Practitioner.identifier.value\">value</a><a name=\"Practitioner.identifier.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The value that is unique</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck125.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitioner-definitions.html#Practitioner.identifier:NPI\" title=\"Slice NPI\">identifier:NPI</a><a name=\"Practitioner.identifier\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Identifier\">Identifier</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">An identifier for the person as this agent</span><br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1240.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Identifier.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">The namespace for the identifier value<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">http://hl7.org/fhir/sid/us-npi</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitioner-definitions.html#Practitioner.name\">name</a><a name=\"Practitioner.name\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#HumanName\">HumanName</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The name(s) associated with the practitioner</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitioner-definitions.html#Practitioner.name.family\">family</a><a name=\"Practitioner.name.family\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Family name (often called 'Surname')</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
-	"version": "4.0.0",
-	"name": "USCorePractitionerProfile",
-	"title": "US Core Practitioner Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2019-09-02",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The practitioner(s) referenced in US Core profiles.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "servd",
-			"uri": "http://www.omg.org/spec/ServD/1.0/",
-			"name": "ServD"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Practitioner",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Practitioner",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Practitioner",
-				"path": "Practitioner",
-				"short": "A person with a  formal responsibility in the provisioning of healthcare or related services",
-				"definition": "This is basic constraint on provider for use in US Core resources.",
-				"alias": [
-					"Provider"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Practitioner",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "v2",
-						"map": "PRD (as one example)"
-					},
-					{
-						"identity": "rim",
-						"map": "Role"
-					},
-					{
-						"identity": "servd",
-						"map": "Provider"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.id",
-				"path": "Practitioner.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Practitioner.meta",
-				"path": "Practitioner.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Practitioner.implicitRules",
-				"path": "Practitioner.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Practitioner.language",
-				"path": "Practitioner.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Practitioner.text",
-				"path": "Practitioner.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.contained",
-				"path": "Practitioner.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.extension",
-				"path": "Practitioner.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.modifierExtension",
-				"path": "Practitioner.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.identifier",
-				"path": "Practitioner.identifier",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "$this"
-						}
-					],
-					"rules": "open"
-				},
-				"short": "An identifier for the person as this agent",
-				"definition": "An identifier that applies to this person in this role.",
-				"comment": "NPI must be supported as the identifier system in the US, Tax id is allowed, Local id is allowed in addition to another identifier supplied by a jurisdictional authority such as a practitioner's *Drug Enforcement Administration (DEA)* number.",
-				"requirements": "Often, specific identities are assigned for the agent.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Practitioner.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "PRD-7 (or XCN.1)"
-					},
-					{
-						"identity": "rim",
-						"map": "./id"
-					},
-					{
-						"identity": "servd",
-						"map": "./Identifiers"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.identifier.id",
-				"path": "Practitioner.identifier.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.identifier.extension",
-				"path": "Practitioner.identifier.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.identifier.use",
-				"path": "Practitioner.identifier.use",
-				"short": "usual | official | temp | secondary | old (If known)",
-				"definition": "The purpose of this identifier.",
-				"comment": "Applications can assume that an identifier is permanent unless it explicitly says that it is temporary.",
-				"requirements": "Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.use",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary id for a permanent one.",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "IdentifierUse"
-						}
-					],
-					"strength": "required",
-					"description": "Identifies the purpose for this identifier, if known .",
-					"valueSet": "http://hl7.org/fhir/ValueSet/identifier-use|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "Role.code or implied by context"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.identifier.type",
-				"path": "Practitioner.identifier.type",
-				"short": "Description of identifier",
-				"definition": "A coded type for the identifier that can be used to determine which identifier to use for a specific purpose.",
-				"comment": "This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage.   Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type.",
-				"requirements": "Allows users to make use of identifiers when the identifier system is not known.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "IdentifierType"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "extensible",
-					"description": "A coded type for an identifier that can be used to determine which identifier to use for a specific purpose.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/identifier-type"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.5"
-					},
-					{
-						"identity": "rim",
-						"map": "Role.code or implied by context"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.identifier.system",
-				"path": "Practitioner.identifier.system",
-				"short": "The namespace for the identifier value",
-				"definition": "Establishes the namespace for the value - that is, a URL that describes a set values that are unique.",
-				"comment": "Identifier.system is always case sensitive.",
-				"requirements": "There are many sets  of identifiers.  To perform matching of two identifiers, we need to know what set we're dealing with. The system identifies a particular set of unique identifiers.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Identifier.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueUri": "http://www.acme.com/identifiers/patient"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.4 / EI-2-4"
-					},
-					{
-						"identity": "rim",
-						"map": "II.root or Role.id.root"
-					},
-					{
-						"identity": "servd",
-						"map": "./IdentifierType"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.identifier.value",
-				"path": "Practitioner.identifier.value",
-				"short": "The value that is unique",
-				"definition": "The portion of the identifier typically relevant to the user and which is unique within the context of the system.",
-				"comment": "If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986.  The value's primary purpose is computational mapping.  As a result, it may be normalized for comparison purposes (e.g. removing non-significant whitespace, dashes, etc.)  A value formatted for human display can be conveyed using the [Rendered Value extension](http://hl7.org/fhir/R4/extension-rendered-value.html). Identifier.value is to be treated as case sensitive unless knowledge of the Identifier.system allows the processer to be confident that non-case-sensitive processing is safe.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Identifier.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"example": [
-					{
-						"label": "General",
-						"valueString": "123456"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.1 / EI.1"
-					},
-					{
-						"identity": "rim",
-						"map": "II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)"
-					},
-					{
-						"identity": "servd",
-						"map": "./Value"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.identifier.period",
-				"path": "Practitioner.identifier.period",
-				"short": "Time period when id is/was valid for use",
-				"definition": "Time period during which identifier is/was valid for use.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.7 + CX.8"
-					},
-					{
-						"identity": "rim",
-						"map": "Role.effectiveTime or implied by context"
-					},
-					{
-						"identity": "servd",
-						"map": "./StartDate and ./EndDate"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.identifier.assigner",
-				"path": "Practitioner.identifier.assigner",
-				"short": "Organization that issued id (may be just text)",
-				"definition": "Organization that issued/manages the identifier.",
-				"comment": "The Identifier.assigner may omit the .reference element and only contain a .display element reflecting the name or other textual information about the assigning organization.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Identifier.assigner",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CX.4 / (CX.4,CX.9,CX.10)"
-					},
-					{
-						"identity": "rim",
-						"map": "II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper"
-					},
-					{
-						"identity": "servd",
-						"map": "./IdentifierIssuingAuthority"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.identifier:NPI",
-				"path": "Practitioner.identifier",
-				"sliceName": "NPI",
-				"short": "An identifier for the person as this agent",
-				"definition": "An identifier that applies to this person in this role.",
-				"requirements": "Often, specific identities are assigned for the agent.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Practitioner.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"patternIdentifier": {
-					"system": "http://hl7.org/fhir/sid/us-npi"
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "PRD-7 (or XCN.1)"
-					},
-					{
-						"identity": "rim",
-						"map": "./id"
-					},
-					{
-						"identity": "servd",
-						"map": "./Identifiers"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.active",
-				"path": "Practitioner.active",
-				"short": "Whether this practitioner's record is in active use",
-				"definition": "Whether this practitioner's record is in active use.",
-				"comment": "If the practitioner is not in use by one organization, then it should mark the period on the PractitonerRole with an end date (even if they are active) as they may be active in another role.",
-				"requirements": "Need to be able to mark a practitioner record as not to be used because it was created in error.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Practitioner.active",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"meaningWhenMissing": "This resource is generally assumed to be active if no value is provided for the active element",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "rim",
-						"map": "./statusCode"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.name",
-				"path": "Practitioner.name",
-				"short": "The name(s) associated with the practitioner",
-				"definition": "The name(s) associated with the practitioner.",
-				"comment": "The selection of the use property should ensure that there is a single usual name specified, and others use the nickname (alias), old, or other values as appropriate.  \r\rIn general, select the value to be used in the ResourceReference.display based on this:\r\r1. There is more than 1 name\r2. Use = usual\r3. Period is current to the date of the usage\r4. Use = official\r5. Other order as decided by internal business rules.",
-				"requirements": "The name(s) that a Practitioner is known by. Where there are multiple, the name that the practitioner is usually known as should be used in the display.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Practitioner.name",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "HumanName"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XCN Components"
-					},
-					{
-						"identity": "rim",
-						"map": "./name"
-					},
-					{
-						"identity": "servd",
-						"map": "./PreferredName (GivenNames, FamilyName, TitleCode)"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.name.id",
-				"path": "Practitioner.name.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.name.extension",
-				"path": "Practitioner.name.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.name.use",
-				"path": "Practitioner.name.use",
-				"short": "usual | official | temp | nickname | anonymous | old | maiden",
-				"definition": "Identifies the purpose for this name.",
-				"comment": "Applications can assume that a name is current unless it explicitly says that it is temporary or old.",
-				"requirements": "Allows the appropriate name for a particular context of use to be selected from among a set of names.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "HumanName.use",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old name etc.for a current/permanent one",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "NameUse"
-						}
-					],
-					"strength": "required",
-					"description": "The use of a human name.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/name-use|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XPN.7, but often indicated by which field contains the name"
-					},
-					{
-						"identity": "rim",
-						"map": "unique(./use)"
-					},
-					{
-						"identity": "servd",
-						"map": "./NamePurpose"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.name.text",
-				"path": "Practitioner.name.text",
-				"short": "Text representation of the full name",
-				"definition": "Specifies the entire name as it should be displayed e.g. on an application UI. This may be provided instead of or as well as the specific parts.",
-				"comment": "Can provide both a text representation and parts. Applications updating a name SHALL ensure that when both text and parts are present,  no content is included in the text that isn't found in a part.",
-				"requirements": "A renderable, unencoded form.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "HumanName.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "implied by XPN.11"
-					},
-					{
-						"identity": "rim",
-						"map": "./formatted"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.name.family",
-				"path": "Practitioner.name.family",
-				"short": "Family name (often called 'Surname')",
-				"definition": "The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father.",
-				"comment": "Family Name may be decomposed into specific parts using extensions (de, nl, es related cultures).",
-				"alias": [
-					"surname"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "HumanName.family",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XPN.1/FN.1"
-					},
-					{
-						"identity": "rim",
-						"map": "./part[partType = FAM]"
-					},
-					{
-						"identity": "servd",
-						"map": "./FamilyName"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.name.given",
-				"path": "Practitioner.name.given",
-				"short": "Given names (not always 'first'). Includes middle names",
-				"definition": "Given name.",
-				"comment": "If only initials are recorded, they may be used in place of the full name parts. Initials may be separated into multiple given names but often aren't due to paractical limitations.  This element is not called \"first name\" since given names do not always come first.",
-				"alias": [
-					"first name",
-					"middle name"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "HumanName.given",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"orderMeaning": "Given Names appear in the correct order for presenting the name",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XPN.2 + XPN.3"
-					},
-					{
-						"identity": "rim",
-						"map": "./part[partType = GIV]"
-					},
-					{
-						"identity": "servd",
-						"map": "./GivenNames"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.name.prefix",
-				"path": "Practitioner.name.prefix",
-				"short": "Parts that come before the name",
-				"definition": "Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "HumanName.prefix",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"orderMeaning": "Prefixes appear in the correct order for presenting the name",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XPN.5"
-					},
-					{
-						"identity": "rim",
-						"map": "./part[partType = PFX]"
-					},
-					{
-						"identity": "servd",
-						"map": "./TitleCode"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.name.suffix",
-				"path": "Practitioner.name.suffix",
-				"short": "Parts that come after the name",
-				"definition": "Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "HumanName.suffix",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"orderMeaning": "Suffixes appear in the correct order for presenting the name",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XPN/4"
-					},
-					{
-						"identity": "rim",
-						"map": "./part[partType = SFX]"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.name.period",
-				"path": "Practitioner.name.period",
-				"short": "Time period when name was/is in use",
-				"definition": "Indicates the period of time when this name was valid for the named person.",
-				"requirements": "Allows names to be placed in historical context.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "HumanName.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XPN.13 + XPN.14"
-					},
-					{
-						"identity": "rim",
-						"map": "./usablePeriod[type=\"IVL<TS>\"]"
-					},
-					{
-						"identity": "servd",
-						"map": "./StartDate and ./EndDate"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.telecom",
-				"path": "Practitioner.telecom",
-				"short": "A contact detail for the practitioner (that apply to all roles)",
-				"definition": "A contact detail for the practitioner, e.g. a telephone number or an email address.",
-				"comment": "Person may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and to help with identification.  These typically will have home numbers, or mobile numbers that are not role specific.",
-				"requirements": "Need to know how to reach a practitioner independent to any roles the practitioner may have.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Practitioner.telecom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "ContactPoint"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PRT-15, STF-10, ROL-12"
-					},
-					{
-						"identity": "rim",
-						"map": "./telecom"
-					},
-					{
-						"identity": "servd",
-						"map": "./ContactPoints"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.address",
-				"path": "Practitioner.address",
-				"short": "Address(es) of the practitioner that are not role specific (typically home address)",
-				"definition": "Address(es) of the practitioner that are not role specific (typically home address). \rWork addresses are not typically entered in this property as they are usually role dependent.",
-				"comment": "The PractitionerRole does not have an address value on it, as it is expected that the location property be used for this purpose (which has an address).",
-				"requirements": "The home/mailing address of the practitioner is often required for employee administration purposes, and also for some rostering services where the start point (practitioners home) can be used in calculations.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Practitioner.address",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Address"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "ORC-24, STF-11, ROL-11, PRT-14"
-					},
-					{
-						"identity": "rim",
-						"map": "./addr"
-					},
-					{
-						"identity": "servd",
-						"map": "./Addresses"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.gender",
-				"path": "Practitioner.gender",
-				"short": "male | female | other | unknown",
-				"definition": "Administrative Gender - the gender that the person is considered to have for administration and record keeping purposes.",
-				"requirements": "Needed to address the person correctly.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Practitioner.gender",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "AdministrativeGender"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "required",
-					"description": "The gender of a person used for administrative purposes.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/administrative-gender|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "STF-5"
-					},
-					{
-						"identity": "rim",
-						"map": "./administrativeGender"
-					},
-					{
-						"identity": "servd",
-						"map": "./GenderCode"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.birthDate",
-				"path": "Practitioner.birthDate",
-				"short": "The date  on which the practitioner was born",
-				"definition": "The date of birth for the practitioner.",
-				"requirements": "Needed for identification.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Practitioner.birthDate",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "date"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "STF-6"
-					},
-					{
-						"identity": "rim",
-						"map": "./birthTime"
-					},
-					{
-						"identity": "servd",
-						"map": "(not represented in ServD)"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.photo",
-				"path": "Practitioner.photo",
-				"short": "Image of the person",
-				"definition": "Image of the person.",
-				"requirements": "Many EHR systems have the capability to capture an image of patients and personnel. Fits with newer social media usage too.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Practitioner.photo",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Attachment"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "./subjectOf/ObservationEvent[code=\"photo\"]/value"
-					},
-					{
-						"identity": "servd",
-						"map": "./ImageURI (only supports the URI reference)"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.qualification",
-				"path": "Practitioner.qualification",
-				"short": "Certification, licenses, or training pertaining to the provision of care",
-				"definition": "The official certifications, training, and licenses that authorize or otherwise pertain to the provision of care by the practitioner.  For example, a medical license issued by a medical board authorizing the practitioner to practice medicine within a certian locality.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Practitioner.qualification",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "CER?"
-					},
-					{
-						"identity": "rim",
-						"map": ".playingEntity.playingRole[classCode=QUAL].code"
-					},
-					{
-						"identity": "servd",
-						"map": "./Qualifications"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.qualification.id",
-				"path": "Practitioner.qualification.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.qualification.extension",
-				"path": "Practitioner.qualification.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.qualification.modifierExtension",
-				"path": "Practitioner.qualification.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.qualification.identifier",
-				"path": "Practitioner.qualification.identifier",
-				"short": "An identifier for this qualification for the practitioner",
-				"definition": "An identifier that applies to this person's qualification in this role.",
-				"requirements": "Often, specific identities are assigned for the qualification.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Practitioner.qualification.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".playingEntity.playingRole[classCode=QUAL].id"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.qualification.code",
-				"path": "Practitioner.qualification.code",
-				"short": "Coded representation of the qualification",
-				"definition": "Coded representation of the qualification.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Practitioner.qualification.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Qualification"
-						}
-					],
-					"strength": "example",
-					"description": "Specific qualification the practitioner has to provide a service.",
-					"valueSet": "http://terminology.hl7.org/ValueSet/v2-2.7-0360"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".playingEntity.playingRole[classCode=QUAL].code"
-					},
-					{
-						"identity": "servd",
-						"map": "./Qualifications.Value"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.qualification.period",
-				"path": "Practitioner.qualification.period",
-				"short": "Period during which the qualification is valid",
-				"definition": "Period during which the qualification is valid.",
-				"requirements": "Qualifications are often for a limited period of time, and can be revoked.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Practitioner.qualification.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".playingEntity.playingRole[classCode=QUAL].effectiveTime"
-					},
-					{
-						"identity": "servd",
-						"map": "./Qualifications.StartDate and ./Qualifications.EndDate"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.qualification.issuer",
-				"path": "Practitioner.qualification.issuer",
-				"short": "Organization that regulates and issues the qualification",
-				"definition": "Organization that regulates and issues the qualification.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Practitioner.qualification.issuer",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".playingEntity.playingRole[classCode=QUAL].scoper"
-					}
-				]
-			},
-			{
-				"id": "Practitioner.communication",
-				"path": "Practitioner.communication",
-				"short": "A language the practitioner can use in patient communication",
-				"definition": "A language the practitioner can use in patient communication.",
-				"comment": "The structure aa-BB with this exact casing is one the most widely used notations for locale. However not all systems code this but instead have it as free text. Hence CodeableConcept instead of code as the data type.",
-				"requirements": "Knowing which language a practitioner speaks can help in facilitating communication with patients.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Practitioner.communication",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PID-15, NK1-20, LAN-2"
-					},
-					{
-						"identity": "rim",
-						"map": "./languageCommunication"
-					},
-					{
-						"identity": "servd",
-						"map": "./Languages.LanguageSpokenCode"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Practitioner",
-				"path": "Practitioner",
-				"definition": "This is basic constraint on provider for use in US Core resources.",
-				"alias": [
-					"Provider"
-				],
-				"mustSupport": false
-			},
-			{
-				"id": "Practitioner.identifier",
-				"path": "Practitioner.identifier",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "$this"
-						}
-					],
-					"rules": "open"
-				},
-				"comment": "NPI must be supported as the identifier system in the US, Tax id is allowed, Local id is allowed in addition to another identifier supplied by a jurisdictional authority such as a practitioner's *Drug Enforcement Administration (DEA)* number.",
-				"min": 1,
-				"max": "*",
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Practitioner.identifier.system",
-				"path": "Practitioner.identifier.system",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Practitioner.identifier.value",
-				"path": "Practitioner.identifier.value",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Practitioner.identifier:NPI",
-				"path": "Practitioner.identifier",
-				"sliceName": "NPI",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"patternIdentifier": {
-					"system": "http://hl7.org/fhir/sid/us-npi"
-				},
-				"mustSupport": true
-			},
-			{
-				"id": "Practitioner.name",
-				"path": "Practitioner.name",
-				"min": 1,
-				"max": "*",
-				"type": [
-					{
-						"code": "HumanName"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Practitioner.name.family",
-				"path": "Practitioner.name.family",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-practitioner",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
+    "version": "4.0.0",
+    "name": "USCorePractitionerProfile",
+    "title": "US Core Practitioner Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2019-09-02",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The practitioner(s) referenced in US Core profiles.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "servd",
+            "uri": "http://www.omg.org/spec/ServD/1.0/",
+            "name": "ServD"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Practitioner",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Practitioner",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Practitioner",
+                "path": "Practitioner",
+                "short": "A person with a  formal responsibility in the provisioning of healthcare or related services",
+                "definition": "This is basic constraint on provider for use in US Core resources.",
+                "alias": [
+                    "Provider"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Practitioner",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRD (as one example)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Role"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "Provider"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.id",
+                "path": "Practitioner.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Practitioner.meta",
+                "path": "Practitioner.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Practitioner.implicitRules",
+                "path": "Practitioner.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Practitioner.language",
+                "path": "Practitioner.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Practitioner.text",
+                "path": "Practitioner.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.contained",
+                "path": "Practitioner.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.extension",
+                "path": "Practitioner.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.modifierExtension",
+                "path": "Practitioner.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.identifier",
+                "path": "Practitioner.identifier",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "$this"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "short": "An identifier for the person as this agent",
+                "definition": "An identifier that applies to this person in this role.",
+                "comment": "NPI must be supported as the identifier system in the US, Tax id is allowed, Local id is allowed in addition to another identifier supplied by a jurisdictional authority such as a practitioner's *Drug Enforcement Administration (DEA)* number.",
+                "requirements": "Often, specific identities are assigned for the agent.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Practitioner.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRD-7 (or XCN.1)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./id"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Identifiers"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.identifier.id",
+                "path": "Practitioner.identifier.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.identifier.extension",
+                "path": "Practitioner.identifier.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.identifier.use",
+                "path": "Practitioner.identifier.use",
+                "short": "usual | official | temp | secondary | old (If known)",
+                "definition": "The purpose of this identifier.",
+                "comment": "Applications can assume that an identifier is permanent unless it explicitly says that it is temporary.",
+                "requirements": "Allows the appropriate identifier for a particular context of use to be selected from among a set of identifiers.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.use",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary id for a permanent one.",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "IdentifierUse"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Identifies the purpose for this identifier, if known .",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/identifier-use|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Role.code or implied by context"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.identifier.type",
+                "path": "Practitioner.identifier.type",
+                "short": "Description of identifier",
+                "definition": "A coded type for the identifier that can be used to determine which identifier to use for a specific purpose.",
+                "comment": "This element deals only with general categories of identifiers.  It SHOULD not be used for codes that correspond 1..1 with the Identifier.system. Some identifiers may fall into multiple categories due to common usage.   Where the system is known, a type is unnecessary because the type is always part of the system definition. However systems often need to handle identifiers where the system is not known. There is not a 1:1 relationship between type and system, since many different systems have the same type.",
+                "requirements": "Allows users to make use of identifiers when the identifier system is not known.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "IdentifierType"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "A coded type for an identifier that can be used to determine which identifier to use for a specific purpose.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/identifier-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Role.code or implied by context"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.identifier.system",
+                "path": "Practitioner.identifier.system",
+                "short": "The namespace for the identifier value",
+                "definition": "Establishes the namespace for the value - that is, a URL that describes a set values that are unique.",
+                "comment": "Identifier.system is always case sensitive.",
+                "requirements": "There are many sets  of identifiers.  To perform matching of two identifiers, we need to know what set we're dealing with. The system identifies a particular set of unique identifiers.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueUri": "http://www.acme.com/identifiers/patient"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.4 / EI-2-4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "II.root or Role.id.root"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./IdentifierType"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.identifier.value",
+                "path": "Practitioner.identifier.value",
+                "short": "The value that is unique",
+                "definition": "The portion of the identifier typically relevant to the user and which is unique within the context of the system.",
+                "comment": "If the value is a full URI, then the system SHALL be urn:ietf:rfc:3986.  The value's primary purpose is computational mapping.  As a result, it may be normalized for comparison purposes (e.g. removing non-significant whitespace, dashes, etc.)  A value formatted for human display can be conveyed using the [Rendered Value extension](http://hl7.org/fhir/R4/extension-rendered-value.html). Identifier.value is to be treated as case sensitive unless knowledge of the Identifier.system allows the processer to be confident that non-case-sensitive processing is safe.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "example": [
+                    {
+                        "label": "General",
+                        "valueString": "123456"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.1 / EI.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "II.extension or II.root if system indicates OID or GUID (Or Role.id.extension or root)"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Value"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.identifier.period",
+                "path": "Practitioner.identifier.period",
+                "short": "Time period when id is/was valid for use",
+                "definition": "Time period during which identifier is/was valid for use.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.7 + CX.8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Role.effectiveTime or implied by context"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./StartDate and ./EndDate"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.identifier.assigner",
+                "path": "Practitioner.identifier.assigner",
+                "short": "Organization that issued id (may be just text)",
+                "definition": "Organization that issued/manages the identifier.",
+                "comment": "The Identifier.assigner may omit the .reference element and only contain a .display element reflecting the name or other textual information about the assigning organization.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Identifier.assigner",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CX.4 / (CX.4,CX.9,CX.10)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "II.assigningAuthorityName but note that this is an improper use by the definition of the field.  Also Role.scoper"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./IdentifierIssuingAuthority"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.identifier:NPI",
+                "path": "Practitioner.identifier",
+                "sliceName": "NPI",
+                "short": "An identifier for the person as this agent",
+                "definition": "An identifier that applies to this person in this role.",
+                "requirements": "Often, specific identities are assigned for the agent.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Practitioner.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "patternIdentifier": {
+                    "system": "http://hl7.org/fhir/sid/us-npi"
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRD-7 (or XCN.1)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./id"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Identifiers"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.active",
+                "path": "Practitioner.active",
+                "short": "Whether this practitioner's record is in active use",
+                "definition": "Whether this practitioner's record is in active use.",
+                "comment": "If the practitioner is not in use by one organization, then it should mark the period on the PractitonerRole with an end date (even if they are active) as they may be active in another role.",
+                "requirements": "Need to be able to mark a practitioner record as not to be used because it was created in error.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Practitioner.active",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "meaningWhenMissing": "This resource is generally assumed to be active if no value is provided for the active element",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./statusCode"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.name",
+                "path": "Practitioner.name",
+                "short": "The name(s) associated with the practitioner",
+                "definition": "The name(s) associated with the practitioner.",
+                "comment": "The selection of the use property should ensure that there is a single usual name specified, and others use the nickname (alias), old, or other values as appropriate.  \r\rIn general, select the value to be used in the ResourceReference.display based on this:\r\r1. There is more than 1 name\r2. Use = usual\r3. Period is current to the date of the usage\r4. Use = official\r5. Other order as decided by internal business rules.",
+                "requirements": "The name(s) that a Practitioner is known by. Where there are multiple, the name that the practitioner is usually known as should be used in the display.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Practitioner.name",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "HumanName"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XCN Components"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./name"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./PreferredName (GivenNames, FamilyName, TitleCode)"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.name.id",
+                "path": "Practitioner.name.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.name.extension",
+                "path": "Practitioner.name.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.name.use",
+                "path": "Practitioner.name.use",
+                "short": "usual | official | temp | nickname | anonymous | old | maiden",
+                "definition": "Identifies the purpose for this name.",
+                "comment": "Applications can assume that a name is current unless it explicitly says that it is temporary or old.",
+                "requirements": "Allows the appropriate name for a particular context of use to be selected from among a set of names.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "HumanName.use",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old name etc.for a current/permanent one",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "NameUse"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The use of a human name.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/name-use|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XPN.7, but often indicated by which field contains the name"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "unique(./use)"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./NamePurpose"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.name.text",
+                "path": "Practitioner.name.text",
+                "short": "Text representation of the full name",
+                "definition": "Specifies the entire name as it should be displayed e.g. on an application UI. This may be provided instead of or as well as the specific parts.",
+                "comment": "Can provide both a text representation and parts. Applications updating a name SHALL ensure that when both text and parts are present,  no content is included in the text that isn't found in a part.",
+                "requirements": "A renderable, unencoded form.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "HumanName.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "implied by XPN.11"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./formatted"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.name.family",
+                "path": "Practitioner.name.family",
+                "short": "Family name (often called 'Surname')",
+                "definition": "The part of a name that links to the genealogy. In some cultures (e.g. Eritrea) the family name of a son is the first name of his father.",
+                "comment": "Family Name may be decomposed into specific parts using extensions (de, nl, es related cultures).",
+                "alias": [
+                    "surname"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "HumanName.family",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XPN.1/FN.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./part[partType = FAM]"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./FamilyName"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.name.given",
+                "path": "Practitioner.name.given",
+                "short": "Given names (not always 'first'). Includes middle names",
+                "definition": "Given name.",
+                "comment": "If only initials are recorded, they may be used in place of the full name parts. Initials may be separated into multiple given names but often aren't due to paractical limitations.  This element is not called \"first name\" since given names do not always come first.",
+                "alias": [
+                    "first name",
+                    "middle name"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "HumanName.given",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "orderMeaning": "Given Names appear in the correct order for presenting the name",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XPN.2 + XPN.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./part[partType = GIV]"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./GivenNames"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.name.prefix",
+                "path": "Practitioner.name.prefix",
+                "short": "Parts that come before the name",
+                "definition": "Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the start of the name.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "HumanName.prefix",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "orderMeaning": "Prefixes appear in the correct order for presenting the name",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XPN.5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./part[partType = PFX]"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./TitleCode"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.name.suffix",
+                "path": "Practitioner.name.suffix",
+                "short": "Parts that come after the name",
+                "definition": "Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "HumanName.suffix",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "orderMeaning": "Suffixes appear in the correct order for presenting the name",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XPN/4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./part[partType = SFX]"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.name.period",
+                "path": "Practitioner.name.period",
+                "short": "Time period when name was/is in use",
+                "definition": "Indicates the period of time when this name was valid for the named person.",
+                "requirements": "Allows names to be placed in historical context.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "HumanName.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XPN.13 + XPN.14"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./usablePeriod[type=\"IVL<TS>\"]"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./StartDate and ./EndDate"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.telecom",
+                "path": "Practitioner.telecom",
+                "short": "A contact detail for the practitioner (that apply to all roles)",
+                "definition": "A contact detail for the practitioner, e.g. a telephone number or an email address.",
+                "comment": "Person may have multiple ways to be contacted with different uses or applicable periods.  May need to have options for contacting the person urgently and to help with identification.  These typically will have home numbers, or mobile numbers that are not role specific.",
+                "requirements": "Need to know how to reach a practitioner independent to any roles the practitioner may have.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Practitioner.telecom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "ContactPoint"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PRT-15, STF-10, ROL-12"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./telecom"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./ContactPoints"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.address",
+                "path": "Practitioner.address",
+                "short": "Address(es) of the practitioner that are not role specific (typically home address)",
+                "definition": "Address(es) of the practitioner that are not role specific (typically home address). \rWork addresses are not typically entered in this property as they are usually role dependent.",
+                "comment": "The PractitionerRole does not have an address value on it, as it is expected that the location property be used for this purpose (which has an address).",
+                "requirements": "The home/mailing address of the practitioner is often required for employee administration purposes, and also for some rostering services where the start point (practitioners home) can be used in calculations.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Practitioner.address",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Address"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "ORC-24, STF-11, ROL-11, PRT-14"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./addr"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Addresses"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.gender",
+                "path": "Practitioner.gender",
+                "short": "male | female | other | unknown",
+                "definition": "Administrative Gender - the gender that the person is considered to have for administration and record keeping purposes.",
+                "requirements": "Needed to address the person correctly.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Practitioner.gender",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "AdministrativeGender"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The gender of a person used for administrative purposes.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/administrative-gender|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "STF-5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./administrativeGender"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./GenderCode"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.birthDate",
+                "path": "Practitioner.birthDate",
+                "short": "The date  on which the practitioner was born",
+                "definition": "The date of birth for the practitioner.",
+                "requirements": "Needed for identification.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Practitioner.birthDate",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "date"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "STF-6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./birthTime"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "(not represented in ServD)"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.photo",
+                "path": "Practitioner.photo",
+                "short": "Image of the person",
+                "definition": "Image of the person.",
+                "requirements": "Many EHR systems have the capability to capture an image of patients and personnel. Fits with newer social media usage too.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Practitioner.photo",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Attachment"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "./subjectOf/ObservationEvent[code=\"photo\"]/value"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./ImageURI (only supports the URI reference)"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.qualification",
+                "path": "Practitioner.qualification",
+                "short": "Certification, licenses, or training pertaining to the provision of care",
+                "definition": "The official certifications, training, and licenses that authorize or otherwise pertain to the provision of care by the practitioner.  For example, a medical license issued by a medical board authorizing the practitioner to practice medicine within a certian locality.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Practitioner.qualification",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "CER?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".playingEntity.playingRole[classCode=QUAL].code"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Qualifications"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.qualification.id",
+                "path": "Practitioner.qualification.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.qualification.extension",
+                "path": "Practitioner.qualification.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.qualification.modifierExtension",
+                "path": "Practitioner.qualification.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.qualification.identifier",
+                "path": "Practitioner.qualification.identifier",
+                "short": "An identifier for this qualification for the practitioner",
+                "definition": "An identifier that applies to this person's qualification in this role.",
+                "requirements": "Often, specific identities are assigned for the qualification.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Practitioner.qualification.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".playingEntity.playingRole[classCode=QUAL].id"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.qualification.code",
+                "path": "Practitioner.qualification.code",
+                "short": "Coded representation of the qualification",
+                "definition": "Coded representation of the qualification.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Practitioner.qualification.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Qualification"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Specific qualification the practitioner has to provide a service.",
+                    "valueSet": "http://terminology.hl7.org/ValueSet/v2-2.7-0360"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".playingEntity.playingRole[classCode=QUAL].code"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Qualifications.Value"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.qualification.period",
+                "path": "Practitioner.qualification.period",
+                "short": "Period during which the qualification is valid",
+                "definition": "Period during which the qualification is valid.",
+                "requirements": "Qualifications are often for a limited period of time, and can be revoked.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Practitioner.qualification.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".playingEntity.playingRole[classCode=QUAL].effectiveTime"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Qualifications.StartDate and ./Qualifications.EndDate"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.qualification.issuer",
+                "path": "Practitioner.qualification.issuer",
+                "short": "Organization that regulates and issues the qualification",
+                "definition": "Organization that regulates and issues the qualification.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Practitioner.qualification.issuer",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".playingEntity.playingRole[classCode=QUAL].scoper"
+                    }
+                ]
+            },
+            {
+                "id": "Practitioner.communication",
+                "path": "Practitioner.communication",
+                "short": "A language the practitioner can use in patient communication",
+                "definition": "A language the practitioner can use in patient communication.",
+                "comment": "The structure aa-BB with this exact casing is one the most widely used notations for locale. However not all systems code this but instead have it as free text. Hence CodeableConcept instead of code as the data type.",
+                "requirements": "Knowing which language a practitioner speaks can help in facilitating communication with patients.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Practitioner.communication",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PID-15, NK1-20, LAN-2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./languageCommunication"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Languages.LanguageSpokenCode"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Practitioner",
+                "path": "Practitioner",
+                "definition": "This is basic constraint on provider for use in US Core resources.",
+                "alias": [
+                    "Provider"
+                ],
+                "mustSupport": false
+            },
+            {
+                "id": "Practitioner.identifier",
+                "path": "Practitioner.identifier",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "$this"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "comment": "NPI must be supported as the identifier system in the US, Tax id is allowed, Local id is allowed in addition to another identifier supplied by a jurisdictional authority such as a practitioner's *Drug Enforcement Administration (DEA)* number.",
+                "min": 1,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Practitioner.identifier.system",
+                "path": "Practitioner.identifier.system",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Practitioner.identifier.value",
+                "path": "Practitioner.identifier.value",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Practitioner.identifier:NPI",
+                "path": "Practitioner.identifier",
+                "sliceName": "NPI",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "patternIdentifier": {
+                    "system": "http://hl7.org/fhir/sid/us-npi"
+                },
+                "mustSupport": true
+            },
+            {
+                "id": "Practitioner.name",
+                "path": "Practitioner.name",
+                "min": 1,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "HumanName"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Practitioner.name.family",
+                "path": "Practitioner.name.family",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-practitionerrole.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-practitionerrole.json
@@ -1,2121 +1,2121 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-practitionerrole",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitionerrole-definitions.html#PractitionerRole\" title=\"This is basic constraint on PractitionerRole for use in US Core resources.\">PractitionerRole</a><a name=\"PractitionerRole\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (pd-1, us-core-13)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/practitionerrole.html\">PractitionerRole</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Roles/organizations the practitioner is associated with</span><br/><span style=\"font-weight:bold\">pd-1: </span>SHALL have contact information or a reference to an Endpoint<br/><span style=\"font-weight:bold\">us-core-13: </span>SHALL have a practitioner, an organization, a healthcare service, or a location.</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitionerrole-definitions.html#PractitionerRole.practitioner\">practitioner</a><a name=\"PractitionerRole.practitioner\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-13)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-practitioner.html\">US Core Practitioner Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Practitioner that is able to provide the defined services for the organization</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitionerrole-definitions.html#PractitionerRole.organization\">organization</a><a name=\"PractitionerRole.organization\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-13)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-organization.html\">US Core Organization Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Organization where the roles are available</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitionerrole-definitions.html#PractitionerRole.code\">code</a><a name=\"PractitionerRole.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Roles which this practitioner may perform</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-provider-role.html\">US Core Provider Role (NUCC)</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>): Provider role codes consisting of NUCC Health Care Provider Taxonomy Code Set for providers.<br/><br/><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitionerrole-definitions.html#PractitionerRole.specialty\">specialty</a><a name=\"PractitionerRole.specialty\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Specific specialty of the practitioner</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.114222.4.11.1066/expansion\">Healthcare Provider Taxonomy</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)<br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitionerrole-definitions.html#PractitionerRole.location\">location</a><a name=\"PractitionerRole.location\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-13)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"http://hl7.org/fhir/R4/location.html\">Location</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The location(s) at which this practitioner provides care</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitionerrole-definitions.html#PractitionerRole.healthcareService\">healthcareService</a><a name=\"PractitionerRole.healthcareService\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (us-core-13)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/healthcareservice.html\">HealthcareService</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The list of healthcare services that this worker provides for this role's Organization/Location(s)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitionerrole-definitions.html#PractitionerRole.telecom\">telecom</a><a name=\"PractitionerRole.telecom\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (pd-1)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#ContactPoint\">ContactPoint</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Contact details that are specific to the role/location/service</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitionerrole-definitions.html#PractitionerRole.telecom.system\">system</a><a name=\"PractitionerRole.telecom.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">phone | fax | email | pager | url | sms | other</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitionerrole-definitions.html#PractitionerRole.telecom.value\">value</a><a name=\"PractitionerRole.telecom.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">The actual contact point details</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck00.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-practitionerrole-definitions.html#PractitionerRole.endpoint\">endpoint</a><a name=\"PractitionerRole.endpoint\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (pd-1)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/endpoint.html\">Endpoint</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Technical endpoints providing access to services operated for the practitioner with this role</span><br/></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
-	"version": "4.0.0",
-	"name": "USCorePractitionerRoleProfile",
-	"title": "US Core PractitionerRole Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2019-08-11",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The practitioner roles referenced in the US Core profiles.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "servd",
-			"uri": "http://www.omg.org/spec/ServD/1.0/",
-			"name": "ServD"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "PractitionerRole",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "PractitionerRole",
-				"path": "PractitionerRole",
-				"short": "Roles/organizations the practitioner is associated with",
-				"definition": "This is basic constraint on PractitionerRole for use in US Core resources.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "PractitionerRole",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "pd-1",
-						"severity": "error",
-						"human": "SHALL have contact information or a reference to an Endpoint",
-						"expression": "telecom or endpoint",
-						"xpath": "exists(f:telecom) or exists(f:endpoint)"
-					},
-					{
-						"key": "us-core-13",
-						"severity": "error",
-						"human": "SHALL have a practitioner, an organization, a healthcare service, or a location.",
-						"expression": "practitioner or organization or healthcareService or location",
-						"xpath": "exists(f:practitioner) or exists(f:organization) or exists(f:healthcareService) or exists(f:location)"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "v2",
-						"map": "PRD (as one example)"
-					},
-					{
-						"identity": "rim",
-						"map": "Role"
-					},
-					{
-						"identity": "servd",
-						"map": "ServiceSiteProvider"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.id",
-				"path": "PractitionerRole.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "PractitionerRole.meta",
-				"path": "PractitionerRole.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "PractitionerRole.implicitRules",
-				"path": "PractitionerRole.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "PractitionerRole.language",
-				"path": "PractitionerRole.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "PractitionerRole.text",
-				"path": "PractitionerRole.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.contained",
-				"path": "PractitionerRole.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.extension",
-				"path": "PractitionerRole.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.modifierExtension",
-				"path": "PractitionerRole.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.identifier",
-				"path": "PractitionerRole.identifier",
-				"short": "Business Identifiers that are specific to a role/location",
-				"definition": "Business Identifiers that are specific to a role/location.",
-				"requirements": "Often, specific identities are assigned for the agent.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "PractitionerRole.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "PRD-7 (or XCN.1)"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					},
-					{
-						"identity": "servd",
-						"map": "./Identifiers"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.active",
-				"path": "PractitionerRole.active",
-				"short": "Whether this practitioner role record is in active use",
-				"definition": "Whether this practitioner role record is in active use.",
-				"comment": "If this value is false, you may refer to the period to see when the role was in active use. If there is no period specified, no inference can be made about when it was active.",
-				"requirements": "Need to be able to mark a practitioner role record as not to be used because it was created in error, or otherwise no longer in active use.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "PractitionerRole.active",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"meaningWhenMissing": "This resource is generally assumed to be active if no value is provided for the active element",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "v2",
-						"map": "STF-7"
-					},
-					{
-						"identity": "rim",
-						"map": ".statusCode"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.period",
-				"path": "PractitionerRole.period",
-				"short": "The period during which the practitioner is authorized to perform in these role(s)",
-				"definition": "The period during which the person is authorized to act as a practitioner in these role(s) for the organization.",
-				"requirements": "Even after the agencies is revoked, the fact that it existed must still be recorded.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "PractitionerRole.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PRD-8/9 / PRA-5.4"
-					},
-					{
-						"identity": "rim",
-						"map": ".performance[@typeCode <= 'PPRF'].ActDefinitionOrEvent.effectiveTime"
-					},
-					{
-						"identity": "servd",
-						"map": "(ServD maps Practitioners and Organizations via another entity, so this concept is not available)"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.practitioner",
-				"path": "PractitionerRole.practitioner",
-				"short": "Practitioner that is able to provide the defined services for the organization",
-				"definition": "Practitioner that is able to provide the defined services for the organization.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "PractitionerRole.practitioner",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
-						]
-					}
-				],
-				"condition": [
-					"us-core-13"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".player"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.organization",
-				"path": "PractitionerRole.organization",
-				"short": "Organization where the roles are available",
-				"definition": "The organization where the Practitioner performs the roles associated.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "PractitionerRole.organization",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
-						]
-					}
-				],
-				"condition": [
-					"us-core-13"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".scoper"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.code",
-				"path": "PractitionerRole.code",
-				"short": "Roles which this practitioner may perform",
-				"definition": "Roles which this practitioner is authorized to perform for the organization.",
-				"comment": "A person may have more than one role.",
-				"requirements": "Need to know what authority the practitioner has - what can they do?",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "PractitionerRole.code",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Provider role codes consisting of NUCC Health Care Provider Taxonomy Code Set for providers.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-provider-role"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PRD-1 / STF-18  / PRA-3  / PRT-4  / ROL-3 / ORC-12 / OBR-16 / PV1-7 / PV1-8 / PV1-9 / PV1-17"
-					},
-					{
-						"identity": "rim",
-						"map": ".code"
-					},
-					{
-						"identity": "servd",
-						"map": "(ServD maps Practitioners and Organizations via another entity, so this concept is not available)"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.specialty",
-				"path": "PractitionerRole.specialty",
-				"short": "Specific specialty of the practitioner",
-				"definition": "Specific specialty of the practitioner.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "PractitionerRole.specialty",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.1066"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "PRA-5"
-					},
-					{
-						"identity": "rim",
-						"map": ".player.HealthCareProvider[@classCode = 'PROV'].code"
-					},
-					{
-						"identity": "servd",
-						"map": "./Specialty"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.location",
-				"path": "PractitionerRole.location",
-				"short": "The location(s) at which this practitioner provides care",
-				"definition": "The location(s) at which this practitioner provides care.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "PractitionerRole.location",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Location"
-						]
-					}
-				],
-				"condition": [
-					"us-core-13"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.where[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".performance.ActDefinitionOrEvent.ServiceDeliveryLocation[@classCode = 'SDLOC']"
-					},
-					{
-						"identity": "servd",
-						"map": "(ServD maps Practitioners and Organizations via another entity, so this concept is not available)<br/> However these are accessed via the Site.ServiceSite.ServiceSiteProvider record. (The Site has the location)"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.healthcareService",
-				"path": "PractitionerRole.healthcareService",
-				"short": "The list of healthcare services that this worker provides for this role's Organization/Location(s)",
-				"definition": "The list of healthcare services that this worker provides for this role's Organization/Location(s).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "PractitionerRole.healthcareService",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/HealthcareService"
-						]
-					}
-				],
-				"condition": [
-					"us-core-13"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "EDU-2 / AFF-3"
-					},
-					{
-						"identity": "rim",
-						"map": ".player.QualifiedEntity[@classCode = 'QUAL'].code"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.telecom",
-				"path": "PractitionerRole.telecom",
-				"short": "Contact details that are specific to the role/location/service",
-				"definition": "Contact details that are specific to the role/location/service.",
-				"requirements": "Often practitioners have a dedicated line for each location (or service) that they work at, and need to be able to define separate contact details for each of these.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "PractitionerRole.telecom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "ContactPoint"
-					}
-				],
-				"condition": [
-					"pd-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".telecom"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.telecom.id",
-				"path": "PractitionerRole.telecom.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.telecom.extension",
-				"path": "PractitionerRole.telecom.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.telecom.system",
-				"path": "PractitionerRole.telecom.system",
-				"short": "phone | fax | email | pager | url | sms | other",
-				"definition": "Telecommunications form for contact point - what communications system is required to make use of the contact.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "ContactPoint.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"condition": [
-					"cpt-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ContactPointSystem"
-						}
-					],
-					"strength": "required",
-					"description": "Telecommunications form for contact point.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/contact-point-system|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XTN.3"
-					},
-					{
-						"identity": "rim",
-						"map": "./scheme"
-					},
-					{
-						"identity": "servd",
-						"map": "./ContactPointType"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.telecom.value",
-				"path": "PractitionerRole.telecom.value",
-				"short": "The actual contact point details",
-				"definition": "The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address).",
-				"comment": "Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value.",
-				"requirements": "Need to support legacy numbers that are not in a tightly controlled format.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "ContactPoint.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XTN.1 (or XTN.12)"
-					},
-					{
-						"identity": "rim",
-						"map": "./url"
-					},
-					{
-						"identity": "servd",
-						"map": "./Value"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.telecom.use",
-				"path": "PractitionerRole.telecom.use",
-				"short": "home | work | temp | old | mobile - purpose of this contact point",
-				"definition": "Identifies the purpose for the contact point.",
-				"comment": "Applications can assume that a contact is current unless it explicitly says that it is temporary or old.",
-				"requirements": "Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "ContactPoint.use",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old contact etc.for a current/permanent one",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ContactPointUse"
-						}
-					],
-					"strength": "required",
-					"description": "Use of contact point.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/contact-point-use|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "XTN.2 - but often indicated by field"
-					},
-					{
-						"identity": "rim",
-						"map": "unique(./use)"
-					},
-					{
-						"identity": "servd",
-						"map": "./ContactPointPurpose"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.telecom.rank",
-				"path": "PractitionerRole.telecom.rank",
-				"short": "Specify preferred order of use (1 = highest)",
-				"definition": "Specifies a preferred order in which to use a set of contacts. ContactPoints with lower rank values are more preferred than those with higher rank values.",
-				"comment": "Note that rank does not necessarily follow the order in which the contacts are represented in the instance.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "ContactPoint.rank",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "positiveInt"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "n/a"
-					},
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.telecom.period",
-				"path": "PractitionerRole.telecom.period",
-				"short": "Time period when the contact point was/is in use",
-				"definition": "Time period when the contact point was/is in use.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "ContactPoint.period",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "./usablePeriod[type=\"IVL<TS>\"]"
-					},
-					{
-						"identity": "servd",
-						"map": "./StartDate and ./EndDate"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.availableTime",
-				"path": "PractitionerRole.availableTime",
-				"short": "Times the Service Site is available",
-				"definition": "A collection of times the practitioner is available or performing this role at the location and/or healthcareservice.",
-				"comment": "More detailed availability information may be provided in associated Schedule/Slot resources.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "PractitionerRole.availableTime",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.availableTime.id",
-				"path": "PractitionerRole.availableTime.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.availableTime.extension",
-				"path": "PractitionerRole.availableTime.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.availableTime.modifierExtension",
-				"path": "PractitionerRole.availableTime.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.availableTime.daysOfWeek",
-				"path": "PractitionerRole.availableTime.daysOfWeek",
-				"short": "mon | tue | wed | thu | fri | sat | sun",
-				"definition": "Indicates which days of the week are available between the start and end Times.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "PractitionerRole.availableTime.daysOfWeek",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "DaysOfWeek"
-						}
-					],
-					"strength": "required",
-					"description": "The days of the week.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/days-of-week|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.availableTime.allDay",
-				"path": "PractitionerRole.availableTime.allDay",
-				"short": "Always available? e.g. 24 hour service",
-				"definition": "Is this always available? (hence times are irrelevant) e.g. 24 hour service.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "PractitionerRole.availableTime.allDay",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.availableTime.availableStartTime",
-				"path": "PractitionerRole.availableTime.availableStartTime",
-				"short": "Opening time of day (ignored if allDay = true)",
-				"definition": "The opening time of day. Note: If the AllDay flag is set, then this time is ignored.",
-				"comment": "The timezone is expected to be for where this HealthcareService is provided at.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "PractitionerRole.availableTime.availableStartTime",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "time"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.availableTime.availableEndTime",
-				"path": "PractitionerRole.availableTime.availableEndTime",
-				"short": "Closing time of day (ignored if allDay = true)",
-				"definition": "The closing time of day. Note: If the AllDay flag is set, then this time is ignored.",
-				"comment": "The timezone is expected to be for where this HealthcareService is provided at.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "PractitionerRole.availableTime.availableEndTime",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "time"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.notAvailable",
-				"path": "PractitionerRole.notAvailable",
-				"short": "Not available during this time due to provided reason",
-				"definition": "The practitioner is not available or performing this role during this period of time due to the provided reason.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "PractitionerRole.notAvailable",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.notAvailable.id",
-				"path": "PractitionerRole.notAvailable.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.notAvailable.extension",
-				"path": "PractitionerRole.notAvailable.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.notAvailable.modifierExtension",
-				"path": "PractitionerRole.notAvailable.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.notAvailable.description",
-				"path": "PractitionerRole.notAvailable.description",
-				"short": "Reason presented to the user explaining why time not available",
-				"definition": "The reason that can be presented to the user as to why this time is not available.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "PractitionerRole.notAvailable.description",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.notAvailable.during",
-				"path": "PractitionerRole.notAvailable.during",
-				"short": "Service not available from this date",
-				"definition": "Service is not available (seasonally or for a public holiday) from this date.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "PractitionerRole.notAvailable.during",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.availabilityExceptions",
-				"path": "PractitionerRole.availabilityExceptions",
-				"short": "Description of availability exceptions",
-				"definition": "A description of site availability exceptions, e.g. public holiday availability. Succinctly describing all possible exceptions to normal site availability as details in the available Times and not available Times.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "PractitionerRole.availabilityExceptions",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "PractitionerRole.endpoint",
-				"path": "PractitionerRole.endpoint",
-				"short": "Technical endpoints providing access to services operated for the practitioner with this role",
-				"definition": "Technical endpoints providing access to services operated for the practitioner with this role.",
-				"requirements": "Organizations have multiple systems that provide various services and ,ay also be different for practitioners too.\r\rSo the endpoint satisfies the need to be able to define the technical connection details for how to connect to them, and for what purpose.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "PractitionerRole.endpoint",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Endpoint"
-						]
-					}
-				],
-				"condition": [
-					"pd-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "PractitionerRole",
-				"path": "PractitionerRole",
-				"definition": "This is basic constraint on PractitionerRole for use in US Core resources.",
-				"constraint": [
-					{
-						"key": "pd-1",
-						"severity": "error",
-						"human": "SHALL have contact information or a reference to an Endpoint",
-						"expression": "telecom or endpoint",
-						"xpath": "exists(f:telecom) or exists(f:endpoint)"
-					},
-					{
-						"key": "us-core-13",
-						"severity": "error",
-						"human": "SHALL have a practitioner, an organization, a healthcare service, or a location.",
-						"expression": "practitioner or organization or healthcareService or location",
-						"xpath": "exists(f:practitioner) or exists(f:organization) or exists(f:healthcareService) or exists(f:location)"
-					}
-				],
-				"mustSupport": false
-			},
-			{
-				"id": "PractitionerRole.practitioner",
-				"path": "PractitionerRole.practitioner",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
-						]
-					}
-				],
-				"condition": [
-					"us-core-13"
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "PractitionerRole.organization",
-				"path": "PractitionerRole.organization",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
-						]
-					}
-				],
-				"condition": [
-					"us-core-13"
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "PractitionerRole.code",
-				"path": "PractitionerRole.code",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Provider role codes consisting of NUCC Health Care Provider Taxonomy Code Set for providers.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-provider-role"
-				}
-			},
-			{
-				"id": "PractitionerRole.specialty",
-				"path": "PractitionerRole.specialty",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.1066"
-				}
-			},
-			{
-				"id": "PractitionerRole.location",
-				"path": "PractitionerRole.location",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Location"
-						]
-					}
-				],
-				"condition": [
-					"us-core-13"
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "PractitionerRole.healthcareService",
-				"path": "PractitionerRole.healthcareService",
-				"condition": [
-					"us-core-13"
-				]
-			},
-			{
-				"id": "PractitionerRole.telecom",
-				"path": "PractitionerRole.telecom",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "ContactPoint"
-					}
-				],
-				"condition": [
-					"pd-1"
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "PractitionerRole.telecom.system",
-				"path": "PractitionerRole.telecom.system",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "PractitionerRole.telecom.value",
-				"path": "PractitionerRole.telecom.value",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "PractitionerRole.endpoint",
-				"path": "PractitionerRole.endpoint",
-				"min": 0,
-				"max": "*",
-				"condition": [
-					"pd-1"
-				],
-				"mustSupport": true
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-practitionerrole",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
+    "version": "4.0.0",
+    "name": "USCorePractitionerRoleProfile",
+    "title": "US Core PractitionerRole Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2019-08-11",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The practitioner roles referenced in the US Core profiles.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "servd",
+            "uri": "http://www.omg.org/spec/ServD/1.0/",
+            "name": "ServD"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "PractitionerRole",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "PractitionerRole",
+                "path": "PractitionerRole",
+                "short": "Roles/organizations the practitioner is associated with",
+                "definition": "This is basic constraint on PractitionerRole for use in US Core resources.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "PractitionerRole",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "pd-1",
+                        "severity": "error",
+                        "human": "SHALL have contact information or a reference to an Endpoint",
+                        "expression": "telecom or endpoint",
+                        "xpath": "exists(f:telecom) or exists(f:endpoint)"
+                    },
+                    {
+                        "key": "us-core-13",
+                        "severity": "error",
+                        "human": "SHALL have a practitioner, an organization, a healthcare service, or a location.",
+                        "expression": "practitioner or organization or healthcareService or location",
+                        "xpath": "exists(f:practitioner) or exists(f:organization) or exists(f:healthcareService) or exists(f:location)"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRD (as one example)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Role"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "ServiceSiteProvider"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.id",
+                "path": "PractitionerRole.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "PractitionerRole.meta",
+                "path": "PractitionerRole.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "PractitionerRole.implicitRules",
+                "path": "PractitionerRole.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "PractitionerRole.language",
+                "path": "PractitionerRole.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "PractitionerRole.text",
+                "path": "PractitionerRole.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.contained",
+                "path": "PractitionerRole.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.extension",
+                "path": "PractitionerRole.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.modifierExtension",
+                "path": "PractitionerRole.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.identifier",
+                "path": "PractitionerRole.identifier",
+                "short": "Business Identifiers that are specific to a role/location",
+                "definition": "Business Identifiers that are specific to a role/location.",
+                "requirements": "Often, specific identities are assigned for the agent.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "PractitionerRole.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRD-7 (or XCN.1)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Identifiers"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.active",
+                "path": "PractitionerRole.active",
+                "short": "Whether this practitioner role record is in active use",
+                "definition": "Whether this practitioner role record is in active use.",
+                "comment": "If this value is false, you may refer to the period to see when the role was in active use. If there is no period specified, no inference can be made about when it was active.",
+                "requirements": "Need to be able to mark a practitioner role record as not to be used because it was created in error, or otherwise no longer in active use.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "PractitionerRole.active",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "meaningWhenMissing": "This resource is generally assumed to be active if no value is provided for the active element",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "STF-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".statusCode"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.period",
+                "path": "PractitionerRole.period",
+                "short": "The period during which the practitioner is authorized to perform in these role(s)",
+                "definition": "The period during which the person is authorized to act as a practitioner in these role(s) for the organization.",
+                "requirements": "Even after the agencies is revoked, the fact that it existed must still be recorded.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "PractitionerRole.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PRD-8/9 / PRA-5.4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".performance[@typeCode <= 'PPRF'].ActDefinitionOrEvent.effectiveTime"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "(ServD maps Practitioners and Organizations via another entity, so this concept is not available)"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.practitioner",
+                "path": "PractitionerRole.practitioner",
+                "short": "Practitioner that is able to provide the defined services for the organization",
+                "definition": "Practitioner that is able to provide the defined services for the organization.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "PractitionerRole.practitioner",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "us-core-13"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".player"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.organization",
+                "path": "PractitionerRole.organization",
+                "short": "Organization where the roles are available",
+                "definition": "The organization where the Practitioner performs the roles associated.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "PractitionerRole.organization",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "us-core-13"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".scoper"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.code",
+                "path": "PractitionerRole.code",
+                "short": "Roles which this practitioner may perform",
+                "definition": "Roles which this practitioner is authorized to perform for the organization.",
+                "comment": "A person may have more than one role.",
+                "requirements": "Need to know what authority the practitioner has - what can they do?",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "PractitionerRole.code",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Provider role codes consisting of NUCC Health Care Provider Taxonomy Code Set for providers.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-provider-role"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PRD-1 / STF-18  / PRA-3  / PRT-4  / ROL-3 / ORC-12 / OBR-16 / PV1-7 / PV1-8 / PV1-9 / PV1-17"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".code"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "(ServD maps Practitioners and Organizations via another entity, so this concept is not available)"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.specialty",
+                "path": "PractitionerRole.specialty",
+                "short": "Specific specialty of the practitioner",
+                "definition": "Specific specialty of the practitioner.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "PractitionerRole.specialty",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.1066"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "PRA-5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".player.HealthCareProvider[@classCode = 'PROV'].code"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Specialty"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.location",
+                "path": "PractitionerRole.location",
+                "short": "The location(s) at which this practitioner provides care",
+                "definition": "The location(s) at which this practitioner provides care.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "PractitionerRole.location",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Location"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "us-core-13"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.where[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".performance.ActDefinitionOrEvent.ServiceDeliveryLocation[@classCode = 'SDLOC']"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "(ServD maps Practitioners and Organizations via another entity, so this concept is not available)<br/> However these are accessed via the Site.ServiceSite.ServiceSiteProvider record. (The Site has the location)"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.healthcareService",
+                "path": "PractitionerRole.healthcareService",
+                "short": "The list of healthcare services that this worker provides for this role's Organization/Location(s)",
+                "definition": "The list of healthcare services that this worker provides for this role's Organization/Location(s).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "PractitionerRole.healthcareService",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/HealthcareService"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "us-core-13"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "EDU-2 / AFF-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".player.QualifiedEntity[@classCode = 'QUAL'].code"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.telecom",
+                "path": "PractitionerRole.telecom",
+                "short": "Contact details that are specific to the role/location/service",
+                "definition": "Contact details that are specific to the role/location/service.",
+                "requirements": "Often practitioners have a dedicated line for each location (or service) that they work at, and need to be able to define separate contact details for each of these.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "PractitionerRole.telecom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "ContactPoint"
+                    }
+                ],
+                "condition": [
+                    "pd-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".telecom"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.telecom.id",
+                "path": "PractitionerRole.telecom.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.telecom.extension",
+                "path": "PractitionerRole.telecom.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.telecom.system",
+                "path": "PractitionerRole.telecom.system",
+                "short": "phone | fax | email | pager | url | sms | other",
+                "definition": "Telecommunications form for contact point - what communications system is required to make use of the contact.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "ContactPoint.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "condition": [
+                    "cpt-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ContactPointSystem"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Telecommunications form for contact point.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/contact-point-system|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XTN.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./scheme"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./ContactPointType"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.telecom.value",
+                "path": "PractitionerRole.telecom.value",
+                "short": "The actual contact point details",
+                "definition": "The actual contact point details, in a form that is meaningful to the designated communication system (i.e. phone number or email address).",
+                "comment": "Additional text data such as phone extension numbers, or notes about use of the contact are sometimes included in the value.",
+                "requirements": "Need to support legacy numbers that are not in a tightly controlled format.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "ContactPoint.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XTN.1 (or XTN.12)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./url"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./Value"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.telecom.use",
+                "path": "PractitionerRole.telecom.use",
+                "short": "home | work | temp | old | mobile - purpose of this contact point",
+                "definition": "Identifies the purpose for the contact point.",
+                "comment": "Applications can assume that a contact is current unless it explicitly says that it is temporary or old.",
+                "requirements": "Need to track the way a person uses this contact, so a user can choose which is appropriate for their purpose.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "ContactPoint.use",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because applications should not mistake a temporary or old contact etc.for a current/permanent one",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ContactPointUse"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "Use of contact point.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/contact-point-use|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "XTN.2 - but often indicated by field"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "unique(./use)"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./ContactPointPurpose"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.telecom.rank",
+                "path": "PractitionerRole.telecom.rank",
+                "short": "Specify preferred order of use (1 = highest)",
+                "definition": "Specifies a preferred order in which to use a set of contacts. ContactPoints with lower rank values are more preferred than those with higher rank values.",
+                "comment": "Note that rank does not necessarily follow the order in which the contacts are represented in the instance.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "ContactPoint.rank",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "positiveInt"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "n/a"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.telecom.period",
+                "path": "PractitionerRole.telecom.period",
+                "short": "Time period when the contact point was/is in use",
+                "definition": "Time period when the contact point was/is in use.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "ContactPoint.period",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./usablePeriod[type=\"IVL<TS>\"]"
+                    },
+                    {
+                        "identity": "servd",
+                        "map": "./StartDate and ./EndDate"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.availableTime",
+                "path": "PractitionerRole.availableTime",
+                "short": "Times the Service Site is available",
+                "definition": "A collection of times the practitioner is available or performing this role at the location and/or healthcareservice.",
+                "comment": "More detailed availability information may be provided in associated Schedule/Slot resources.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "PractitionerRole.availableTime",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.availableTime.id",
+                "path": "PractitionerRole.availableTime.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.availableTime.extension",
+                "path": "PractitionerRole.availableTime.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.availableTime.modifierExtension",
+                "path": "PractitionerRole.availableTime.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.availableTime.daysOfWeek",
+                "path": "PractitionerRole.availableTime.daysOfWeek",
+                "short": "mon | tue | wed | thu | fri | sat | sun",
+                "definition": "Indicates which days of the week are available between the start and end Times.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "PractitionerRole.availableTime.daysOfWeek",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "DaysOfWeek"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "The days of the week.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/days-of-week|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.availableTime.allDay",
+                "path": "PractitionerRole.availableTime.allDay",
+                "short": "Always available? e.g. 24 hour service",
+                "definition": "Is this always available? (hence times are irrelevant) e.g. 24 hour service.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "PractitionerRole.availableTime.allDay",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.availableTime.availableStartTime",
+                "path": "PractitionerRole.availableTime.availableStartTime",
+                "short": "Opening time of day (ignored if allDay = true)",
+                "definition": "The opening time of day. Note: If the AllDay flag is set, then this time is ignored.",
+                "comment": "The timezone is expected to be for where this HealthcareService is provided at.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "PractitionerRole.availableTime.availableStartTime",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "time"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.availableTime.availableEndTime",
+                "path": "PractitionerRole.availableTime.availableEndTime",
+                "short": "Closing time of day (ignored if allDay = true)",
+                "definition": "The closing time of day. Note: If the AllDay flag is set, then this time is ignored.",
+                "comment": "The timezone is expected to be for where this HealthcareService is provided at.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "PractitionerRole.availableTime.availableEndTime",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "time"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.notAvailable",
+                "path": "PractitionerRole.notAvailable",
+                "short": "Not available during this time due to provided reason",
+                "definition": "The practitioner is not available or performing this role during this period of time due to the provided reason.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "PractitionerRole.notAvailable",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.notAvailable.id",
+                "path": "PractitionerRole.notAvailable.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.notAvailable.extension",
+                "path": "PractitionerRole.notAvailable.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.notAvailable.modifierExtension",
+                "path": "PractitionerRole.notAvailable.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.notAvailable.description",
+                "path": "PractitionerRole.notAvailable.description",
+                "short": "Reason presented to the user explaining why time not available",
+                "definition": "The reason that can be presented to the user as to why this time is not available.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "PractitionerRole.notAvailable.description",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.notAvailable.during",
+                "path": "PractitionerRole.notAvailable.during",
+                "short": "Service not available from this date",
+                "definition": "Service is not available (seasonally or for a public holiday) from this date.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "PractitionerRole.notAvailable.during",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.availabilityExceptions",
+                "path": "PractitionerRole.availabilityExceptions",
+                "short": "Description of availability exceptions",
+                "definition": "A description of site availability exceptions, e.g. public holiday availability. Succinctly describing all possible exceptions to normal site availability as details in the available Times and not available Times.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "PractitionerRole.availabilityExceptions",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "PractitionerRole.endpoint",
+                "path": "PractitionerRole.endpoint",
+                "short": "Technical endpoints providing access to services operated for the practitioner with this role",
+                "definition": "Technical endpoints providing access to services operated for the practitioner with this role.",
+                "requirements": "Organizations have multiple systems that provide various services and ,ay also be different for practitioners too.\r\rSo the endpoint satisfies the need to be able to define the technical connection details for how to connect to them, and for what purpose.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "PractitionerRole.endpoint",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Endpoint"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "pd-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "PractitionerRole",
+                "path": "PractitionerRole",
+                "definition": "This is basic constraint on PractitionerRole for use in US Core resources.",
+                "constraint": [
+                    {
+                        "key": "pd-1",
+                        "severity": "error",
+                        "human": "SHALL have contact information or a reference to an Endpoint",
+                        "expression": "telecom or endpoint",
+                        "xpath": "exists(f:telecom) or exists(f:endpoint)"
+                    },
+                    {
+                        "key": "us-core-13",
+                        "severity": "error",
+                        "human": "SHALL have a practitioner, an organization, a healthcare service, or a location.",
+                        "expression": "practitioner or organization or healthcareService or location",
+                        "xpath": "exists(f:practitioner) or exists(f:organization) or exists(f:healthcareService) or exists(f:location)"
+                    }
+                ],
+                "mustSupport": false
+            },
+            {
+                "id": "PractitionerRole.practitioner",
+                "path": "PractitionerRole.practitioner",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "us-core-13"
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "PractitionerRole.organization",
+                "path": "PractitionerRole.organization",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "us-core-13"
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "PractitionerRole.code",
+                "path": "PractitionerRole.code",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Provider role codes consisting of NUCC Health Care Provider Taxonomy Code Set for providers.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-provider-role"
+                }
+            },
+            {
+                "id": "PractitionerRole.specialty",
+                "path": "PractitionerRole.specialty",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.1066"
+                }
+            },
+            {
+                "id": "PractitionerRole.location",
+                "path": "PractitionerRole.location",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Location"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "us-core-13"
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "PractitionerRole.healthcareService",
+                "path": "PractitionerRole.healthcareService",
+                "condition": [
+                    "us-core-13"
+                ]
+            },
+            {
+                "id": "PractitionerRole.telecom",
+                "path": "PractitionerRole.telecom",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "ContactPoint"
+                    }
+                ],
+                "condition": [
+                    "pd-1"
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "PractitionerRole.telecom.system",
+                "path": "PractitionerRole.telecom.system",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "PractitionerRole.telecom.value",
+                "path": "PractitionerRole.telecom.value",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "PractitionerRole.endpoint",
+                "path": "PractitionerRole.endpoint",
+                "min": 0,
+                "max": "*",
+                "condition": [
+                    "pd-1"
+                ],
+                "mustSupport": true
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-procedure.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-procedure.json
@@ -1,2477 +1,2477 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-procedure",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-procedure-definitions.html#Procedure\" title=\"The US Core Condition Profile is based upon the core FHIR Procedure Resource and created to meet the 2015 Edition Common Clinical Data Set 'Procedures' requirements.\">Procedure</a><a name=\"Procedure\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/procedure.html\">Procedure</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">An action that is being or was performed on a patient</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-procedure-definitions.html#Procedure.status\">status</a><a name=\"Procedure.status\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">preparation | in-progress | not-done | on-hold | stopped | completed | entered-in-error | unknown</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-event-status.html\">EventStatus</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-procedure-definitions.html#Procedure.code\">code</a><a name=\"Procedure.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Identification of the procedure</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-procedure-code.html\">US Core Procedure Codes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>): Codes describing the type of  Procedure<br/><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-procedure-definitions.html#Procedure.subject\">subject</a><a name=\"Procedure.subject\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who the procedure was performed on</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_choice.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Choice of Types\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-procedure-definitions.html#Procedure.performed[x]\">performed[x]</a><a name=\"Procedure.performed_x_\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">When the procedure was performed</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for dateTime Type: A date, date-time or partial date (e.g. just year or year + month).  If hours and minutes are specified, a time zone SHALL be populated. The format is a union of the schema types gYear, gYearMonth, date and dateTime. Seconds must be provided due to schema type constraints but may be zero-filled and may be ignored.                 Dates SHALL be valid dates.\">performedDateTime</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#dateTime\">dateTime</a> <span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This type must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for Period Type: A time period defined by a start and end date and optionally time.\">performedPeriod</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Period\">Period</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for string Type: A sequence of Unicode characters\">performedString</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for Age Type: A duration of time during which an organism (or a process) has existed.\">performedAge</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Age\">Age</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for Range Type: A set of ordered Quantities defined by a low and high limit.\">performedRange</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Range\">Range</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure",
-	"version": "4.0.0",
-	"name": "USCoreProcedureProfile",
-	"title": "US Core Procedure Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-06-29",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the Procedure resource for the minimal set of data to query and retrieve patient's procedure information.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Procedure",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Procedure",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Procedure",
-				"path": "Procedure",
-				"short": "An action that is being or was performed on a patient",
-				"definition": "The US Core Condition Profile is based upon the core FHIR Procedure Resource and created to meet the 2015 Edition Common Clinical Data Set 'Procedures' requirements.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "rim",
-						"map": "Procedure[moodCode=EVN]"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Procedure"
-					}
-				]
-			},
-			{
-				"id": "Procedure.id",
-				"path": "Procedure.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Procedure.meta",
-				"path": "Procedure.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Procedure.implicitRules",
-				"path": "Procedure.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Procedure.language",
-				"path": "Procedure.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Procedure.text",
-				"path": "Procedure.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Procedure.contained",
-				"path": "Procedure.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Procedure.extension",
-				"path": "Procedure.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Procedure.modifierExtension",
-				"path": "Procedure.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Procedure.identifier",
-				"path": "Procedure.identifier",
-				"short": "External Identifiers for this procedure",
-				"definition": "Business identifiers assigned to this procedure by the performer or other systems which remain constant as the resource is updated and is propagated from server to server.",
-				"comment": "This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and Person resource instances might share the same social insurance number.",
-				"requirements": "Allows identification of the procedure as it is known by various participating systems and in a way that remains consistent across servers.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "Some combination of ORC-2 / ORC-3 / OBR-2 / OBR-3 / IPC-1 / IPC-2 / IPC-3 / IPC-4"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					}
-				]
-			},
-			{
-				"id": "Procedure.instantiatesCanonical",
-				"path": "Procedure.instantiatesCanonical",
-				"short": "Instantiates FHIR protocol or definition",
-				"definition": "The URL pointing to a FHIR-defined protocol, guideline, order set or other definition that is adhered to in whole or in part by this Procedure.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.instantiatesCanonical",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "canonical",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/PlanDefinition",
-							"http://hl7.org/fhir/StructureDefinition/ActivityDefinition",
-							"http://hl7.org/fhir/StructureDefinition/Measure",
-							"http://hl7.org/fhir/StructureDefinition/OperationDefinition",
-							"http://hl7.org/fhir/StructureDefinition/Questionnaire"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.instantiatesCanonical"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=DEFN].target"
-					}
-				]
-			},
-			{
-				"id": "Procedure.instantiatesUri",
-				"path": "Procedure.instantiatesUri",
-				"short": "Instantiates external protocol or definition",
-				"definition": "The URL pointing to an externally maintained protocol, guideline, order set or other definition that is adhered to in whole or in part by this Procedure.",
-				"comment": "This might be an HTML page, PDF, etc. or could just be a non-resolvable URI identifier.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.instantiatesUri",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.instantiatesUri"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=DEFN].target"
-					}
-				]
-			},
-			{
-				"id": "Procedure.basedOn",
-				"path": "Procedure.basedOn",
-				"short": "A request for this procedure",
-				"definition": "A reference to a resource that contains details of the request for this procedure.",
-				"alias": [
-					"fulfills"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.basedOn"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=FLFS].target[classCode=(various e.g. PROC, OBS, PCPR, ACT,  moodCode=RQO].code"
-					}
-				]
-			},
-			{
-				"id": "Procedure.partOf",
-				"path": "Procedure.partOf",
-				"short": "Part of referenced event",
-				"definition": "A larger event of which this particular procedure is a component or step.",
-				"comment": "The MedicationAdministration resource has a partOf reference to Procedure, but this is not a circular reference.   For example, the anesthesia MedicationAdministration is part of the surgical Procedure (MedicationAdministration.partOf = Procedure).  For example, the procedure to insert the IV port for an IV medication administration is part of the medication administration (Procedure.partOf = MedicationAdministration).",
-				"alias": [
-					"container"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.partOf",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Procedure",
-							"http://hl7.org/fhir/StructureDefinition/Observation",
-							"http://hl7.org/fhir/StructureDefinition/MedicationAdministration"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.partOf"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[classCode=SBADM or PROC or OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Procedure.status",
-				"path": "Procedure.status",
-				"short": "preparation | in-progress | not-done | on-hold | stopped | completed | entered-in-error | unknown",
-				"definition": "A code specifying the state of the procedure. Generally, this will be the in-progress or completed state.",
-				"comment": "The \"unknown\" code is not to be used to convey other statuses.  The \"unknown\" code should be used when one of the statuses applies, but the authoring system doesn't know the current state of the procedure.\n\nThis element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Procedure.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labelled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/event-status"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "rim",
-						"map": "statusCode"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Procedure.status"
-					}
-				]
-			},
-			{
-				"id": "Procedure.statusReason",
-				"path": "Procedure.statusReason",
-				"short": "Reason for current status",
-				"definition": "Captures the reason for the current state of the procedure.",
-				"comment": "This is generally only used for \"exception\" statuses such as \"not-done\", \"suspended\" or \"aborted\". The reason for performing the event at all is captured in reasonCode, not here.",
-				"alias": [
-					"Suspended Reason",
-					"Cancelled Reason"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Procedure.statusReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProcedureNegationReason"
-						}
-					],
-					"strength": "example",
-					"description": "A code that identifies the reason a procedure was not performed.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/procedure-not-performed-reason"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.statusReason"
-					},
-					{
-						"identity": "rim",
-						"map": ".reason.Observation.value"
-					}
-				]
-			},
-			{
-				"id": "Procedure.category",
-				"path": "Procedure.category",
-				"short": "Classification of the procedure",
-				"definition": "A code that classifies the procedure for searching, sorting and display purposes (e.g. \"Surgical Procedure\").",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Procedure.category",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProcedureCategory"
-						}
-					],
-					"strength": "example",
-					"description": "A code that classifies a procedure for searching, sorting and display purposes.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/procedure-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Procedure.code",
-				"path": "Procedure.code",
-				"short": "Identification of the procedure",
-				"definition": "The specific procedure that is performed. Use text if the exact nature of the procedure cannot be coded (e.g. \"Laparoscopic Appendectomy\").",
-				"requirements": "0..1 to account for primarily narrative only resources.",
-				"alias": [
-					"type"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Procedure.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Codes describing the type of  Procedure",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-code"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-44/OBR-45"
-					},
-					{
-						"identity": "rim",
-						"map": ".code"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Procedure.code"
-					}
-				]
-			},
-			{
-				"id": "Procedure.subject",
-				"path": "Procedure.subject",
-				"short": "Who the procedure was performed on",
-				"definition": "The person, animal or group on which the procedure was performed.",
-				"alias": [
-					"patient"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Procedure.subject",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=SBJ].role"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Procedure.subject"
-					}
-				]
-			},
-			{
-				"id": "Procedure.encounter",
-				"path": "Procedure.encounter",
-				"short": "Encounter created as part of",
-				"definition": "The Encounter during which this Procedure was created or performed or to which the creation of this record is tightly associated.",
-				"comment": "This will typically be the encounter the event occurred within, but some activities may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Procedure.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1-19"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Procedure.performed[x]",
-				"path": "Procedure.performed[x]",
-				"short": "When the procedure was performed",
-				"definition": "Estimated or actual date, date-time, period, or age when the procedure was performed.  Allows a period to support complex procedures that span more than one date, and also allows for the length of the procedure to be captured.",
-				"comment": "Age is generally used when the patient reports an age at which the procedure was performed. Range is generally used when the patient reports an age range when the procedure was performed, such as sometime between 20-25 years old.  dateTime supports a range of precision due to some procedures being reported as past procedures that might not have millisecond precision while other procedures performed and documented during the encounter might have more precise UTC timestamps with timezone.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Procedure.performed[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "Age"
-					},
-					{
-						"code": "Range"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR-7"
-					},
-					{
-						"identity": "rim",
-						"map": ".effectiveTime"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Procedure.performed[x]"
-					}
-				]
-			},
-			{
-				"id": "Procedure.recorder",
-				"path": "Procedure.recorder",
-				"short": "Who recorded the procedure",
-				"definition": "Individual who recorded the record and takes responsibility for its content.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Procedure.recorder",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson",
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.author"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=AUT].role"
-					}
-				]
-			},
-			{
-				"id": "Procedure.asserter",
-				"path": "Procedure.asserter",
-				"short": "Person who asserts this procedure",
-				"definition": "Individual who is making the procedure statement.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Procedure.asserter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson",
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.source"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=INF].role"
-					}
-				]
-			},
-			{
-				"id": "Procedure.performer",
-				"path": "Procedure.performer",
-				"short": "The people who performed the procedure",
-				"definition": "Limited to \"real\" people rather than equipment.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.performer",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=PRF]"
-					}
-				]
-			},
-			{
-				"id": "Procedure.performer.id",
-				"path": "Procedure.performer.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Procedure.performer.extension",
-				"path": "Procedure.performer.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Procedure.performer.modifierExtension",
-				"path": "Procedure.performer.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Procedure.performer.function",
-				"path": "Procedure.performer.function",
-				"short": "Type of performance",
-				"definition": "Distinguishes the type of involvement of the performer in the procedure. For example, surgeon, anaesthetist, endoscopist.",
-				"requirements": "Allows disambiguation of the types of involvement of different performers.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Procedure.performer.function",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProcedurePerformerRole"
-						}
-					],
-					"strength": "example",
-					"description": "A code that identifies the role of a performer of the procedure.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/performer-role"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.function"
-					},
-					{
-						"identity": "v2",
-						"map": "Some combination of STF-18 / PRA-3 / PRT-4 / ROL-3 / ORC-12 / OBR-16 / PV1-7 / PV1-8 / PV1-9 / PV1-17 / OBX-25"
-					},
-					{
-						"identity": "rim",
-						"map": ".functionCode"
-					}
-				]
-			},
-			{
-				"id": "Procedure.performer.actor",
-				"path": "Procedure.performer.actor",
-				"short": "The reference to the practitioner",
-				"definition": "The practitioner who was involved in the procedure.",
-				"requirements": "A reference to Device supports use cases, such as pacemakers.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Procedure.performer.actor",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson",
-							"http://hl7.org/fhir/StructureDefinition/Device"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC-19/PRT-5"
-					},
-					{
-						"identity": "rim",
-						"map": ".role"
-					}
-				]
-			},
-			{
-				"id": "Procedure.performer.onBehalfOf",
-				"path": "Procedure.performer.onBehalfOf",
-				"short": "Organization the device or practitioner was acting for",
-				"definition": "The organization the device or practitioner was acting on behalf of.",
-				"requirements": "Practitioners and Devices can be associated with multiple organizations.  This element indicates which organization they were acting on behalf of when performing the action.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Procedure.performer.onBehalfOf",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".scoper"
-					}
-				]
-			},
-			{
-				"id": "Procedure.location",
-				"path": "Procedure.location",
-				"short": "Where the procedure happened",
-				"definition": "The location where the procedure actually happened.  E.g. a newborn at home, a tracheostomy at a restaurant.",
-				"requirements": "Ties a procedure to where the records are likely kept.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Procedure.location",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Location"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.where[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=LOC].role[classCode=SDLOC]"
-					}
-				]
-			},
-			{
-				"id": "Procedure.reasonCode",
-				"path": "Procedure.reasonCode",
-				"short": "Coded reason procedure performed",
-				"definition": "The coded reason why the procedure was performed. This may be a coded entity of some type, or may simply be present as text.",
-				"comment": "Use Procedure.reasonCode when a code sufficiently describes the reason.  Use Procedure.reasonReference when referencing a resource, which allows more information to be conveyed, such as onset date. Procedure.reasonCode and Procedure.reasonReference are not meant to be duplicative.  For a single reason, either Procedure.reasonCode or Procedure.reasonReference can be used.  Procedure.reasonCode may be a summary code, or Procedure.reasonReference may be used to reference a very precise definition of the reason using Condition | Observation | Procedure | DiagnosticReport | DocumentReference.  Both Procedure.reasonCode and Procedure.reasonReference can be used if they are describing different reasons for the procedure.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.reasonCode",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProcedureReason"
-						}
-					],
-					"strength": "example",
-					"description": "A code that identifies the reason a procedure is  required.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/procedure-reason"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.reasonCode"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.why[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".reasonCode"
-					}
-				]
-			},
-			{
-				"id": "Procedure.reasonReference",
-				"path": "Procedure.reasonReference",
-				"short": "The justification that the procedure was performed",
-				"definition": "The justification of why the procedure was performed.",
-				"comment": "It is possible for a procedure to be a reason (such as C-Section) for another procedure (such as an epidural). Other examples include endoscopy for dilatation and biopsy (a combination of diagnostic and therapeutic use). \nUse Procedure.reasonCode when a code sufficiently describes the reason.  Use Procedure.reasonReference when referencing a resource, which allows more information to be conveyed, such as onset date. Procedure.reasonCode and Procedure.reasonReference are not meant to be duplicative.  For a single reason, either Procedure.reasonCode or Procedure.reasonReference can be used.  Procedure.reasonCode may be a summary code, or Procedure.reasonReference may be used to reference a very precise definition of the reason using Condition | Observation | Procedure | DiagnosticReport | DocumentReference.  Both Procedure.reasonCode and Procedure.reasonReference can be used if they are describing different reasons for the procedure.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.reasonReference",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Condition",
-							"http://hl7.org/fhir/StructureDefinition/Observation",
-							"http://hl7.org/fhir/StructureDefinition/Procedure",
-							"http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
-							"http://hl7.org/fhir/StructureDefinition/DocumentReference"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.reasonReference"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.why[x]"
-					},
-					{
-						"identity": "rim",
-						"map": ".reasonCode"
-					}
-				]
-			},
-			{
-				"id": "Procedure.bodySite",
-				"path": "Procedure.bodySite",
-				"short": "Target body sites",
-				"definition": "Detailed and structured anatomical location information. Multiple locations are allowed - e.g. multiple punch biopsies of a lesion.",
-				"comment": "If the use case requires attributes from the BodySite resource (e.g. to identify and track separately) then use the standard extension [procedure-targetbodystructure](http://hl7.org/fhir/R4/extension-procedure-targetbodystructure.html).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.bodySite",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "BodySite"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing anatomical locations. May include laterality.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/body-site"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-20"
-					},
-					{
-						"identity": "rim",
-						"map": ".targetSiteCode"
-					}
-				]
-			},
-			{
-				"id": "Procedure.outcome",
-				"path": "Procedure.outcome",
-				"short": "The result of procedure",
-				"definition": "The outcome of the procedure - did it resolve the reasons for the procedure being performed?",
-				"comment": "If outcome contains narrative text only, it can be captured using the CodeableConcept.text.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Procedure.outcome",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProcedureOutcome"
-						}
-					],
-					"strength": "example",
-					"description": "An outcome of a procedure - whether it was resolved or otherwise.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/procedure-outcome"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=OUT].target.text"
-					}
-				]
-			},
-			{
-				"id": "Procedure.report",
-				"path": "Procedure.report",
-				"short": "Any report resulting from the procedure",
-				"definition": "This could be a histology result, pathology report, surgical report, etc.",
-				"comment": "There could potentially be multiple reports - e.g. if this was a procedure which took multiple biopsies resulting in a number of anatomical pathology reports.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.report",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
-							"http://hl7.org/fhir/StructureDefinition/DocumentReference",
-							"http://hl7.org/fhir/StructureDefinition/Composition"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Procedure.complication",
-				"path": "Procedure.complication",
-				"short": "Complication following the procedure",
-				"definition": "Any complications that occurred during the procedure, or in the immediate post-performance period. These are generally tracked separately from the notes, which will typically describe the procedure itself rather than any 'post procedure' issues.",
-				"comment": "If complications are only expressed by the narrative text, they can be captured using the CodeableConcept.text.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.complication",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProcedureComplication"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing complications that resulted from a procedure.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/condition-code"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=OUTC].target[classCode=OBS, code=\"complication\", moodCode=EVN].value"
-					}
-				]
-			},
-			{
-				"id": "Procedure.complicationDetail",
-				"path": "Procedure.complicationDetail",
-				"short": "A condition that is a result of the procedure",
-				"definition": "Any complications that occurred during the procedure, or in the immediate post-performance period.",
-				"requirements": "This is used to document a condition that is a result of the procedure, not the condition that was the reason for the procedure.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.complicationDetail",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Condition"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=OUTC].target[classCode=OBS, code=\"complication\", moodCode=EVN].value"
-					}
-				]
-			},
-			{
-				"id": "Procedure.followUp",
-				"path": "Procedure.followUp",
-				"short": "Instructions for follow up",
-				"definition": "If the procedure required specific follow up - e.g. removal of sutures. The follow up may be represented as a simple note or could potentially be more complex, in which case the CarePlan resource can be used.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.followUp",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProcedureFollowUp"
-						}
-					],
-					"strength": "example",
-					"description": "Specific follow up required for a procedure e.g. removal of sutures.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/procedure-followup"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=COMP].target[classCode=ACT, moodCode=INT].code"
-					}
-				]
-			},
-			{
-				"id": "Procedure.note",
-				"path": "Procedure.note",
-				"short": "Additional information about the procedure",
-				"definition": "Any other notes and comments about the procedure.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.note"
-					},
-					{
-						"identity": "v2",
-						"map": "NTE"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "Procedure.focalDevice",
-				"path": "Procedure.focalDevice",
-				"short": "Manipulated, implanted, or removed device",
-				"definition": "A device that is implanted, removed or otherwise manipulated (calibration, battery replacement, fitting a prosthesis, attaching a wound-vac, etc.) as a focal portion of the Procedure.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.focalDevice",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=DEV].role[classCode=MANU]"
-					}
-				]
-			},
-			{
-				"id": "Procedure.focalDevice.id",
-				"path": "Procedure.focalDevice.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Procedure.focalDevice.extension",
-				"path": "Procedure.focalDevice.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Procedure.focalDevice.modifierExtension",
-				"path": "Procedure.focalDevice.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Procedure.focalDevice.action",
-				"path": "Procedure.focalDevice.action",
-				"short": "Kind of change to device",
-				"definition": "The kind of change that happened to the device during the procedure.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Procedure.focalDevice.action",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "DeviceActionKind"
-						}
-					],
-					"strength": "preferred",
-					"description": "A kind of change that happened to the device during the procedure.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/device-action"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"procedure device action\"].value=:procedure device action codes"
-					}
-				]
-			},
-			{
-				"id": "Procedure.focalDevice.manipulated",
-				"path": "Procedure.focalDevice.manipulated",
-				"short": "Device that was changed",
-				"definition": "The device that was manipulated (changed) during the procedure.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Procedure.focalDevice.manipulated",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Device"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=DEV].role[classCode=SDLOC]"
-					}
-				]
-			},
-			{
-				"id": "Procedure.usedReference",
-				"path": "Procedure.usedReference",
-				"short": "Items used during procedure",
-				"definition": "Identifies medications, devices and any other substance used as part of the procedure.",
-				"comment": "For devices actually implanted or removed, use Procedure.device.",
-				"requirements": "Used for tracking contamination, etc.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.usedReference",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/Medication",
-							"http://hl7.org/fhir/StructureDefinition/Substance"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".participation[typeCode=DEV].role[classCode=MANU] or\n.participation[typeCode=CSM].role[classCode=ADMM] (for Medication or Substance)"
-					}
-				]
-			},
-			{
-				"id": "Procedure.usedCode",
-				"path": "Procedure.usedCode",
-				"short": "Coded items used during the procedure",
-				"definition": "Identifies coded items that were used as part of the procedure.",
-				"comment": "For devices actually implanted or removed, use Procedure.device.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Procedure.usedCode",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProcedureUsed"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing items used during a procedure.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/device-kind"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=Dev].role[classCode=MANU]"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Procedure",
-				"path": "Procedure",
-				"definition": "The US Core Condition Profile is based upon the core FHIR Procedure Resource and created to meet the 2015 Edition Common Clinical Data Set 'Procedures' requirements.",
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Procedure"
-					}
-				]
-			},
-			{
-				"id": "Procedure.status",
-				"path": "Procedure.status",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/event-status"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Procedure.status"
-					}
-				]
-			},
-			{
-				"id": "Procedure.code",
-				"path": "Procedure.code",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Codes describing the type of  Procedure",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-code"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Procedure.code"
-					}
-				]
-			},
-			{
-				"id": "Procedure.subject",
-				"path": "Procedure.subject",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Procedure.subject"
-					}
-				]
-			},
-			{
-				"id": "Procedure.performed[x]",
-				"path": "Procedure.performed[x]",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "Age"
-					},
-					{
-						"code": "Range"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Procedure.performed[x]"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-procedure",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure",
+    "version": "4.0.0",
+    "name": "USCoreProcedureProfile",
+    "title": "US Core Procedure Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-06-29",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the Procedure resource for the minimal set of data to query and retrieve patient's procedure information.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Procedure",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Procedure",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Procedure",
+                "path": "Procedure",
+                "short": "An action that is being or was performed on a patient",
+                "definition": "The US Core Condition Profile is based upon the core FHIR Procedure Resource and created to meet the 2015 Edition Common Clinical Data Set 'Procedures' requirements.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Procedure[moodCode=EVN]"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Procedure"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.id",
+                "path": "Procedure.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Procedure.meta",
+                "path": "Procedure.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Procedure.implicitRules",
+                "path": "Procedure.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Procedure.language",
+                "path": "Procedure.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Procedure.text",
+                "path": "Procedure.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.contained",
+                "path": "Procedure.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.extension",
+                "path": "Procedure.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.modifierExtension",
+                "path": "Procedure.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.identifier",
+                "path": "Procedure.identifier",
+                "short": "External Identifiers for this procedure",
+                "definition": "Business identifiers assigned to this procedure by the performer or other systems which remain constant as the resource is updated and is propagated from server to server.",
+                "comment": "This is a business identifier, not a resource identifier (see [discussion](http://hl7.org/fhir/R4/resource.html#identifiers)).  It is best practice for the identifier to only appear on a single resource instance, however business practices may occasionally dictate that multiple resource instances with the same identifier can exist - possibly even with different resource types.  For example, multiple Patient and Person resource instances might share the same social insurance number.",
+                "requirements": "Allows identification of the procedure as it is known by various participating systems and in a way that remains consistent across servers.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "Some combination of ORC-2 / ORC-3 / OBR-2 / OBR-3 / IPC-1 / IPC-2 / IPC-3 / IPC-4"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.instantiatesCanonical",
+                "path": "Procedure.instantiatesCanonical",
+                "short": "Instantiates FHIR protocol or definition",
+                "definition": "The URL pointing to a FHIR-defined protocol, guideline, order set or other definition that is adhered to in whole or in part by this Procedure.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.instantiatesCanonical",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "canonical",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/PlanDefinition",
+                            "http://hl7.org/fhir/StructureDefinition/ActivityDefinition",
+                            "http://hl7.org/fhir/StructureDefinition/Measure",
+                            "http://hl7.org/fhir/StructureDefinition/OperationDefinition",
+                            "http://hl7.org/fhir/StructureDefinition/Questionnaire"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.instantiatesCanonical"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=DEFN].target"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.instantiatesUri",
+                "path": "Procedure.instantiatesUri",
+                "short": "Instantiates external protocol or definition",
+                "definition": "The URL pointing to an externally maintained protocol, guideline, order set or other definition that is adhered to in whole or in part by this Procedure.",
+                "comment": "This might be an HTML page, PDF, etc. or could just be a non-resolvable URI identifier.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.instantiatesUri",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.instantiatesUri"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=DEFN].target"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.basedOn",
+                "path": "Procedure.basedOn",
+                "short": "A request for this procedure",
+                "definition": "A reference to a resource that contains details of the request for this procedure.",
+                "alias": [
+                    "fulfills"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.basedOn"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=FLFS].target[classCode=(various e.g. PROC, OBS, PCPR, ACT,  moodCode=RQO].code"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.partOf",
+                "path": "Procedure.partOf",
+                "short": "Part of referenced event",
+                "definition": "A larger event of which this particular procedure is a component or step.",
+                "comment": "The MedicationAdministration resource has a partOf reference to Procedure, but this is not a circular reference.   For example, the anesthesia MedicationAdministration is part of the surgical Procedure (MedicationAdministration.partOf = Procedure).  For example, the procedure to insert the IV port for an IV medication administration is part of the medication administration (Procedure.partOf = MedicationAdministration).",
+                "alias": [
+                    "container"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.partOf",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Procedure",
+                            "http://hl7.org/fhir/StructureDefinition/Observation",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationAdministration"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.partOf"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[classCode=SBADM or PROC or OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.status",
+                "path": "Procedure.status",
+                "short": "preparation | in-progress | not-done | on-hold | stopped | completed | entered-in-error | unknown",
+                "definition": "A code specifying the state of the procedure. Generally, this will be the in-progress or completed state.",
+                "comment": "The \"unknown\" code is not to be used to convey other statuses.  The \"unknown\" code should be used when one of the statuses applies, but the authoring system doesn't know the current state of the procedure.\n\nThis element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labelled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/event-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "statusCode"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Procedure.status"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.statusReason",
+                "path": "Procedure.statusReason",
+                "short": "Reason for current status",
+                "definition": "Captures the reason for the current state of the procedure.",
+                "comment": "This is generally only used for \"exception\" statuses such as \"not-done\", \"suspended\" or \"aborted\". The reason for performing the event at all is captured in reasonCode, not here.",
+                "alias": [
+                    "Suspended Reason",
+                    "Cancelled Reason"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.statusReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProcedureNegationReason"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "A code that identifies the reason a procedure was not performed.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/procedure-not-performed-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.statusReason"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".reason.Observation.value"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.category",
+                "path": "Procedure.category",
+                "short": "Classification of the procedure",
+                "definition": "A code that classifies the procedure for searching, sorting and display purposes (e.g. \"Surgical Procedure\").",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.category",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProcedureCategory"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "A code that classifies a procedure for searching, sorting and display purposes.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/procedure-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.code",
+                "path": "Procedure.code",
+                "short": "Identification of the procedure",
+                "definition": "The specific procedure that is performed. Use text if the exact nature of the procedure cannot be coded (e.g. \"Laparoscopic Appendectomy\").",
+                "requirements": "0..1 to account for primarily narrative only resources.",
+                "alias": [
+                    "type"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Codes describing the type of  Procedure",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-code"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-44/OBR-45"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".code"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Procedure.code"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.subject",
+                "path": "Procedure.subject",
+                "short": "Who the procedure was performed on",
+                "definition": "The person, animal or group on which the procedure was performed.",
+                "alias": [
+                    "patient"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.subject",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=SBJ].role"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Procedure.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.encounter",
+                "path": "Procedure.encounter",
+                "short": "Encounter created as part of",
+                "definition": "The Encounter during which this Procedure was created or performed or to which the creation of this record is tightly associated.",
+                "comment": "This will typically be the encounter the event occurred within, but some activities may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1-19"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.performed[x]",
+                "path": "Procedure.performed[x]",
+                "short": "When the procedure was performed",
+                "definition": "Estimated or actual date, date-time, period, or age when the procedure was performed.  Allows a period to support complex procedures that span more than one date, and also allows for the length of the procedure to be captured.",
+                "comment": "Age is generally used when the patient reports an age at which the procedure was performed. Range is generally used when the patient reports an age range when the procedure was performed, such as sometime between 20-25 years old.  dateTime supports a range of precision due to some procedures being reported as past procedures that might not have millisecond precision while other procedures performed and documented during the encounter might have more precise UTC timestamps with timezone.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.performed[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "Age"
+                    },
+                    {
+                        "code": "Range"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".effectiveTime"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Procedure.performed[x]"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.recorder",
+                "path": "Procedure.recorder",
+                "short": "Who recorded the procedure",
+                "definition": "Individual who recorded the record and takes responsibility for its content.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.recorder",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.author"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=AUT].role"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.asserter",
+                "path": "Procedure.asserter",
+                "short": "Person who asserts this procedure",
+                "definition": "Individual who is making the procedure statement.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.asserter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.source"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=INF].role"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.performer",
+                "path": "Procedure.performer",
+                "short": "The people who performed the procedure",
+                "definition": "Limited to \"real\" people rather than equipment.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.performer",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=PRF]"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.performer.id",
+                "path": "Procedure.performer.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.performer.extension",
+                "path": "Procedure.performer.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.performer.modifierExtension",
+                "path": "Procedure.performer.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.performer.function",
+                "path": "Procedure.performer.function",
+                "short": "Type of performance",
+                "definition": "Distinguishes the type of involvement of the performer in the procedure. For example, surgeon, anaesthetist, endoscopist.",
+                "requirements": "Allows disambiguation of the types of involvement of different performers.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.performer.function",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProcedurePerformerRole"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "A code that identifies the role of a performer of the procedure.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/performer-role"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.function"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "Some combination of STF-18 / PRA-3 / PRT-4 / ROL-3 / ORC-12 / OBR-16 / PV1-7 / PV1-8 / PV1-9 / PV1-17 / OBX-25"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".functionCode"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.performer.actor",
+                "path": "Procedure.performer.actor",
+                "short": "The reference to the practitioner",
+                "definition": "The practitioner who was involved in the procedure.",
+                "requirements": "A reference to Device supports use cases, such as pacemakers.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.performer.actor",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+                            "http://hl7.org/fhir/StructureDefinition/Device"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC-19/PRT-5"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".role"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.performer.onBehalfOf",
+                "path": "Procedure.performer.onBehalfOf",
+                "short": "Organization the device or practitioner was acting for",
+                "definition": "The organization the device or practitioner was acting on behalf of.",
+                "requirements": "Practitioners and Devices can be associated with multiple organizations.  This element indicates which organization they were acting on behalf of when performing the action.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.performer.onBehalfOf",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".scoper"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.location",
+                "path": "Procedure.location",
+                "short": "Where the procedure happened",
+                "definition": "The location where the procedure actually happened.  E.g. a newborn at home, a tracheostomy at a restaurant.",
+                "requirements": "Ties a procedure to where the records are likely kept.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.location",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Location"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.where[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=LOC].role[classCode=SDLOC]"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.reasonCode",
+                "path": "Procedure.reasonCode",
+                "short": "Coded reason procedure performed",
+                "definition": "The coded reason why the procedure was performed. This may be a coded entity of some type, or may simply be present as text.",
+                "comment": "Use Procedure.reasonCode when a code sufficiently describes the reason.  Use Procedure.reasonReference when referencing a resource, which allows more information to be conveyed, such as onset date. Procedure.reasonCode and Procedure.reasonReference are not meant to be duplicative.  For a single reason, either Procedure.reasonCode or Procedure.reasonReference can be used.  Procedure.reasonCode may be a summary code, or Procedure.reasonReference may be used to reference a very precise definition of the reason using Condition | Observation | Procedure | DiagnosticReport | DocumentReference.  Both Procedure.reasonCode and Procedure.reasonReference can be used if they are describing different reasons for the procedure.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.reasonCode",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProcedureReason"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "A code that identifies the reason a procedure is  required.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/procedure-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.reasonCode"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.why[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".reasonCode"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.reasonReference",
+                "path": "Procedure.reasonReference",
+                "short": "The justification that the procedure was performed",
+                "definition": "The justification of why the procedure was performed.",
+                "comment": "It is possible for a procedure to be a reason (such as C-Section) for another procedure (such as an epidural). Other examples include endoscopy for dilatation and biopsy (a combination of diagnostic and therapeutic use). \nUse Procedure.reasonCode when a code sufficiently describes the reason.  Use Procedure.reasonReference when referencing a resource, which allows more information to be conveyed, such as onset date. Procedure.reasonCode and Procedure.reasonReference are not meant to be duplicative.  For a single reason, either Procedure.reasonCode or Procedure.reasonReference can be used.  Procedure.reasonCode may be a summary code, or Procedure.reasonReference may be used to reference a very precise definition of the reason using Condition | Observation | Procedure | DiagnosticReport | DocumentReference.  Both Procedure.reasonCode and Procedure.reasonReference can be used if they are describing different reasons for the procedure.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.reasonReference",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Condition",
+                            "http://hl7.org/fhir/StructureDefinition/Observation",
+                            "http://hl7.org/fhir/StructureDefinition/Procedure",
+                            "http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
+                            "http://hl7.org/fhir/StructureDefinition/DocumentReference"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.reasonReference"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.why[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".reasonCode"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.bodySite",
+                "path": "Procedure.bodySite",
+                "short": "Target body sites",
+                "definition": "Detailed and structured anatomical location information. Multiple locations are allowed - e.g. multiple punch biopsies of a lesion.",
+                "comment": "If the use case requires attributes from the BodySite resource (e.g. to identify and track separately) then use the standard extension [procedure-targetbodystructure](http://hl7.org/fhir/R4/extension-procedure-targetbodystructure.html).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.bodySite",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "BodySite"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing anatomical locations. May include laterality.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/body-site"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-20"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".targetSiteCode"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.outcome",
+                "path": "Procedure.outcome",
+                "short": "The result of procedure",
+                "definition": "The outcome of the procedure - did it resolve the reasons for the procedure being performed?",
+                "comment": "If outcome contains narrative text only, it can be captured using the CodeableConcept.text.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.outcome",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProcedureOutcome"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "An outcome of a procedure - whether it was resolved or otherwise.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/procedure-outcome"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=OUT].target.text"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.report",
+                "path": "Procedure.report",
+                "short": "Any report resulting from the procedure",
+                "definition": "This could be a histology result, pathology report, surgical report, etc.",
+                "comment": "There could potentially be multiple reports - e.g. if this was a procedure which took multiple biopsies resulting in a number of anatomical pathology reports.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.report",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/DiagnosticReport",
+                            "http://hl7.org/fhir/StructureDefinition/DocumentReference",
+                            "http://hl7.org/fhir/StructureDefinition/Composition"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.complication",
+                "path": "Procedure.complication",
+                "short": "Complication following the procedure",
+                "definition": "Any complications that occurred during the procedure, or in the immediate post-performance period. These are generally tracked separately from the notes, which will typically describe the procedure itself rather than any 'post procedure' issues.",
+                "comment": "If complications are only expressed by the narrative text, they can be captured using the CodeableConcept.text.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.complication",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProcedureComplication"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing complications that resulted from a procedure.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/condition-code"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=OUTC].target[classCode=OBS, code=\"complication\", moodCode=EVN].value"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.complicationDetail",
+                "path": "Procedure.complicationDetail",
+                "short": "A condition that is a result of the procedure",
+                "definition": "Any complications that occurred during the procedure, or in the immediate post-performance period.",
+                "requirements": "This is used to document a condition that is a result of the procedure, not the condition that was the reason for the procedure.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.complicationDetail",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Condition"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=OUTC].target[classCode=OBS, code=\"complication\", moodCode=EVN].value"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.followUp",
+                "path": "Procedure.followUp",
+                "short": "Instructions for follow up",
+                "definition": "If the procedure required specific follow up - e.g. removal of sutures. The follow up may be represented as a simple note or could potentially be more complex, in which case the CarePlan resource can be used.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.followUp",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProcedureFollowUp"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Specific follow up required for a procedure e.g. removal of sutures.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/procedure-followup"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=COMP].target[classCode=ACT, moodCode=INT].code"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.note",
+                "path": "Procedure.note",
+                "short": "Additional information about the procedure",
+                "definition": "Any other notes and comments about the procedure.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.note"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "NTE"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.focalDevice",
+                "path": "Procedure.focalDevice",
+                "short": "Manipulated, implanted, or removed device",
+                "definition": "A device that is implanted, removed or otherwise manipulated (calibration, battery replacement, fitting a prosthesis, attaching a wound-vac, etc.) as a focal portion of the Procedure.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.focalDevice",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=DEV].role[classCode=MANU]"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.focalDevice.id",
+                "path": "Procedure.focalDevice.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.focalDevice.extension",
+                "path": "Procedure.focalDevice.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.focalDevice.modifierExtension",
+                "path": "Procedure.focalDevice.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.focalDevice.action",
+                "path": "Procedure.focalDevice.action",
+                "short": "Kind of change to device",
+                "definition": "The kind of change that happened to the device during the procedure.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.focalDevice.action",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "DeviceActionKind"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A kind of change that happened to the device during the procedure.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/device-action"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=SUBJ].source[classCode=OBS, moodCode=EVN, code=\"procedure device action\"].value=:procedure device action codes"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.focalDevice.manipulated",
+                "path": "Procedure.focalDevice.manipulated",
+                "short": "Device that was changed",
+                "definition": "The device that was manipulated (changed) during the procedure.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Procedure.focalDevice.manipulated",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Device"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=DEV].role[classCode=SDLOC]"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.usedReference",
+                "path": "Procedure.usedReference",
+                "short": "Items used during procedure",
+                "definition": "Identifies medications, devices and any other substance used as part of the procedure.",
+                "comment": "For devices actually implanted or removed, use Procedure.device.",
+                "requirements": "Used for tracking contamination, etc.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.usedReference",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/Medication",
+                            "http://hl7.org/fhir/StructureDefinition/Substance"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".participation[typeCode=DEV].role[classCode=MANU] or\n.participation[typeCode=CSM].role[classCode=ADMM] (for Medication or Substance)"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.usedCode",
+                "path": "Procedure.usedCode",
+                "short": "Coded items used during the procedure",
+                "definition": "Identifies coded items that were used as part of the procedure.",
+                "comment": "For devices actually implanted or removed, use Procedure.device.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Procedure.usedCode",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProcedureUsed"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing items used during a procedure.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/device-kind"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=Dev].role[classCode=MANU]"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Procedure",
+                "path": "Procedure",
+                "definition": "The US Core Condition Profile is based upon the core FHIR Procedure Resource and created to meet the 2015 Edition Common Clinical Data Set 'Procedures' requirements.",
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Procedure"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.status",
+                "path": "Procedure.status",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/event-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Procedure.status"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.code",
+                "path": "Procedure.code",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Codes describing the type of  Procedure",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-code"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Procedure.code"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.subject",
+                "path": "Procedure.subject",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Procedure.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Procedure.performed[x]",
+                "path": "Procedure.performed[x]",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "Age"
+                    },
+                    {
+                        "code": "Range"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Procedure.performed[x]"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-provenance.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-provenance.json
@@ -1,2962 +1,2962 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-provenance",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-provenance-definitions.html#Provenance\" title=\"The US Core Provenance Profile is based upon the Argonaut Data Query requirements.\">Provenance</a><a name=\"Provenance\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/provenance.html\">Provenance</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">US Core Provenance</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-provenance-definitions.html#Provenance.target\">target</a><a name=\"Provenance.target\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"http://hl7.org/fhir/R4/resource.html\">Resource</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">The Resource this Provenance record supports<br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-provenance-definitions.html#Provenance.target.reference\">reference</a><a name=\"Provenance.target.reference\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..<span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Literal reference, Relative, internal or absolute URL</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-provenance-definitions.html#Provenance.recorded\" title=\"The instant of time at which the activity was recorded.\">recorded</a><a name=\"Provenance.recorded\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#instant\">instant</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Timestamp when the activity was recorded / updated</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck03.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Slice Definition\" class=\"hierarchy\"/> <a style=\"font-style: italic\" href=\"StructureDefinition-us-core-provenance-definitions.html#Provenance.agent\">Slices for agent</a><a name=\"Provenance.agent\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red; font-style: italic\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"font-style: italic\"/><span style=\"font-style: italic\">1</span><span style=\"font-style: italic\">..</span><span style=\"font-style: italic\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5; font-style: italic\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5; font-style: italic\">Actor involved</span><br style=\"font-style: italic\"/><span style=\"font-weight:bold; font-style: italic\">Slice: </span><span style=\"font-style: italic\">Unordered, Open by pattern:type</span><br style=\"font-style: italic\"/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck033.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> agent:All Slices<a name=\"Provenance.agent\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Content/Rules for all slices</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0330.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-provenance-definitions.html#Provenance.agent.type\">type</a><a name=\"Provenance.agent.type\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">How the agent participated</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-provenance-participant-type.html\">US Core Provenance Participant Type Codes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0330.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-provenance-definitions.html#Provenance.agent.who\">who</a><a name=\"Provenance.agent.who\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-practitioner.html\">US Core Practitioner Profile</a> <span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This target must be supported\">S</span> | <a href=\"StructureDefinition-us-core-organization.html\">US Core Organization Profile</a> | <a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a> | <a href=\"StructureDefinition-us-core-practitionerrole.html\">US Core PractitionerRole Profile</a> | <a href=\"http://hl7.org/fhir/R4/relatedperson.html\">RelatedPerson</a> | <a href=\"http://hl7.org/fhir/R4/device.html\">Device</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who participated</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0320.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-provenance-definitions.html#Provenance.agent.onBehalfOf\">onBehalfOf</a><a name=\"Provenance.agent.onBehalfOf\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span><span style=\"padding-left: 3px; padding-right: 3px; color: black; null\" title=\"This element has or is affected by some invariants (provenance-1)\">I</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-organization.html\">US Core Organization Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who the agent is representing</span><br/><span style=\"font-weight:bold\">provenance-1: </span>onBehalfOf SHALL be present when Provenance.agent.who is a Practitioner or Device</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck035.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-provenance-definitions.html#Provenance.agent:ProvenanceAuthor\" title=\"Slice ProvenanceAuthor\">agent:ProvenanceAuthor</a><a name=\"Provenance.agent\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Actor involved</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0341.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-provenance-definitions.html#Provenance.agent:ProvenanceAuthor.type\">type</a><a name=\"Provenance.agent.type\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">How the agent participated</span><br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck03401.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#CodeableConcept.coding\">coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Code defined by a terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">(complex)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck034010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"https://terminology.hl7.org/1.0.0//CodeSystem-provenance-participant-type.html\">http://terminology.hl7.org/CodeSystem/provenance-participant-type</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck034000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">author</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck025.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-provenance-definitions.html#Provenance.agent:ProvenanceTransmitter\" title=\"Slice ProvenanceTransmitter: The entity that provided the copy to your system.\">agent:ProvenanceTransmitter</a><a name=\"Provenance.agent\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Actor involved</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0241.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-provenance-definitions.html#Provenance.agent:ProvenanceTransmitter.type\">type</a><a name=\"Provenance.agent.type\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">How the agent participated</span><br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck02401.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#CodeableConcept.coding\">coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Code defined by a terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">(complex)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck024010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"CodeSystem-us-core-provenance-participant-type.html\">http://hl7.org/fhir/us/core/CodeSystem/us-core-provenance-participant-type</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck024000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">transmitter</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance",
-	"version": "4.0.0",
-	"name": "USCoreProvenance",
-	"title": "US Core Provenance Profile",
-	"status": "active",
-	"date": "2019-08-05",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Draft set of requirements to satisfy Basic Provenance Requirements.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w3c.prov",
-			"uri": "http://www.w3.org/ns/prov",
-			"name": "W3C PROV"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "fhirauditevent",
-			"uri": "http://hl7.org/fhir/auditevent",
-			"name": "FHIR AuditEvent Mapping"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Provenance",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Provenance",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Provenance",
-				"path": "Provenance",
-				"short": "US Core Provenance",
-				"definition": "The US Core Provenance Profile is based upon the Argonaut Data Query requirements.",
-				"comment": "Some parties may be duplicated between the target resource and its provenance.  For instance, the prescriber is usually (but not always) the author of the prescription resource. This resource is defined with close consideration for W3C Provenance.",
-				"alias": [
-					"History",
-					"Event",
-					"Activity",
-					"Basic Provenance"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Provenance",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "rim",
-						"map": "ControlAct[isNormalAct() and subsumes(CACT, classCode) and moodCode=EVN]"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Activity"
-					}
-				]
-			},
-			{
-				"id": "Provenance.id",
-				"path": "Provenance.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Provenance.meta",
-				"path": "Provenance.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Provenance.implicitRules",
-				"path": "Provenance.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Provenance.language",
-				"path": "Provenance.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Provenance.text",
-				"path": "Provenance.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Provenance.contained",
-				"path": "Provenance.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Provenance.extension",
-				"path": "Provenance.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Provenance.modifierExtension",
-				"path": "Provenance.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Provenance.target",
-				"path": "Provenance.target",
-				"short": "The Resource this Provenance record supports",
-				"definition": "The Reference(s) that were generated or updated by  the activity described in this resource. A provenance can point to more than one target if multiple resources were created/updated by the same activity.",
-				"comment": "Target references are usually version specific, but might not be, if a version has not been assigned or if the provenance information is part of the set of resources being maintained (i.e. a document). When using the RESTful API, the identity of the resource might not be known (especially not the version specific one); the client may either submit the resource first, and then the provenance, or it may submit both using a single transaction. See the notes on transaction for further discussion.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Provenance.target",
-					"min": 1,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "rim",
-						"map": "./outboundRelationship[isNormalActRelationship() and typeCode=SUBJ]/target  OR  ./participation[isNormalParticipation() and typeCode=SBJ]/role  OR  ./participation[isNormalParticipation() and typeCode=SBJ]/role[isNormalRole()]/player"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.entity.reference"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Entity Created/Updated"
-					}
-				]
-			},
-			{
-				"id": "Provenance.target.id",
-				"path": "Provenance.target.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Provenance.target.extension",
-				"path": "Provenance.target.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Provenance.target.reference",
-				"path": "Provenance.target.reference",
-				"short": "Literal reference, Relative, internal or absolute URL",
-				"definition": "A reference to a location at which the other resource is found. The reference may be a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with '#') refer to contained resources.",
-				"comment": "Using absolute URLs provides a stable scalable approach suitable for a cloud/web context, while using relative/logical references provides a flexible approach suitable for use when trading across closed eco-system boundaries.   Absolute URLs do not need to point to a FHIR RESTful server, though this is the preferred approach. If the URL conforms to the structure \"/[type]/[id]\" then it should be assumed that the reference is to a FHIR RESTful server.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Reference.reference",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"condition": [
-					"ref-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Provenance.target.type",
-				"path": "Provenance.target.type",
-				"short": "Type the reference refers to (e.g. \"Patient\")",
-				"definition": "The expected type of the target of the reference. If both Reference.type and Reference.reference are populated and Reference.reference is a FHIR URL, both SHALL be consistent.\n\nThe type is the Canonical URL of Resource Definition that is the type this reference refers to. References are URLs that are relative to http://hl7.org/fhir/StructureDefinition/ e.g. \"Patient\" is a reference to http://hl7.org/fhir/StructureDefinition/Patient. Absolute URLs are only allowed for logical models (and can only be used in references in logical models, not resources).",
-				"comment": "This element is used to indicate the type of  the target of the reference. This may be used which ever of the other elements are populated (or not). In some cases, the type of the target may be determined by inspection of the reference (e.g. a RESTful URL) or by resolving the target of the reference; if both the type and a reference is provided, the reference SHALL resolve to a resource of the same type as that specified.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Reference.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "FHIRResourceTypeExt"
-						}
-					],
-					"strength": "extensible",
-					"description": "Aa resource (or, for logical models, the URI of the logical model).",
-					"valueSet": "http://hl7.org/fhir/ValueSet/resource-types"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Provenance.target.identifier",
-				"path": "Provenance.target.identifier",
-				"short": "Logical reference, when literal reference is not known",
-				"definition": "An identifier for the target resource. This is used when there is no way to reference the other resource directly, either because the entity it represents is not available through a FHIR server, or because there is no way for the author of the resource to convert a known identifier to an actual location. There is no requirement that a Reference.identifier point to something that is actually exposed as a FHIR instance, but it SHALL point to a business concept that would be expected to be exposed as a FHIR instance, and that instance would need to be of a FHIR resource type allowed by the reference.",
-				"comment": "When an identifier is provided in place of a reference, any system processing the reference will only be able to resolve the identifier to a reference if it understands the business context in which the identifier is used. Sometimes this is global (e.g. a national identifier) but often it is not. For this reason, none of the useful mechanisms described for working with references (e.g. chaining, includes) are possible, nor should servers be expected to be able resolve the reference. Servers may accept an identifier based reference untouched, resolve it, and/or reject it - see CapabilityStatement.rest.resource.referencePolicy. \n\nWhen both an identifier and a literal reference are provided, the literal reference is preferred. Applications processing the resource are allowed - but not required - to check that the identifier matches the literal reference\n\nApplications converting a logical reference to a literal reference may choose to leave the logical reference present, or remove it.\n\nReference is intended to point to a structure that can potentially be expressed as a FHIR resource, though there is no need for it to exist as an actual FHIR resource instance - except in as much as an application wishes to actual find the target of the reference. The content referred to be the identifier must meet the logical constraints implied by any limitations on what resource types are permitted for the reference.  For example, it would not be legitimate to send the identifier for a drug prescription if the type were Reference(Observation|DiagnosticReport).  One of the use-cases for Reference.identifier is the situation where no FHIR representation exists (where the type is Reference (Any).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Reference.identifier",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".identifier"
-					}
-				]
-			},
-			{
-				"id": "Provenance.target.display",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Provenance.target.display",
-				"short": "Text alternative for the resource",
-				"definition": "Plain text narrative that identifies the resource in addition to the resource reference.",
-				"comment": "This is generally not the same as the Resource.text of the referenced resource.  The purpose is to identify what's being referenced, not to fully describe it.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Reference.display",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Provenance.occurred[x]",
-				"path": "Provenance.occurred[x]",
-				"short": "When the activity occurred",
-				"definition": "The period during which the activity occurred.",
-				"comment": "The period can be a little arbitrary; where possible, the time should correspond to human assessment of the activity time.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Provenance.occurred[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Period"
-					},
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurred[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "rim",
-						"map": "./effectiveTime[type=IVL_TS]"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Activity.startTime & Activity.endTime"
-					}
-				]
-			},
-			{
-				"id": "Provenance.recorded",
-				"path": "Provenance.recorded",
-				"short": "Timestamp when the activity was recorded / updated",
-				"definition": "The instant of time at which the activity was recorded.",
-				"comment": "This can be a little different from the time stamp on the resource if there is a delay between recording the event and updating the provenance and target resource.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Provenance.recorded",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "rim",
-						"map": "unique(./participation[isNormalParticipation() and typeCode=AUT]/time[type=TS])"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.recorded"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Activity.when"
-					}
-				]
-			},
-			{
-				"id": "Provenance.policy",
-				"path": "Provenance.policy",
-				"short": "Policy or plan the activity was defined by",
-				"definition": "Policy or plan the activity was defined by. Typically, a single activity may have multiple applicable policy documents, such as patient consent, guarantor funding, etc.",
-				"comment": "For example: Where an OAuth token authorizes, the unique identifier from the OAuth token is placed into the policy element Where a policy engine (e.g. XACML) holds policy logic, the unique policy identifier is placed into the policy element.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Provenance.policy",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "./inboundRelationship[isNormalActRelationship() and typeCode=\"SUBJ\"]/source[isNormalAct and subsumes(POLICY, classCode) and moodCode=EVN]/text[typeCode='ED'/tel"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.agent.policy"
-					}
-				]
-			},
-			{
-				"id": "Provenance.location",
-				"path": "Provenance.location",
-				"short": "Where the activity occurred, if relevant",
-				"definition": "Where the activity occurred, if relevant.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Provenance.location",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Location"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.location"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.where[x]"
-					},
-					{
-						"identity": "rim",
-						"map": "unique(./participation[isNormalParticipation() and typeCode=LOC]/role[isNormalRole() and subsumes(SDLOC, classCode)]/player[isNormalEntity and classCode=\"LOC\" and determinerCode=\"INST\"]"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.agent.location"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Activity.location"
-					}
-				]
-			},
-			{
-				"id": "Provenance.reason",
-				"path": "Provenance.reason",
-				"short": "Reason the activity is occurring",
-				"definition": "The reason that the activity was taking place.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Provenance.reason",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProvenanceReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "The reason the activity took place.",
-					"valueSet": "http://terminology.hl7.org/ValueSet/v3-PurposeOfUse"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.reasonCode"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.why[x]"
-					},
-					{
-						"identity": "rim",
-						"map": "unique(./reasonCode)"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.purposeOfEvent"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Activity.Activity"
-					}
-				]
-			},
-			{
-				"id": "Provenance.activity",
-				"path": "Provenance.activity",
-				"short": "Activity that occurred",
-				"definition": "An activity is something that occurs over a period of time and acts upon or with entities; it may include consuming, processing, transforming, modifying, relocating, using, or generating entities.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Provenance.activity",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProvenanceActivity"
-						}
-					],
-					"strength": "extensible",
-					"description": "The activity that took place.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/provenance-activity-type"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.why[x]"
-					},
-					{
-						"identity": "rim",
-						"map": "Act.code"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Activity.Activity"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent",
-				"path": "Provenance.agent",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "type"
-						}
-					],
-					"rules": "open"
-				},
-				"short": "Actor involved",
-				"definition": "An actor taking a role in an activity  for which it can be assigned some degree of responsibility for the activity taking place.",
-				"comment": "Several agents may be associated (i.e. has some responsibility for an activity) with an activity and vice-versa.",
-				"requirements": "An agent can be a person, an organization, software, device, or other entities that may be ascribed responsibility.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Provenance.agent",
-					"min": 1,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.who"
-					},
-					{
-						"identity": "rim",
-						"map": "./participation[isNormalParticipation()]  OR  ./outboundRelationship[isNormalActRelationship() and typeCode='DRIV']"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.agent"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Agent"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent.id",
-				"path": "Provenance.agent.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent.extension",
-				"path": "Provenance.agent.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent.modifierExtension",
-				"path": "Provenance.agent.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent.type",
-				"path": "Provenance.agent.type",
-				"short": "How the agent participated",
-				"definition": "The participation the agent had with respect to the activity.",
-				"comment": "For example: author, performer, enterer, attester, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Provenance.agent.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-provenance-participant-type"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.function"
-					},
-					{
-						"identity": "rim",
-						"map": ".role"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.agent.type"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Agent.Attribution"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent.role",
-				"path": "Provenance.agent.role",
-				"short": "What the agents role was",
-				"definition": "The function of the agent with respect to the activity. The security role enabling the agent with respect to the activity.",
-				"comment": "For example: doctor, nurse, clerk, etc.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Provenance.agent.role",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProvenanceAgentRole"
-						}
-					],
-					"strength": "example",
-					"description": "The role that a provenance agent played with respect to the activity.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/security-role-type"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".typecode"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.agent.role"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent.who",
-				"path": "Provenance.agent.who",
-				"short": "Who participated",
-				"definition": "The individual, device or organization that participated in the event.",
-				"comment": "whoIdentity should be used when the agent is not a Resource type.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Provenance.agent.who",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson",
-							"http://hl7.org/fhir/StructureDefinition/Device"
-						],
-						"_targetProfile": [
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": true
-									},
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": true
-									},
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									},
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									},
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									},
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							null,
-							null,
-							null,
-							null,
-							null
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent.onBehalfOf",
-				"path": "Provenance.agent.onBehalfOf",
-				"short": "Who the agent is representing",
-				"definition": "The individual, device, or organization for whom the change was made.",
-				"comment": "onBehalfOfIdentity should be used when the agent is not a Resource type.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Provenance.agent.onBehalfOf",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "provenance-1",
-						"severity": "error",
-						"human": "onBehalfOf SHALL be present when Provenance.agent.who is a Practitioner or Device",
-						"expression": "((%resource.agent.who.resolve() is Practitioner) or (%resource.agent.who.resolve() is Device)) implies exists()"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Person, Practitioner, Organization, Device :* .role [classCode = RoleClassMutualRelationship; role.code and * .scopes[Role](classCode=IDENT) and *.plays [Role.Code]"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceAuthor",
-				"path": "Provenance.agent",
-				"sliceName": "ProvenanceAuthor",
-				"short": "Actor involved",
-				"definition": "An actor taking a role in an activity  for which it can be assigned some degree of responsibility for the activity taking place.",
-				"comment": "Several agents may be associated (i.e. has some responsibility for an activity) with an activity and vice-versa.",
-				"requirements": "An agent can be a person, an organization, software, device, or other entities that may be ascribed responsibility.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Provenance.agent",
-					"min": 1,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.who"
-					},
-					{
-						"identity": "rim",
-						"map": "./participation[isNormalParticipation()]  OR  ./outboundRelationship[isNormalActRelationship() and typeCode='DRIV']"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.agent"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Agent"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceAuthor.id",
-				"path": "Provenance.agent.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceAuthor.extension",
-				"path": "Provenance.agent.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceAuthor.modifierExtension",
-				"path": "Provenance.agent.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceAuthor.type",
-				"path": "Provenance.agent.type",
-				"short": "How the agent participated",
-				"definition": "The participation the agent had with respect to the activity.",
-				"comment": "For example: author, performer, enterer, attester, etc.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Provenance.agent.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-							"code": "author"
-						}
-					]
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProvenanceAgentType"
-						}
-					],
-					"strength": "extensible",
-					"description": "The type of participation that a provenance agent played with respect to the activity.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/provenance-agent-type"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.function"
-					},
-					{
-						"identity": "rim",
-						"map": ".role"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.agent.type"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Agent.Attribution"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceAuthor.role",
-				"path": "Provenance.agent.role",
-				"short": "What the agents role was",
-				"definition": "The function of the agent with respect to the activity. The security role enabling the agent with respect to the activity.",
-				"comment": "For example: doctor, nurse, clerk, etc.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Provenance.agent.role",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProvenanceAgentRole"
-						}
-					],
-					"strength": "example",
-					"description": "The role that a provenance agent played with respect to the activity.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/security-role-type"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".typecode"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.agent.role"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceAuthor.who",
-				"path": "Provenance.agent.who",
-				"short": "Who participated",
-				"definition": "The individual, device or organization that participated in the event.",
-				"comment": "whoIdentity should be used when the agent is not a Resource type.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Provenance.agent.who",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceAuthor.onBehalfOf",
-				"path": "Provenance.agent.onBehalfOf",
-				"short": "Who the agent is representing",
-				"definition": "The individual, device, or organization for whom the change was made.",
-				"comment": "onBehalfOfIdentity should be used when the agent is not a Resource type.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Provenance.agent.onBehalfOf",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Person, Practitioner, Organization, Device :* .role [classCode = RoleClassMutualRelationship; role.code and * .scopes[Role](classCode=IDENT) and *.plays [Role.Code]"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceTransmitter",
-				"path": "Provenance.agent",
-				"sliceName": "ProvenanceTransmitter",
-				"short": "Actor involved",
-				"definition": "The entity that provided the copy to your system.",
-				"comment": "Several agents may be associated (i.e. has some responsibility for an activity) with an activity and vice-versa.",
-				"requirements": "An agent can be a person, an organization, software, device, or other entities that may be ascribed responsibility.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Provenance.agent",
-					"min": 1,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.who"
-					},
-					{
-						"identity": "rim",
-						"map": "./participation[isNormalParticipation()]  OR  ./outboundRelationship[isNormalActRelationship() and typeCode='DRIV']"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.agent"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Agent"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceTransmitter.id",
-				"path": "Provenance.agent.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceTransmitter.extension",
-				"path": "Provenance.agent.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceTransmitter.modifierExtension",
-				"path": "Provenance.agent.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceTransmitter.type",
-				"path": "Provenance.agent.type",
-				"short": "How the agent participated",
-				"definition": "The participation the agent had with respect to the activity.",
-				"comment": "For example: author, performer, enterer, attester, etc.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Provenance.agent.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-provenance-participant-type",
-							"code": "transmitter"
-						}
-					]
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProvenanceAgentType"
-						}
-					],
-					"strength": "extensible",
-					"description": "The type of participation that a provenance agent played with respect to the activity.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/provenance-agent-type"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.function"
-					},
-					{
-						"identity": "rim",
-						"map": ".role"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.agent.type"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Agent.Attribution"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceTransmitter.role",
-				"path": "Provenance.agent.role",
-				"short": "What the agents role was",
-				"definition": "The function of the agent with respect to the activity. The security role enabling the agent with respect to the activity.",
-				"comment": "For example: doctor, nurse, clerk, etc.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Provenance.agent.role",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProvenanceAgentRole"
-						}
-					],
-					"strength": "example",
-					"description": "The role that a provenance agent played with respect to the activity.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/security-role-type"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": ".typecode"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.agent.role"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceTransmitter.who",
-				"path": "Provenance.agent.who",
-				"short": "Who participated",
-				"definition": "The individual, device or organization that participated in the event.",
-				"comment": "whoIdentity should be used when the agent is not a Resource type.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Provenance.agent.who",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "rim",
-						"map": ".id"
-					}
-				]
-			},
-			{
-				"id": "Provenance.agent:ProvenanceTransmitter.onBehalfOf",
-				"path": "Provenance.agent.onBehalfOf",
-				"short": "Who the agent is representing",
-				"definition": "The individual, device, or organization for whom the change was made.",
-				"comment": "onBehalfOfIdentity should be used when the agent is not a Resource type.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Provenance.agent.onBehalfOf",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/Organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Person, Practitioner, Organization, Device :* .role [classCode = RoleClassMutualRelationship; role.code and * .scopes[Role](classCode=IDENT) and *.plays [Role.Code]"
-					}
-				]
-			},
-			{
-				"id": "Provenance.entity",
-				"path": "Provenance.entity",
-				"short": "An entity used in this activity",
-				"definition": "An entity used in this activity.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Provenance.entity",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "./subjectOf"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.entity"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Entity"
-					}
-				]
-			},
-			{
-				"id": "Provenance.entity.id",
-				"path": "Provenance.entity.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Provenance.entity.extension",
-				"path": "Provenance.entity.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Provenance.entity.modifierExtension",
-				"path": "Provenance.entity.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Provenance.entity.role",
-				"path": "Provenance.entity.role",
-				"short": "derivation | revision | quotation | source | removal",
-				"definition": "How the entity was used during the activity.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Provenance.entity.role",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ProvenanceEntityRole"
-						}
-					],
-					"strength": "required",
-					"description": "How an entity was used in an activity.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/provenance-entity-role|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "./typeCode"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.entity.lifecycle"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Entity.role"
-					}
-				]
-			},
-			{
-				"id": "Provenance.entity.what",
-				"path": "Provenance.entity.what",
-				"short": "Identity of entity",
-				"definition": "Identity of the  Entity used. May be a logical or physical uri and maybe absolute or relative.",
-				"comment": "whatIdentity should be used for entities that are not a Resource type.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Provenance.entity.what",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "./text/reference"
-					},
-					{
-						"identity": "fhirauditevent",
-						"map": "AuditEvent.entity.reference"
-					},
-					{
-						"identity": "w3c.prov",
-						"map": "Entity.Identity"
-					}
-				]
-			},
-			{
-				"id": "Provenance.entity.agent",
-				"path": "Provenance.entity.agent",
-				"short": "Entity is attributed to this agent",
-				"definition": "The entity is attributed to an agent to express the agent's responsibility for that entity, possibly along with other agents. This description can be understood as shorthand for saying that the agent was responsible for the activity which generated the entity.",
-				"comment": "A usecase where one Provenance.entity.agent is used where the Entity that was used in the creation/updating of the Target, is not in the context of the same custodianship as the Target, and thus the meaning of Provenance.entity.agent is to say that the entity referenced is managed elsewhere and that this Agent provided access to it.  This would be similar to where the Entity being referenced is managed outside FHIR, such as through HL7 v2, v3, or XDS. This might be where the Entity being referenced is managed in another FHIR resource server. Thus it explains the Provenance of that Entity's use in the context of this Provenance activity.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Provenance.entity.agent",
-					"min": 0,
-					"max": "*"
-				},
-				"contentReference": "http://hl7.org/fhir/StructureDefinition/Provenance#Provenance.agent",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "./author/role"
-					}
-				]
-			},
-			{
-				"id": "Provenance.signature",
-				"path": "Provenance.signature",
-				"short": "Signature on target",
-				"definition": "A digital signature on the target Reference(s). The signer should match a Provenance.agent. The purpose of the signature is indicated.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Provenance.signature",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Signature"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "./signatureText"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Provenance",
-				"path": "Provenance",
-				"short": "US Core Provenance",
-				"definition": "The US Core Provenance Profile is based upon the Argonaut Data Query requirements.",
-				"alias": [
-					"Basic Provenance"
-				],
-				"mustSupport": false,
-				"isModifier": false
-			},
-			{
-				"id": "Provenance.target",
-				"path": "Provenance.target",
-				"short": "The Resource this Provenance record supports",
-				"min": 1,
-				"max": "*",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "Provenance.target.reference",
-				"path": "Provenance.target.reference",
-				"min": 1,
-				"mustSupport": true
-			},
-			{
-				"id": "Provenance.recorded",
-				"path": "Provenance.recorded",
-				"short": "Timestamp when the activity was recorded / updated",
-				"definition": "The instant of time at which the activity was recorded.",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "Provenance.agent",
-				"path": "Provenance.agent",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "type"
-						}
-					],
-					"rules": "open"
-				},
-				"min": 1,
-				"max": "*",
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "Provenance.agent.type",
-				"path": "Provenance.agent.type",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-provenance-participant-type"
-				}
-			},
-			{
-				"id": "Provenance.agent.who",
-				"path": "Provenance.agent.who",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson",
-							"http://hl7.org/fhir/StructureDefinition/Device"
-						],
-						"_targetProfile": [
-							{
-								"extension": [
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": true
-									},
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": true
-									},
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									},
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									},
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									},
-									{
-										"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-										"valueBoolean": false
-									}
-								]
-							},
-							null,
-							null,
-							null,
-							null,
-							null
-						]
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "Provenance.agent.onBehalfOf",
-				"path": "Provenance.agent.onBehalfOf",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "provenance-1",
-						"severity": "error",
-						"human": "onBehalfOf SHALL be present when Provenance.agent.who is a Practitioner or Device",
-						"expression": "((%resource.agent.who.resolve() is Practitioner) or (%resource.agent.who.resolve() is Device)) implies exists()"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "Provenance.agent:ProvenanceAuthor",
-				"path": "Provenance.agent",
-				"sliceName": "ProvenanceAuthor",
-				"min": 0,
-				"max": "*",
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "Provenance.agent:ProvenanceAuthor.type",
-				"path": "Provenance.agent.type",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
-							"code": "author"
-						}
-					]
-				},
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "Provenance.agent:ProvenanceTransmitter",
-				"path": "Provenance.agent",
-				"sliceName": "ProvenanceTransmitter",
-				"definition": "The entity that provided the copy to your system.",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true,
-				"isModifier": false
-			},
-			{
-				"id": "Provenance.agent:ProvenanceTransmitter.type",
-				"path": "Provenance.agent.type",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-provenance-participant-type",
-							"code": "transmitter"
-						}
-					]
-				},
-				"mustSupport": true,
-				"isModifier": false
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-provenance",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance",
+    "version": "4.0.0",
+    "name": "USCoreProvenance",
+    "title": "US Core Provenance Profile",
+    "status": "active",
+    "date": "2019-08-05",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Draft set of requirements to satisfy Basic Provenance Requirements.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w3c.prov",
+            "uri": "http://www.w3.org/ns/prov",
+            "name": "W3C PROV"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "fhirauditevent",
+            "uri": "http://hl7.org/fhir/auditevent",
+            "name": "FHIR AuditEvent Mapping"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Provenance",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Provenance",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Provenance",
+                "path": "Provenance",
+                "short": "US Core Provenance",
+                "definition": "The US Core Provenance Profile is based upon the Argonaut Data Query requirements.",
+                "comment": "Some parties may be duplicated between the target resource and its provenance.  For instance, the prescriber is usually (but not always) the author of the prescription resource. This resource is defined with close consideration for W3C Provenance.",
+                "alias": [
+                    "History",
+                    "Event",
+                    "Activity",
+                    "Basic Provenance"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Provenance",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "ControlAct[isNormalAct() and subsumes(CACT, classCode) and moodCode=EVN]"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Activity"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.id",
+                "path": "Provenance.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Provenance.meta",
+                "path": "Provenance.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Provenance.implicitRules",
+                "path": "Provenance.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Provenance.language",
+                "path": "Provenance.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Provenance.text",
+                "path": "Provenance.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.contained",
+                "path": "Provenance.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.extension",
+                "path": "Provenance.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.modifierExtension",
+                "path": "Provenance.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.target",
+                "path": "Provenance.target",
+                "short": "The Resource this Provenance record supports",
+                "definition": "The Reference(s) that were generated or updated by  the activity described in this resource. A provenance can point to more than one target if multiple resources were created/updated by the same activity.",
+                "comment": "Target references are usually version specific, but might not be, if a version has not been assigned or if the provenance information is part of the set of resources being maintained (i.e. a document). When using the RESTful API, the identity of the resource might not be known (especially not the version specific one); the client may either submit the resource first, and then the provenance, or it may submit both using a single transaction. See the notes on transaction for further discussion.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Provenance.target",
+                    "min": 1,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./outboundRelationship[isNormalActRelationship() and typeCode=SUBJ]/target  OR  ./participation[isNormalParticipation() and typeCode=SBJ]/role  OR  ./participation[isNormalParticipation() and typeCode=SBJ]/role[isNormalRole()]/player"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.entity.reference"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Entity Created/Updated"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.target.id",
+                "path": "Provenance.target.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.target.extension",
+                "path": "Provenance.target.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.target.reference",
+                "path": "Provenance.target.reference",
+                "short": "Literal reference, Relative, internal or absolute URL",
+                "definition": "A reference to a location at which the other resource is found. The reference may be a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with '#') refer to contained resources.",
+                "comment": "Using absolute URLs provides a stable scalable approach suitable for a cloud/web context, while using relative/logical references provides a flexible approach suitable for use when trading across closed eco-system boundaries.   Absolute URLs do not need to point to a FHIR RESTful server, though this is the preferred approach. If the URL conforms to the structure \"/[type]/[id]\" then it should be assumed that the reference is to a FHIR RESTful server.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Reference.reference",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "condition": [
+                    "ref-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.target.type",
+                "path": "Provenance.target.type",
+                "short": "Type the reference refers to (e.g. \"Patient\")",
+                "definition": "The expected type of the target of the reference. If both Reference.type and Reference.reference are populated and Reference.reference is a FHIR URL, both SHALL be consistent.\n\nThe type is the Canonical URL of Resource Definition that is the type this reference refers to. References are URLs that are relative to http://hl7.org/fhir/StructureDefinition/ e.g. \"Patient\" is a reference to http://hl7.org/fhir/StructureDefinition/Patient. Absolute URLs are only allowed for logical models (and can only be used in references in logical models, not resources).",
+                "comment": "This element is used to indicate the type of  the target of the reference. This may be used which ever of the other elements are populated (or not). In some cases, the type of the target may be determined by inspection of the reference (e.g. a RESTful URL) or by resolving the target of the reference; if both the type and a reference is provided, the reference SHALL resolve to a resource of the same type as that specified.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Reference.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "FHIRResourceTypeExt"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Aa resource (or, for logical models, the URI of the logical model).",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/resource-types"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.target.identifier",
+                "path": "Provenance.target.identifier",
+                "short": "Logical reference, when literal reference is not known",
+                "definition": "An identifier for the target resource. This is used when there is no way to reference the other resource directly, either because the entity it represents is not available through a FHIR server, or because there is no way for the author of the resource to convert a known identifier to an actual location. There is no requirement that a Reference.identifier point to something that is actually exposed as a FHIR instance, but it SHALL point to a business concept that would be expected to be exposed as a FHIR instance, and that instance would need to be of a FHIR resource type allowed by the reference.",
+                "comment": "When an identifier is provided in place of a reference, any system processing the reference will only be able to resolve the identifier to a reference if it understands the business context in which the identifier is used. Sometimes this is global (e.g. a national identifier) but often it is not. For this reason, none of the useful mechanisms described for working with references (e.g. chaining, includes) are possible, nor should servers be expected to be able resolve the reference. Servers may accept an identifier based reference untouched, resolve it, and/or reject it - see CapabilityStatement.rest.resource.referencePolicy. \n\nWhen both an identifier and a literal reference are provided, the literal reference is preferred. Applications processing the resource are allowed - but not required - to check that the identifier matches the literal reference\n\nApplications converting a logical reference to a literal reference may choose to leave the logical reference present, or remove it.\n\nReference is intended to point to a structure that can potentially be expressed as a FHIR resource, though there is no need for it to exist as an actual FHIR resource instance - except in as much as an application wishes to actual find the target of the reference. The content referred to be the identifier must meet the logical constraints implied by any limitations on what resource types are permitted for the reference.  For example, it would not be legitimate to send the identifier for a drug prescription if the type were Reference(Observation|DiagnosticReport).  One of the use-cases for Reference.identifier is the situation where no FHIR representation exists (where the type is Reference (Any).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Reference.identifier",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".identifier"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.target.display",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Provenance.target.display",
+                "short": "Text alternative for the resource",
+                "definition": "Plain text narrative that identifies the resource in addition to the resource reference.",
+                "comment": "This is generally not the same as the Resource.text of the referenced resource.  The purpose is to identify what's being referenced, not to fully describe it.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Reference.display",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.occurred[x]",
+                "path": "Provenance.occurred[x]",
+                "short": "When the activity occurred",
+                "definition": "The period during which the activity occurred.",
+                "comment": "The period can be a little arbitrary; where possible, the time should correspond to human assessment of the activity time.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.occurred[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Period"
+                    },
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurred[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./effectiveTime[type=IVL_TS]"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Activity.startTime & Activity.endTime"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.recorded",
+                "path": "Provenance.recorded",
+                "short": "Timestamp when the activity was recorded / updated",
+                "definition": "The instant of time at which the activity was recorded.",
+                "comment": "This can be a little different from the time stamp on the resource if there is a delay between recording the event and updating the provenance and target resource.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.recorded",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "unique(./participation[isNormalParticipation() and typeCode=AUT]/time[type=TS])"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.recorded"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Activity.when"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.policy",
+                "path": "Provenance.policy",
+                "short": "Policy or plan the activity was defined by",
+                "definition": "Policy or plan the activity was defined by. Typically, a single activity may have multiple applicable policy documents, such as patient consent, guarantor funding, etc.",
+                "comment": "For example: Where an OAuth token authorizes, the unique identifier from the OAuth token is placed into the policy element Where a policy engine (e.g. XACML) holds policy logic, the unique policy identifier is placed into the policy element.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Provenance.policy",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "./inboundRelationship[isNormalActRelationship() and typeCode=\"SUBJ\"]/source[isNormalAct and subsumes(POLICY, classCode) and moodCode=EVN]/text[typeCode='ED'/tel"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.agent.policy"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.location",
+                "path": "Provenance.location",
+                "short": "Where the activity occurred, if relevant",
+                "definition": "Where the activity occurred, if relevant.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.location",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Location"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.location"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.where[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "unique(./participation[isNormalParticipation() and typeCode=LOC]/role[isNormalRole() and subsumes(SDLOC, classCode)]/player[isNormalEntity and classCode=\"LOC\" and determinerCode=\"INST\"]"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.agent.location"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Activity.location"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.reason",
+                "path": "Provenance.reason",
+                "short": "Reason the activity is occurring",
+                "definition": "The reason that the activity was taking place.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Provenance.reason",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProvenanceReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "The reason the activity took place.",
+                    "valueSet": "http://terminology.hl7.org/ValueSet/v3-PurposeOfUse"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.reasonCode"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.why[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "unique(./reasonCode)"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.purposeOfEvent"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Activity.Activity"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.activity",
+                "path": "Provenance.activity",
+                "short": "Activity that occurred",
+                "definition": "An activity is something that occurs over a period of time and acts upon or with entities; it may include consuming, processing, transforming, modifying, relocating, using, or generating entities.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.activity",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProvenanceActivity"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "The activity that took place.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/provenance-activity-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.why[x]"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Act.code"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Activity.Activity"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent",
+                "path": "Provenance.agent",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "type"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "short": "Actor involved",
+                "definition": "An actor taking a role in an activity  for which it can be assigned some degree of responsibility for the activity taking place.",
+                "comment": "Several agents may be associated (i.e. has some responsibility for an activity) with an activity and vice-versa.",
+                "requirements": "An agent can be a person, an organization, software, device, or other entities that may be ascribed responsibility.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Provenance.agent",
+                    "min": 1,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.who"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./participation[isNormalParticipation()]  OR  ./outboundRelationship[isNormalActRelationship() and typeCode='DRIV']"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.agent"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Agent"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent.id",
+                "path": "Provenance.agent.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent.extension",
+                "path": "Provenance.agent.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent.modifierExtension",
+                "path": "Provenance.agent.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent.type",
+                "path": "Provenance.agent.type",
+                "short": "How the agent participated",
+                "definition": "The participation the agent had with respect to the activity.",
+                "comment": "For example: author, performer, enterer, attester, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.agent.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-provenance-participant-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.function"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".role"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.agent.type"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Agent.Attribution"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent.role",
+                "path": "Provenance.agent.role",
+                "short": "What the agents role was",
+                "definition": "The function of the agent with respect to the activity. The security role enabling the agent with respect to the activity.",
+                "comment": "For example: doctor, nurse, clerk, etc.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Provenance.agent.role",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProvenanceAgentRole"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "The role that a provenance agent played with respect to the activity.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/security-role-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".typecode"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.agent.role"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent.who",
+                "path": "Provenance.agent.who",
+                "short": "Who participated",
+                "definition": "The individual, device or organization that participated in the event.",
+                "comment": "whoIdentity should be used when the agent is not a Resource type.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.agent.who",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+                            "http://hl7.org/fhir/StructureDefinition/Device"
+                        ],
+                        "_targetProfile": [
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": true
+                                    },
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": true
+                                    },
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    },
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    },
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    },
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            null,
+                            null,
+                            null,
+                            null,
+                            null
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent.onBehalfOf",
+                "path": "Provenance.agent.onBehalfOf",
+                "short": "Who the agent is representing",
+                "definition": "The individual, device, or organization for whom the change was made.",
+                "comment": "onBehalfOfIdentity should be used when the agent is not a Resource type.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.agent.onBehalfOf",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "provenance-1",
+                        "severity": "error",
+                        "human": "onBehalfOf SHALL be present when Provenance.agent.who is a Practitioner or Device",
+                        "expression": "((%resource.agent.who.resolve() is Practitioner) or (%resource.agent.who.resolve() is Device)) implies exists()"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Person, Practitioner, Organization, Device :* .role [classCode = RoleClassMutualRelationship; role.code and * .scopes[Role](classCode=IDENT) and *.plays [Role.Code]"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceAuthor",
+                "path": "Provenance.agent",
+                "sliceName": "ProvenanceAuthor",
+                "short": "Actor involved",
+                "definition": "An actor taking a role in an activity  for which it can be assigned some degree of responsibility for the activity taking place.",
+                "comment": "Several agents may be associated (i.e. has some responsibility for an activity) with an activity and vice-versa.",
+                "requirements": "An agent can be a person, an organization, software, device, or other entities that may be ascribed responsibility.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Provenance.agent",
+                    "min": 1,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.who"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./participation[isNormalParticipation()]  OR  ./outboundRelationship[isNormalActRelationship() and typeCode='DRIV']"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.agent"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Agent"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceAuthor.id",
+                "path": "Provenance.agent.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceAuthor.extension",
+                "path": "Provenance.agent.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceAuthor.modifierExtension",
+                "path": "Provenance.agent.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceAuthor.type",
+                "path": "Provenance.agent.type",
+                "short": "How the agent participated",
+                "definition": "The participation the agent had with respect to the activity.",
+                "comment": "For example: author, performer, enterer, attester, etc.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.agent.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                            "code": "author"
+                        }
+                    ]
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProvenanceAgentType"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "The type of participation that a provenance agent played with respect to the activity.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/provenance-agent-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.function"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".role"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.agent.type"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Agent.Attribution"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceAuthor.role",
+                "path": "Provenance.agent.role",
+                "short": "What the agents role was",
+                "definition": "The function of the agent with respect to the activity. The security role enabling the agent with respect to the activity.",
+                "comment": "For example: doctor, nurse, clerk, etc.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Provenance.agent.role",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProvenanceAgentRole"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "The role that a provenance agent played with respect to the activity.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/security-role-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".typecode"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.agent.role"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceAuthor.who",
+                "path": "Provenance.agent.who",
+                "short": "Who participated",
+                "definition": "The individual, device or organization that participated in the event.",
+                "comment": "whoIdentity should be used when the agent is not a Resource type.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.agent.who",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceAuthor.onBehalfOf",
+                "path": "Provenance.agent.onBehalfOf",
+                "short": "Who the agent is representing",
+                "definition": "The individual, device, or organization for whom the change was made.",
+                "comment": "onBehalfOfIdentity should be used when the agent is not a Resource type.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.agent.onBehalfOf",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Person, Practitioner, Organization, Device :* .role [classCode = RoleClassMutualRelationship; role.code and * .scopes[Role](classCode=IDENT) and *.plays [Role.Code]"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceTransmitter",
+                "path": "Provenance.agent",
+                "sliceName": "ProvenanceTransmitter",
+                "short": "Actor involved",
+                "definition": "The entity that provided the copy to your system.",
+                "comment": "Several agents may be associated (i.e. has some responsibility for an activity) with an activity and vice-versa.",
+                "requirements": "An agent can be a person, an organization, software, device, or other entities that may be ascribed responsibility.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.agent",
+                    "min": 1,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.who"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./participation[isNormalParticipation()]  OR  ./outboundRelationship[isNormalActRelationship() and typeCode='DRIV']"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.agent"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Agent"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceTransmitter.id",
+                "path": "Provenance.agent.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceTransmitter.extension",
+                "path": "Provenance.agent.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceTransmitter.modifierExtension",
+                "path": "Provenance.agent.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceTransmitter.type",
+                "path": "Provenance.agent.type",
+                "short": "How the agent participated",
+                "definition": "The participation the agent had with respect to the activity.",
+                "comment": "For example: author, performer, enterer, attester, etc.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.agent.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-provenance-participant-type",
+                            "code": "transmitter"
+                        }
+                    ]
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProvenanceAgentType"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "The type of participation that a provenance agent played with respect to the activity.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/provenance-agent-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.function"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".role"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.agent.type"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Agent.Attribution"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceTransmitter.role",
+                "path": "Provenance.agent.role",
+                "short": "What the agents role was",
+                "definition": "The function of the agent with respect to the activity. The security role enabling the agent with respect to the activity.",
+                "comment": "For example: doctor, nurse, clerk, etc.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Provenance.agent.role",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProvenanceAgentRole"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "The role that a provenance agent played with respect to the activity.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/security-role-type"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": ".typecode"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.agent.role"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceTransmitter.who",
+                "path": "Provenance.agent.who",
+                "short": "Who participated",
+                "definition": "The individual, device or organization that participated in the event.",
+                "comment": "whoIdentity should be used when the agent is not a Resource type.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.agent.who",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".id"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.agent:ProvenanceTransmitter.onBehalfOf",
+                "path": "Provenance.agent.onBehalfOf",
+                "short": "Who the agent is representing",
+                "definition": "The individual, device, or organization for whom the change was made.",
+                "comment": "onBehalfOfIdentity should be used when the agent is not a Resource type.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.agent.onBehalfOf",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/Organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Person, Practitioner, Organization, Device :* .role [classCode = RoleClassMutualRelationship; role.code and * .scopes[Role](classCode=IDENT) and *.plays [Role.Code]"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.entity",
+                "path": "Provenance.entity",
+                "short": "An entity used in this activity",
+                "definition": "An entity used in this activity.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Provenance.entity",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "./subjectOf"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.entity"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Entity"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.entity.id",
+                "path": "Provenance.entity.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.entity.extension",
+                "path": "Provenance.entity.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.entity.modifierExtension",
+                "path": "Provenance.entity.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.entity.role",
+                "path": "Provenance.entity.role",
+                "short": "derivation | revision | quotation | source | removal",
+                "definition": "How the entity was used during the activity.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.entity.role",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ProvenanceEntityRole"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "How an entity was used in an activity.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/provenance-entity-role|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "./typeCode"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.entity.lifecycle"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Entity.role"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.entity.what",
+                "path": "Provenance.entity.what",
+                "short": "Identity of entity",
+                "definition": "Identity of the  Entity used. May be a logical or physical uri and maybe absolute or relative.",
+                "comment": "whatIdentity should be used for entities that are not a Resource type.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Provenance.entity.what",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "./text/reference"
+                    },
+                    {
+                        "identity": "fhirauditevent",
+                        "map": "AuditEvent.entity.reference"
+                    },
+                    {
+                        "identity": "w3c.prov",
+                        "map": "Entity.Identity"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.entity.agent",
+                "path": "Provenance.entity.agent",
+                "short": "Entity is attributed to this agent",
+                "definition": "The entity is attributed to an agent to express the agent's responsibility for that entity, possibly along with other agents. This description can be understood as shorthand for saying that the agent was responsible for the activity which generated the entity.",
+                "comment": "A usecase where one Provenance.entity.agent is used where the Entity that was used in the creation/updating of the Target, is not in the context of the same custodianship as the Target, and thus the meaning of Provenance.entity.agent is to say that the entity referenced is managed elsewhere and that this Agent provided access to it.  This would be similar to where the Entity being referenced is managed outside FHIR, such as through HL7 v2, v3, or XDS. This might be where the Entity being referenced is managed in another FHIR resource server. Thus it explains the Provenance of that Entity's use in the context of this Provenance activity.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Provenance.entity.agent",
+                    "min": 0,
+                    "max": "*"
+                },
+                "contentReference": "http://hl7.org/fhir/StructureDefinition/Provenance#Provenance.agent",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "./author/role"
+                    }
+                ]
+            },
+            {
+                "id": "Provenance.signature",
+                "path": "Provenance.signature",
+                "short": "Signature on target",
+                "definition": "A digital signature on the target Reference(s). The signer should match a Provenance.agent. The purpose of the signature is indicated.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Provenance.signature",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Signature"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "./signatureText"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Provenance",
+                "path": "Provenance",
+                "short": "US Core Provenance",
+                "definition": "The US Core Provenance Profile is based upon the Argonaut Data Query requirements.",
+                "alias": [
+                    "Basic Provenance"
+                ],
+                "mustSupport": false,
+                "isModifier": false
+            },
+            {
+                "id": "Provenance.target",
+                "path": "Provenance.target",
+                "short": "The Resource this Provenance record supports",
+                "min": 1,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "Provenance.target.reference",
+                "path": "Provenance.target.reference",
+                "min": 1,
+                "mustSupport": true
+            },
+            {
+                "id": "Provenance.recorded",
+                "path": "Provenance.recorded",
+                "short": "Timestamp when the activity was recorded / updated",
+                "definition": "The instant of time at which the activity was recorded.",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "Provenance.agent",
+                "path": "Provenance.agent",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "type"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "min": 1,
+                "max": "*",
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "Provenance.agent.type",
+                "path": "Provenance.agent.type",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-provenance-participant-type"
+                }
+            },
+            {
+                "id": "Provenance.agent.who",
+                "path": "Provenance.agent.who",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient",
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson",
+                            "http://hl7.org/fhir/StructureDefinition/Device"
+                        ],
+                        "_targetProfile": [
+                            {
+                                "extension": [
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": true
+                                    },
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": true
+                                    },
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    },
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    },
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    },
+                                    {
+                                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                        "valueBoolean": false
+                                    }
+                                ]
+                            },
+                            null,
+                            null,
+                            null,
+                            null,
+                            null
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "Provenance.agent.onBehalfOf",
+                "path": "Provenance.agent.onBehalfOf",
+                "min": 0,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "provenance-1",
+                        "severity": "error",
+                        "human": "onBehalfOf SHALL be present when Provenance.agent.who is a Practitioner or Device",
+                        "expression": "((%resource.agent.who.resolve() is Practitioner) or (%resource.agent.who.resolve() is Device)) implies exists()"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "Provenance.agent:ProvenanceAuthor",
+                "path": "Provenance.agent",
+                "sliceName": "ProvenanceAuthor",
+                "min": 0,
+                "max": "*",
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "Provenance.agent:ProvenanceAuthor.type",
+                "path": "Provenance.agent.type",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/provenance-participant-type",
+                            "code": "author"
+                        }
+                    ]
+                },
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "Provenance.agent:ProvenanceTransmitter",
+                "path": "Provenance.agent",
+                "sliceName": "ProvenanceTransmitter",
+                "definition": "The entity that provided the copy to your system.",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true,
+                "isModifier": false
+            },
+            {
+                "id": "Provenance.agent:ProvenanceTransmitter.type",
+                "path": "Provenance.agent.type",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-provenance-participant-type",
+                            "code": "transmitter"
+                        }
+                    ]
+                },
+                "mustSupport": true,
+                "isModifier": false
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-pulse-oximetry.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-pulse-oximetry.json
@@ -1,5503 +1,5503 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-pulse-oximetry",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation\" title=\"Defines constraints on the Observation resource to represent inspired O2 by pulse oximetry and inspired oxygen concentration observations with a standard LOINC codes and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.\">Observation</a><a name=\"Observation\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"StructureDefinition-us-core-vital-signs.html\">USCoreVitalSignsProfile</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">US Core Pulse Oximetry Profile</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.code\">code</a><a name=\"Observation.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">1</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Oxygen Saturation by Pulse Oximetry</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck103.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Slice Definition\" class=\"hierarchy\"/> <a style=\"font-style: italic\" href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.code.coding\">Slices for coding</a><a name=\"Observation.code.coding\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red; font-style: italic\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"font-style: italic\"/><span style=\"opacity: 0.5; font-style: italic\">0</span><span style=\"opacity: 0.5; font-style: italic\">..</span><span style=\"opacity: 0.5; font-style: italic\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5; font-style: italic\" href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5; font-style: italic\">Code defined by a terminology system</span><br style=\"font-style: italic\"/><span style=\"font-weight:bold; font-style: italic\">Slice: </span><span style=\"font-style: italic\">Unordered, Open by pattern:$this</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1035.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.code.coding:PulseOx\" title=\"Slice PulseOx\">coding:PulseOx</a><a name=\"Observation.code.coding\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Code defined by a terminology system</span><br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10350.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/loinc.html\">http://loinc.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10340.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">59408-5</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1025.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.code.coding:O2Sat\" title=\"Slice O2Sat\">coding:O2Sat</a><a name=\"Observation.code.coding\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Code defined by a terminology system</span><br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10250.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/loinc.html\">http://loinc.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10240.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">2708-6</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck03.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Definition\" class=\"hierarchy\"/> <a style=\"font-style: italic\" href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.component\" title=\"Used when reporting flow rates or oxygen concentration.\">Slices for component</a><a name=\"Observation.component\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red; font-style: italic\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"font-style: italic\"/><span style=\"opacity: 0.5; font-style: italic\">0</span><span style=\"opacity: 0.5; font-style: italic\">..</span><span style=\"opacity: 0.5; font-style: italic\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5; font-style: italic\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"font-style: italic\">Used when reporting flow rates or oxygen concentration.</span><br style=\"font-style: italic\"/><span style=\"font-weight:bold; font-style: italic\">Slice: </span><span style=\"font-style: italic\">Unordered, Open by pattern:code</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck035.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.component:FlowRate\" title=\"Slice FlowRate\">component:FlowRate</a><a name=\"Observation.component\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Inhaled oxygen flow rate</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0351.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.component:FlowRate.code\">code</a><a name=\"Observation.component.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">1</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Type of component observation (code / type)</span><br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck03501.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#CodeableConcept.coding\">coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Code defined by a terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">(complex)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck035010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/loinc.html\">http://loinc.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck035000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">3151-8</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0341.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.component:FlowRate.valueQuantity\">valueQuantity</a><a name=\"Observation.component.valueQuantity\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Quantity\">Quantity</a> <span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This type must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Vital Sign Component Value</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck03410.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.component:FlowRate.valueQuantity.value\">value</a><a name=\"Observation.component.valueQuantity.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#decimal\">decimal</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Numerical value (with implicit precision)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck03410.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.component:FlowRate.valueQuantity.unit\">unit</a><a name=\"Observation.component.valueQuantity.unit\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Unit representation</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck03410.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.component:FlowRate.valueQuantity.system\">system</a><a name=\"Observation.component.valueQuantity.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">System that defines coded unit form</span><br/><span style=\"font-weight:bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/ucum.html\">http://unitsofmeasure.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck03400.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.component:FlowRate.valueQuantity.code\">code</a><a name=\"Observation.component.valueQuantity.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Coded form of the unit</span><br/><span style=\"font-weight:bold\">Fixed Value: </span><span style=\"color: darkgreen\">L/min</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck025.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.component:Concentration\" title=\"Slice Concentration\">component:Concentration</a><a name=\"Observation.component\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Inhaled oxygen concentration</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0251.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.component:Concentration.code\">code</a><a name=\"Observation.component.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">1</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Type of component observation (code / type)</span><br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck02501.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#CodeableConcept.coding\">coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Code defined by a terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">(complex)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck025010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/loinc.html\">http://loinc.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck025000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">3150-0</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0241.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.component:Concentration.valueQuantity\">valueQuantity</a><a name=\"Observation.component.valueQuantity\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Quantity\">Quantity</a> <span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This type must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Vital Sign Component Value</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck02410.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.component:Concentration.valueQuantity.value\">value</a><a name=\"Observation.component.valueQuantity.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#decimal\">decimal</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Numerical value (with implicit precision)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck02410.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.component:Concentration.valueQuantity.unit\">unit</a><a name=\"Observation.component.valueQuantity.unit\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Unit representation</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck02410.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.component:Concentration.valueQuantity.system\">system</a><a name=\"Observation.component.valueQuantity.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">System that defines coded unit form</span><br/><span style=\"font-weight:bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/ucum.html\">http://unitsofmeasure.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck02400.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-pulse-oximetry-definitions.html#Observation.component:Concentration.valueQuantity.code\">code</a><a name=\"Observation.component.valueQuantity.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Coded form of the unit</span><br/><span style=\"font-weight:bold\">Fixed Value: </span><span style=\"color: darkgreen\">%</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry",
-	"version": "4.0.0",
-	"name": "USCorePulseOximetryProfile",
-	"title": "US Core Pulse Oximetry Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-18",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints on the Observation resource to represent inspired O2 by pulse oximetry and inspired oxygen concentration observations with a standard LOINC codes and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "sct-concept",
-			"uri": "http://snomed.info/conceptdomain",
-			"name": "SNOMED CT Concept Domain Binding"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "sct-attr",
-			"uri": "http://snomed.org/attributebinding",
-			"name": "SNOMED CT Attribute Binding"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Observation",
-	"baseDefinition": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "US Core Pulse Oximetry Profile",
-				"definition": "Defines constraints on the Observation resource to represent inspired O2 by pulse oximetry and inspired oxygen concentration observations with a standard LOINC codes and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
-				"alias": [
-					"Vital Signs",
-					"Measurement",
-					"Results",
-					"Tests"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "obs-6",
-						"severity": "error",
-						"human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
-						"expression": "dataAbsentReason.empty() or value.empty()",
-						"xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "obs-7",
-						"severity": "error",
-						"human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
-						"expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
-						"xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "vs-2",
-						"severity": "error",
-						"human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
-						"expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
-						"xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.id",
-				"path": "Observation.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.meta",
-				"path": "Observation.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.implicitRules",
-				"path": "Observation.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Observation.language",
-				"path": "Observation.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Observation.text",
-				"path": "Observation.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Observation.contained",
-				"path": "Observation.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.extension",
-				"path": "Observation.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.modifierExtension",
-				"path": "Observation.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.identifier",
-				"path": "Observation.identifier",
-				"short": "Business Identifier for observation",
-				"definition": "A unique identifier assigned to this observation.",
-				"requirements": "Allows observations to be distinguished and referenced.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
-					},
-					{
-						"identity": "rim",
-						"map": "id"
-					}
-				]
-			},
-			{
-				"id": "Observation.basedOn",
-				"path": "Observation.basedOn",
-				"short": "Fulfills plan, proposal or order",
-				"definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
-				"requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
-				"alias": [
-					"Fulfills"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan",
-							"http://hl7.org/fhir/StructureDefinition/DeviceRequest",
-							"http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
-							"http://hl7.org/fhir/StructureDefinition/MedicationRequest",
-							"http://hl7.org/fhir/StructureDefinition/NutritionOrder",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.basedOn"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.partOf",
-				"path": "Observation.partOf",
-				"short": "Part of referenced event",
-				"definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
-				"comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
-				"alias": [
-					"Container"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.partOf",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
-							"http://hl7.org/fhir/StructureDefinition/MedicationDispense",
-							"http://hl7.org/fhir/StructureDefinition/MedicationStatement",
-							"http://hl7.org/fhir/StructureDefinition/Procedure",
-							"http://hl7.org/fhir/StructureDefinition/Immunization",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.partOf"
-					},
-					{
-						"identity": "v2",
-						"map": "Varies by domain"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=FLFS].target"
-					}
-				]
-			},
-			{
-				"id": "Observation.status",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
-						"valueString": "default: final"
-					}
-				],
-				"path": "Observation.status",
-				"short": "registered | preliminary | final | amended +",
-				"definition": "The status of the result value.",
-				"comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
-				"requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Status"
-						}
-					],
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 445584004 |Report by finality status|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-11"
-					},
-					{
-						"identity": "rim",
-						"map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
-					}
-				]
-			},
-			{
-				"id": "Observation.category",
-				"path": "Observation.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "coding.code"
-						},
-						{
-							"type": "value",
-							"path": "coding.system"
-						}
-					],
-					"ordered": false,
-					"rules": "open"
-				},
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat",
-				"path": "Observation.category",
-				"sliceName": "VSCat",
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.id",
-				"path": "Observation.category.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.extension",
-				"path": "Observation.category.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding",
-				"path": "Observation.category.coding",
-				"short": "Code defined by a terminology system",
-				"definition": "A reference to a code defined by a terminology system.",
-				"comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
-				"requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "CodeableConcept.coding",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1-8, C*E.10-22"
-					},
-					{
-						"identity": "rim",
-						"map": "union(., ./translation)"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.id",
-				"path": "Observation.category.coding.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.extension",
-				"path": "Observation.category.coding.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.system",
-				"path": "Observation.category.coding.system",
-				"short": "Identity of the terminology system",
-				"definition": "The identification of the code system that defines the meaning of the symbol in the code.",
-				"comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
-				"requirements": "Need to be unambiguous about the source of the definition of the symbol.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.3"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystem"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.version",
-				"path": "Observation.category.coding.version",
-				"short": "Version of the system - if relevant",
-				"definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
-				"comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.version",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.7"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystemVersion"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.code",
-				"path": "Observation.category.coding.code",
-				"short": "Symbol in syntax defined by the system",
-				"definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
-				"requirements": "Need to refer to a particular code in the system.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "vital-signs",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1"
-					},
-					{
-						"identity": "rim",
-						"map": "./code"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.display",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.coding.display",
-				"short": "Representation defined by the system",
-				"definition": "A representation of the meaning of the code in the system, following the rules of the system.",
-				"requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.display",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.2 - but note this is not well followed"
-					},
-					{
-						"identity": "rim",
-						"map": "CV.displayName"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.userSelected",
-				"path": "Observation.category.coding.userSelected",
-				"short": "If this coding was chosen directly by the user",
-				"definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
-				"comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
-				"requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.userSelected",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Sometimes implied by being first"
-					},
-					{
-						"identity": "rim",
-						"map": "CD.codingRationale"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.text",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.text",
-				"short": "Plain text representation of the concept",
-				"definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
-				"comment": "Very often the text is the same as a displayName of one of the codings.",
-				"requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CodeableConcept.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.9. But note many systems use C*E.2 for this"
-					},
-					{
-						"identity": "rim",
-						"map": "./originalText[mediaType/code=\"text/plain\"]/data"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
-					}
-				]
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Oxygen Saturation by Pulse Oximetry",
-				"definition": "Coded Responses from C-CDA Vital Sign Results.",
-				"comment": "The code (59408-5 Oxygen saturation in Arterial blood by Pulse oximetry) is included as an additional observation code to FHIR Core vital Oxygen Saturation code (2708-6 Oxygen saturation in Arterial blood).",
-				"requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
-				"alias": [
-					"Name"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "116680003 |Is a|"
-					}
-				]
-			},
-			{
-				"id": "Observation.code.id",
-				"path": "Observation.code.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.code.extension",
-				"path": "Observation.code.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.code.coding",
-				"path": "Observation.code.coding",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "$this"
-						}
-					],
-					"rules": "open"
-				},
-				"short": "Code defined by a terminology system",
-				"definition": "A reference to a code defined by a terminology system.",
-				"comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
-				"requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "CodeableConcept.coding",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1-8, C*E.10-22"
-					},
-					{
-						"identity": "rim",
-						"map": "union(., ./translation)"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
-					}
-				]
-			},
-			{
-				"id": "Observation.code.coding:PulseOx",
-				"path": "Observation.code.coding",
-				"sliceName": "PulseOx",
-				"short": "Code defined by a terminology system",
-				"definition": "A reference to a code defined by a terminology system.",
-				"comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
-				"requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "CodeableConcept.coding",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"patternCoding": {
-					"system": "http://loinc.org",
-					"code": "59408-5"
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1-8, C*E.10-22"
-					},
-					{
-						"identity": "rim",
-						"map": "union(., ./translation)"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
-					}
-				]
-			},
-			{
-				"id": "Observation.code.coding:O2Sat",
-				"path": "Observation.code.coding",
-				"sliceName": "O2Sat",
-				"short": "Code defined by a terminology system",
-				"definition": "A reference to a code defined by a terminology system.",
-				"comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
-				"requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "CodeableConcept.coding",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"patternCoding": {
-					"system": "http://loinc.org",
-					"code": "2708-6"
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1-8, C*E.10-22"
-					},
-					{
-						"identity": "rim",
-						"map": "union(., ./translation)"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
-					}
-				]
-			},
-			{
-				"id": "Observation.code.text",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.code.text",
-				"short": "Plain text representation of the concept",
-				"definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
-				"comment": "Very often the text is the same as a displayName of one of the codings.",
-				"requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CodeableConcept.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.9. But note many systems use C*E.2 for this"
-					},
-					{
-						"identity": "rim",
-						"map": "./originalText[mediaType/code=\"text/plain\"]/data"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
-					}
-				]
-			},
-			{
-				"id": "Observation.subject",
-				"path": "Observation.subject",
-				"short": "Who and/or what the observation is about",
-				"definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
-				"comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
-				"requirements": "Observations have no value if you don't know who or what they're about.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=RTGT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.focus",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
-						"valueCode": "trial-use"
-					}
-				],
-				"path": "Observation.focus",
-				"short": "What the observation is about, when it is not about the subject of record",
-				"definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
-				"comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.focus",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SBJ]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.encounter",
-				"path": "Observation.encounter",
-				"short": "Healthcare event during which this observation is made",
-				"definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
-				"comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
-				"requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
-				"alias": [
-					"Context"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.effective[x]",
-				"path": "Observation.effective[x]",
-				"short": "Often just a dateTime for Vital Signs",
-				"definition": "Often just a dateTime for Vital Signs.",
-				"comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
-				"requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
-				"alias": [
-					"Occurrence"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.effective[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-1",
-						"severity": "error",
-						"human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
-						"expression": "($this as dateTime).toString().length() >= 8",
-						"xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "Observation.issued",
-				"path": "Observation.issued",
-				"short": "Date/Time this version was made available",
-				"definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
-				"comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.issued",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=AUT].time"
-					}
-				]
-			},
-			{
-				"id": "Observation.performer",
-				"path": "Observation.performer",
-				"short": "Who is responsible for the observation",
-				"definition": "Who was responsible for asserting the observed value as \"true\".",
-				"requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.performer",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=PRF]"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]",
-				"path": "Observation.value[x]",
-				"short": "Vital Signs Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "Quantity"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.dataAbsentReason",
-				"path": "Observation.dataAbsentReason",
-				"short": "Why the result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
-				"comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.interpretation",
-				"path": "Observation.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.note",
-				"path": "Observation.note",
-				"short": "Comments about the observation",
-				"definition": "Comments about the observation or the results.",
-				"comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
-				"requirements": "Need to be able to provide free text additional information.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
-					},
-					{
-						"identity": "rim",
-						"map": "subjectOf.observationEvent[code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.bodySite",
-				"path": "Observation.bodySite",
-				"short": "Observed body part",
-				"definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
-				"comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.bodySite",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "BodySite"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing anatomical locations. May include laterality.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/body-site"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123037004 |Body structure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-20"
-					},
-					{
-						"identity": "rim",
-						"map": "targetSiteCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "718497002 |Inherent location|"
-					}
-				]
-			},
-			{
-				"id": "Observation.method",
-				"path": "Observation.method",
-				"short": "How it was done",
-				"definition": "Indicates the mechanism used to perform the observation.",
-				"comment": "Only used if not implicit in code for Observation.code.",
-				"requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.method",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationMethod"
-						}
-					],
-					"strength": "example",
-					"description": "Methods for simple observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-17"
-					},
-					{
-						"identity": "rim",
-						"map": "methodCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.specimen",
-				"path": "Observation.specimen",
-				"short": "Specimen used for this observation",
-				"definition": "The specimen that was used when this observation was made.",
-				"comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.specimen",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Specimen"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123038009 |Specimen|"
-					},
-					{
-						"identity": "v2",
-						"map": "SPM segment"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SPC].specimen"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "704319004 |Inherent in|"
-					}
-				]
-			},
-			{
-				"id": "Observation.device",
-				"path": "Observation.device",
-				"short": "(Measurement) Device",
-				"definition": "The device used to generate the observation data.",
-				"comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.device",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/DeviceMetric"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 49062001 |Device|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-17 / PRT -10"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=DEV]"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "424226004 |Using device|"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange",
-				"path": "Observation.referenceRange",
-				"short": "Provides guide for interpretation",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "obs-3",
-						"severity": "error",
-						"human": "Must have at least a low or a high or text",
-						"expression": "low.exists() or high.exists() or text.exists()",
-						"xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.id",
-				"path": "Observation.referenceRange.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.extension",
-				"path": "Observation.referenceRange.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.modifierExtension",
-				"path": "Observation.referenceRange.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.low",
-				"path": "Observation.referenceRange.low",
-				"short": "Low Range, if relevant",
-				"definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.low",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.low"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.high",
-				"path": "Observation.referenceRange.high",
-				"short": "High Range, if relevant",
-				"definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.high",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.high"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.type",
-				"path": "Observation.referenceRange.type",
-				"short": "Reference range qualifier",
-				"definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
-				"requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeMeaning"
-						}
-					],
-					"strength": "preferred",
-					"description": "Code for the meaning of a reference range.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.appliesTo",
-				"path": "Observation.referenceRange.appliesTo",
-				"short": "Reference range population",
-				"definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
-				"requirements": "Need to be able to identify the target population for proper interpretation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange.appliesTo",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeType"
-						}
-					],
-					"strength": "example",
-					"description": "Codes identifying the population the reference range applies to.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.age",
-				"path": "Observation.referenceRange.age",
-				"short": "Applicable age range, if relevant",
-				"definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
-				"requirements": "Some analytes vary greatly over age.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.age",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Range"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.text",
-				"path": "Observation.referenceRange.text",
-				"short": "Text based reference range in an observation",
-				"definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:ST"
-					}
-				]
-			},
-			{
-				"id": "Observation.hasMember",
-				"path": "Observation.hasMember",
-				"short": "Used when reporting vital signs panel components",
-				"definition": "Used when reporting vital signs panel components.",
-				"comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.hasMember",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship"
-					}
-				]
-			},
-			{
-				"id": "Observation.derivedFrom",
-				"path": "Observation.derivedFrom",
-				"short": "Related measurements the observation is made from",
-				"definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
-				"comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.derivedFrom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/DocumentReference",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy",
-							"http://hl7.org/fhir/StructureDefinition/Media",
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": ".targetObservation"
-					}
-				]
-			},
-			{
-				"id": "Observation.component",
-				"path": "Observation.component",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "code"
-						}
-					],
-					"rules": "open"
-				},
-				"short": "Used when reporting flow rates or oxygen concentration.",
-				"definition": "Used when reporting flow rates or oxygen concentration.",
-				"comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-3",
-						"severity": "error",
-						"human": "If there is no a value a data absent reason must be present",
-						"expression": "value.exists() or dataAbsentReason.exists()",
-						"xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "containment by OBX-4?"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=COMP]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.id",
-				"path": "Observation.component.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.extension",
-				"path": "Observation.component.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.modifierExtension",
-				"path": "Observation.component.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.code",
-				"path": "Observation.component.code",
-				"short": "Type of component observation (code / type)",
-				"definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
-				"comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.value[x]",
-				"path": "Observation.component.value[x]",
-				"short": "Vital Sign Component Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
-				"comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "Quantity"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.dataAbsentReason",
-				"path": "Observation.component.dataAbsentReason",
-				"short": "Why the component result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
-				"comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.interpretation",
-				"path": "Observation.component.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.referenceRange",
-				"path": "Observation.component.referenceRange",
-				"short": "Provides guide for interpretation of component result",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate",
-				"path": "Observation.component",
-				"sliceName": "FlowRate",
-				"short": "Inhaled oxygen flow rate",
-				"definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
-				"comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-3",
-						"severity": "error",
-						"human": "If there is no a value a data absent reason must be present",
-						"expression": "value.exists() or dataAbsentReason.exists()",
-						"xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "containment by OBX-4?"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=COMP]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate.id",
-				"path": "Observation.component.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate.extension",
-				"path": "Observation.component.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate.modifierExtension",
-				"path": "Observation.component.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate.code",
-				"path": "Observation.component.code",
-				"short": "Type of component observation (code / type)",
-				"definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
-				"comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "3151-8"
-						}
-					]
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate.value[x]",
-				"path": "Observation.component.value[x]",
-				"short": "Vital Sign Component Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
-				"comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate.value[x].id",
-				"path": "Observation.component.value[x].id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate.value[x].extension",
-				"path": "Observation.component.value[x].extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate.value[x].value",
-				"path": "Observation.component.value[x].value",
-				"short": "Numerical value (with implicit precision)",
-				"definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
-				"comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
-				"requirements": "Precision is handled implicitly in almost all cases of measurement.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.2  / CQ - N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate.value[x].comparator",
-				"path": "Observation.component.value[x].comparator",
-				"short": "< | <= | >= | > - how to understand the value",
-				"definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
-				"requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Quantity.comparator",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "QuantityComparator"
-						}
-					],
-					"strength": "required",
-					"description": "How the Quantity should be understood and represented.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.1  / CQ.1"
-					},
-					{
-						"identity": "rim",
-						"map": "IVL properties"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate.value[x].unit",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.component.value[x].unit",
-				"short": "Unit representation",
-				"definition": "A human-readable form of the unit.",
-				"requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.unit",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.unit"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate.value[x].system",
-				"path": "Observation.component.value[x].system",
-				"short": "System that defines coded unit form",
-				"definition": "The identification of the system that provides the coded form of the unit.",
-				"requirements": "Need to know the system that defines the coded form of the unit.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"condition": [
-					"qty-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "CO.codeSystem, PQ.translation.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate.value[x].code",
-				"path": "Observation.component.value[x].code",
-				"short": "Coded form of the unit",
-				"definition": "A computer processable form of the unit in some unit representation system.",
-				"comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
-				"requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "L/min",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.code, MO.currency, PQ.translation.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate.dataAbsentReason",
-				"path": "Observation.component.dataAbsentReason",
-				"short": "Why the component result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
-				"comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate.interpretation",
-				"path": "Observation.component.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:FlowRate.referenceRange",
-				"path": "Observation.component.referenceRange",
-				"short": "Provides guide for interpretation of component result",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration",
-				"path": "Observation.component",
-				"sliceName": "Concentration",
-				"short": "Inhaled oxygen concentration",
-				"definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
-				"comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-3",
-						"severity": "error",
-						"human": "If there is no a value a data absent reason must be present",
-						"expression": "value.exists() or dataAbsentReason.exists()",
-						"xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "containment by OBX-4?"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=COMP]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration.id",
-				"path": "Observation.component.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration.extension",
-				"path": "Observation.component.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration.modifierExtension",
-				"path": "Observation.component.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration.code",
-				"path": "Observation.component.code",
-				"short": "Type of component observation (code / type)",
-				"definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
-				"comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "3150-0"
-						}
-					]
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration.value[x]",
-				"path": "Observation.component.value[x]",
-				"short": "Vital Sign Component Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
-				"comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration.value[x].id",
-				"path": "Observation.component.value[x].id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration.value[x].extension",
-				"path": "Observation.component.value[x].extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration.value[x].value",
-				"path": "Observation.component.value[x].value",
-				"short": "Numerical value (with implicit precision)",
-				"definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
-				"comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
-				"requirements": "Precision is handled implicitly in almost all cases of measurement.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.2  / CQ - N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration.value[x].comparator",
-				"path": "Observation.component.value[x].comparator",
-				"short": "< | <= | >= | > - how to understand the value",
-				"definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
-				"requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Quantity.comparator",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "QuantityComparator"
-						}
-					],
-					"strength": "required",
-					"description": "How the Quantity should be understood and represented.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.1  / CQ.1"
-					},
-					{
-						"identity": "rim",
-						"map": "IVL properties"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration.value[x].unit",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.component.value[x].unit",
-				"short": "Unit representation",
-				"definition": "A human-readable form of the unit.",
-				"requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.unit",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.unit"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration.value[x].system",
-				"path": "Observation.component.value[x].system",
-				"short": "System that defines coded unit form",
-				"definition": "The identification of the system that provides the coded form of the unit.",
-				"requirements": "Need to know the system that defines the coded form of the unit.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"condition": [
-					"qty-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "CO.codeSystem, PQ.translation.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration.value[x].code",
-				"path": "Observation.component.value[x].code",
-				"short": "Coded form of the unit",
-				"definition": "A computer processable form of the unit in some unit representation system.",
-				"comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
-				"requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "%",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.code, MO.currency, PQ.translation.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration.dataAbsentReason",
-				"path": "Observation.component.dataAbsentReason",
-				"short": "Why the component result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
-				"comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration.interpretation",
-				"path": "Observation.component.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component:Concentration.referenceRange",
-				"path": "Observation.component.referenceRange",
-				"short": "Provides guide for interpretation of component result",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "US Core Pulse Oximetry Profile",
-				"definition": "Defines constraints on the Observation resource to represent inspired O2 by pulse oximetry and inspired oxygen concentration observations with a standard LOINC codes and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"mustSupport": false
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Oxygen Saturation by Pulse Oximetry",
-				"comment": "The code (59408-5 Oxygen saturation in Arterial blood by Pulse oximetry) is included as an additional observation code to FHIR Core vital Oxygen Saturation code (2708-6 Oxygen saturation in Arterial blood).",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.code.coding",
-				"path": "Observation.code.coding",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "$this"
-						}
-					],
-					"rules": "open"
-				},
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.code.coding:PulseOx",
-				"path": "Observation.code.coding",
-				"sliceName": "PulseOx",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"patternCoding": {
-					"system": "http://loinc.org",
-					"code": "59408-5"
-				},
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.code.coding:O2Sat",
-				"path": "Observation.code.coding",
-				"sliceName": "O2Sat",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"patternCoding": {
-					"system": "http://loinc.org",
-					"code": "2708-6"
-				},
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component",
-				"path": "Observation.component",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "code"
-						}
-					],
-					"rules": "open"
-				},
-				"short": "Used when reporting flow rates or oxygen concentration.",
-				"definition": "Used when reporting flow rates or oxygen concentration.",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:FlowRate",
-				"path": "Observation.component",
-				"sliceName": "FlowRate",
-				"short": "Inhaled oxygen flow rate",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:FlowRate.code",
-				"path": "Observation.component.code",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "3151-8"
-						}
-					]
-				},
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:FlowRate.valueQuantity",
-				"path": "Observation.component.valueQuantity",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:FlowRate.valueQuantity.value",
-				"path": "Observation.component.valueQuantity.value",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:FlowRate.valueQuantity.unit",
-				"path": "Observation.component.valueQuantity.unit",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:FlowRate.valueQuantity.system",
-				"path": "Observation.component.valueQuantity.system",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:FlowRate.valueQuantity.code",
-				"path": "Observation.component.valueQuantity.code",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "L/min",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:Concentration",
-				"path": "Observation.component",
-				"sliceName": "Concentration",
-				"short": "Inhaled oxygen concentration",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:Concentration.code",
-				"path": "Observation.component.code",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "3150-0"
-						}
-					]
-				},
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:Concentration.valueQuantity",
-				"path": "Observation.component.valueQuantity",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:Concentration.valueQuantity.value",
-				"path": "Observation.component.valueQuantity.value",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:Concentration.valueQuantity.unit",
-				"path": "Observation.component.valueQuantity.unit",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:Concentration.valueQuantity.system",
-				"path": "Observation.component.valueQuantity.system",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component:Concentration.valueQuantity.code",
-				"path": "Observation.component.valueQuantity.code",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "%",
-				"mustSupport": true
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-pulse-oximetry",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry",
+    "version": "4.0.0",
+    "name": "USCorePulseOximetryProfile",
+    "title": "US Core Pulse Oximetry Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-18",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints on the Observation resource to represent inspired O2 by pulse oximetry and inspired oxygen concentration observations with a standard LOINC codes and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "sct-concept",
+            "uri": "http://snomed.info/conceptdomain",
+            "name": "SNOMED CT Concept Domain Binding"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "sct-attr",
+            "uri": "http://snomed.org/attributebinding",
+            "name": "SNOMED CT Attribute Binding"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Observation",
+    "baseDefinition": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "US Core Pulse Oximetry Profile",
+                "definition": "Defines constraints on the Observation resource to represent inspired O2 by pulse oximetry and inspired oxygen concentration observations with a standard LOINC codes and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
+                "alias": [
+                    "Vital Signs",
+                    "Measurement",
+                    "Results",
+                    "Tests"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "obs-6",
+                        "severity": "error",
+                        "human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
+                        "expression": "dataAbsentReason.empty() or value.empty()",
+                        "xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "obs-7",
+                        "severity": "error",
+                        "human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
+                        "expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
+                        "xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "vs-2",
+                        "severity": "error",
+                        "human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
+                        "expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
+                        "xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.id",
+                "path": "Observation.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.meta",
+                "path": "Observation.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.implicitRules",
+                "path": "Observation.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Observation.language",
+                "path": "Observation.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Observation.text",
+                "path": "Observation.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.contained",
+                "path": "Observation.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.extension",
+                "path": "Observation.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.modifierExtension",
+                "path": "Observation.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.identifier",
+                "path": "Observation.identifier",
+                "short": "Business Identifier for observation",
+                "definition": "A unique identifier assigned to this observation.",
+                "requirements": "Allows observations to be distinguished and referenced.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "id"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.basedOn",
+                "path": "Observation.basedOn",
+                "short": "Fulfills plan, proposal or order",
+                "definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
+                "requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
+                "alias": [
+                    "Fulfills"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceRequest",
+                            "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+                            "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.basedOn"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.partOf",
+                "path": "Observation.partOf",
+                "short": "Part of referenced event",
+                "definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
+                "comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
+                "alias": [
+                    "Container"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.partOf",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationDispense",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationStatement",
+                            "http://hl7.org/fhir/StructureDefinition/Procedure",
+                            "http://hl7.org/fhir/StructureDefinition/Immunization",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.partOf"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "Varies by domain"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=FLFS].target"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.status",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
+                        "valueString": "default: final"
+                    }
+                ],
+                "path": "Observation.status",
+                "short": "registered | preliminary | final | amended +",
+                "definition": "The status of the result value.",
+                "comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
+                "requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Status"
+                        }
+                    ],
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 445584004 |Report by finality status|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-11"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category",
+                "path": "Observation.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "coding.code"
+                        },
+                        {
+                            "type": "value",
+                            "path": "coding.system"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "open"
+                },
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat",
+                "path": "Observation.category",
+                "sliceName": "VSCat",
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.id",
+                "path": "Observation.category.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.extension",
+                "path": "Observation.category.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding",
+                "path": "Observation.category.coding",
+                "short": "Code defined by a terminology system",
+                "definition": "A reference to a code defined by a terminology system.",
+                "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+                "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "CodeableConcept.coding",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1-8, C*E.10-22"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "union(., ./translation)"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.id",
+                "path": "Observation.category.coding.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.extension",
+                "path": "Observation.category.coding.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.system",
+                "path": "Observation.category.coding.system",
+                "short": "Identity of the terminology system",
+                "definition": "The identification of the code system that defines the meaning of the symbol in the code.",
+                "comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
+                "requirements": "Need to be unambiguous about the source of the definition of the symbol.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystem"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.version",
+                "path": "Observation.category.coding.version",
+                "short": "Version of the system - if relevant",
+                "definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
+                "comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.version",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystemVersion"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.code",
+                "path": "Observation.category.coding.code",
+                "short": "Symbol in syntax defined by the system",
+                "definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
+                "requirements": "Need to refer to a particular code in the system.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "vital-signs",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./code"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.display",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.coding.display",
+                "short": "Representation defined by the system",
+                "definition": "A representation of the meaning of the code in the system, following the rules of the system.",
+                "requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.display",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.2 - but note this is not well followed"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CV.displayName"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.userSelected",
+                "path": "Observation.category.coding.userSelected",
+                "short": "If this coding was chosen directly by the user",
+                "definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
+                "comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
+                "requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.userSelected",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Sometimes implied by being first"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CD.codingRationale"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.text",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.text",
+                "short": "Plain text representation of the concept",
+                "definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
+                "comment": "Very often the text is the same as a displayName of one of the codings.",
+                "requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CodeableConcept.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.9. But note many systems use C*E.2 for this"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./originalText[mediaType/code=\"text/plain\"]/data"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Oxygen Saturation by Pulse Oximetry",
+                "definition": "Coded Responses from C-CDA Vital Sign Results.",
+                "comment": "The code (59408-5 Oxygen saturation in Arterial blood by Pulse oximetry) is included as an additional observation code to FHIR Core vital Oxygen Saturation code (2708-6 Oxygen saturation in Arterial blood).",
+                "requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
+                "alias": [
+                    "Name"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "116680003 |Is a|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code.id",
+                "path": "Observation.code.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code.extension",
+                "path": "Observation.code.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code.coding",
+                "path": "Observation.code.coding",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "$this"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "short": "Code defined by a terminology system",
+                "definition": "A reference to a code defined by a terminology system.",
+                "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+                "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "CodeableConcept.coding",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1-8, C*E.10-22"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "union(., ./translation)"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code.coding:PulseOx",
+                "path": "Observation.code.coding",
+                "sliceName": "PulseOx",
+                "short": "Code defined by a terminology system",
+                "definition": "A reference to a code defined by a terminology system.",
+                "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+                "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "CodeableConcept.coding",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "patternCoding": {
+                    "system": "http://loinc.org",
+                    "code": "59408-5"
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1-8, C*E.10-22"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "union(., ./translation)"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code.coding:O2Sat",
+                "path": "Observation.code.coding",
+                "sliceName": "O2Sat",
+                "short": "Code defined by a terminology system",
+                "definition": "A reference to a code defined by a terminology system.",
+                "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+                "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "CodeableConcept.coding",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "patternCoding": {
+                    "system": "http://loinc.org",
+                    "code": "2708-6"
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1-8, C*E.10-22"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "union(., ./translation)"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code.text",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.code.text",
+                "short": "Plain text representation of the concept",
+                "definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
+                "comment": "Very often the text is the same as a displayName of one of the codings.",
+                "requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CodeableConcept.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.9. But note many systems use C*E.2 for this"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./originalText[mediaType/code=\"text/plain\"]/data"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.subject",
+                "path": "Observation.subject",
+                "short": "Who and/or what the observation is about",
+                "definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
+                "comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
+                "requirements": "Observations have no value if you don't know who or what they're about.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=RTGT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.focus",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+                        "valueCode": "trial-use"
+                    }
+                ],
+                "path": "Observation.focus",
+                "short": "What the observation is about, when it is not about the subject of record",
+                "definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
+                "comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.focus",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SBJ]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.encounter",
+                "path": "Observation.encounter",
+                "short": "Healthcare event during which this observation is made",
+                "definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
+                "comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
+                "requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
+                "alias": [
+                    "Context"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.effective[x]",
+                "path": "Observation.effective[x]",
+                "short": "Often just a dateTime for Vital Signs",
+                "definition": "Often just a dateTime for Vital Signs.",
+                "comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
+                "requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
+                "alias": [
+                    "Occurrence"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.effective[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-1",
+                        "severity": "error",
+                        "human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
+                        "expression": "($this as dateTime).toString().length() >= 8",
+                        "xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.issued",
+                "path": "Observation.issued",
+                "short": "Date/Time this version was made available",
+                "definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
+                "comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.issued",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.performer",
+                "path": "Observation.performer",
+                "short": "Who is responsible for the observation",
+                "definition": "Who was responsible for asserting the observed value as \"true\".",
+                "requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.performer",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=PRF]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]",
+                "path": "Observation.value[x]",
+                "short": "Vital Signs Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.dataAbsentReason",
+                "path": "Observation.dataAbsentReason",
+                "short": "Why the result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
+                "comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.interpretation",
+                "path": "Observation.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.note",
+                "path": "Observation.note",
+                "short": "Comments about the observation",
+                "definition": "Comments about the observation or the results.",
+                "comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
+                "requirements": "Need to be able to provide free text additional information.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "subjectOf.observationEvent[code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.bodySite",
+                "path": "Observation.bodySite",
+                "short": "Observed body part",
+                "definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
+                "comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.bodySite",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "BodySite"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing anatomical locations. May include laterality.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/body-site"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123037004 |Body structure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-20"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "targetSiteCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "718497002 |Inherent location|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.method",
+                "path": "Observation.method",
+                "short": "How it was done",
+                "definition": "Indicates the mechanism used to perform the observation.",
+                "comment": "Only used if not implicit in code for Observation.code.",
+                "requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.method",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationMethod"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Methods for simple observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "methodCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.specimen",
+                "path": "Observation.specimen",
+                "short": "Specimen used for this observation",
+                "definition": "The specimen that was used when this observation was made.",
+                "comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.specimen",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Specimen"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123038009 |Specimen|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "SPM segment"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SPC].specimen"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "704319004 |Inherent in|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.device",
+                "path": "Observation.device",
+                "short": "(Measurement) Device",
+                "definition": "The device used to generate the observation data.",
+                "comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.device",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceMetric"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 49062001 |Device|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17 / PRT -10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=DEV]"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "424226004 |Using device|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange",
+                "path": "Observation.referenceRange",
+                "short": "Provides guide for interpretation",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "obs-3",
+                        "severity": "error",
+                        "human": "Must have at least a low or a high or text",
+                        "expression": "low.exists() or high.exists() or text.exists()",
+                        "xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.id",
+                "path": "Observation.referenceRange.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.extension",
+                "path": "Observation.referenceRange.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.modifierExtension",
+                "path": "Observation.referenceRange.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.low",
+                "path": "Observation.referenceRange.low",
+                "short": "Low Range, if relevant",
+                "definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.low",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.low"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.high",
+                "path": "Observation.referenceRange.high",
+                "short": "High Range, if relevant",
+                "definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.high",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.high"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.type",
+                "path": "Observation.referenceRange.type",
+                "short": "Reference range qualifier",
+                "definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
+                "requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeMeaning"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Code for the meaning of a reference range.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.appliesTo",
+                "path": "Observation.referenceRange.appliesTo",
+                "short": "Reference range population",
+                "definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
+                "requirements": "Need to be able to identify the target population for proper interpretation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange.appliesTo",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes identifying the population the reference range applies to.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.age",
+                "path": "Observation.referenceRange.age",
+                "short": "Applicable age range, if relevant",
+                "definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
+                "requirements": "Some analytes vary greatly over age.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.age",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Range"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.text",
+                "path": "Observation.referenceRange.text",
+                "short": "Text based reference range in an observation",
+                "definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:ST"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.hasMember",
+                "path": "Observation.hasMember",
+                "short": "Used when reporting vital signs panel components",
+                "definition": "Used when reporting vital signs panel components.",
+                "comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.hasMember",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.derivedFrom",
+                "path": "Observation.derivedFrom",
+                "short": "Related measurements the observation is made from",
+                "definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
+                "comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.derivedFrom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/DocumentReference",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy",
+                            "http://hl7.org/fhir/StructureDefinition/Media",
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".targetObservation"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component",
+                "path": "Observation.component",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "code"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "short": "Used when reporting flow rates or oxygen concentration.",
+                "definition": "Used when reporting flow rates or oxygen concentration.",
+                "comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-3",
+                        "severity": "error",
+                        "human": "If there is no a value a data absent reason must be present",
+                        "expression": "value.exists() or dataAbsentReason.exists()",
+                        "xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "containment by OBX-4?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=COMP]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.id",
+                "path": "Observation.component.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.extension",
+                "path": "Observation.component.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.modifierExtension",
+                "path": "Observation.component.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.code",
+                "path": "Observation.component.code",
+                "short": "Type of component observation (code / type)",
+                "definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
+                "comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.value[x]",
+                "path": "Observation.component.value[x]",
+                "short": "Vital Sign Component Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
+                "comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.dataAbsentReason",
+                "path": "Observation.component.dataAbsentReason",
+                "short": "Why the component result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
+                "comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.interpretation",
+                "path": "Observation.component.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.referenceRange",
+                "path": "Observation.component.referenceRange",
+                "short": "Provides guide for interpretation of component result",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate",
+                "path": "Observation.component",
+                "sliceName": "FlowRate",
+                "short": "Inhaled oxygen flow rate",
+                "definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
+                "comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-3",
+                        "severity": "error",
+                        "human": "If there is no a value a data absent reason must be present",
+                        "expression": "value.exists() or dataAbsentReason.exists()",
+                        "xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "containment by OBX-4?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=COMP]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate.id",
+                "path": "Observation.component.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate.extension",
+                "path": "Observation.component.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate.modifierExtension",
+                "path": "Observation.component.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate.code",
+                "path": "Observation.component.code",
+                "short": "Type of component observation (code / type)",
+                "definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
+                "comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "3151-8"
+                        }
+                    ]
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate.value[x]",
+                "path": "Observation.component.value[x]",
+                "short": "Vital Sign Component Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
+                "comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate.value[x].id",
+                "path": "Observation.component.value[x].id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate.value[x].extension",
+                "path": "Observation.component.value[x].extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate.value[x].value",
+                "path": "Observation.component.value[x].value",
+                "short": "Numerical value (with implicit precision)",
+                "definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
+                "comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
+                "requirements": "Precision is handled implicitly in almost all cases of measurement.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.2  / CQ - N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate.value[x].comparator",
+                "path": "Observation.component.value[x].comparator",
+                "short": "< | <= | >= | > - how to understand the value",
+                "definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
+                "requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.comparator",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "QuantityComparator"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "How the Quantity should be understood and represented.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.1  / CQ.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "IVL properties"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate.value[x].unit",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.component.value[x].unit",
+                "short": "Unit representation",
+                "definition": "A human-readable form of the unit.",
+                "requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.unit",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.unit"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate.value[x].system",
+                "path": "Observation.component.value[x].system",
+                "short": "System that defines coded unit form",
+                "definition": "The identification of the system that provides the coded form of the unit.",
+                "requirements": "Need to know the system that defines the coded form of the unit.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "condition": [
+                    "qty-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CO.codeSystem, PQ.translation.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate.value[x].code",
+                "path": "Observation.component.value[x].code",
+                "short": "Coded form of the unit",
+                "definition": "A computer processable form of the unit in some unit representation system.",
+                "comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
+                "requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "L/min",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.code, MO.currency, PQ.translation.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate.dataAbsentReason",
+                "path": "Observation.component.dataAbsentReason",
+                "short": "Why the component result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
+                "comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate.interpretation",
+                "path": "Observation.component.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:FlowRate.referenceRange",
+                "path": "Observation.component.referenceRange",
+                "short": "Provides guide for interpretation of component result",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration",
+                "path": "Observation.component",
+                "sliceName": "Concentration",
+                "short": "Inhaled oxygen concentration",
+                "definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
+                "comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-3",
+                        "severity": "error",
+                        "human": "If there is no a value a data absent reason must be present",
+                        "expression": "value.exists() or dataAbsentReason.exists()",
+                        "xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "containment by OBX-4?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=COMP]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration.id",
+                "path": "Observation.component.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration.extension",
+                "path": "Observation.component.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration.modifierExtension",
+                "path": "Observation.component.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration.code",
+                "path": "Observation.component.code",
+                "short": "Type of component observation (code / type)",
+                "definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
+                "comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "3150-0"
+                        }
+                    ]
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration.value[x]",
+                "path": "Observation.component.value[x]",
+                "short": "Vital Sign Component Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
+                "comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration.value[x].id",
+                "path": "Observation.component.value[x].id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration.value[x].extension",
+                "path": "Observation.component.value[x].extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration.value[x].value",
+                "path": "Observation.component.value[x].value",
+                "short": "Numerical value (with implicit precision)",
+                "definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
+                "comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
+                "requirements": "Precision is handled implicitly in almost all cases of measurement.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.2  / CQ - N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration.value[x].comparator",
+                "path": "Observation.component.value[x].comparator",
+                "short": "< | <= | >= | > - how to understand the value",
+                "definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
+                "requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.comparator",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "QuantityComparator"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "How the Quantity should be understood and represented.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.1  / CQ.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "IVL properties"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration.value[x].unit",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.component.value[x].unit",
+                "short": "Unit representation",
+                "definition": "A human-readable form of the unit.",
+                "requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.unit",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.unit"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration.value[x].system",
+                "path": "Observation.component.value[x].system",
+                "short": "System that defines coded unit form",
+                "definition": "The identification of the system that provides the coded form of the unit.",
+                "requirements": "Need to know the system that defines the coded form of the unit.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "condition": [
+                    "qty-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CO.codeSystem, PQ.translation.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration.value[x].code",
+                "path": "Observation.component.value[x].code",
+                "short": "Coded form of the unit",
+                "definition": "A computer processable form of the unit in some unit representation system.",
+                "comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
+                "requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "%",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.code, MO.currency, PQ.translation.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration.dataAbsentReason",
+                "path": "Observation.component.dataAbsentReason",
+                "short": "Why the component result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
+                "comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration.interpretation",
+                "path": "Observation.component.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component:Concentration.referenceRange",
+                "path": "Observation.component.referenceRange",
+                "short": "Provides guide for interpretation of component result",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "US Core Pulse Oximetry Profile",
+                "definition": "Defines constraints on the Observation resource to represent inspired O2 by pulse oximetry and inspired oxygen concentration observations with a standard LOINC codes and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "mustSupport": false
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Oxygen Saturation by Pulse Oximetry",
+                "comment": "The code (59408-5 Oxygen saturation in Arterial blood by Pulse oximetry) is included as an additional observation code to FHIR Core vital Oxygen Saturation code (2708-6 Oxygen saturation in Arterial blood).",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.code.coding",
+                "path": "Observation.code.coding",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "$this"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.code.coding:PulseOx",
+                "path": "Observation.code.coding",
+                "sliceName": "PulseOx",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "patternCoding": {
+                    "system": "http://loinc.org",
+                    "code": "59408-5"
+                },
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.code.coding:O2Sat",
+                "path": "Observation.code.coding",
+                "sliceName": "O2Sat",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "patternCoding": {
+                    "system": "http://loinc.org",
+                    "code": "2708-6"
+                },
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component",
+                "path": "Observation.component",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "code"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "short": "Used when reporting flow rates or oxygen concentration.",
+                "definition": "Used when reporting flow rates or oxygen concentration.",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:FlowRate",
+                "path": "Observation.component",
+                "sliceName": "FlowRate",
+                "short": "Inhaled oxygen flow rate",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:FlowRate.code",
+                "path": "Observation.component.code",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "3151-8"
+                        }
+                    ]
+                },
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:FlowRate.valueQuantity",
+                "path": "Observation.component.valueQuantity",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:FlowRate.valueQuantity.value",
+                "path": "Observation.component.valueQuantity.value",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:FlowRate.valueQuantity.unit",
+                "path": "Observation.component.valueQuantity.unit",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:FlowRate.valueQuantity.system",
+                "path": "Observation.component.valueQuantity.system",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:FlowRate.valueQuantity.code",
+                "path": "Observation.component.valueQuantity.code",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "L/min",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:Concentration",
+                "path": "Observation.component",
+                "sliceName": "Concentration",
+                "short": "Inhaled oxygen concentration",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:Concentration.code",
+                "path": "Observation.component.code",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "3150-0"
+                        }
+                    ]
+                },
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:Concentration.valueQuantity",
+                "path": "Observation.component.valueQuantity",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:Concentration.valueQuantity.value",
+                "path": "Observation.component.valueQuantity.value",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:Concentration.valueQuantity.unit",
+                "path": "Observation.component.valueQuantity.unit",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:Concentration.valueQuantity.system",
+                "path": "Observation.component.valueQuantity.system",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component:Concentration.valueQuantity.code",
+                "path": "Observation.component.valueQuantity.code",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "%",
+                "mustSupport": true
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-race.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-race.json
@@ -1,2285 +1,2285 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-race",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-race-definitions.html#Extension\" title=\"Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\n   - American Indian or Alaska Native\n   - Asian\n   - Black or African American\n   - Native Hawaiian or Other Pacific Islander\n   - White.\">Extension</a><a name=\"Extension\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/extensibility.html#Extension\">Extension</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">US Core Race Extension</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck15.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-race-definitions.html#Extension.extension:ombCategory\" title=\"Slice ombCategory: The 5 race category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).\">extension:ombCategory</a><a name=\"Extension.extension\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..5</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/extensibility.html#Extension\">Extension</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">American Indian or Alaska Native|Asian|Black or African American|Native Hawaiian or Other Pacific Islander|White</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck150.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-race-definitions.html#Extension.extension:ombCategory.url\">url</a><a name=\"Extension.extension.url\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"color: darkgreen\">&quot;ombCategory&quot;</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck140.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-race-definitions.html#Extension.extension:ombCategory.valueCoding\">valueCoding</a><a name=\"Extension.extension.valueCoding\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Value of extension</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-omb-race-category.html\">OMB Race Categories</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>): The 5 race category codes according to the <a href=\"https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf\">OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997</a>.<br/><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck15.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-race-definitions.html#Extension.extension:detailed\" title=\"Slice detailed: The 900+ CDC race codes that are grouped under one of the 5 OMB race category codes:.\">extension:detailed</a><a name=\"Extension.extension\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/extensibility.html#Extension\">Extension</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Extended race codes<br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck150.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-race-definitions.html#Extension.extension:detailed.url\">url</a><a name=\"Extension.extension.url\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"color: darkgreen\">&quot;detailed&quot;</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck140.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-race-definitions.html#Extension.extension:detailed.valueCoding\">valueCoding</a><a name=\"Extension.extension.valueCoding\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Value of extension</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-detailed-race.html\">Detailed Race</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck15.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-race-definitions.html#Extension.extension:text\" title=\"Slice text: Plain text representation of the race concept(s).\">extension:text</a><a name=\"Extension.extension\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/extensibility.html#Extension\">Extension</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Race Text</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck150.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-race-definitions.html#Extension.extension:text.url\">url</a><a name=\"Extension.extension.url\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"color: darkgreen\">&quot;text&quot;</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck140.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-race-definitions.html#Extension.extension:text.valueString\">valueString</a><a name=\"Extension.extension.valueString\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Value of extension</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-race-definitions.html#Extension.url\">url</a><a name=\"Extension.url\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"color: darkgreen\">&quot;http://hl7.org/fhir/us/core/StructureDefinition/us-core-race&quot;</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck00.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <span style=\"text-decoration:line-through\">value[x]</span><a name=\"Extension.value_x_\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"text-decoration:line-through\"/><span style=\"text-decoration:line-through\">0</span><span style=\"text-decoration:line-through\">..</span><span style=\"text-decoration:line-through\">0</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
-	"version": "4.0.0",
-	"name": "USCoreRaceExtension",
-	"title": "US Core Race Extension",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\n - American Indian or Alaska Native\n - Asian\n - Black or African American\n - Native Hawaiian or Other Pacific Islander\n - White.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"purpose": "Complies with 2015 Edition Common Clinical Data Set for patient race.",
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		}
-	],
-	"kind": "complex-type",
-	"abstract": false,
-	"context": [
-		{
-			"type": "element",
-			"expression": "Patient"
-		},
-		{
-			"type": "element",
-			"expression": "RelatedPerson"
-		},
-		{
-			"type": "element",
-			"expression": "Person"
-		},
-		{
-			"type": "element",
-			"expression": "Practitioner"
-		}
-	],
-	"type": "Extension",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Extension",
-				"path": "Extension",
-				"short": "US Core Race Extension",
-				"definition": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\n   - American Indian or Alaska Native\n   - Asian\n   - Black or African American\n   - Native Hawaiian or Other Pacific Islander\n   - White.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Extension",
-					"min": 0,
-					"max": "*"
-				},
-				"condition": [
-					"ele-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false
-			},
-			{
-				"id": "Extension.id",
-				"path": "Extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension",
-				"path": "Extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory",
-				"path": "Extension.extension",
-				"sliceName": "ombCategory",
-				"short": "American Indian or Alaska Native|Asian|Black or African American|Native Hawaiian or Other Pacific Islander|White",
-				"definition": "The 5 race category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
-				"min": 0,
-				"max": "5",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "iso11179",
-						"map": "/ClinicalDocument/recordTarget/patientRole/patient/raceCode"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.id",
-				"path": "Extension.extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.extension",
-				"path": "Extension.extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.extension.id",
-				"path": "Extension.extension.extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.extension.extension",
-				"path": "Extension.extension.extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.extension.url",
-				"path": "Extension.extension.extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "uri"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.extension.value[x]",
-				"path": "Extension.extension.extension.value[x]",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "base64Binary"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "canonical"
-					},
-					{
-						"code": "code"
-					},
-					{
-						"code": "date"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "decimal"
-					},
-					{
-						"code": "id"
-					},
-					{
-						"code": "instant"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "markdown"
-					},
-					{
-						"code": "oid"
-					},
-					{
-						"code": "positiveInt"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "unsignedInt"
-					},
-					{
-						"code": "uri"
-					},
-					{
-						"code": "url"
-					},
-					{
-						"code": "uuid"
-					},
-					{
-						"code": "Address"
-					},
-					{
-						"code": "Age"
-					},
-					{
-						"code": "Annotation"
-					},
-					{
-						"code": "Attachment"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "Coding"
-					},
-					{
-						"code": "ContactPoint"
-					},
-					{
-						"code": "Count"
-					},
-					{
-						"code": "Distance"
-					},
-					{
-						"code": "Duration"
-					},
-					{
-						"code": "HumanName"
-					},
-					{
-						"code": "Identifier"
-					},
-					{
-						"code": "Money"
-					},
-					{
-						"code": "Period"
-					},
-					{
-						"code": "Quantity"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "Reference"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "Signature"
-					},
-					{
-						"code": "Timing"
-					},
-					{
-						"code": "ContactDetail"
-					},
-					{
-						"code": "Contributor"
-					},
-					{
-						"code": "DataRequirement"
-					},
-					{
-						"code": "Expression"
-					},
-					{
-						"code": "ParameterDefinition"
-					},
-					{
-						"code": "RelatedArtifact"
-					},
-					{
-						"code": "TriggerDefinition"
-					},
-					{
-						"code": "UsageContext"
-					},
-					{
-						"code": "Dosage"
-					},
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.url",
-				"path": "Extension.extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "ombCategory",
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.value[x]",
-				"path": "Extension.extension.value[x]",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "type",
-							"path": "$this"
-						}
-					],
-					"ordered": false,
-					"rules": "closed"
-				},
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.value[x]:valueCoding",
-				"path": "Extension.extension.value[x]",
-				"sliceName": "valueCoding",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"strength": "required",
-					"description": "The 5 race category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/omb-race-category"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed",
-				"path": "Extension.extension",
-				"sliceName": "detailed",
-				"short": "Extended race codes",
-				"definition": "The 900+ CDC race codes that are grouped under one of the 5 OMB race category codes:.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "iso11179",
-						"map": "/ClinicalDocument/recordTarget/patientRole/patient/sdtc:raceCode"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.id",
-				"path": "Extension.extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.extension",
-				"path": "Extension.extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.extension.id",
-				"path": "Extension.extension.extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.extension.extension",
-				"path": "Extension.extension.extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.extension.url",
-				"path": "Extension.extension.extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "uri"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.extension.value[x]",
-				"path": "Extension.extension.extension.value[x]",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "base64Binary"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "canonical"
-					},
-					{
-						"code": "code"
-					},
-					{
-						"code": "date"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "decimal"
-					},
-					{
-						"code": "id"
-					},
-					{
-						"code": "instant"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "markdown"
-					},
-					{
-						"code": "oid"
-					},
-					{
-						"code": "positiveInt"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "unsignedInt"
-					},
-					{
-						"code": "uri"
-					},
-					{
-						"code": "url"
-					},
-					{
-						"code": "uuid"
-					},
-					{
-						"code": "Address"
-					},
-					{
-						"code": "Age"
-					},
-					{
-						"code": "Annotation"
-					},
-					{
-						"code": "Attachment"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "Coding"
-					},
-					{
-						"code": "ContactPoint"
-					},
-					{
-						"code": "Count"
-					},
-					{
-						"code": "Distance"
-					},
-					{
-						"code": "Duration"
-					},
-					{
-						"code": "HumanName"
-					},
-					{
-						"code": "Identifier"
-					},
-					{
-						"code": "Money"
-					},
-					{
-						"code": "Period"
-					},
-					{
-						"code": "Quantity"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "Reference"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "Signature"
-					},
-					{
-						"code": "Timing"
-					},
-					{
-						"code": "ContactDetail"
-					},
-					{
-						"code": "Contributor"
-					},
-					{
-						"code": "DataRequirement"
-					},
-					{
-						"code": "Expression"
-					},
-					{
-						"code": "ParameterDefinition"
-					},
-					{
-						"code": "RelatedArtifact"
-					},
-					{
-						"code": "TriggerDefinition"
-					},
-					{
-						"code": "UsageContext"
-					},
-					{
-						"code": "Dosage"
-					},
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.url",
-				"path": "Extension.extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "detailed",
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.value[x]",
-				"path": "Extension.extension.value[x]",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "type",
-							"path": "$this"
-						}
-					],
-					"ordered": false,
-					"rules": "closed"
-				},
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.value[x]:valueCoding",
-				"path": "Extension.extension.value[x]",
-				"sliceName": "valueCoding",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/detailed-race"
-				},
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text",
-				"path": "Extension.extension",
-				"sliceName": "text",
-				"short": "Race Text",
-				"definition": "Plain text representation of the race concept(s).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false
-			},
-			{
-				"id": "Extension.extension:text.id",
-				"path": "Extension.extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text.extension",
-				"path": "Extension.extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text.extension.id",
-				"path": "Extension.extension.extension.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text.extension.extension",
-				"path": "Extension.extension.extension.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text.extension.url",
-				"path": "Extension.extension.extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "uri"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text.extension.value[x]",
-				"path": "Extension.extension.extension.value[x]",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "base64Binary"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "canonical"
-					},
-					{
-						"code": "code"
-					},
-					{
-						"code": "date"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "decimal"
-					},
-					{
-						"code": "id"
-					},
-					{
-						"code": "instant"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "markdown"
-					},
-					{
-						"code": "oid"
-					},
-					{
-						"code": "positiveInt"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "unsignedInt"
-					},
-					{
-						"code": "uri"
-					},
-					{
-						"code": "url"
-					},
-					{
-						"code": "uuid"
-					},
-					{
-						"code": "Address"
-					},
-					{
-						"code": "Age"
-					},
-					{
-						"code": "Annotation"
-					},
-					{
-						"code": "Attachment"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "Coding"
-					},
-					{
-						"code": "ContactPoint"
-					},
-					{
-						"code": "Count"
-					},
-					{
-						"code": "Distance"
-					},
-					{
-						"code": "Duration"
-					},
-					{
-						"code": "HumanName"
-					},
-					{
-						"code": "Identifier"
-					},
-					{
-						"code": "Money"
-					},
-					{
-						"code": "Period"
-					},
-					{
-						"code": "Quantity"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "Reference"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "Signature"
-					},
-					{
-						"code": "Timing"
-					},
-					{
-						"code": "ContactDetail"
-					},
-					{
-						"code": "Contributor"
-					},
-					{
-						"code": "DataRequirement"
-					},
-					{
-						"code": "Expression"
-					},
-					{
-						"code": "ParameterDefinition"
-					},
-					{
-						"code": "RelatedArtifact"
-					},
-					{
-						"code": "TriggerDefinition"
-					},
-					{
-						"code": "UsageContext"
-					},
-					{
-						"code": "Dosage"
-					},
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text.url",
-				"path": "Extension.extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "text",
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text.value[x]",
-				"path": "Extension.extension.value[x]",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "type",
-							"path": "$this"
-						}
-					],
-					"ordered": false,
-					"rules": "closed"
-				},
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:text.value[x]:valueString",
-				"path": "Extension.extension.value[x]",
-				"sliceName": "valueString",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.url",
-				"path": "Extension.url",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "identifies the meaning of the extension",
-				"definition": "Source of the definition for the extension code - a logical name or a URL.",
-				"comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Extension.url",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "uri"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Extension.value[x]",
-				"path": "Extension.value[x]",
-				"short": "Value of extension",
-				"definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
-				"min": 0,
-				"max": "0",
-				"base": {
-					"path": "Extension.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "base64Binary"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "canonical"
-					},
-					{
-						"code": "code"
-					},
-					{
-						"code": "date"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "decimal"
-					},
-					{
-						"code": "id"
-					},
-					{
-						"code": "instant"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "markdown"
-					},
-					{
-						"code": "oid"
-					},
-					{
-						"code": "positiveInt"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "unsignedInt"
-					},
-					{
-						"code": "uri"
-					},
-					{
-						"code": "url"
-					},
-					{
-						"code": "uuid"
-					},
-					{
-						"code": "Address"
-					},
-					{
-						"code": "Age"
-					},
-					{
-						"code": "Annotation"
-					},
-					{
-						"code": "Attachment"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "Coding"
-					},
-					{
-						"code": "ContactPoint"
-					},
-					{
-						"code": "Count"
-					},
-					{
-						"code": "Distance"
-					},
-					{
-						"code": "Duration"
-					},
-					{
-						"code": "HumanName"
-					},
-					{
-						"code": "Identifier"
-					},
-					{
-						"code": "Money"
-					},
-					{
-						"code": "Period"
-					},
-					{
-						"code": "Quantity"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "Reference"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "Signature"
-					},
-					{
-						"code": "Timing"
-					},
-					{
-						"code": "ContactDetail"
-					},
-					{
-						"code": "Contributor"
-					},
-					{
-						"code": "DataRequirement"
-					},
-					{
-						"code": "Expression"
-					},
-					{
-						"code": "ParameterDefinition"
-					},
-					{
-						"code": "RelatedArtifact"
-					},
-					{
-						"code": "TriggerDefinition"
-					},
-					{
-						"code": "UsageContext"
-					},
-					{
-						"code": "Dosage"
-					},
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Extension",
-				"path": "Extension",
-				"short": "US Core Race Extension",
-				"definition": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\n   - American Indian or Alaska Native\n   - Asian\n   - Black or African American\n   - Native Hawaiian or Other Pacific Islander\n   - White.",
-				"min": 0,
-				"max": "1"
-			},
-			{
-				"id": "Extension.extension:ombCategory",
-				"path": "Extension.extension",
-				"sliceName": "ombCategory",
-				"short": "American Indian or Alaska Native|Asian|Black or African American|Native Hawaiian or Other Pacific Islander|White",
-				"definition": "The 5 race category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
-				"min": 0,
-				"max": "5",
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "iso11179",
-						"map": "/ClinicalDocument/recordTarget/patientRole/patient/raceCode"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:ombCategory.url",
-				"path": "Extension.extension.url",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "ombCategory"
-			},
-			{
-				"id": "Extension.extension:ombCategory.valueCoding",
-				"path": "Extension.extension.valueCoding",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"binding": {
-					"strength": "required",
-					"description": "The 5 race category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/omb-race-category"
-				}
-			},
-			{
-				"id": "Extension.extension:detailed",
-				"path": "Extension.extension",
-				"sliceName": "detailed",
-				"short": "Extended race codes",
-				"definition": "The 900+ CDC race codes that are grouped under one of the 5 OMB race category codes:.",
-				"min": 0,
-				"max": "*",
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"mapping": [
-					{
-						"identity": "iso11179",
-						"map": "/ClinicalDocument/recordTarget/patientRole/patient/sdtc:raceCode"
-					}
-				]
-			},
-			{
-				"id": "Extension.extension:detailed.url",
-				"path": "Extension.extension.url",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "detailed"
-			},
-			{
-				"id": "Extension.extension:detailed.valueCoding",
-				"path": "Extension.extension.valueCoding",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/detailed-race"
-				}
-			},
-			{
-				"id": "Extension.extension:text",
-				"path": "Extension.extension",
-				"sliceName": "text",
-				"short": "Race Text",
-				"definition": "Plain text representation of the race concept(s).",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Extension.extension:text.url",
-				"path": "Extension.extension.url",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "text"
-			},
-			{
-				"id": "Extension.extension:text.valueString",
-				"path": "Extension.extension.valueString",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				]
-			},
-			{
-				"id": "Extension.url",
-				"path": "Extension.url",
-				"min": 1,
-				"max": "1",
-				"fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
-			},
-			{
-				"id": "Extension.value[x]",
-				"path": "Extension.value[x]",
-				"min": 0,
-				"max": "0"
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-race",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+    "version": "4.0.0",
+    "name": "USCoreRaceExtension",
+    "title": "US Core Race Extension",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\n - American Indian or Alaska Native\n - Asian\n - Black or African American\n - Native Hawaiian or Other Pacific Islander\n - White.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "purpose": "Complies with 2015 Edition Common Clinical Data Set for patient race.",
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        }
+    ],
+    "kind": "complex-type",
+    "abstract": false,
+    "context": [
+        {
+            "type": "element",
+            "expression": "Patient"
+        },
+        {
+            "type": "element",
+            "expression": "RelatedPerson"
+        },
+        {
+            "type": "element",
+            "expression": "Person"
+        },
+        {
+            "type": "element",
+            "expression": "Practitioner"
+        }
+    ],
+    "type": "Extension",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Extension",
+                "path": "Extension",
+                "short": "US Core Race Extension",
+                "definition": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\n   - American Indian or Alaska Native\n   - Asian\n   - Black or African American\n   - Native Hawaiian or Other Pacific Islander\n   - White.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "condition": [
+                    "ele-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), 'value')])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false
+            },
+            {
+                "id": "Extension.id",
+                "path": "Extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension",
+                "path": "Extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory",
+                "path": "Extension.extension",
+                "sliceName": "ombCategory",
+                "short": "American Indian or Alaska Native|Asian|Black or African American|Native Hawaiian or Other Pacific Islander|White",
+                "definition": "The 5 race category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
+                "min": 0,
+                "max": "5",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "iso11179",
+                        "map": "/ClinicalDocument/recordTarget/patientRole/patient/raceCode"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.id",
+                "path": "Extension.extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.extension",
+                "path": "Extension.extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.extension.id",
+                "path": "Extension.extension.extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.extension.extension",
+                "path": "Extension.extension.extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.extension.url",
+                "path": "Extension.extension.extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "uri"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.extension.value[x]",
+                "path": "Extension.extension.extension.value[x]",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "base64Binary"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "canonical"
+                    },
+                    {
+                        "code": "code"
+                    },
+                    {
+                        "code": "date"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "decimal"
+                    },
+                    {
+                        "code": "id"
+                    },
+                    {
+                        "code": "instant"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "markdown"
+                    },
+                    {
+                        "code": "oid"
+                    },
+                    {
+                        "code": "positiveInt"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "unsignedInt"
+                    },
+                    {
+                        "code": "uri"
+                    },
+                    {
+                        "code": "url"
+                    },
+                    {
+                        "code": "uuid"
+                    },
+                    {
+                        "code": "Address"
+                    },
+                    {
+                        "code": "Age"
+                    },
+                    {
+                        "code": "Annotation"
+                    },
+                    {
+                        "code": "Attachment"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "Coding"
+                    },
+                    {
+                        "code": "ContactPoint"
+                    },
+                    {
+                        "code": "Count"
+                    },
+                    {
+                        "code": "Distance"
+                    },
+                    {
+                        "code": "Duration"
+                    },
+                    {
+                        "code": "HumanName"
+                    },
+                    {
+                        "code": "Identifier"
+                    },
+                    {
+                        "code": "Money"
+                    },
+                    {
+                        "code": "Period"
+                    },
+                    {
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "Reference"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "Signature"
+                    },
+                    {
+                        "code": "Timing"
+                    },
+                    {
+                        "code": "ContactDetail"
+                    },
+                    {
+                        "code": "Contributor"
+                    },
+                    {
+                        "code": "DataRequirement"
+                    },
+                    {
+                        "code": "Expression"
+                    },
+                    {
+                        "code": "ParameterDefinition"
+                    },
+                    {
+                        "code": "RelatedArtifact"
+                    },
+                    {
+                        "code": "TriggerDefinition"
+                    },
+                    {
+                        "code": "UsageContext"
+                    },
+                    {
+                        "code": "Dosage"
+                    },
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.url",
+                "path": "Extension.extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "ombCategory",
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.value[x]",
+                "path": "Extension.extension.value[x]",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "type",
+                            "path": "$this"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "closed"
+                },
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.value[x]:valueCoding",
+                "path": "Extension.extension.value[x]",
+                "sliceName": "valueCoding",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "strength": "required",
+                    "description": "The 5 race category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/omb-race-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed",
+                "path": "Extension.extension",
+                "sliceName": "detailed",
+                "short": "Extended race codes",
+                "definition": "The 900+ CDC race codes that are grouped under one of the 5 OMB race category codes:.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "iso11179",
+                        "map": "/ClinicalDocument/recordTarget/patientRole/patient/sdtc:raceCode"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.id",
+                "path": "Extension.extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.extension",
+                "path": "Extension.extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.extension.id",
+                "path": "Extension.extension.extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.extension.extension",
+                "path": "Extension.extension.extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.extension.url",
+                "path": "Extension.extension.extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "uri"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.extension.value[x]",
+                "path": "Extension.extension.extension.value[x]",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "base64Binary"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "canonical"
+                    },
+                    {
+                        "code": "code"
+                    },
+                    {
+                        "code": "date"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "decimal"
+                    },
+                    {
+                        "code": "id"
+                    },
+                    {
+                        "code": "instant"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "markdown"
+                    },
+                    {
+                        "code": "oid"
+                    },
+                    {
+                        "code": "positiveInt"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "unsignedInt"
+                    },
+                    {
+                        "code": "uri"
+                    },
+                    {
+                        "code": "url"
+                    },
+                    {
+                        "code": "uuid"
+                    },
+                    {
+                        "code": "Address"
+                    },
+                    {
+                        "code": "Age"
+                    },
+                    {
+                        "code": "Annotation"
+                    },
+                    {
+                        "code": "Attachment"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "Coding"
+                    },
+                    {
+                        "code": "ContactPoint"
+                    },
+                    {
+                        "code": "Count"
+                    },
+                    {
+                        "code": "Distance"
+                    },
+                    {
+                        "code": "Duration"
+                    },
+                    {
+                        "code": "HumanName"
+                    },
+                    {
+                        "code": "Identifier"
+                    },
+                    {
+                        "code": "Money"
+                    },
+                    {
+                        "code": "Period"
+                    },
+                    {
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "Reference"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "Signature"
+                    },
+                    {
+                        "code": "Timing"
+                    },
+                    {
+                        "code": "ContactDetail"
+                    },
+                    {
+                        "code": "Contributor"
+                    },
+                    {
+                        "code": "DataRequirement"
+                    },
+                    {
+                        "code": "Expression"
+                    },
+                    {
+                        "code": "ParameterDefinition"
+                    },
+                    {
+                        "code": "RelatedArtifact"
+                    },
+                    {
+                        "code": "TriggerDefinition"
+                    },
+                    {
+                        "code": "UsageContext"
+                    },
+                    {
+                        "code": "Dosage"
+                    },
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.url",
+                "path": "Extension.extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "detailed",
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.value[x]",
+                "path": "Extension.extension.value[x]",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "type",
+                            "path": "$this"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "closed"
+                },
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.value[x]:valueCoding",
+                "path": "Extension.extension.value[x]",
+                "sliceName": "valueCoding",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/detailed-race"
+                },
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text",
+                "path": "Extension.extension",
+                "sliceName": "text",
+                "short": "Race Text",
+                "definition": "Plain text representation of the race concept(s).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false
+            },
+            {
+                "id": "Extension.extension:text.id",
+                "path": "Extension.extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text.extension",
+                "path": "Extension.extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text.extension.id",
+                "path": "Extension.extension.extension.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text.extension.extension",
+                "path": "Extension.extension.extension.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text.extension.url",
+                "path": "Extension.extension.extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "uri"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text.extension.value[x]",
+                "path": "Extension.extension.extension.value[x]",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "base64Binary"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "canonical"
+                    },
+                    {
+                        "code": "code"
+                    },
+                    {
+                        "code": "date"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "decimal"
+                    },
+                    {
+                        "code": "id"
+                    },
+                    {
+                        "code": "instant"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "markdown"
+                    },
+                    {
+                        "code": "oid"
+                    },
+                    {
+                        "code": "positiveInt"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "unsignedInt"
+                    },
+                    {
+                        "code": "uri"
+                    },
+                    {
+                        "code": "url"
+                    },
+                    {
+                        "code": "uuid"
+                    },
+                    {
+                        "code": "Address"
+                    },
+                    {
+                        "code": "Age"
+                    },
+                    {
+                        "code": "Annotation"
+                    },
+                    {
+                        "code": "Attachment"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "Coding"
+                    },
+                    {
+                        "code": "ContactPoint"
+                    },
+                    {
+                        "code": "Count"
+                    },
+                    {
+                        "code": "Distance"
+                    },
+                    {
+                        "code": "Duration"
+                    },
+                    {
+                        "code": "HumanName"
+                    },
+                    {
+                        "code": "Identifier"
+                    },
+                    {
+                        "code": "Money"
+                    },
+                    {
+                        "code": "Period"
+                    },
+                    {
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "Reference"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "Signature"
+                    },
+                    {
+                        "code": "Timing"
+                    },
+                    {
+                        "code": "ContactDetail"
+                    },
+                    {
+                        "code": "Contributor"
+                    },
+                    {
+                        "code": "DataRequirement"
+                    },
+                    {
+                        "code": "Expression"
+                    },
+                    {
+                        "code": "ParameterDefinition"
+                    },
+                    {
+                        "code": "RelatedArtifact"
+                    },
+                    {
+                        "code": "TriggerDefinition"
+                    },
+                    {
+                        "code": "UsageContext"
+                    },
+                    {
+                        "code": "Dosage"
+                    },
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text.url",
+                "path": "Extension.extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "text",
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text.value[x]",
+                "path": "Extension.extension.value[x]",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "type",
+                            "path": "$this"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "closed"
+                },
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:text.value[x]:valueString",
+                "path": "Extension.extension.value[x]",
+                "sliceName": "valueString",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.url",
+                "path": "Extension.url",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "identifies the meaning of the extension",
+                "definition": "Source of the definition for the extension code - a logical name or a URL.",
+                "comment": "The definition may point directly to a computable or human-readable definition of the extensibility codes, or it may be a logical URI as declared in some other specification. The definition SHALL be a URI for the Structure Definition defining the extension.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Extension.url",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "uri"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race",
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.value[x]",
+                "path": "Extension.value[x]",
+                "short": "Value of extension",
+                "definition": "Value of extension - must be one of a constrained set of the data types (see [Extensibility](http://hl7.org/fhir/R4/extensibility.html) for a list).",
+                "min": 0,
+                "max": "0",
+                "base": {
+                    "path": "Extension.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "base64Binary"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "canonical"
+                    },
+                    {
+                        "code": "code"
+                    },
+                    {
+                        "code": "date"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "decimal"
+                    },
+                    {
+                        "code": "id"
+                    },
+                    {
+                        "code": "instant"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "markdown"
+                    },
+                    {
+                        "code": "oid"
+                    },
+                    {
+                        "code": "positiveInt"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "unsignedInt"
+                    },
+                    {
+                        "code": "uri"
+                    },
+                    {
+                        "code": "url"
+                    },
+                    {
+                        "code": "uuid"
+                    },
+                    {
+                        "code": "Address"
+                    },
+                    {
+                        "code": "Age"
+                    },
+                    {
+                        "code": "Annotation"
+                    },
+                    {
+                        "code": "Attachment"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "Coding"
+                    },
+                    {
+                        "code": "ContactPoint"
+                    },
+                    {
+                        "code": "Count"
+                    },
+                    {
+                        "code": "Distance"
+                    },
+                    {
+                        "code": "Duration"
+                    },
+                    {
+                        "code": "HumanName"
+                    },
+                    {
+                        "code": "Identifier"
+                    },
+                    {
+                        "code": "Money"
+                    },
+                    {
+                        "code": "Period"
+                    },
+                    {
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "Reference"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "Signature"
+                    },
+                    {
+                        "code": "Timing"
+                    },
+                    {
+                        "code": "ContactDetail"
+                    },
+                    {
+                        "code": "Contributor"
+                    },
+                    {
+                        "code": "DataRequirement"
+                    },
+                    {
+                        "code": "Expression"
+                    },
+                    {
+                        "code": "ParameterDefinition"
+                    },
+                    {
+                        "code": "RelatedArtifact"
+                    },
+                    {
+                        "code": "TriggerDefinition"
+                    },
+                    {
+                        "code": "UsageContext"
+                    },
+                    {
+                        "code": "Dosage"
+                    },
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Extension",
+                "path": "Extension",
+                "short": "US Core Race Extension",
+                "definition": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\n   - American Indian or Alaska Native\n   - Asian\n   - Black or African American\n   - Native Hawaiian or Other Pacific Islander\n   - White.",
+                "min": 0,
+                "max": "1"
+            },
+            {
+                "id": "Extension.extension:ombCategory",
+                "path": "Extension.extension",
+                "sliceName": "ombCategory",
+                "short": "American Indian or Alaska Native|Asian|Black or African American|Native Hawaiian or Other Pacific Islander|White",
+                "definition": "The 5 race category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
+                "min": 0,
+                "max": "5",
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "iso11179",
+                        "map": "/ClinicalDocument/recordTarget/patientRole/patient/raceCode"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:ombCategory.url",
+                "path": "Extension.extension.url",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "ombCategory"
+            },
+            {
+                "id": "Extension.extension:ombCategory.valueCoding",
+                "path": "Extension.extension.valueCoding",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "binding": {
+                    "strength": "required",
+                    "description": "The 5 race category codes according to the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/omb-race-category"
+                }
+            },
+            {
+                "id": "Extension.extension:detailed",
+                "path": "Extension.extension",
+                "sliceName": "detailed",
+                "short": "Extended race codes",
+                "definition": "The 900+ CDC race codes that are grouped under one of the 5 OMB race category codes:.",
+                "min": 0,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "mapping": [
+                    {
+                        "identity": "iso11179",
+                        "map": "/ClinicalDocument/recordTarget/patientRole/patient/sdtc:raceCode"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.extension:detailed.url",
+                "path": "Extension.extension.url",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "detailed"
+            },
+            {
+                "id": "Extension.extension:detailed.valueCoding",
+                "path": "Extension.extension.valueCoding",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/detailed-race"
+                }
+            },
+            {
+                "id": "Extension.extension:text",
+                "path": "Extension.extension",
+                "sliceName": "text",
+                "short": "Race Text",
+                "definition": "Plain text representation of the race concept(s).",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Extension.extension:text.url",
+                "path": "Extension.extension.url",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "text"
+            },
+            {
+                "id": "Extension.extension:text.valueString",
+                "path": "Extension.extension.valueString",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ]
+            },
+            {
+                "id": "Extension.url",
+                "path": "Extension.url",
+                "min": 1,
+                "max": "1",
+                "fixedUri": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
+            },
+            {
+                "id": "Extension.value[x]",
+                "path": "Extension.value[x]",
+                "min": 0,
+                "max": "0"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-respiratory-rate.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-respiratory-rate.json
@@ -1,3808 +1,3808 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-respiratory-rate",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-respiratory-rate-definitions.html#Observation\" title=\"Defines constraints on Observation to represent respiratory rate observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.\">Observation</a><a name=\"Observation\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"StructureDefinition-us-core-vital-signs.html\">USCoreVitalSignsProfile</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">US Core Respiratory Rate Profile</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-respiratory-rate-definitions.html#Observation.code\">code</a><a name=\"Observation.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">1</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Respiratory Rate<br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck101.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#CodeableConcept.coding\">coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Code defined by a terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">(complex)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/loinc.html\">http://loinc.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">9279-1</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-respiratory-rate-definitions.html#Observation.valueQuantity\">valueQuantity</a><a name=\"Observation.valueQuantity\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">0..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#Quantity\">Quantity</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Vital Signs Value</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-respiratory-rate-definitions.html#Observation.valueQuantity.value\">value</a><a name=\"Observation.valueQuantity.value\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#decimal\">decimal</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Numerical value (with implicit precision)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-respiratory-rate-definitions.html#Observation.valueQuantity.unit\">unit</a><a name=\"Observation.valueQuantity.unit\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Unit representation</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-respiratory-rate-definitions.html#Observation.valueQuantity.system\">system</a><a name=\"Observation.valueQuantity.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">System that defines coded unit form</span><br/><span style=\"font-weight:bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"http://hl7.org/fhir/R4/ucum.html\">http://unitsofmeasure.org</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-respiratory-rate-definitions.html#Observation.valueQuantity.code\">code</a><a name=\"Observation.valueQuantity.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Coded responses from the common UCUM units for vital signs value set.<br/><span style=\"font-weight:bold\">Fixed Value: </span><span style=\"color: darkgreen\">/min</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-respiratory-rate",
-	"version": "4.0.0",
-	"name": "USCoreRespiratoryRateProfile",
-	"title": "US Core Respiratory Rate Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-17",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints on Observation to represent respiratory rate observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "sct-concept",
-			"uri": "http://snomed.info/conceptdomain",
-			"name": "SNOMED CT Concept Domain Binding"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "sct-attr",
-			"uri": "http://snomed.org/attributebinding",
-			"name": "SNOMED CT Attribute Binding"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Observation",
-	"baseDefinition": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "US Core Respiratory Rate Profile",
-				"definition": "Defines constraints on Observation to represent respiratory rate observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
-				"alias": [
-					"Vital Signs",
-					"Measurement",
-					"Results",
-					"Tests"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "obs-6",
-						"severity": "error",
-						"human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
-						"expression": "dataAbsentReason.empty() or value.empty()",
-						"xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "obs-7",
-						"severity": "error",
-						"human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
-						"expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
-						"xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "vs-2",
-						"severity": "error",
-						"human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
-						"expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
-						"xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.id",
-				"path": "Observation.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.meta",
-				"path": "Observation.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.implicitRules",
-				"path": "Observation.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Observation.language",
-				"path": "Observation.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Observation.text",
-				"path": "Observation.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Observation.contained",
-				"path": "Observation.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.extension",
-				"path": "Observation.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.modifierExtension",
-				"path": "Observation.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.identifier",
-				"path": "Observation.identifier",
-				"short": "Business Identifier for observation",
-				"definition": "A unique identifier assigned to this observation.",
-				"requirements": "Allows observations to be distinguished and referenced.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
-					},
-					{
-						"identity": "rim",
-						"map": "id"
-					}
-				]
-			},
-			{
-				"id": "Observation.basedOn",
-				"path": "Observation.basedOn",
-				"short": "Fulfills plan, proposal or order",
-				"definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
-				"requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
-				"alias": [
-					"Fulfills"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan",
-							"http://hl7.org/fhir/StructureDefinition/DeviceRequest",
-							"http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
-							"http://hl7.org/fhir/StructureDefinition/MedicationRequest",
-							"http://hl7.org/fhir/StructureDefinition/NutritionOrder",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.basedOn"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.partOf",
-				"path": "Observation.partOf",
-				"short": "Part of referenced event",
-				"definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
-				"comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
-				"alias": [
-					"Container"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.partOf",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
-							"http://hl7.org/fhir/StructureDefinition/MedicationDispense",
-							"http://hl7.org/fhir/StructureDefinition/MedicationStatement",
-							"http://hl7.org/fhir/StructureDefinition/Procedure",
-							"http://hl7.org/fhir/StructureDefinition/Immunization",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.partOf"
-					},
-					{
-						"identity": "v2",
-						"map": "Varies by domain"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=FLFS].target"
-					}
-				]
-			},
-			{
-				"id": "Observation.status",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
-						"valueString": "default: final"
-					}
-				],
-				"path": "Observation.status",
-				"short": "registered | preliminary | final | amended +",
-				"definition": "The status of the result value.",
-				"comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
-				"requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Status"
-						}
-					],
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 445584004 |Report by finality status|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-11"
-					},
-					{
-						"identity": "rim",
-						"map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
-					}
-				]
-			},
-			{
-				"id": "Observation.category",
-				"path": "Observation.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "coding.code"
-						},
-						{
-							"type": "value",
-							"path": "coding.system"
-						}
-					],
-					"ordered": false,
-					"rules": "open"
-				},
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat",
-				"path": "Observation.category",
-				"sliceName": "VSCat",
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.id",
-				"path": "Observation.category.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.extension",
-				"path": "Observation.category.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding",
-				"path": "Observation.category.coding",
-				"short": "Code defined by a terminology system",
-				"definition": "A reference to a code defined by a terminology system.",
-				"comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
-				"requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "CodeableConcept.coding",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1-8, C*E.10-22"
-					},
-					{
-						"identity": "rim",
-						"map": "union(., ./translation)"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.id",
-				"path": "Observation.category.coding.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.extension",
-				"path": "Observation.category.coding.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.system",
-				"path": "Observation.category.coding.system",
-				"short": "Identity of the terminology system",
-				"definition": "The identification of the code system that defines the meaning of the symbol in the code.",
-				"comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
-				"requirements": "Need to be unambiguous about the source of the definition of the symbol.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.3"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystem"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.version",
-				"path": "Observation.category.coding.version",
-				"short": "Version of the system - if relevant",
-				"definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
-				"comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.version",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.7"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystemVersion"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.code",
-				"path": "Observation.category.coding.code",
-				"short": "Symbol in syntax defined by the system",
-				"definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
-				"requirements": "Need to refer to a particular code in the system.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "vital-signs",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1"
-					},
-					{
-						"identity": "rim",
-						"map": "./code"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.display",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.coding.display",
-				"short": "Representation defined by the system",
-				"definition": "A representation of the meaning of the code in the system, following the rules of the system.",
-				"requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.display",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.2 - but note this is not well followed"
-					},
-					{
-						"identity": "rim",
-						"map": "CV.displayName"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.userSelected",
-				"path": "Observation.category.coding.userSelected",
-				"short": "If this coding was chosen directly by the user",
-				"definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
-				"comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
-				"requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.userSelected",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Sometimes implied by being first"
-					},
-					{
-						"identity": "rim",
-						"map": "CD.codingRationale"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.text",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.text",
-				"short": "Plain text representation of the concept",
-				"definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
-				"comment": "Very often the text is the same as a displayName of one of the codings.",
-				"requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CodeableConcept.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.9. But note many systems use C*E.2 for this"
-					},
-					{
-						"identity": "rim",
-						"map": "./originalText[mediaType/code=\"text/plain\"]/data"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
-					}
-				]
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Respiratory Rate",
-				"definition": "Coded Responses from C-CDA Vital Sign Results.",
-				"comment": "*All* code-value and, if present, component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
-				"alias": [
-					"Name"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "9279-1"
-						}
-					]
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "116680003 |Is a|"
-					}
-				]
-			},
-			{
-				"id": "Observation.subject",
-				"path": "Observation.subject",
-				"short": "Who and/or what the observation is about",
-				"definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
-				"comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
-				"requirements": "Observations have no value if you don't know who or what they're about.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=RTGT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.focus",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
-						"valueCode": "trial-use"
-					}
-				],
-				"path": "Observation.focus",
-				"short": "What the observation is about, when it is not about the subject of record",
-				"definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
-				"comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.focus",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SBJ]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.encounter",
-				"path": "Observation.encounter",
-				"short": "Healthcare event during which this observation is made",
-				"definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
-				"comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
-				"requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
-				"alias": [
-					"Context"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.effective[x]",
-				"path": "Observation.effective[x]",
-				"short": "Often just a dateTime for Vital Signs",
-				"definition": "Often just a dateTime for Vital Signs.",
-				"comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
-				"requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
-				"alias": [
-					"Occurrence"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.effective[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-1",
-						"severity": "error",
-						"human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
-						"expression": "($this as dateTime).toString().length() >= 8",
-						"xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "Observation.issued",
-				"path": "Observation.issued",
-				"short": "Date/Time this version was made available",
-				"definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
-				"comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.issued",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=AUT].time"
-					}
-				]
-			},
-			{
-				"id": "Observation.performer",
-				"path": "Observation.performer",
-				"short": "Who is responsible for the observation",
-				"definition": "Who was responsible for asserting the observed value as \"true\".",
-				"requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.performer",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=PRF]"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]",
-				"path": "Observation.value[x]",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "type",
-							"path": "$this"
-						}
-					],
-					"ordered": false,
-					"rules": "closed"
-				},
-				"short": "Vital Signs Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity",
-				"path": "Observation.value[x]",
-				"sliceName": "valueQuantity",
-				"short": "Vital Signs Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.id",
-				"path": "Observation.value[x].id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.extension",
-				"path": "Observation.value[x].extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.value",
-				"path": "Observation.value[x].value",
-				"short": "Numerical value (with implicit precision)",
-				"definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
-				"comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
-				"requirements": "Precision is handled implicitly in almost all cases of measurement.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.value",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.2  / CQ - N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.comparator",
-				"path": "Observation.value[x].comparator",
-				"short": "< | <= | >= | > - how to understand the value",
-				"definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
-				"requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Quantity.comparator",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "QuantityComparator"
-						}
-					],
-					"strength": "required",
-					"description": "How the Quantity should be understood and represented.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "SN.1  / CQ.1"
-					},
-					{
-						"identity": "rim",
-						"map": "IVL properties"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.unit",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.value[x].unit",
-				"short": "Unit representation",
-				"definition": "A human-readable form of the unit.",
-				"requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.unit",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.unit"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.system",
-				"path": "Observation.value[x].system",
-				"short": "System that defines coded unit form",
-				"definition": "The identification of the system that provides the coded form of the unit.",
-				"requirements": "Need to know the system that defines the coded form of the unit.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"condition": [
-					"qty-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "CO.codeSystem, PQ.translation.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueQuantity.code",
-				"path": "Observation.value[x].code",
-				"short": "Coded responses from the common UCUM units for vital signs value set.",
-				"definition": "A computer processable form of the unit in some unit representation system.",
-				"comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
-				"requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Quantity.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "/min",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "(see OBX.6 etc.) / CQ.2"
-					},
-					{
-						"identity": "rim",
-						"map": "PQ.code, MO.currency, PQ.translation.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.dataAbsentReason",
-				"path": "Observation.dataAbsentReason",
-				"short": "Why the result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
-				"comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.interpretation",
-				"path": "Observation.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.note",
-				"path": "Observation.note",
-				"short": "Comments about the observation",
-				"definition": "Comments about the observation or the results.",
-				"comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
-				"requirements": "Need to be able to provide free text additional information.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
-					},
-					{
-						"identity": "rim",
-						"map": "subjectOf.observationEvent[code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.bodySite",
-				"path": "Observation.bodySite",
-				"short": "Observed body part",
-				"definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
-				"comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.bodySite",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "BodySite"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing anatomical locations. May include laterality.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/body-site"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123037004 |Body structure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-20"
-					},
-					{
-						"identity": "rim",
-						"map": "targetSiteCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "718497002 |Inherent location|"
-					}
-				]
-			},
-			{
-				"id": "Observation.method",
-				"path": "Observation.method",
-				"short": "How it was done",
-				"definition": "Indicates the mechanism used to perform the observation.",
-				"comment": "Only used if not implicit in code for Observation.code.",
-				"requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.method",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationMethod"
-						}
-					],
-					"strength": "example",
-					"description": "Methods for simple observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-17"
-					},
-					{
-						"identity": "rim",
-						"map": "methodCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.specimen",
-				"path": "Observation.specimen",
-				"short": "Specimen used for this observation",
-				"definition": "The specimen that was used when this observation was made.",
-				"comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.specimen",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Specimen"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123038009 |Specimen|"
-					},
-					{
-						"identity": "v2",
-						"map": "SPM segment"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SPC].specimen"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "704319004 |Inherent in|"
-					}
-				]
-			},
-			{
-				"id": "Observation.device",
-				"path": "Observation.device",
-				"short": "(Measurement) Device",
-				"definition": "The device used to generate the observation data.",
-				"comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.device",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/DeviceMetric"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 49062001 |Device|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-17 / PRT -10"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=DEV]"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "424226004 |Using device|"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange",
-				"path": "Observation.referenceRange",
-				"short": "Provides guide for interpretation",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "obs-3",
-						"severity": "error",
-						"human": "Must have at least a low or a high or text",
-						"expression": "low.exists() or high.exists() or text.exists()",
-						"xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.id",
-				"path": "Observation.referenceRange.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.extension",
-				"path": "Observation.referenceRange.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.modifierExtension",
-				"path": "Observation.referenceRange.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.low",
-				"path": "Observation.referenceRange.low",
-				"short": "Low Range, if relevant",
-				"definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.low",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.low"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.high",
-				"path": "Observation.referenceRange.high",
-				"short": "High Range, if relevant",
-				"definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.high",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.high"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.type",
-				"path": "Observation.referenceRange.type",
-				"short": "Reference range qualifier",
-				"definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
-				"requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeMeaning"
-						}
-					],
-					"strength": "preferred",
-					"description": "Code for the meaning of a reference range.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.appliesTo",
-				"path": "Observation.referenceRange.appliesTo",
-				"short": "Reference range population",
-				"definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
-				"requirements": "Need to be able to identify the target population for proper interpretation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange.appliesTo",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeType"
-						}
-					],
-					"strength": "example",
-					"description": "Codes identifying the population the reference range applies to.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.age",
-				"path": "Observation.referenceRange.age",
-				"short": "Applicable age range, if relevant",
-				"definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
-				"requirements": "Some analytes vary greatly over age.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.age",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Range"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.text",
-				"path": "Observation.referenceRange.text",
-				"short": "Text based reference range in an observation",
-				"definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:ST"
-					}
-				]
-			},
-			{
-				"id": "Observation.hasMember",
-				"path": "Observation.hasMember",
-				"short": "Used when reporting vital signs panel components",
-				"definition": "Used when reporting vital signs panel components.",
-				"comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.hasMember",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship"
-					}
-				]
-			},
-			{
-				"id": "Observation.derivedFrom",
-				"path": "Observation.derivedFrom",
-				"short": "Related measurements the observation is made from",
-				"definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
-				"comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.derivedFrom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/DocumentReference",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy",
-							"http://hl7.org/fhir/StructureDefinition/Media",
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": ".targetObservation"
-					}
-				]
-			},
-			{
-				"id": "Observation.component",
-				"path": "Observation.component",
-				"short": "Component observations",
-				"definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
-				"comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-3",
-						"severity": "error",
-						"human": "If there is no a value a data absent reason must be present",
-						"expression": "value.exists() or dataAbsentReason.exists()",
-						"xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "containment by OBX-4?"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=COMP]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.id",
-				"path": "Observation.component.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.extension",
-				"path": "Observation.component.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.modifierExtension",
-				"path": "Observation.component.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.code",
-				"path": "Observation.component.code",
-				"short": "Type of component observation (code / type)",
-				"definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
-				"comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.value[x]",
-				"path": "Observation.component.value[x]",
-				"short": "Vital Sign Component Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
-				"comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "Quantity"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.dataAbsentReason",
-				"path": "Observation.component.dataAbsentReason",
-				"short": "Why the component result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
-				"comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.interpretation",
-				"path": "Observation.component.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.referenceRange",
-				"path": "Observation.component.referenceRange",
-				"short": "Provides guide for interpretation of component result",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "US Core Respiratory Rate Profile",
-				"definition": "Defines constraints on Observation to represent respiratory rate observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile."
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Respiratory Rate",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://loinc.org",
-							"code": "9279-1"
-						}
-					]
-				},
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity",
-				"path": "Observation.valueQuantity",
-				"min": 0,
-				"max": "1",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.value",
-				"path": "Observation.valueQuantity.value",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "decimal"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.unit",
-				"path": "Observation.valueQuantity.unit",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.system",
-				"path": "Observation.valueQuantity.system",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://unitsofmeasure.org",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.valueQuantity.code",
-				"path": "Observation.valueQuantity.code",
-				"short": "Coded responses from the common UCUM units for vital signs value set.",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "/min",
-				"mustSupport": true
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-respiratory-rate",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-respiratory-rate",
+    "version": "4.0.0",
+    "name": "USCoreRespiratoryRateProfile",
+    "title": "US Core Respiratory Rate Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-17",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints on Observation to represent respiratory rate observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "sct-concept",
+            "uri": "http://snomed.info/conceptdomain",
+            "name": "SNOMED CT Concept Domain Binding"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "sct-attr",
+            "uri": "http://snomed.org/attributebinding",
+            "name": "SNOMED CT Attribute Binding"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Observation",
+    "baseDefinition": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "US Core Respiratory Rate Profile",
+                "definition": "Defines constraints on Observation to represent respiratory rate observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
+                "alias": [
+                    "Vital Signs",
+                    "Measurement",
+                    "Results",
+                    "Tests"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "obs-6",
+                        "severity": "error",
+                        "human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
+                        "expression": "dataAbsentReason.empty() or value.empty()",
+                        "xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "obs-7",
+                        "severity": "error",
+                        "human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
+                        "expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
+                        "xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "vs-2",
+                        "severity": "error",
+                        "human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
+                        "expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
+                        "xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.id",
+                "path": "Observation.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.meta",
+                "path": "Observation.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.implicitRules",
+                "path": "Observation.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Observation.language",
+                "path": "Observation.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Observation.text",
+                "path": "Observation.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.contained",
+                "path": "Observation.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.extension",
+                "path": "Observation.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.modifierExtension",
+                "path": "Observation.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.identifier",
+                "path": "Observation.identifier",
+                "short": "Business Identifier for observation",
+                "definition": "A unique identifier assigned to this observation.",
+                "requirements": "Allows observations to be distinguished and referenced.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "id"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.basedOn",
+                "path": "Observation.basedOn",
+                "short": "Fulfills plan, proposal or order",
+                "definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
+                "requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
+                "alias": [
+                    "Fulfills"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceRequest",
+                            "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+                            "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.basedOn"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.partOf",
+                "path": "Observation.partOf",
+                "short": "Part of referenced event",
+                "definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
+                "comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
+                "alias": [
+                    "Container"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.partOf",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationDispense",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationStatement",
+                            "http://hl7.org/fhir/StructureDefinition/Procedure",
+                            "http://hl7.org/fhir/StructureDefinition/Immunization",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.partOf"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "Varies by domain"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=FLFS].target"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.status",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
+                        "valueString": "default: final"
+                    }
+                ],
+                "path": "Observation.status",
+                "short": "registered | preliminary | final | amended +",
+                "definition": "The status of the result value.",
+                "comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
+                "requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Status"
+                        }
+                    ],
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 445584004 |Report by finality status|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-11"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category",
+                "path": "Observation.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "coding.code"
+                        },
+                        {
+                            "type": "value",
+                            "path": "coding.system"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "open"
+                },
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat",
+                "path": "Observation.category",
+                "sliceName": "VSCat",
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.id",
+                "path": "Observation.category.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.extension",
+                "path": "Observation.category.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding",
+                "path": "Observation.category.coding",
+                "short": "Code defined by a terminology system",
+                "definition": "A reference to a code defined by a terminology system.",
+                "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+                "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "CodeableConcept.coding",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1-8, C*E.10-22"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "union(., ./translation)"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.id",
+                "path": "Observation.category.coding.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.extension",
+                "path": "Observation.category.coding.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.system",
+                "path": "Observation.category.coding.system",
+                "short": "Identity of the terminology system",
+                "definition": "The identification of the code system that defines the meaning of the symbol in the code.",
+                "comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
+                "requirements": "Need to be unambiguous about the source of the definition of the symbol.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystem"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.version",
+                "path": "Observation.category.coding.version",
+                "short": "Version of the system - if relevant",
+                "definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
+                "comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.version",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystemVersion"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.code",
+                "path": "Observation.category.coding.code",
+                "short": "Symbol in syntax defined by the system",
+                "definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
+                "requirements": "Need to refer to a particular code in the system.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "vital-signs",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./code"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.display",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.coding.display",
+                "short": "Representation defined by the system",
+                "definition": "A representation of the meaning of the code in the system, following the rules of the system.",
+                "requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.display",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.2 - but note this is not well followed"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CV.displayName"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.userSelected",
+                "path": "Observation.category.coding.userSelected",
+                "short": "If this coding was chosen directly by the user",
+                "definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
+                "comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
+                "requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.userSelected",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Sometimes implied by being first"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CD.codingRationale"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.text",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.text",
+                "short": "Plain text representation of the concept",
+                "definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
+                "comment": "Very often the text is the same as a displayName of one of the codings.",
+                "requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CodeableConcept.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.9. But note many systems use C*E.2 for this"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./originalText[mediaType/code=\"text/plain\"]/data"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Respiratory Rate",
+                "definition": "Coded Responses from C-CDA Vital Sign Results.",
+                "comment": "*All* code-value and, if present, component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
+                "alias": [
+                    "Name"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "9279-1"
+                        }
+                    ]
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "116680003 |Is a|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.subject",
+                "path": "Observation.subject",
+                "short": "Who and/or what the observation is about",
+                "definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
+                "comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
+                "requirements": "Observations have no value if you don't know who or what they're about.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=RTGT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.focus",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+                        "valueCode": "trial-use"
+                    }
+                ],
+                "path": "Observation.focus",
+                "short": "What the observation is about, when it is not about the subject of record",
+                "definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
+                "comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.focus",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SBJ]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.encounter",
+                "path": "Observation.encounter",
+                "short": "Healthcare event during which this observation is made",
+                "definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
+                "comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
+                "requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
+                "alias": [
+                    "Context"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.effective[x]",
+                "path": "Observation.effective[x]",
+                "short": "Often just a dateTime for Vital Signs",
+                "definition": "Often just a dateTime for Vital Signs.",
+                "comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
+                "requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
+                "alias": [
+                    "Occurrence"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.effective[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-1",
+                        "severity": "error",
+                        "human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
+                        "expression": "($this as dateTime).toString().length() >= 8",
+                        "xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.issued",
+                "path": "Observation.issued",
+                "short": "Date/Time this version was made available",
+                "definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
+                "comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.issued",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.performer",
+                "path": "Observation.performer",
+                "short": "Who is responsible for the observation",
+                "definition": "Who was responsible for asserting the observed value as \"true\".",
+                "requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.performer",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=PRF]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]",
+                "path": "Observation.value[x]",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "type",
+                            "path": "$this"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "closed"
+                },
+                "short": "Vital Signs Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity",
+                "path": "Observation.value[x]",
+                "sliceName": "valueQuantity",
+                "short": "Vital Signs Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.id",
+                "path": "Observation.value[x].id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.extension",
+                "path": "Observation.value[x].extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.value",
+                "path": "Observation.value[x].value",
+                "short": "Numerical value (with implicit precision)",
+                "definition": "The value of the measured amount. The value includes an implicit precision in the presentation of the value.",
+                "comment": "The implicit precision in the value should always be honored. Monetary values have their own rules for handling precision (refer to standard accounting text books).",
+                "requirements": "Precision is handled implicitly in almost all cases of measurement.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.value",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.2  / CQ - N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.value, CO.value, MO.value, IVL.high or IVL.low depending on the value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.comparator",
+                "path": "Observation.value[x].comparator",
+                "short": "< | <= | >= | > - how to understand the value",
+                "definition": "How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \"<\" , then the real value is < stated value.",
+                "requirements": "Need a framework for handling measures where the value is <5ug/L or >400mg/L due to the limitations of measuring methodology.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.comparator",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "meaningWhenMissing": "If there is no comparator, then there is no modification of the value",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This is labeled as \"Is Modifier\" because the comparator modifies the interpretation of the value significantly. If there is no comparator, then there is no modification of the value",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "QuantityComparator"
+                        }
+                    ],
+                    "strength": "required",
+                    "description": "How the Quantity should be understood and represented.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/quantity-comparator|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "SN.1  / CQ.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "IVL properties"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.unit",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.value[x].unit",
+                "short": "Unit representation",
+                "definition": "A human-readable form of the unit.",
+                "requirements": "There are many representations for units of measure and in many contexts, particular representations are fixed and required. I.e. mcg for micrograms.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.unit",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.unit"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.system",
+                "path": "Observation.value[x].system",
+                "short": "System that defines coded unit form",
+                "definition": "The identification of the system that provides the coded form of the unit.",
+                "requirements": "Need to know the system that defines the coded form of the unit.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "condition": [
+                    "qty-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CO.codeSystem, PQ.translation.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueQuantity.code",
+                "path": "Observation.value[x].code",
+                "short": "Coded responses from the common UCUM units for vital signs value set.",
+                "definition": "A computer processable form of the unit in some unit representation system.",
+                "comment": "The preferred system is UCUM, but SNOMED CT can also be used (for customary units) or ISO 4217 for currency.  The context of use may additionally require a code from a particular system.",
+                "requirements": "Need a computable form of the unit that is fixed across all forms. UCUM provides this for quantities, but SNOMED CT provides many units of interest.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Quantity.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "/min",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "(see OBX.6 etc.) / CQ.2"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "PQ.code, MO.currency, PQ.translation.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.dataAbsentReason",
+                "path": "Observation.dataAbsentReason",
+                "short": "Why the result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
+                "comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.interpretation",
+                "path": "Observation.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.note",
+                "path": "Observation.note",
+                "short": "Comments about the observation",
+                "definition": "Comments about the observation or the results.",
+                "comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
+                "requirements": "Need to be able to provide free text additional information.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "subjectOf.observationEvent[code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.bodySite",
+                "path": "Observation.bodySite",
+                "short": "Observed body part",
+                "definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
+                "comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.bodySite",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "BodySite"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing anatomical locations. May include laterality.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/body-site"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123037004 |Body structure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-20"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "targetSiteCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "718497002 |Inherent location|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.method",
+                "path": "Observation.method",
+                "short": "How it was done",
+                "definition": "Indicates the mechanism used to perform the observation.",
+                "comment": "Only used if not implicit in code for Observation.code.",
+                "requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.method",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationMethod"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Methods for simple observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "methodCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.specimen",
+                "path": "Observation.specimen",
+                "short": "Specimen used for this observation",
+                "definition": "The specimen that was used when this observation was made.",
+                "comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.specimen",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Specimen"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123038009 |Specimen|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "SPM segment"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SPC].specimen"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "704319004 |Inherent in|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.device",
+                "path": "Observation.device",
+                "short": "(Measurement) Device",
+                "definition": "The device used to generate the observation data.",
+                "comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.device",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceMetric"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 49062001 |Device|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17 / PRT -10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=DEV]"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "424226004 |Using device|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange",
+                "path": "Observation.referenceRange",
+                "short": "Provides guide for interpretation",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "obs-3",
+                        "severity": "error",
+                        "human": "Must have at least a low or a high or text",
+                        "expression": "low.exists() or high.exists() or text.exists()",
+                        "xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.id",
+                "path": "Observation.referenceRange.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.extension",
+                "path": "Observation.referenceRange.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.modifierExtension",
+                "path": "Observation.referenceRange.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.low",
+                "path": "Observation.referenceRange.low",
+                "short": "Low Range, if relevant",
+                "definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.low",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.low"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.high",
+                "path": "Observation.referenceRange.high",
+                "short": "High Range, if relevant",
+                "definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.high",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.high"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.type",
+                "path": "Observation.referenceRange.type",
+                "short": "Reference range qualifier",
+                "definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
+                "requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeMeaning"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Code for the meaning of a reference range.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.appliesTo",
+                "path": "Observation.referenceRange.appliesTo",
+                "short": "Reference range population",
+                "definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
+                "requirements": "Need to be able to identify the target population for proper interpretation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange.appliesTo",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes identifying the population the reference range applies to.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.age",
+                "path": "Observation.referenceRange.age",
+                "short": "Applicable age range, if relevant",
+                "definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
+                "requirements": "Some analytes vary greatly over age.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.age",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Range"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.text",
+                "path": "Observation.referenceRange.text",
+                "short": "Text based reference range in an observation",
+                "definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:ST"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.hasMember",
+                "path": "Observation.hasMember",
+                "short": "Used when reporting vital signs panel components",
+                "definition": "Used when reporting vital signs panel components.",
+                "comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.hasMember",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.derivedFrom",
+                "path": "Observation.derivedFrom",
+                "short": "Related measurements the observation is made from",
+                "definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
+                "comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.derivedFrom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/DocumentReference",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy",
+                            "http://hl7.org/fhir/StructureDefinition/Media",
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".targetObservation"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component",
+                "path": "Observation.component",
+                "short": "Component observations",
+                "definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
+                "comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-3",
+                        "severity": "error",
+                        "human": "If there is no a value a data absent reason must be present",
+                        "expression": "value.exists() or dataAbsentReason.exists()",
+                        "xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "containment by OBX-4?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=COMP]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.id",
+                "path": "Observation.component.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.extension",
+                "path": "Observation.component.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.modifierExtension",
+                "path": "Observation.component.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.code",
+                "path": "Observation.component.code",
+                "short": "Type of component observation (code / type)",
+                "definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
+                "comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.value[x]",
+                "path": "Observation.component.value[x]",
+                "short": "Vital Sign Component Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
+                "comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.dataAbsentReason",
+                "path": "Observation.component.dataAbsentReason",
+                "short": "Why the component result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
+                "comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.interpretation",
+                "path": "Observation.component.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.referenceRange",
+                "path": "Observation.component.referenceRange",
+                "short": "Provides guide for interpretation of component result",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "US Core Respiratory Rate Profile",
+                "definition": "Defines constraints on Observation to represent respiratory rate observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile."
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Respiratory Rate",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "9279-1"
+                        }
+                    ]
+                },
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity",
+                "path": "Observation.valueQuantity",
+                "min": 0,
+                "max": "1",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.value",
+                "path": "Observation.valueQuantity.value",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "decimal"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.unit",
+                "path": "Observation.valueQuantity.unit",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.system",
+                "path": "Observation.valueQuantity.system",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://unitsofmeasure.org",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.valueQuantity.code",
+                "path": "Observation.valueQuantity.code",
+                "short": "Coded responses from the common UCUM units for vital signs value set.",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "/min",
+                "mustSupport": true
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-smokingstatus.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-smokingstatus.json
@@ -1,3058 +1,3058 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-smokingstatus",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-smokingstatus-definitions.html#Observation\" title=\"The US Core Smoking Status Observation Profile is based upon the core FHIR Observation Resource and created to meet the USCDI Data Set 'Smoking status' requirements.\">Observation</a><a name=\"Observation\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/observation.html\">Observation</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Measurements and simple assertions</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-smokingstatus-definitions.html#Observation.status\">status</a><a name=\"Observation.status\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">registered | preliminary | final | amended +</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-observation-smoking-status-status.html\">US Core Status for Smoking Status Observation</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#required\" title=\"To be conformant, the concept in this element SHALL be from the specified value set.\">required</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck13.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Slice Definition\" class=\"hierarchy\"/> <a style=\"font-style: italic\" href=\"StructureDefinition-us-core-smokingstatus-definitions.html#Observation.category\">Slices for category</a><a name=\"Observation.category\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red; font-style: italic\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"font-style: italic\"/><span style=\"font-style: italic\">1</span><span style=\"font-style: italic\">..</span><span style=\"font-style: italic\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"font-style: italic\" href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5; font-style: italic\">Classification of  type of observation</span><br style=\"font-style: italic\"/><span style=\"font-weight:bold; font-style: italic\">Slice: </span><span style=\"font-style: italic\">Unordered, Open by pattern:$this</span><br style=\"font-style: italic\"/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck125.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-smokingstatus-definitions.html#Observation.category:SocialHistory\" title=\"Slice SocialHistory\">category:SocialHistory</a><a name=\"Observation.category\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Classification of  type of observation</span><br/><span style=\"font-weight:bold\">Required Pattern: </span><span style=\"color: darkgreen\">At least the following</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1241.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#CodeableConcept.coding\">coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Code defined by a terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">(complex)</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck12410.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.system\">system</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Identity of the terminology system<br/><span style=\"font-weight: bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"https://terminology.hl7.org/1.0.0//CodeSystem-observation-category.html\">http://terminology.hl7.org/CodeSystem/observation-category</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck12400.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_fixed.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Fixed Value\" class=\"hierarchy\"/> <a href=\"http://hl7.org/fhir/R4/datatypes-definitions.html#Coding.code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Symbol in syntax defined by the system<br/><span style=\"font-weight: bold\">Fixed Value: </span><span style=\"color: darkgreen\">social-history</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-smokingstatus-definitions.html#Observation.code\">code</a><a name=\"Observation.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Smoking Status<br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-smoking-status-observation-codes.html\">US Core Smoking Status Observation Codes</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>)</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-smokingstatus-definitions.html#Observation.subject\">subject</a><a name=\"Observation.subject\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who and/or what the observation is about</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-smokingstatus-definitions.html#Observation.effectiveDateTime\">effectiveDateTime</a><a name=\"Observation.effectiveDateTime\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#dateTime\">dateTime</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Clinically relevant time/time-period for observation</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck00.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-smokingstatus-definitions.html#Observation.valueCodeableConcept\">valueCodeableConcept</a><a name=\"Observation.valueCodeableConcept\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Coded Responses from Smoking Status Value Set<br/><span style=\"font-weight:bold\">Binding: </span><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.11.20.9.38/expansion\">Smoking Status</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#preferred\" title=\"Instances are encouraged to draw from the specified codes for interoperability purposes but are not required to do so to be considered conformant.\">preferred</a>): This value set enumerates codes SNOMED CT codes historically used for the current smoking status of a patient with a maximum required binding to Snomed CT codes.<br/><br/></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus",
-	"version": "4.0.0",
-	"name": "USCoreSmokingStatusProfile",
-	"title": "US Core Smoking Status Observation Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2019-05-21T00:00:00+00:00",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints and extensions on the Observation  resource for the minimal set of data to query and retrieve patient's Smoking Status information.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "sct-concept",
-			"uri": "http://snomed.info/conceptdomain",
-			"name": "SNOMED CT Concept Domain Binding"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "sct-attr",
-			"uri": "http://snomed.org/attributebinding",
-			"name": "SNOMED CT Attribute Binding"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Observation",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Observation",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "Measurements and simple assertions",
-				"definition": "The US Core Smoking Status Observation Profile is based upon the core FHIR Observation Resource and created to meet the USCDI Data Set 'Smoking status' requirements.",
-				"comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
-				"alias": [
-					"Vital Signs",
-					"Measurement",
-					"Results",
-					"Tests",
-					"Obs"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "obs-6",
-						"severity": "error",
-						"human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
-						"expression": "dataAbsentReason.empty() or value.empty()",
-						"xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "obs-7",
-						"severity": "error",
-						"human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
-						"expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
-						"xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation[classCode=OBS, moodCode=EVN]"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation"
-					}
-				]
-			},
-			{
-				"id": "Observation.id",
-				"path": "Observation.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.meta",
-				"path": "Observation.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.implicitRules",
-				"path": "Observation.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Observation.language",
-				"path": "Observation.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Observation.text",
-				"path": "Observation.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Observation.contained",
-				"path": "Observation.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.extension",
-				"path": "Observation.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.modifierExtension",
-				"path": "Observation.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.identifier",
-				"path": "Observation.identifier",
-				"short": "Business Identifier for observation",
-				"definition": "A unique identifier assigned to this observation.",
-				"requirements": "Allows observations to be distinguished and referenced.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
-					},
-					{
-						"identity": "rim",
-						"map": "id"
-					}
-				]
-			},
-			{
-				"id": "Observation.basedOn",
-				"path": "Observation.basedOn",
-				"short": "Fulfills plan, proposal or order",
-				"definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
-				"requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
-				"alias": [
-					"Fulfills"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan",
-							"http://hl7.org/fhir/StructureDefinition/DeviceRequest",
-							"http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
-							"http://hl7.org/fhir/StructureDefinition/MedicationRequest",
-							"http://hl7.org/fhir/StructureDefinition/NutritionOrder",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.basedOn"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.partOf",
-				"path": "Observation.partOf",
-				"short": "Part of referenced event",
-				"definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
-				"comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/R4/observation.html#obsgrouping) below for guidance on referencing another Observation.",
-				"alias": [
-					"Container"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.partOf",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
-							"http://hl7.org/fhir/StructureDefinition/MedicationDispense",
-							"http://hl7.org/fhir/StructureDefinition/MedicationStatement",
-							"http://hl7.org/fhir/StructureDefinition/Procedure",
-							"http://hl7.org/fhir/StructureDefinition/Immunization",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.partOf"
-					},
-					{
-						"identity": "v2",
-						"map": "Varies by domain"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=FLFS].target"
-					}
-				]
-			},
-			{
-				"id": "Observation.status",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
-						"valueString": "default: final"
-					}
-				],
-				"path": "Observation.status",
-				"short": "registered | preliminary | final | amended +",
-				"definition": "The status of the result value.",
-				"comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
-				"requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smoking-status-status"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 445584004 |Report by finality status|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-11"
-					},
-					{
-						"identity": "rim",
-						"map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.status"
-					}
-				]
-			},
-			{
-				"id": "Observation.category",
-				"path": "Observation.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "$this"
-						}
-					],
-					"rules": "open"
-				},
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:SocialHistory",
-				"path": "Observation.category",
-				"sliceName": "SocialHistory",
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://terminology.hl7.org/CodeSystem/observation-category",
-							"code": "social-history"
-						}
-					]
-				},
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Smoking Status",
-				"definition": "Describes what was observed. Sometimes this is called the observation \"name\".",
-				"comment": "*All* code-value and, if present, component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
-				"alias": [
-					"Name"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-smoking-status-observation-codes"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "116680003 |Is a|"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.subject",
-				"path": "Observation.subject",
-				"short": "Who and/or what the observation is about",
-				"definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
-				"comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
-				"requirements": "Observations have no value if you don't know who or what they're about.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=RTGT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.focus",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
-						"valueCode": "trial-use"
-					}
-				],
-				"path": "Observation.focus",
-				"short": "What the observation is about, when it is not about the subject of record",
-				"definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
-				"comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/R4/extension-observation-focuscode.html).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.focus",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SBJ]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.encounter",
-				"path": "Observation.encounter",
-				"short": "Healthcare event during which this observation is made",
-				"definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
-				"comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
-				"requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
-				"alias": [
-					"Context"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.effective[x]",
-				"path": "Observation.effective[x]",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "type",
-							"path": "$this"
-						}
-					],
-					"ordered": false,
-					"rules": "closed"
-				},
-				"short": "Clinically relevant time/time-period for observation",
-				"definition": "The time or time-period the observed value is asserted as being true. For biological subjects - e.g. human patients - this is usually called the \"physiologically relevant time\". This is usually either the time of the procedure or of specimen collection, but very often the source of the date/time is not known, only the date/time itself.",
-				"comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/R4/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
-				"requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
-				"alias": [
-					"Occurrence"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.effective[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "Observation.effective[x]:effectiveDateTime",
-				"path": "Observation.effective[x]",
-				"sliceName": "effectiveDateTime",
-				"short": "Clinically relevant time/time-period for observation",
-				"definition": "The time or time-period the observed value is asserted as being true. For biological subjects - e.g. human patients - this is usually called the \"physiologically relevant time\". This is usually either the time of the procedure or of specimen collection, but very often the source of the date/time is not known, only the date/time itself.",
-				"comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/R4/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
-				"requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
-				"alias": [
-					"Occurrence"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.effective[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "dateTime"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.issued"
-					}
-				]
-			},
-			{
-				"id": "Observation.issued",
-				"path": "Observation.issued",
-				"short": "Date/Time this version was made available",
-				"definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
-				"comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/R4/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.issued",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=AUT].time"
-					}
-				]
-			},
-			{
-				"id": "Observation.performer",
-				"path": "Observation.performer",
-				"short": "Who is responsible for the observation",
-				"definition": "Who was responsible for asserting the observed value as \"true\".",
-				"requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.performer",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=PRF]"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]",
-				"path": "Observation.value[x]",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "type",
-							"path": "$this"
-						}
-					],
-					"ordered": false,
-					"rules": "closed"
-				},
-				"short": "Actual result",
-				"definition": "The information determined as a result of making the observation, if the information has a simple value.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/R4/observation.html#notes) below.",
-				"requirements": "An observation exists to have a value, though it might not if it is in error, or if it represents a group of observations.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-7"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]:valueCodeableConcept",
-				"path": "Observation.value[x]",
-				"sliceName": "valueCodeableConcept",
-				"short": "Coded Responses from Smoking Status Value Set",
-				"definition": "The information determined as a result of making the observation, if the information has a simple value.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/R4/observation.html#notes) below.",
-				"requirements": "An observation exists to have a value, though it might not if it is in error, or if it represents a group of observations.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-7"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smokingstatus-max"
-						}
-					],
-					"strength": "preferred",
-					"description": "This value set enumerates codes SNOMED CT codes historically used for the current smoking status of a patient with a maximum required binding to Snomed CT codes.",
-					"valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.11.20.9.38"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					},
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.valueCodeableConcept"
-					}
-				]
-			},
-			{
-				"id": "Observation.dataAbsentReason",
-				"path": "Observation.dataAbsentReason",
-				"short": "Why the result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
-				"comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.interpretation",
-				"path": "Observation.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.note",
-				"path": "Observation.note",
-				"short": "Comments about the observation",
-				"definition": "Comments about the observation or the results.",
-				"comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
-				"requirements": "Need to be able to provide free text additional information.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
-					},
-					{
-						"identity": "rim",
-						"map": "subjectOf.observationEvent[code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.bodySite",
-				"path": "Observation.bodySite",
-				"short": "Observed body part",
-				"definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
-				"comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/R4/extension-bodysite.html).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.bodySite",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "BodySite"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing anatomical locations. May include laterality.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/body-site"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123037004 |Body structure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-20"
-					},
-					{
-						"identity": "rim",
-						"map": "targetSiteCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "718497002 |Inherent location|"
-					}
-				]
-			},
-			{
-				"id": "Observation.method",
-				"path": "Observation.method",
-				"short": "How it was done",
-				"definition": "Indicates the mechanism used to perform the observation.",
-				"comment": "Only used if not implicit in code for Observation.code.",
-				"requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.method",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationMethod"
-						}
-					],
-					"strength": "example",
-					"description": "Methods for simple observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-17"
-					},
-					{
-						"identity": "rim",
-						"map": "methodCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.specimen",
-				"path": "Observation.specimen",
-				"short": "Specimen used for this observation",
-				"definition": "The specimen that was used when this observation was made.",
-				"comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.specimen",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Specimen"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123038009 |Specimen|"
-					},
-					{
-						"identity": "v2",
-						"map": "SPM segment"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SPC].specimen"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "704319004 |Inherent in|"
-					}
-				]
-			},
-			{
-				"id": "Observation.device",
-				"path": "Observation.device",
-				"short": "(Measurement) Device",
-				"definition": "The device used to generate the observation data.",
-				"comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.device",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/DeviceMetric"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 49062001 |Device|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-17 / PRT -10"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=DEV]"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "424226004 |Using device|"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange",
-				"path": "Observation.referenceRange",
-				"short": "Provides guide for interpretation",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "obs-3",
-						"severity": "error",
-						"human": "Must have at least a low or a high or text",
-						"expression": "low.exists() or high.exists() or text.exists()",
-						"xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.id",
-				"path": "Observation.referenceRange.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.extension",
-				"path": "Observation.referenceRange.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.modifierExtension",
-				"path": "Observation.referenceRange.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.low",
-				"path": "Observation.referenceRange.low",
-				"short": "Low Range, if relevant",
-				"definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.low",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.low"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.high",
-				"path": "Observation.referenceRange.high",
-				"short": "High Range, if relevant",
-				"definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.high",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.high"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.type",
-				"path": "Observation.referenceRange.type",
-				"short": "Reference range qualifier",
-				"definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
-				"requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeMeaning"
-						}
-					],
-					"strength": "preferred",
-					"description": "Code for the meaning of a reference range.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.appliesTo",
-				"path": "Observation.referenceRange.appliesTo",
-				"short": "Reference range population",
-				"definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
-				"requirements": "Need to be able to identify the target population for proper interpretation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange.appliesTo",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeType"
-						}
-					],
-					"strength": "example",
-					"description": "Codes identifying the population the reference range applies to.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.age",
-				"path": "Observation.referenceRange.age",
-				"short": "Applicable age range, if relevant",
-				"definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
-				"requirements": "Some analytes vary greatly over age.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.age",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Range"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.text",
-				"path": "Observation.referenceRange.text",
-				"short": "Text based reference range in an observation",
-				"definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:ST"
-					}
-				]
-			},
-			{
-				"id": "Observation.hasMember",
-				"path": "Observation.hasMember",
-				"short": "Related resource that belongs to the Observation group",
-				"definition": "This observation is a group observation (e.g. a battery, a panel of tests, a set of vital sign measurements) that includes the target as a member of the group.",
-				"comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/R4/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/R4/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.hasMember",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Observation",
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship"
-					}
-				]
-			},
-			{
-				"id": "Observation.derivedFrom",
-				"path": "Observation.derivedFrom",
-				"short": "Related measurements the observation is made from",
-				"definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
-				"comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/R4/observation.html#obsgrouping) below.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.derivedFrom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/DocumentReference",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy",
-							"http://hl7.org/fhir/StructureDefinition/Media",
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/Observation",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": ".targetObservation"
-					}
-				]
-			},
-			{
-				"id": "Observation.component",
-				"path": "Observation.component",
-				"short": "Component results",
-				"definition": "Some observations have multiple component observations.  These component observations are expressed as separate code value pairs that share the same attributes.  Examples include systolic and diastolic component observations for blood pressure measurement and multiple component observations for genetics observations.",
-				"comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/R4/observation.html#notes) below.",
-				"requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "containment by OBX-4?"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=COMP]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.id",
-				"path": "Observation.component.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.extension",
-				"path": "Observation.component.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.modifierExtension",
-				"path": "Observation.component.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.code",
-				"path": "Observation.component.code",
-				"short": "Type of component observation (code / type)",
-				"definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
-				"comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCode"
-						}
-					],
-					"strength": "example",
-					"description": "Codes identifying names of simple observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-codes"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.value[x]",
-				"path": "Observation.component.value[x]",
-				"short": "Actual component result",
-				"definition": "The information determined as a result of making the observation, if the information has a simple value.",
-				"comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/R4/observation.html#notes) below.",
-				"requirements": "An observation exists to have a value, though it might not if it is in error, or if it represents a group of observations.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.dataAbsentReason",
-				"path": "Observation.component.dataAbsentReason",
-				"short": "Why the component result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
-				"comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.interpretation",
-				"path": "Observation.component.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.referenceRange",
-				"path": "Observation.component.referenceRange",
-				"short": "Provides guide for interpretation of component result",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"definition": "The US Core Smoking Status Observation Profile is based upon the core FHIR Observation Resource and created to meet the USCDI Data Set 'Smoking status' requirements.",
-				"alias": [
-					"Obs"
-				],
-				"mustSupport": false,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation"
-					}
-				]
-			},
-			{
-				"id": "Observation.status",
-				"path": "Observation.status",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true,
-				"binding": {
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smoking-status-status"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.status"
-					}
-				]
-			},
-			{
-				"id": "Observation.category",
-				"path": "Observation.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "$this"
-						}
-					],
-					"rules": "open"
-				},
-				"min": 1,
-				"max": "*",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.category:SocialHistory",
-				"path": "Observation.category",
-				"sliceName": "SocialHistory",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"patternCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://terminology.hl7.org/CodeSystem/observation-category",
-							"code": "social-history"
-						}
-					]
-				},
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Smoking Status",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-smoking-status-observation-codes"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.subject",
-				"path": "Observation.subject",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.effectiveDateTime",
-				"path": "Observation.effectiveDateTime",
-				"min": 1,
-				"max": "1",
-				"mustSupport": true,
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.issued"
-					}
-				]
-			},
-			{
-				"id": "Observation.valueCodeableConcept",
-				"path": "Observation.valueCodeableConcept",
-				"short": "Coded Responses from Smoking Status Value Set",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smokingstatus-max"
-						}
-					],
-					"strength": "preferred",
-					"description": "This value set enumerates codes SNOMED CT codes historically used for the current smoking status of a patient with a maximum required binding to Snomed CT codes.",
-					"valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.11.20.9.38"
-				},
-				"mapping": [
-					{
-						"identity": "argonaut-dq-dstu2",
-						"map": "Observation.valueCodeableConcept"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-smokingstatus",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus",
+    "version": "4.0.0",
+    "name": "USCoreSmokingStatusProfile",
+    "title": "US Core Smoking Status Observation Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2019-05-21T00:00:00+00:00",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints and extensions on the Observation  resource for the minimal set of data to query and retrieve patient's Smoking Status information.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "sct-concept",
+            "uri": "http://snomed.info/conceptdomain",
+            "name": "SNOMED CT Concept Domain Binding"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "sct-attr",
+            "uri": "http://snomed.org/attributebinding",
+            "name": "SNOMED CT Attribute Binding"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Observation",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Observation",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "Measurements and simple assertions",
+                "definition": "The US Core Smoking Status Observation Profile is based upon the core FHIR Observation Resource and created to meet the USCDI Data Set 'Smoking status' requirements.",
+                "comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
+                "alias": [
+                    "Vital Signs",
+                    "Measurement",
+                    "Results",
+                    "Tests",
+                    "Obs"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "obs-6",
+                        "severity": "error",
+                        "human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
+                        "expression": "dataAbsentReason.empty() or value.empty()",
+                        "xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "obs-7",
+                        "severity": "error",
+                        "human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
+                        "expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
+                        "xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    }
+                ],
+                "mustSupport": false,
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation[classCode=OBS, moodCode=EVN]"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.id",
+                "path": "Observation.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.meta",
+                "path": "Observation.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.implicitRules",
+                "path": "Observation.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Observation.language",
+                "path": "Observation.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Observation.text",
+                "path": "Observation.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.contained",
+                "path": "Observation.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.extension",
+                "path": "Observation.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.modifierExtension",
+                "path": "Observation.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.identifier",
+                "path": "Observation.identifier",
+                "short": "Business Identifier for observation",
+                "definition": "A unique identifier assigned to this observation.",
+                "requirements": "Allows observations to be distinguished and referenced.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "id"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.basedOn",
+                "path": "Observation.basedOn",
+                "short": "Fulfills plan, proposal or order",
+                "definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
+                "requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
+                "alias": [
+                    "Fulfills"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceRequest",
+                            "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+                            "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.basedOn"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.partOf",
+                "path": "Observation.partOf",
+                "short": "Part of referenced event",
+                "definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
+                "comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/R4/observation.html#obsgrouping) below for guidance on referencing another Observation.",
+                "alias": [
+                    "Container"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.partOf",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationDispense",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationStatement",
+                            "http://hl7.org/fhir/StructureDefinition/Procedure",
+                            "http://hl7.org/fhir/StructureDefinition/Immunization",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.partOf"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "Varies by domain"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=FLFS].target"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.status",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
+                        "valueString": "default: final"
+                    }
+                ],
+                "path": "Observation.status",
+                "short": "registered | preliminary | final | amended +",
+                "definition": "The status of the result value.",
+                "comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
+                "requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smoking-status-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 445584004 |Report by finality status|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-11"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.status"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category",
+                "path": "Observation.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "$this"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:SocialHistory",
+                "path": "Observation.category",
+                "sliceName": "SocialHistory",
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "social-history"
+                        }
+                    ]
+                },
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Smoking Status",
+                "definition": "Describes what was observed. Sometimes this is called the observation \"name\".",
+                "comment": "*All* code-value and, if present, component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+                "alias": [
+                    "Name"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-smoking-status-observation-codes"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "116680003 |Is a|"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.subject",
+                "path": "Observation.subject",
+                "short": "Who and/or what the observation is about",
+                "definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
+                "comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
+                "requirements": "Observations have no value if you don't know who or what they're about.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=RTGT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.focus",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+                        "valueCode": "trial-use"
+                    }
+                ],
+                "path": "Observation.focus",
+                "short": "What the observation is about, when it is not about the subject of record",
+                "definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
+                "comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/R4/extension-observation-focuscode.html).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.focus",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SBJ]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.encounter",
+                "path": "Observation.encounter",
+                "short": "Healthcare event during which this observation is made",
+                "definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
+                "comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
+                "requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
+                "alias": [
+                    "Context"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.effective[x]",
+                "path": "Observation.effective[x]",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "type",
+                            "path": "$this"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "closed"
+                },
+                "short": "Clinically relevant time/time-period for observation",
+                "definition": "The time or time-period the observed value is asserted as being true. For biological subjects - e.g. human patients - this is usually called the \"physiologically relevant time\". This is usually either the time of the procedure or of specimen collection, but very often the source of the date/time is not known, only the date/time itself.",
+                "comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/R4/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
+                "requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
+                "alias": [
+                    "Occurrence"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.effective[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.effective[x]:effectiveDateTime",
+                "path": "Observation.effective[x]",
+                "sliceName": "effectiveDateTime",
+                "short": "Clinically relevant time/time-period for observation",
+                "definition": "The time or time-period the observed value is asserted as being true. For biological subjects - e.g. human patients - this is usually called the \"physiologically relevant time\". This is usually either the time of the procedure or of specimen collection, but very often the source of the date/time is not known, only the date/time itself.",
+                "comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/R4/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
+                "requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
+                "alias": [
+                    "Occurrence"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.effective[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "dateTime"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.issued"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.issued",
+                "path": "Observation.issued",
+                "short": "Date/Time this version was made available",
+                "definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
+                "comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/R4/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.issued",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.performer",
+                "path": "Observation.performer",
+                "short": "Who is responsible for the observation",
+                "definition": "Who was responsible for asserting the observed value as \"true\".",
+                "requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.performer",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=PRF]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]",
+                "path": "Observation.value[x]",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "type",
+                            "path": "$this"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "closed"
+                },
+                "short": "Actual result",
+                "definition": "The information determined as a result of making the observation, if the information has a simple value.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/R4/observation.html#notes) below.",
+                "requirements": "An observation exists to have a value, though it might not if it is in error, or if it represents a group of observations.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-7"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]:valueCodeableConcept",
+                "path": "Observation.value[x]",
+                "sliceName": "valueCodeableConcept",
+                "short": "Coded Responses from Smoking Status Value Set",
+                "definition": "The information determined as a result of making the observation, if the information has a simple value.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/R4/observation.html#notes) below.",
+                "requirements": "An observation exists to have a value, though it might not if it is in error, or if it represents a group of observations.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-7"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smokingstatus-max"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "This value set enumerates codes SNOMED CT codes historically used for the current smoking status of a patient with a maximum required binding to Snomed CT codes.",
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.11.20.9.38"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    },
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.valueCodeableConcept"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.dataAbsentReason",
+                "path": "Observation.dataAbsentReason",
+                "short": "Why the result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
+                "comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.interpretation",
+                "path": "Observation.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.note",
+                "path": "Observation.note",
+                "short": "Comments about the observation",
+                "definition": "Comments about the observation or the results.",
+                "comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
+                "requirements": "Need to be able to provide free text additional information.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "subjectOf.observationEvent[code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.bodySite",
+                "path": "Observation.bodySite",
+                "short": "Observed body part",
+                "definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
+                "comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/R4/extension-bodysite.html).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.bodySite",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "BodySite"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing anatomical locations. May include laterality.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/body-site"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123037004 |Body structure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-20"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "targetSiteCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "718497002 |Inherent location|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.method",
+                "path": "Observation.method",
+                "short": "How it was done",
+                "definition": "Indicates the mechanism used to perform the observation.",
+                "comment": "Only used if not implicit in code for Observation.code.",
+                "requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.method",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationMethod"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Methods for simple observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "methodCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.specimen",
+                "path": "Observation.specimen",
+                "short": "Specimen used for this observation",
+                "definition": "The specimen that was used when this observation was made.",
+                "comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.specimen",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Specimen"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123038009 |Specimen|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "SPM segment"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SPC].specimen"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "704319004 |Inherent in|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.device",
+                "path": "Observation.device",
+                "short": "(Measurement) Device",
+                "definition": "The device used to generate the observation data.",
+                "comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.device",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceMetric"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 49062001 |Device|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17 / PRT -10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=DEV]"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "424226004 |Using device|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange",
+                "path": "Observation.referenceRange",
+                "short": "Provides guide for interpretation",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "obs-3",
+                        "severity": "error",
+                        "human": "Must have at least a low or a high or text",
+                        "expression": "low.exists() or high.exists() or text.exists()",
+                        "xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.id",
+                "path": "Observation.referenceRange.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.extension",
+                "path": "Observation.referenceRange.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.modifierExtension",
+                "path": "Observation.referenceRange.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.low",
+                "path": "Observation.referenceRange.low",
+                "short": "Low Range, if relevant",
+                "definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.low",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.low"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.high",
+                "path": "Observation.referenceRange.high",
+                "short": "High Range, if relevant",
+                "definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.high",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.high"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.type",
+                "path": "Observation.referenceRange.type",
+                "short": "Reference range qualifier",
+                "definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
+                "requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeMeaning"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Code for the meaning of a reference range.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.appliesTo",
+                "path": "Observation.referenceRange.appliesTo",
+                "short": "Reference range population",
+                "definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
+                "requirements": "Need to be able to identify the target population for proper interpretation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange.appliesTo",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes identifying the population the reference range applies to.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.age",
+                "path": "Observation.referenceRange.age",
+                "short": "Applicable age range, if relevant",
+                "definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
+                "requirements": "Some analytes vary greatly over age.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.age",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Range"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.text",
+                "path": "Observation.referenceRange.text",
+                "short": "Text based reference range in an observation",
+                "definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:ST"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.hasMember",
+                "path": "Observation.hasMember",
+                "short": "Related resource that belongs to the Observation group",
+                "definition": "This observation is a group observation (e.g. a battery, a panel of tests, a set of vital sign measurements) that includes the target as a member of the group.",
+                "comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/R4/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/R4/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.hasMember",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Observation",
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.derivedFrom",
+                "path": "Observation.derivedFrom",
+                "short": "Related measurements the observation is made from",
+                "definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
+                "comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/R4/observation.html#obsgrouping) below.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.derivedFrom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/DocumentReference",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy",
+                            "http://hl7.org/fhir/StructureDefinition/Media",
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/Observation",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".targetObservation"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component",
+                "path": "Observation.component",
+                "short": "Component results",
+                "definition": "Some observations have multiple component observations.  These component observations are expressed as separate code value pairs that share the same attributes.  Examples include systolic and diastolic component observations for blood pressure measurement and multiple component observations for genetics observations.",
+                "comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/R4/observation.html#notes) below.",
+                "requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "containment by OBX-4?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=COMP]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.id",
+                "path": "Observation.component.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.extension",
+                "path": "Observation.component.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.modifierExtension",
+                "path": "Observation.component.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/R4/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.code",
+                "path": "Observation.component.code",
+                "short": "Type of component observation (code / type)",
+                "definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
+                "comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCode"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes identifying names of simple observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-codes"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.value[x]",
+                "path": "Observation.component.value[x]",
+                "short": "Actual component result",
+                "definition": "The information determined as a result of making the observation, if the information has a simple value.",
+                "comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/R4/observation.html#notes) below.",
+                "requirements": "An observation exists to have a value, though it might not if it is in error, or if it represents a group of observations.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.dataAbsentReason",
+                "path": "Observation.component.dataAbsentReason",
+                "short": "Why the component result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
+                "comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.interpretation",
+                "path": "Observation.component.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.referenceRange",
+                "path": "Observation.component.referenceRange",
+                "short": "Provides guide for interpretation of component result",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "definition": "The US Core Smoking Status Observation Profile is based upon the core FHIR Observation Resource and created to meet the USCDI Data Set 'Smoking status' requirements.",
+                "alias": [
+                    "Obs"
+                ],
+                "mustSupport": false,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.status",
+                "path": "Observation.status",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smoking-status-status"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.status"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category",
+                "path": "Observation.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "pattern",
+                            "path": "$this"
+                        }
+                    ],
+                    "rules": "open"
+                },
+                "min": 1,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.category:SocialHistory",
+                "path": "Observation.category",
+                "sliceName": "SocialHistory",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "patternCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                            "code": "social-history"
+                        }
+                    ]
+                },
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Smoking Status",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-smoking-status-observation-codes"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.subject",
+                "path": "Observation.subject",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.effectiveDateTime",
+                "path": "Observation.effectiveDateTime",
+                "min": 1,
+                "max": "1",
+                "mustSupport": true,
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.issued"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.valueCodeableConcept",
+                "path": "Observation.valueCodeableConcept",
+                "short": "Coded Responses from Smoking Status Value Set",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smokingstatus-max"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "This value set enumerates codes SNOMED CT codes historically used for the current smoking status of a patient with a maximum required binding to Snomed CT codes.",
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.11.20.9.38"
+                },
+                "mapping": [
+                    {
+                        "identity": "argonaut-dq-dstu2",
+                        "map": "Observation.valueCodeableConcept"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-vital-signs.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/StructureDefinition-us-core-vital-signs.json
@@ -1,3616 +1,3616 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "us-core-vital-signs",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><table border=\"0\" cellpadding=\"0\" cellspacing=\"0\" style=\"border: 0px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top;\"><tr style=\"border: 1px #F0F0F0 solid; font-size: 11px; font-family: verdana; vertical-align: top\"><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"The logical name of the element\">Name</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Information about the use of the element\">Flags</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Minimum and Maximum # of times the the element can appear in the instance\">Card.</a></th><th style=\"width: 100px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Reference to the type of the element\">Type</a></th><th style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Additional information about the element\">Description &amp; Constraints</a><span style=\"float: right\"><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/></a></span></th></tr><tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_resource.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-vital-signs-definitions.html#Observation\" title=\"Defines constraints on the Observation resource to represent vital signs observation.  This profile is used as the base definition for the other US Core Vital Signs Profiles and based on the FHIR VitalSigns Profile.\">Observation</a><a name=\"Observation\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/vitalsigns.html\">observation-vitalsigns</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">US Core Vital Signs Profile</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-vital-signs-definitions.html#Observation.status\">status</a><a name=\"Observation.status\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">1</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">registered | preliminary | final | amended +</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck13.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Slice Definition\" class=\"hierarchy\"/> <a style=\"font-style: italic\" href=\"StructureDefinition-us-core-vital-signs-definitions.html#Observation.category\">Slices for category</a><a name=\"Observation.category\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red; font-style: italic\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"font-style: italic\"/><span style=\"font-style: italic\">1</span><span style=\"font-style: italic\">..</span><span style=\"font-style: italic\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"font-style: italic\" href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5; font-style: italic\">Classification of  type of observation</span><br style=\"font-style: italic\"/><span style=\"font-weight:bold; font-style: italic\">Slice: </span><span style=\"font-style: italic\">Unordered, Open by value:coding.code, value:coding.system</span><br style=\"font-style: italic\"/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck125.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slicer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_slice_item.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Slice Item\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-vital-signs-definitions.html#Observation.category:VSCat\" title=\"Slice VSCat\">category:VSCat</a><a name=\"Observation.category\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Classification of  type of observation</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck1241.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end_slice.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-vital-signs-definitions.html#Observation.category:VSCat.coding\">coding</a><a name=\"Observation.category.coding\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..*</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Coding\">Coding</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Code defined by a terminology system</span><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck12410.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-vital-signs-definitions.html#Observation.category:VSCat.coding.system\">system</a><a name=\"Observation.category.coding.system\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#uri\">uri</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Identity of the terminology system</span><br/><span style=\"font-weight:bold\">Fixed Value: </span><a style=\"color: darkgreen\" href=\"https://terminology.hl7.org/1.0.0//CodeSystem-observation-category.html\">http://terminology.hl7.org/CodeSystem/observation-category</a></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck12400.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-vital-signs-definitions.html#Observation.category:VSCat.coding.code\">code</a><a name=\"Observation.category.coding.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">1..1</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#code\">code</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Symbol in syntax defined by the system</span><br/><span style=\"font-weight:bold\">Fixed Value: </span><span style=\"color: darkgreen\">vital-signs</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-vital-signs-definitions.html#Observation.code\">code</a><a name=\"Observation.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">1</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Coded Responses from C-CDA Vital Sign Results</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-vital-signs.html\">US Core Vital Signs ValueSet</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>): The vital sign codes from the base FHIR and US Core Vital Signs.<br/><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_reference.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Reference to another Resource\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-vital-signs-definitions.html#Observation.subject\">subject</a><a name=\"Observation.subject\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">1</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/references.html\">Reference</a>(<a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a>)</td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Who and/or what the observation is about</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_choice.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Choice of Types\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-vital-signs-definitions.html#Observation.effective[x]\">effective[x]</a><a name=\"Observation.effective_x_\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">1</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Often just a dateTime for Vital Signs</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for dateTime Type: A date, date-time or partial date (e.g. just year or year + month).  If hours and minutes are specified, a time zone SHALL be populated. The format is a union of the schema types gYear, gYearMonth, date and dateTime. Seconds must be provided due to schema type constraints but may be zero-filled and may be ignored.                 Dates SHALL be valid dates.\">effectiveDateTime</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#dateTime\">dateTime</a> <span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This type must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for Period Type: A time period defined by a start and end date and optionally time.\">effectivePeriod</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Period\">Period</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck11.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_choice.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Choice of Types\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-vital-signs-definitions.html#Observation.value[x]\" title=\"Vital Signs value are typically recorded using the Quantity data type.\">value[x]</a><a name=\"Observation.value_x_\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Vital Signs Value<br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-ucum-vitals-common.html\">VitalSignsUnits</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>): Common UCUM units for recording Vital Signs.<br/><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for Quantity Type: A measured amount (or an amount that can potentially be measured). Note that measured amounts include amounts that are not precisely quantified, including amounts involving arbitrary units and floating currencies.\">valueQuantity</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Quantity\">Quantity</a> <span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This type must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for CodeableConcept Type: A concept that may be defined by a formal reference to a terminology or ontology or may be provided by text.\">valueCodeableConcept</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for string Type: A sequence of Unicode characters\">valueString</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for boolean Type: Value of &quot;true&quot; or &quot;false&quot;\">valueBoolean</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#boolean\">boolean</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for integer Type: A whole number\">valueInteger</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#integer\">integer</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for Range Type: A set of ordered Quantities defined by a low and high limit.\">valueRange</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Range\">Range</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for Ratio Type: A relationship of two Quantity values - expressed as a numerator and a denominator.\">valueRatio</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Ratio\">Ratio</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for SampledData Type: A series of measurements taken by a device, with upper and lower limits. There may be more than one dimension in the data.\">valueSampledData</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#SampledData\">SampledData</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for time Type: A time during the day, with no date specified\">valueTime</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#time\">time</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for dateTime Type: A date, date-time or partial date (e.g. just year or year + month).  If hours and minutes are specified, a time zone SHALL be populated. The format is a union of the schema types gYear, gYearMonth, date and dateTime. Seconds must be provided due to schema type constraints but may be zero-filled and may be ignored.                 Dates SHALL be valid dates.\">valueDateTime</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#dateTime\">dateTime</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for Period Type: A time period defined by a start and end date and optionally time.\">valuePeriod</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Period\">Period</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck10.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-vital-signs-definitions.html#Observation.dataAbsentReason\">dataAbsentReason</a><a name=\"Observation.dataAbsentReason\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Why the result is missing</span></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck01.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-vital-signs-definitions.html#Observation.component\" title=\"Used when reporting component observation such as systolic and diastolic blood pressure.\">component</a><a name=\"Observation.component\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">*</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#BackboneElement\">BackboneElement</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Component observations</td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck010.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-vital-signs-definitions.html#Observation.component.code\">code</a><a name=\"Observation.component.code\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">1</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Type of component observation (code / type)</span><br/><span style=\"font-weight:bold\">Binding: </span><a href=\"ValueSet-us-core-vital-signs.html\">US Core Vital Signs ValueSet</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>): The vital sign codes from the base FHIR and US Core Vital Signs.<br/><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck011.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_choice.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Choice of Types\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-vital-signs-definitions.html#Observation.component.value[x]\" title=\"Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.\">value[x]</a><a name=\"Observation.component.value_x_\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\">Vital Sign Component Value<br/><span style=\"font-weight:bold\">Binding: </span><a href=\"http://hl7.org/fhir/R4/valueset-ucum-vitals-common.html\">VitalSignsUnits</a> (<a href=\"http://hl7.org/fhir/R4/terminologies.html#extensible\" title=\"To be conformant, the concept in this element SHALL be from the specified value set if any of the codes within the value set can apply to the concept being communicated.  If the value set does not cover the concept (based on human review), alternate codings (or, data type allowing, text) may be included instead.\">extensible</a>): Common UCUM units for recording Vital Signs.<br/><br/></td></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for Quantity Type: A measured amount (or an amount that can potentially be measured). Note that measured amounts include amounts that are not precisely quantified, including amounts involving arbitrary units and floating currencies.\">valueQuantity</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Quantity\">Quantity</a> <span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This type must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for CodeableConcept Type: A concept that may be defined by a formal reference to a terminology or ontology or may be provided by text.\">valueCodeableConcept</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for string Type: A sequence of Unicode characters\">valueString</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#string\">string</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for boolean Type: Value of &quot;true&quot; or &quot;false&quot;\">valueBoolean</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#boolean\">boolean</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for integer Type: A whole number\">valueInteger</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#integer\">integer</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for Range Type: A set of ordered Quantities defined by a low and high limit.\">valueRange</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Range\">Range</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for Ratio Type: A relationship of two Quantity values - expressed as a numerator and a denominator.\">valueRatio</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Ratio\">Ratio</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for SampledData Type: A series of measurements taken by a device, with upper and lower limits. There may be more than one dimension in the data.\">valueSampledData</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#SampledData\">SampledData</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for time Type: A time during the day, with no date specified\">valueTime</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#time\">time</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0110.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_primitive.png\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Primitive Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for dateTime Type: A date, date-time or partial date (e.g. just year or year + month).  If hours and minutes are specified, a time zone SHALL be populated. The format is a union of the schema types gYear, gYearMonth, date and dateTime. Seconds must be provided due to schema type constraints but may be zero-filled and may be ignored.                 Dates SHALL be valid dates.\">valueDateTime</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#dateTime\">dateTime</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: white\"><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck0100.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vline.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_datatype.gif\" alt=\".\" style=\"background-color: white; background-color: inherit\" title=\"Data Type\" class=\"hierarchy\"/> <span title=\"Base StructureDefinition for Period Type: A time period defined by a start and end date and optionally time.\">valuePeriod</span></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a href=\"http://hl7.org/fhir/R4/datatypes.html#Period\">Period</a></td><td style=\"vertical-align: top; text-align : left; background-color: white; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"/></tr>\r\n<tr style=\"border: 0px #F0F0F0 solid; padding:0px; vertical-align: top; background-color: #F7F7F7\"><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px; white-space: nowrap; background-image: url(tbl_bck000.png)\" class=\"hierarchy\"><img src=\"tbl_spacer.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_blank.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"tbl_vjoin_end.png\" alt=\".\" style=\"background-color: inherit\" class=\"hierarchy\"/><img src=\"icon_element.gif\" alt=\".\" style=\"background-color: #F7F7F7; background-color: inherit\" title=\"Element\" class=\"hierarchy\"/> <a href=\"StructureDefinition-us-core-vital-signs-definitions.html#Observation.component.dataAbsentReason\">dataAbsentReason</a><a name=\"Observation.component.dataAbsentReason\"> </a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"padding-left: 3px; padding-right: 3px; color: white; background-color: red\" title=\"This element must be supported\">S</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">0</span><span style=\"opacity: 0.5\">..</span><span style=\"opacity: 0.5\">1</span></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><a style=\"opacity: 0.5\" href=\"http://hl7.org/fhir/R4/datatypes.html#CodeableConcept\">CodeableConcept</a></td><td style=\"vertical-align: top; text-align : left; background-color: #F7F7F7; border: 0px #F0F0F0 solid; padding:0px 4px 0px 4px\" class=\"hierarchy\"><span style=\"opacity: 0.5\">Why the component result is missing</span></td></tr>\r\n<tr><td colspan=\"5\" class=\"hierarchy\"><br/><a href=\"http://hl7.org/fhir/R4/formats.html#table\" title=\"Legend for this format\"><img src=\"http://hl7.org/fhir/R4/help16.png\" alt=\"doco\" style=\"background-color: inherit\"/> Documentation for this format</a></td></tr></table></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
-	"version": "4.0.0",
-	"name": "USCoreVitalSignsProfile",
-	"title": "US Core Vital Signs Profile",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-17",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Defines constraints on the Observation resource to represent vital signs observations.  This profile is used as the base definition for the other US Core Vital Signs Profiles and based on the FHIR VitalSigns Profile.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"fhirVersion": "4.0.1",
-	"mapping": [
-		{
-			"identity": "workflow",
-			"uri": "http://hl7.org/fhir/workflow",
-			"name": "Workflow Pattern"
-		},
-		{
-			"identity": "sct-concept",
-			"uri": "http://snomed.info/conceptdomain",
-			"name": "SNOMED CT Concept Domain Binding"
-		},
-		{
-			"identity": "v2",
-			"uri": "http://hl7.org/v2",
-			"name": "HL7 v2 Mapping"
-		},
-		{
-			"identity": "rim",
-			"uri": "http://hl7.org/v3",
-			"name": "RIM Mapping"
-		},
-		{
-			"identity": "w5",
-			"uri": "http://hl7.org/fhir/fivews",
-			"name": "FiveWs Pattern Mapping"
-		},
-		{
-			"identity": "sct-attr",
-			"uri": "http://snomed.org/attributebinding",
-			"name": "SNOMED CT Attribute Binding"
-		}
-	],
-	"kind": "resource",
-	"abstract": false,
-	"type": "Observation",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/vitalsigns",
-	"derivation": "constraint",
-	"snapshot": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "US Core Vital Signs Profile",
-				"definition": "Defines constraints on the Observation resource to represent vital signs observation.  This profile is used as the base definition for the other US Core Vital Signs Profiles and based on the FHIR VitalSigns Profile.",
-				"comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
-				"alias": [
-					"Vital Signs",
-					"Measurement",
-					"Results",
-					"Tests"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation",
-					"min": 0,
-					"max": "*"
-				},
-				"constraint": [
-					{
-						"key": "dom-2",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
-						"expression": "contained.contained.empty()",
-						"xpath": "not(parent::f:contained and f:contained)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-3",
-						"severity": "error",
-						"human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
-						"expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
-						"xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-4",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
-						"expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "dom-5",
-						"severity": "error",
-						"human": "If a resource is contained in another resource, it SHALL NOT have a security label",
-						"expression": "contained.meta.security.empty()",
-						"xpath": "not(exists(f:contained/*/f:meta/f:security))",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
-								"valueBoolean": true
-							},
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
-								"valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
-							}
-						],
-						"key": "dom-6",
-						"severity": "warning",
-						"human": "A resource should have narrative for robust management",
-						"expression": "text.`div`.exists()",
-						"xpath": "exists(f:text/h:div)",
-						"source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
-					},
-					{
-						"key": "obs-6",
-						"severity": "error",
-						"human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
-						"expression": "dataAbsentReason.empty() or value.empty()",
-						"xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "obs-7",
-						"severity": "error",
-						"human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
-						"expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
-						"xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
-						"source": "http://hl7.org/fhir/StructureDefinition/Observation"
-					},
-					{
-						"key": "vs-2",
-						"severity": "error",
-						"human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
-						"expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
-						"xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Entity. Role, or Act"
-					},
-					{
-						"identity": "workflow",
-						"map": "Event"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX"
-					},
-					{
-						"identity": "rim",
-						"map": "Observation[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.id",
-				"path": "Observation.id",
-				"short": "Logical id of this artifact",
-				"definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
-				"comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.meta",
-				"path": "Observation.meta",
-				"short": "Metadata about the resource",
-				"definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.meta",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Meta"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true
-			},
-			{
-				"id": "Observation.implicitRules",
-				"path": "Observation.implicitRules",
-				"short": "A set of rules under which this content was created",
-				"definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
-				"comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.implicitRules",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
-				"isSummary": true
-			},
-			{
-				"id": "Observation.language",
-				"path": "Observation.language",
-				"short": "Language of the resource content",
-				"definition": "The base language in which the resource is written.",
-				"comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Resource.language",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
-							"valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Language"
-						},
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
-							"valueBoolean": true
-						}
-					],
-					"strength": "preferred",
-					"description": "A human language.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/languages"
-				}
-			},
-			{
-				"id": "Observation.text",
-				"path": "Observation.text",
-				"short": "Text summary of the resource, for human interpretation",
-				"definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
-				"comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
-				"alias": [
-					"narrative",
-					"html",
-					"xhtml",
-					"display"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "DomainResource.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Narrative"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "Act.text?"
-					}
-				]
-			},
-			{
-				"id": "Observation.contained",
-				"path": "Observation.contained",
-				"short": "Contained, inline Resources",
-				"definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
-				"comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
-				"alias": [
-					"inline resources",
-					"anonymous resources",
-					"contained resources"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.contained",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Resource"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.extension",
-				"path": "Observation.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.modifierExtension",
-				"path": "Observation.modifierExtension",
-				"short": "Extensions that cannot be ignored",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "DomainResource.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.identifier",
-				"path": "Observation.identifier",
-				"short": "Business Identifier for observation",
-				"definition": "A unique identifier assigned to this observation.",
-				"requirements": "Allows observations to be distinguished and referenced.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.identifier",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Identifier"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.identifier"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.identifier"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
-					},
-					{
-						"identity": "rim",
-						"map": "id"
-					}
-				]
-			},
-			{
-				"id": "Observation.basedOn",
-				"path": "Observation.basedOn",
-				"short": "Fulfills plan, proposal or order",
-				"definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
-				"requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
-				"alias": [
-					"Fulfills"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.basedOn",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/CarePlan",
-							"http://hl7.org/fhir/StructureDefinition/DeviceRequest",
-							"http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
-							"http://hl7.org/fhir/StructureDefinition/MedicationRequest",
-							"http://hl7.org/fhir/StructureDefinition/NutritionOrder",
-							"http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.basedOn"
-					},
-					{
-						"identity": "v2",
-						"map": "ORC"
-					},
-					{
-						"identity": "rim",
-						"map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.partOf",
-				"path": "Observation.partOf",
-				"short": "Part of referenced event",
-				"definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
-				"comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
-				"alias": [
-					"Container"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.partOf",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
-							"http://hl7.org/fhir/StructureDefinition/MedicationDispense",
-							"http://hl7.org/fhir/StructureDefinition/MedicationStatement",
-							"http://hl7.org/fhir/StructureDefinition/Procedure",
-							"http://hl7.org/fhir/StructureDefinition/Immunization",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.partOf"
-					},
-					{
-						"identity": "v2",
-						"map": "Varies by domain"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=FLFS].target"
-					}
-				]
-			},
-			{
-				"id": "Observation.status",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
-						"valueString": "default: final"
-					}
-				],
-				"path": "Observation.status",
-				"short": "registered | preliminary | final | amended +",
-				"definition": "The status of the result value.",
-				"comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
-				"requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.status",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": true,
-				"isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
-				"isSummary": true,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "Status"
-						}
-					],
-					"strength": "required",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.status"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.status"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 445584004 |Report by finality status|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-11"
-					},
-					{
-						"identity": "rim",
-						"map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
-					}
-				]
-			},
-			{
-				"id": "Observation.category",
-				"path": "Observation.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "coding.code"
-						},
-						{
-							"type": "value",
-							"path": "coding.system"
-						}
-					],
-					"ordered": false,
-					"rules": "open"
-				},
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat",
-				"path": "Observation.category",
-				"sliceName": "VSCat",
-				"short": "Classification of  type of observation",
-				"definition": "A code that classifies the general type of observation being made.",
-				"comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
-				"requirements": "Used for filtering what observations are retrieved and displayed.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.category",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationCategory"
-						}
-					],
-					"strength": "preferred",
-					"description": "Codes for high level observation categories.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.class"
-					},
-					{
-						"identity": "rim",
-						"map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.id",
-				"path": "Observation.category.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.extension",
-				"path": "Observation.category.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding",
-				"path": "Observation.category.coding",
-				"short": "Code defined by a terminology system",
-				"definition": "A reference to a code defined by a terminology system.",
-				"comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
-				"requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
-				"min": 1,
-				"max": "*",
-				"base": {
-					"path": "CodeableConcept.coding",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1-8, C*E.10-22"
-					},
-					{
-						"identity": "rim",
-						"map": "union(., ./translation)"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.id",
-				"path": "Observation.category.coding.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.extension",
-				"path": "Observation.category.coding.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"description": "Extensions are always sliced by (at least) url",
-					"rules": "open"
-				},
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.system",
-				"path": "Observation.category.coding.system",
-				"short": "Identity of the terminology system",
-				"definition": "The identification of the code system that defines the meaning of the symbol in the code.",
-				"comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
-				"requirements": "Need to be unambiguous about the source of the definition of the symbol.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.system",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.3"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystem"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.version",
-				"path": "Observation.category.coding.version",
-				"short": "Version of the system - if relevant",
-				"definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
-				"comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.version",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.7"
-					},
-					{
-						"identity": "rim",
-						"map": "./codeSystemVersion"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.code",
-				"path": "Observation.category.coding.code",
-				"short": "Symbol in syntax defined by the system",
-				"definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
-				"requirements": "Need to refer to a particular code in the system.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Coding.code",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "vital-signs",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.1"
-					},
-					{
-						"identity": "rim",
-						"map": "./code"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.display",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.coding.display",
-				"short": "Representation defined by the system",
-				"definition": "A representation of the meaning of the code in the system, following the rules of the system.",
-				"requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.display",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.2 - but note this is not well followed"
-					},
-					{
-						"identity": "rim",
-						"map": "CV.displayName"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.coding.userSelected",
-				"path": "Observation.category.coding.userSelected",
-				"short": "If this coding was chosen directly by the user",
-				"definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
-				"comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
-				"requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Coding.userSelected",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "boolean"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Sometimes implied by being first"
-					},
-					{
-						"identity": "rim",
-						"map": "CD.codingRationale"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
-					}
-				]
-			},
-			{
-				"id": "Observation.category:VSCat.text",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
-						"valueBoolean": true
-					}
-				],
-				"path": "Observation.category.text",
-				"short": "Plain text representation of the concept",
-				"definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
-				"comment": "Very often the text is the same as a displayName of one of the codings.",
-				"requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "CodeableConcept.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "C*E.9. But note many systems use C*E.2 for this"
-					},
-					{
-						"identity": "rim",
-						"map": "./originalText[mediaType/code=\"text/plain\"]/data"
-					},
-					{
-						"identity": "orim",
-						"map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
-					}
-				]
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"short": "Coded Responses from C-CDA Vital Sign Results",
-				"definition": "Coded Responses from C-CDA Vital Sign Results.",
-				"comment": "*All* code-value and, if present, component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
-				"alias": [
-					"Name"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				},
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.code"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "116680003 |Is a|"
-					}
-				]
-			},
-			{
-				"id": "Observation.subject",
-				"path": "Observation.subject",
-				"short": "Who and/or what the observation is about",
-				"definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
-				"comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
-				"requirements": "Observations have no value if you don't know who or what they're about.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.subject",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.subject"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "PID-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=RTGT]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.focus",
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
-						"valueCode": "trial-use"
-					}
-				],
-				"path": "Observation.focus",
-				"short": "What the observation is about, when it is not about the subject of record",
-				"definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
-				"comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.focus",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Resource"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SBJ]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.subject"
-					}
-				]
-			},
-			{
-				"id": "Observation.encounter",
-				"path": "Observation.encounter",
-				"short": "Healthcare event during which this observation is made",
-				"definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
-				"comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
-				"requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
-				"alias": [
-					"Context"
-				],
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.encounter",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Encounter"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.context"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.context"
-					},
-					{
-						"identity": "v2",
-						"map": "PV1"
-					},
-					{
-						"identity": "rim",
-						"map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.effective[x]",
-				"path": "Observation.effective[x]",
-				"short": "Often just a dateTime for Vital Signs",
-				"definition": "Often just a dateTime for Vital Signs.",
-				"comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
-				"requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
-				"alias": [
-					"Occurrence"
-				],
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.effective[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-1"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-1",
-						"severity": "error",
-						"human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
-						"expression": "($this as dateTime).toString().length() >= 8",
-						"xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.occurrence[x]"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.done[x]"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "effectiveTime"
-					}
-				]
-			},
-			{
-				"id": "Observation.issued",
-				"path": "Observation.issued",
-				"short": "Date/Time this version was made available",
-				"definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
-				"comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.issued",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "instant"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.recorded"
-					},
-					{
-						"identity": "v2",
-						"map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=AUT].time"
-					}
-				]
-			},
-			{
-				"id": "Observation.performer",
-				"path": "Observation.performer",
-				"short": "Who is responsible for the observation",
-				"definition": "Who was responsible for asserting the observed value as \"true\".",
-				"requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.performer",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Practitioner",
-							"http://hl7.org/fhir/StructureDefinition/PractitionerRole",
-							"http://hl7.org/fhir/StructureDefinition/Organization",
-							"http://hl7.org/fhir/StructureDefinition/CareTeam",
-							"http://hl7.org/fhir/StructureDefinition/Patient",
-							"http://hl7.org/fhir/StructureDefinition/RelatedPerson"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "workflow",
-						"map": "Event.performer.actor"
-					},
-					{
-						"identity": "w5",
-						"map": "FiveWs.actor"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=PRF]"
-					}
-				]
-			},
-			{
-				"id": "Observation.value[x]",
-				"path": "Observation.value[x]",
-				"short": "Vital Signs Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type.",
-				"comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "Quantity"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"obs-7",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.dataAbsentReason",
-				"path": "Observation.dataAbsentReason",
-				"short": "Why the result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
-				"comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-2"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.interpretation",
-				"path": "Observation.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.note",
-				"path": "Observation.note",
-				"short": "Comments about the observation",
-				"definition": "Comments about the observation or the results.",
-				"comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
-				"requirements": "Need to be able to provide free text additional information.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.note",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Annotation"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
-					},
-					{
-						"identity": "rim",
-						"map": "subjectOf.observationEvent[code=\"annotation\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.bodySite",
-				"path": "Observation.bodySite",
-				"short": "Observed body part",
-				"definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
-				"comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.bodySite",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "BodySite"
-						}
-					],
-					"strength": "example",
-					"description": "Codes describing anatomical locations. May include laterality.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/body-site"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123037004 |Body structure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-20"
-					},
-					{
-						"identity": "rim",
-						"map": "targetSiteCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "718497002 |Inherent location|"
-					}
-				]
-			},
-			{
-				"id": "Observation.method",
-				"path": "Observation.method",
-				"short": "How it was done",
-				"definition": "Indicates the mechanism used to perform the observation.",
-				"comment": "Only used if not implicit in code for Observation.code.",
-				"requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.method",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationMethod"
-						}
-					],
-					"strength": "example",
-					"description": "Methods for simple observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-17"
-					},
-					{
-						"identity": "rim",
-						"map": "methodCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.specimen",
-				"path": "Observation.specimen",
-				"short": "Specimen used for this observation",
-				"definition": "The specimen that was used when this observation was made.",
-				"comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.specimen",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Specimen"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 123038009 |Specimen|"
-					},
-					{
-						"identity": "v2",
-						"map": "SPM segment"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=SPC].specimen"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "704319004 |Inherent in|"
-					}
-				]
-			},
-			{
-				"id": "Observation.device",
-				"path": "Observation.device",
-				"short": "(Measurement) Device",
-				"definition": "The device used to generate the observation data.",
-				"comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.device",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/Device",
-							"http://hl7.org/fhir/StructureDefinition/DeviceMetric"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 49062001 |Device|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-17 / PRT -10"
-					},
-					{
-						"identity": "rim",
-						"map": "participation[typeCode=DEV]"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "424226004 |Using device|"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange",
-				"path": "Observation.referenceRange",
-				"short": "Provides guide for interpretation",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "obs-3",
-						"severity": "error",
-						"human": "Must have at least a low or a high or text",
-						"expression": "low.exists() or high.exists() or text.exists()",
-						"xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.id",
-				"path": "Observation.referenceRange.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.extension",
-				"path": "Observation.referenceRange.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.modifierExtension",
-				"path": "Observation.referenceRange.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.low",
-				"path": "Observation.referenceRange.low",
-				"short": "Low Range, if relevant",
-				"definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.low",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.low"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.high",
-				"path": "Observation.referenceRange.high",
-				"short": "High Range, if relevant",
-				"definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.high",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Quantity",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
-						]
-					}
-				],
-				"condition": [
-					"obs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:IVL_PQ.high"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.type",
-				"path": "Observation.referenceRange.type",
-				"short": "Reference range qualifier",
-				"definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
-				"requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.type",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeMeaning"
-						}
-					],
-					"strength": "preferred",
-					"description": "Code for the meaning of a reference range.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.appliesTo",
-				"path": "Observation.referenceRange.appliesTo",
-				"short": "Reference range population",
-				"definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
-				"comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
-				"requirements": "Need to be able to identify the target population for proper interpretation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.referenceRange.appliesTo",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationRangeType"
-						}
-					],
-					"strength": "example",
-					"description": "Codes identifying the population the reference range applies to.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-10"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.age",
-				"path": "Observation.referenceRange.age",
-				"short": "Applicable age range, if relevant",
-				"definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
-				"requirements": "Some analytes vary greatly over age.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.age",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "Range"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
-					}
-				]
-			},
-			{
-				"id": "Observation.referenceRange.text",
-				"path": "Observation.referenceRange.text",
-				"short": "Text based reference range in an observation",
-				"definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.referenceRange.text",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "string"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX-7"
-					},
-					{
-						"identity": "rim",
-						"map": "value:ST"
-					}
-				]
-			},
-			{
-				"id": "Observation.hasMember",
-				"path": "Observation.hasMember",
-				"short": "Used when reporting vital signs panel components",
-				"definition": "Used when reporting vital signs panel components.",
-				"comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.hasMember",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship"
-					}
-				]
-			},
-			{
-				"id": "Observation.derivedFrom",
-				"path": "Observation.derivedFrom",
-				"short": "Related measurements the observation is made from",
-				"definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
-				"comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.derivedFrom",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/StructureDefinition/DocumentReference",
-							"http://hl7.org/fhir/StructureDefinition/ImagingStudy",
-							"http://hl7.org/fhir/StructureDefinition/Media",
-							"http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
-							"http://hl7.org/fhir/StructureDefinition/MolecularSequence",
-							"http://hl7.org/fhir/StructureDefinition/vitalsigns"
-						]
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "Relationships established by OBX-4 usage"
-					},
-					{
-						"identity": "rim",
-						"map": ".targetObservation"
-					}
-				]
-			},
-			{
-				"id": "Observation.component",
-				"path": "Observation.component",
-				"short": "Component observations",
-				"definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
-				"comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "BackboneElement"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "vs-3",
-						"severity": "error",
-						"human": "If there is no a value a data absent reason must be present",
-						"expression": "value.exists() or dataAbsentReason.exists()",
-						"xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
-						"source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "containment by OBX-4?"
-					},
-					{
-						"identity": "rim",
-						"map": "outBoundRelationship[typeCode=COMP]"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.id",
-				"path": "Observation.component.id",
-				"representation": [
-					"xmlAttr"
-				],
-				"short": "Unique id for inter-element referencing",
-				"definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Element.id",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
-								"valueUrl": "string"
-							}
-						],
-						"code": "http://hl7.org/fhirpath/System.String"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.extension",
-				"path": "Observation.component.extension",
-				"short": "Additional content defined by implementations",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"alias": [
-					"extensions",
-					"user content"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Element.extension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "n/a"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.modifierExtension",
-				"path": "Observation.component.modifierExtension",
-				"short": "Extensions that cannot be ignored even if unrecognized",
-				"definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
-				"comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
-				"requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
-				"alias": [
-					"extensions",
-					"user content",
-					"modifiers"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "BackboneElement.modifierExtension",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "Extension"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					},
-					{
-						"key": "ext-1",
-						"severity": "error",
-						"human": "Must have either extensions or value[x], not both",
-						"expression": "extension.exists() != value.exists()",
-						"xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
-						"source": "http://hl7.org/fhir/StructureDefinition/Extension"
-					}
-				],
-				"isModifier": true,
-				"isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
-				"isSummary": true,
-				"mapping": [
-					{
-						"identity": "rim",
-						"map": "N/A"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.code",
-				"path": "Observation.component.code",
-				"short": "Type of component observation (code / type)",
-				"definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
-				"comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
-				"requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
-				"min": 1,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.code",
-					"min": 1,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				},
-				"mapping": [
-					{
-						"identity": "w5",
-						"map": "FiveWs.what[x]"
-					},
-					{
-						"identity": "sct-concept",
-						"map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-3"
-					},
-					{
-						"identity": "rim",
-						"map": "code"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.value[x]",
-				"path": "Observation.component.value[x]",
-				"short": "Vital Sign Component Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
-				"comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
-				"requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.value[x]",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "Quantity"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"condition": [
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX.2, OBX.5, OBX.6"
-					},
-					{
-						"identity": "rim",
-						"map": "value"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363714003 |Interprets|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.dataAbsentReason",
-				"path": "Observation.component.dataAbsentReason",
-				"short": "Why the component result is missing",
-				"definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
-				"comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
-				"requirements": "For many results it is necessary to handle exceptional values in measurements.",
-				"min": 0,
-				"max": "1",
-				"base": {
-					"path": "Observation.component.dataAbsentReason",
-					"min": 0,
-					"max": "1"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"condition": [
-					"obs-6",
-					"vs-3"
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"mustSupport": true,
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationValueAbsentReason"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
-				},
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "N/A"
-					},
-					{
-						"identity": "rim",
-						"map": "value.nullFlavor"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.interpretation",
-				"path": "Observation.component.interpretation",
-				"short": "High, low, normal, etc.",
-				"definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
-				"comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
-				"requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
-				"alias": [
-					"Abnormal Flag"
-				],
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.interpretation",
-					"min": 0,
-					"max": "*"
-				},
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"binding": {
-					"extension": [
-						{
-							"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
-							"valueString": "ObservationInterpretation"
-						}
-					],
-					"strength": "extensible",
-					"description": "Codes identifying interpretations of observations.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
-				},
-				"mapping": [
-					{
-						"identity": "sct-concept",
-						"map": "< 260245000 |Findings values|"
-					},
-					{
-						"identity": "v2",
-						"map": "OBX-8"
-					},
-					{
-						"identity": "rim",
-						"map": "interpretationCode"
-					},
-					{
-						"identity": "sct-attr",
-						"map": "363713009 |Has interpretation|"
-					}
-				]
-			},
-			{
-				"id": "Observation.component.referenceRange",
-				"path": "Observation.component.referenceRange",
-				"short": "Provides guide for interpretation of component result",
-				"definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
-				"comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
-				"requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
-				"min": 0,
-				"max": "*",
-				"base": {
-					"path": "Observation.component.referenceRange",
-					"min": 0,
-					"max": "*"
-				},
-				"contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
-				"constraint": [
-					{
-						"key": "ele-1",
-						"severity": "error",
-						"human": "All FHIR elements must have a @value or children",
-						"expression": "hasValue() or (children().count() > id.count())",
-						"xpath": "@value|f:*|h:div",
-						"source": "http://hl7.org/fhir/StructureDefinition/Element"
-					}
-				],
-				"isModifier": false,
-				"isSummary": false,
-				"mapping": [
-					{
-						"identity": "v2",
-						"map": "OBX.7"
-					},
-					{
-						"identity": "rim",
-						"map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
-					}
-				]
-			}
-		]
-	},
-	"differential": {
-		"element": [
-			{
-				"id": "Observation",
-				"path": "Observation",
-				"short": "US Core Vital Signs Profile",
-				"definition": "Defines constraints on the Observation resource to represent vital signs observation.  This profile is used as the base definition for the other US Core Vital Signs Profiles and based on the FHIR VitalSigns Profile."
-			},
-			{
-				"id": "Observation.status",
-				"path": "Observation.status",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.category",
-				"path": "Observation.category",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "coding.code"
-						},
-						{
-							"type": "value",
-							"path": "coding.system"
-						}
-					],
-					"ordered": false,
-					"rules": "open"
-				},
-				"min": 1,
-				"max": "*",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.category:VSCat",
-				"path": "Observation.category",
-				"sliceName": "VSCat",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "CodeableConcept"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.category:VSCat.coding",
-				"path": "Observation.category.coding",
-				"min": 1,
-				"max": "*",
-				"type": [
-					{
-						"code": "Coding"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.category:VSCat.coding.system",
-				"path": "Observation.category.coding.system",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "uri"
-					}
-				],
-				"fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.category:VSCat.coding.code",
-				"path": "Observation.category.coding.code",
-				"min": 1,
-				"max": "1",
-				"type": [
-					{
-						"code": "code"
-					}
-				],
-				"fixedCode": "vital-signs",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.code",
-				"path": "Observation.code",
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				}
-			},
-			{
-				"id": "Observation.subject",
-				"path": "Observation.subject",
-				"type": [
-					{
-						"code": "Reference",
-						"targetProfile": [
-							"http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-						]
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.effective[x]",
-				"path": "Observation.effective[x]",
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.value[x]",
-				"path": "Observation.value[x]",
-				"short": "Vital Signs Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type.",
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "Quantity"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				}
-			},
-			{
-				"id": "Observation.dataAbsentReason",
-				"path": "Observation.dataAbsentReason",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component",
-				"path": "Observation.component",
-				"short": "Component observations",
-				"definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
-				"mustSupport": true
-			},
-			{
-				"id": "Observation.component.code",
-				"path": "Observation.component.code",
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
-				}
-			},
-			{
-				"id": "Observation.component.value[x]",
-				"path": "Observation.component.value[x]",
-				"short": "Vital Sign Component Value",
-				"definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
-				"type": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
-								"valueBoolean": true
-							}
-						],
-						"code": "Quantity"
-					},
-					{
-						"code": "CodeableConcept"
-					},
-					{
-						"code": "string"
-					},
-					{
-						"code": "boolean"
-					},
-					{
-						"code": "integer"
-					},
-					{
-						"code": "Range"
-					},
-					{
-						"code": "Ratio"
-					},
-					{
-						"code": "SampledData"
-					},
-					{
-						"code": "time"
-					},
-					{
-						"code": "dateTime"
-					},
-					{
-						"code": "Period"
-					}
-				],
-				"mustSupport": true,
-				"binding": {
-					"strength": "extensible",
-					"description": "Common UCUM units for recording Vital Signs.",
-					"valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
-				}
-			},
-			{
-				"id": "Observation.component.dataAbsentReason",
-				"path": "Observation.component.dataAbsentReason",
-				"mustSupport": true
-			}
-		]
-	}
+    "resourceType": "StructureDefinition",
+    "id": "us-core-vital-signs",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
+    "version": "4.0.0",
+    "name": "USCoreVitalSignsProfile",
+    "title": "US Core Vital Signs Profile",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-17",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Defines constraints on the Observation resource to represent vital signs observations.  This profile is used as the base definition for the other US Core Vital Signs Profiles and based on the FHIR VitalSigns Profile.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "fhirVersion": "4.0.1",
+    "mapping": [
+        {
+            "identity": "workflow",
+            "uri": "http://hl7.org/fhir/workflow",
+            "name": "Workflow Pattern"
+        },
+        {
+            "identity": "sct-concept",
+            "uri": "http://snomed.info/conceptdomain",
+            "name": "SNOMED CT Concept Domain Binding"
+        },
+        {
+            "identity": "v2",
+            "uri": "http://hl7.org/v2",
+            "name": "HL7 v2 Mapping"
+        },
+        {
+            "identity": "rim",
+            "uri": "http://hl7.org/v3",
+            "name": "RIM Mapping"
+        },
+        {
+            "identity": "w5",
+            "uri": "http://hl7.org/fhir/fivews",
+            "name": "FiveWs Pattern Mapping"
+        },
+        {
+            "identity": "sct-attr",
+            "uri": "http://snomed.org/attributebinding",
+            "name": "SNOMED CT Attribute Binding"
+        }
+    ],
+    "kind": "resource",
+    "abstract": false,
+    "type": "Observation",
+    "baseDefinition": "http://hl7.org/fhir/StructureDefinition/vitalsigns",
+    "derivation": "constraint",
+    "snapshot": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "US Core Vital Signs Profile",
+                "definition": "Defines constraints on the Observation resource to represent vital signs observation.  This profile is used as the base definition for the other US Core Vital Signs Profiles and based on the FHIR VitalSigns Profile.",
+                "comment": "Used for simple observations such as device measurements, laboratory atomic results, vital signs, height, weight, smoking status, comments, etc.  Other resources are used to provide context for observations such as laboratory reports, etc.",
+                "alias": [
+                    "Vital Signs",
+                    "Measurement",
+                    "Results",
+                    "Tests"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "constraint": [
+                    {
+                        "key": "dom-2",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL NOT contain nested Resources",
+                        "expression": "contained.contained.empty()",
+                        "xpath": "not(parent::f:contained and f:contained)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-3",
+                        "severity": "error",
+                        "human": "If the resource is contained in another resource, it SHALL be referred to from elsewhere in the resource or SHALL refer to the containing resource",
+                        "expression": "contained.where((('#'+id in (%resource.descendants().reference | %resource.descendants().as(canonical) | %resource.descendants().as(uri) | %resource.descendants().as(url))) or descendants().where(reference = '#').exists() or descendants().where(as(canonical) = '#').exists() or descendants().where(as(canonical) = '#').exists()).not()).trace('unmatched', id).empty()",
+                        "xpath": "not(exists(for $id in f:contained/*/f:id/@value return $contained[not(parent::*/descendant::f:reference/@value=concat('#', $contained/*/id/@value) or descendant::f:reference[@value='#'])]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-4",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a meta.versionId or a meta.lastUpdated",
+                        "expression": "contained.meta.versionId.empty() and contained.meta.lastUpdated.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:versionId)) and not(exists(f:contained/*/f:meta/f:lastUpdated))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "dom-5",
+                        "severity": "error",
+                        "human": "If a resource is contained in another resource, it SHALL NOT have a security label",
+                        "expression": "contained.meta.security.empty()",
+                        "xpath": "not(exists(f:contained/*/f:meta/f:security))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice",
+                                "valueBoolean": true
+                            },
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bestpractice-explanation",
+                                "valueMarkdown": "When a resource has no narrative, only systems that fully understand the data can display the resource to a human safely. Including a human readable representation in the resource makes for a much more robust eco-system and cheaper handling of resources by intermediary systems. Some ecosystems restrict distribution of resources to only those systems that do fully understand the resources, and as a consequence implementers may believe that the narrative is superfluous. However experience shows that such eco-systems often open up to new participants over time."
+                            }
+                        ],
+                        "key": "dom-6",
+                        "severity": "warning",
+                        "human": "A resource should have narrative for robust management",
+                        "expression": "text.`div`.exists()",
+                        "xpath": "exists(f:text/h:div)",
+                        "source": "http://hl7.org/fhir/StructureDefinition/DomainResource"
+                    },
+                    {
+                        "key": "obs-6",
+                        "severity": "error",
+                        "human": "dataAbsentReason SHALL only be present if Observation.value[x] is not present",
+                        "expression": "dataAbsentReason.empty() or value.empty()",
+                        "xpath": "not(exists(f:dataAbsentReason)) or (not(exists(*[starts-with(local-name(.), 'value')])))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "obs-7",
+                        "severity": "error",
+                        "human": "If Observation.code is the same as an Observation.component.code then the value element associated with the code SHALL NOT be present",
+                        "expression": "value.empty() or component.code.where(coding.intersect(%resource.code.coding).exists()).empty()",
+                        "xpath": "not(f:*[starts-with(local-name(.), 'value')] and (for $coding in f:code/f:coding return f:component/f:code/f:coding[f:code/@value=$coding/f:code/@value] [f:system/@value=$coding/f:system/@value]))",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Observation"
+                    },
+                    {
+                        "key": "vs-2",
+                        "severity": "error",
+                        "human": "If there is no component or hasMember element then either a value[x] or a data absent reason must be present.",
+                        "expression": "(component.empty() and hasMember.empty()) implies (dataAbsentReason.exists() or value.exists())",
+                        "xpath": "f:component or f:memberOF or f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Entity. Role, or Act"
+                    },
+                    {
+                        "identity": "workflow",
+                        "map": "Event"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "Observation[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.id",
+                "path": "Observation.id",
+                "short": "Logical id of this artifact",
+                "definition": "The logical id of the resource, as used in the URL for the resource. Once assigned, this value never changes.",
+                "comment": "The only time that a resource does not have an id is when it is being submitted to the server using a create operation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.meta",
+                "path": "Observation.meta",
+                "short": "Metadata about the resource",
+                "definition": "The metadata about the resource. This is content that is maintained by the infrastructure. Changes to the content might not always be associated with version changes to the resource.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.meta",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Meta"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true
+            },
+            {
+                "id": "Observation.implicitRules",
+                "path": "Observation.implicitRules",
+                "short": "A set of rules under which this content was created",
+                "definition": "A reference to a set of rules that were followed when the resource was constructed, and which must be understood when processing the content. Often, this is a reference to an implementation guide that defines the special rules along with other profiles etc.",
+                "comment": "Asserting this rule set restricts the content to be only understood by a limited set of trading partners. This inherently limits the usefulness of the data in the long term. However, the existing health eco-system is highly fractured, and not yet ready to define, collect, and exchange data in a generally computable sense. Wherever possible, implementers and/or specification writers should avoid using this element. Often, when used, the URL is a reference to an implementation guide that defines these special rules as part of it's narrative along with other profiles, value sets, etc.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.implicitRules",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because the implicit rules may provide additional knowledge about the resource that modifies it's meaning or interpretation",
+                "isSummary": true
+            },
+            {
+                "id": "Observation.language",
+                "path": "Observation.language",
+                "short": "Language of the resource content",
+                "definition": "The base language in which the resource is written.",
+                "comment": "Language is provided to support indexing and accessibility (typically, services such as text to speech use the language tag). The html language tag in the narrative applies  to the narrative. The language tag on the resource may be used to specify the language of other presentations generated from the data in the resource. Not all the content has to be in the base language. The Resource.language should not be assumed to apply to the narrative automatically. If a language is specified, it should it also be specified on the div element in the html (see rules in HTML5 for information about the relationship between xml:lang and the html lang attribute).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Resource.language",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-maxValueSet",
+                            "valueCanonical": "http://hl7.org/fhir/ValueSet/all-languages"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Language"
+                        },
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-isCommonBinding",
+                            "valueBoolean": true
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "A human language.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/languages"
+                }
+            },
+            {
+                "id": "Observation.text",
+                "path": "Observation.text",
+                "short": "Text summary of the resource, for human interpretation",
+                "definition": "A human-readable narrative that contains a summary of the resource and can be used to represent the content of the resource to a human. The narrative need not encode all the structured data, but is required to contain sufficient detail to make it \"clinically safe\" for a human to just read the narrative. Resource definitions may define what content should be represented in the narrative to ensure clinical safety.",
+                "comment": "Contained resources do not have narrative. Resources that are not contained SHOULD have a narrative. In some cases, a resource may only have text with little or no additional discrete data (as long as all minOccurs=1 elements are satisfied).  This may be necessary for data from legacy systems where information is captured as a \"text blob\" or where text is additionally entered raw or narrated and encoded information is added later.",
+                "alias": [
+                    "narrative",
+                    "html",
+                    "xhtml",
+                    "display"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "DomainResource.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Narrative"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "Act.text?"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.contained",
+                "path": "Observation.contained",
+                "short": "Contained, inline Resources",
+                "definition": "These resources do not have an independent existence apart from the resource that contains them - they cannot be identified independently, and nor can they have their own independent transaction scope.",
+                "comment": "This should never be done when the content can be identified properly, as once identification is lost, it is extremely difficult (and context dependent) to restore it again. Contained resources may have profiles and tags In their meta elements, but SHALL NOT have security labels.",
+                "alias": [
+                    "inline resources",
+                    "anonymous resources",
+                    "contained resources"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.contained",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Resource"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.extension",
+                "path": "Observation.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.modifierExtension",
+                "path": "Observation.modifierExtension",
+                "short": "Extensions that cannot be ignored",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the resource and that modifies the understanding of the element that contains it and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer is allowed to define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "DomainResource.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the resource that contains them",
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.identifier",
+                "path": "Observation.identifier",
+                "short": "Business Identifier for observation",
+                "definition": "A unique identifier assigned to this observation.",
+                "requirements": "Allows observations to be distinguished and referenced.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.identifier",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Identifier"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.identifier"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.identifier"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.21  For OBX segments from systems without OBX-21 support a combination of ORC/OBR and OBX must be negotiated between trading partners to uniquely identify the OBX segment. Depending on how V2 has been implemented each of these may be an option: 1) OBR-3 + OBX-3 + OBX-4 or 2) OBR-3 + OBR-4 + OBX-3 + OBX-4 or 2) some other way to uniquely ID the OBR/ORC + OBX-3 + OBX-4."
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "id"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.basedOn",
+                "path": "Observation.basedOn",
+                "short": "Fulfills plan, proposal or order",
+                "definition": "A plan, proposal or order that is fulfilled in whole or in part by this event.  For example, a MedicationRequest may require a patient to have laboratory test performed before  it is dispensed.",
+                "requirements": "Allows tracing of authorization for the event and tracking whether proposals/recommendations were acted upon.",
+                "alias": [
+                    "Fulfills"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.basedOn",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/CarePlan",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceRequest",
+                            "http://hl7.org/fhir/StructureDefinition/ImmunizationRecommendation",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationRequest",
+                            "http://hl7.org/fhir/StructureDefinition/NutritionOrder",
+                            "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.basedOn"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "ORC"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".inboundRelationship[typeCode=COMP].source[moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.partOf",
+                "path": "Observation.partOf",
+                "short": "Part of referenced event",
+                "definition": "A larger event of which this particular Observation is a component or step.  For example,  an observation as part of a procedure.",
+                "comment": "To link an Observation to an Encounter use `encounter`.  See the  [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below for guidance on referencing another Observation.",
+                "alias": [
+                    "Container"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.partOf",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/MedicationAdministration",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationDispense",
+                            "http://hl7.org/fhir/StructureDefinition/MedicationStatement",
+                            "http://hl7.org/fhir/StructureDefinition/Procedure",
+                            "http://hl7.org/fhir/StructureDefinition/Immunization",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.partOf"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "Varies by domain"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=FLFS].target"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.status",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-display-hint",
+                        "valueString": "default: final"
+                    }
+                ],
+                "path": "Observation.status",
+                "short": "registered | preliminary | final | amended +",
+                "definition": "The status of the result value.",
+                "comment": "This element is labeled as a modifier because the status contains codes that mark the resource as not currently valid.",
+                "requirements": "Need to track the status of individual results. Some results are finalized before the whole report is finalized.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.status",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": true,
+                "isModifierReason": "This element is labeled as a modifier because it is a status element that contains status entered-in-error which means that the resource should not be treated as valid",
+                "isSummary": true,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "Status"
+                        }
+                    ],
+                    "strength": "required",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-status|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.status"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.status"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 445584004 |Report by finality status|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-11"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "status  Amended & Final are differentiated by whether it is the subject of a ControlAct event with a type of \"revise\""
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category",
+                "path": "Observation.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "coding.code"
+                        },
+                        {
+                            "type": "value",
+                            "path": "coding.system"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "open"
+                },
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat",
+                "path": "Observation.category",
+                "sliceName": "VSCat",
+                "short": "Classification of  type of observation",
+                "definition": "A code that classifies the general type of observation being made.",
+                "comment": "In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once.  The level of granularity is defined by the category concepts in the value set.",
+                "requirements": "Used for filtering what observations are retrieved and displayed.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.category",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationCategory"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Codes for high level observation categories.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-category"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.class"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".outboundRelationship[typeCode=\"COMP].target[classCode=\"LIST\", moodCode=\"EVN\"].code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.id",
+                "path": "Observation.category.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.extension",
+                "path": "Observation.category.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding",
+                "path": "Observation.category.coding",
+                "short": "Code defined by a terminology system",
+                "definition": "A reference to a code defined by a terminology system.",
+                "comment": "Codes may be defined very casually in enumerations, or code lists, up to very formal definitions such as SNOMED CT - see the HL7 v3 Core Principles for more information.  Ordering of codings is undefined and SHALL NOT be used to infer meaning. Generally, at most only one of the coding values will be labeled as UserSelected = true.",
+                "requirements": "Allows for alternative encodings within a code system, and translations to other code systems.",
+                "min": 1,
+                "max": "*",
+                "base": {
+                    "path": "CodeableConcept.coding",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1-8, C*E.10-22"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "union(., ./translation)"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.coding rdfs:subPropertyOf dt:CD.coding"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.id",
+                "path": "Observation.category.coding.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.extension",
+                "path": "Observation.category.coding.extension",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "url"
+                        }
+                    ],
+                    "description": "Extensions are always sliced by (at least) url",
+                    "rules": "open"
+                },
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.system",
+                "path": "Observation.category.coding.system",
+                "short": "Identity of the terminology system",
+                "definition": "The identification of the code system that defines the meaning of the symbol in the code.",
+                "comment": "The URI may be an OID (urn:oid:...) or a UUID (urn:uuid:...).  OIDs and UUIDs SHALL be references to the HL7 OID registry. Otherwise, the URI should come from HL7's list of FHIR defined special URIs or it should reference to some definition that establishes the system clearly and unambiguously.",
+                "requirements": "Need to be unambiguous about the source of the definition of the symbol.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.system",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystem"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.system rdfs:subPropertyOf dt:CDCoding.codeSystem"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.version",
+                "path": "Observation.category.coding.version",
+                "short": "Version of the system - if relevant",
+                "definition": "The version of the code system which was used when choosing this code. Note that a well-maintained code system does not need the version reported, because the meaning of codes is consistent across versions. However this cannot consistently be assured, and when the meaning is not guaranteed to be consistent, the version SHOULD be exchanged.",
+                "comment": "Where the terminology does not clearly define what string should be used to identify code system versions, the recommendation is to use the date (expressed in FHIR date format) on which that version was officially published as the version date.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.version",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./codeSystemVersion"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.version rdfs:subPropertyOf dt:CDCoding.codeSystemVersion"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.code",
+                "path": "Observation.category.coding.code",
+                "short": "Symbol in syntax defined by the system",
+                "definition": "A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination).",
+                "requirements": "Need to refer to a particular code in the system.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Coding.code",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "vital-signs",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./code"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.code rdfs:subPropertyOf dt:CDCoding.code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.display",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.coding.display",
+                "short": "Representation defined by the system",
+                "definition": "A representation of the meaning of the code in the system, following the rules of the system.",
+                "requirements": "Need to be able to carry a human-readable meaning of the code for readers that do not know  the system.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.display",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.2 - but note this is not well followed"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CV.displayName"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.display rdfs:subPropertyOf dt:CDCoding.displayName"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.coding.userSelected",
+                "path": "Observation.category.coding.userSelected",
+                "short": "If this coding was chosen directly by the user",
+                "definition": "Indicates that this coding was chosen by a user directly - e.g. off a pick list of available items (codes or displays).",
+                "comment": "Amongst a set of alternatives, a directly chosen code is the most appropriate starting point for new translations. There is some ambiguity about what exactly 'directly chosen' implies, and trading partner agreement may be needed to clarify the use of this element and its consequences more completely.",
+                "requirements": "This has been identified as a clinical safety criterium - that this exact system/code pair was chosen explicitly, rather than inferred by the system based on some rules or language processing.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Coding.userSelected",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "boolean"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Sometimes implied by being first"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "CD.codingRationale"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:Coding.userSelected fhir:mapsTo dt:CDCoding.codingRationale. fhir:Coding.userSelected fhir:hasMap fhir:Coding.userSelected.map. fhir:Coding.userSelected.map a fhir:Map;   fhir:target dt:CDCoding.codingRationale. fhir:Coding.userSelected\\#true a [     fhir:source \"true\";     fhir:target dt:CDCoding.codingRationale\\#O   ]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.category:VSCat.text",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-translatable",
+                        "valueBoolean": true
+                    }
+                ],
+                "path": "Observation.category.text",
+                "short": "Plain text representation of the concept",
+                "definition": "A human language representation of the concept as seen/selected/uttered by the user who entered the data and/or which represents the intended meaning of the user.",
+                "comment": "Very often the text is the same as a displayName of one of the codings.",
+                "requirements": "The codes from the terminologies do not always capture the correct meaning with all the nuances of the human using them, or sometimes there is no appropriate code at all. In these cases, the text is used to capture the full meaning of the source.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "CodeableConcept.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "C*E.9. But note many systems use C*E.2 for this"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "./originalText[mediaType/code=\"text/plain\"]/data"
+                    },
+                    {
+                        "identity": "orim",
+                        "map": "fhir:CodeableConcept.text rdfs:subPropertyOf dt:CD.originalText"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "short": "Coded Responses from C-CDA Vital Sign Results",
+                "definition": "Coded Responses from C-CDA Vital Sign Results.",
+                "comment": "*All* code-value and, if present, component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "5. SHALL contain exactly one [1..1] code, where the @code SHOULD be selected from ValueSet HITSP Vital Sign Result Type 2.16.840.1.113883.3.88.12.80.62 DYNAMIC (CONF:7301).",
+                "alias": [
+                    "Name"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                },
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.code"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR < 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "116680003 |Is a|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.subject",
+                "path": "Observation.subject",
+                "short": "Who and/or what the observation is about",
+                "definition": "The patient, or group of patients, location, or device this observation is about and into whose record the observation is placed. If the actual focus of the observation is different from the subject (or a sample of, part, or region of the subject), the `focus` element or the `code` itself specifies the actual focus of the observation.",
+                "comment": "One would expect this element to be a cardinality of 1..1. The only circumstance in which the subject can be missing is when the observation is made by a device that does not know the patient. In this case, the observation SHALL be matched to a patient through some context/channel matching technique, and at this point, the observation should be updated.",
+                "requirements": "Observations have no value if you don't know who or what they're about.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.subject",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.subject"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PID-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=RTGT]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.focus",
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+                        "valueCode": "trial-use"
+                    }
+                ],
+                "path": "Observation.focus",
+                "short": "What the observation is about, when it is not about the subject of record",
+                "definition": "The actual focus of an observation when it is not the patient of record representing something or someone associated with the patient such as a spouse, parent, fetus, or donor. For example, fetus observations in a mother's record.  The focus of an observation could also be an existing condition,  an intervention, the subject's diet,  another observation of the subject,  or a body structure such as tumor or implanted device.   An example use case would be using the Observation resource to capture whether the mother is trained to change her child's tracheostomy tube. In this example, the child is the patient of record and the mother is the focus.",
+                "comment": "Typically, an observation is made about the subject - a patient, or group of patients, location, or device - and the distinction between the subject and what is directly measured for an observation is specified in the observation code itself ( e.g., \"Blood Glucose\") and does not need to be represented separately using this element.  Use `specimen` if a reference to a specimen is required.  If a code is required instead of a resource use either  `bodysite` for bodysites or the standard extension [focusCode](http://hl7.org/fhir/extension-observation-focuscode.html).",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.focus",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Resource"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SBJ]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.subject"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.encounter",
+                "path": "Observation.encounter",
+                "short": "Healthcare event during which this observation is made",
+                "definition": "The healthcare event  (e.g. a patient and healthcare provider interaction) during which this observation is made.",
+                "comment": "This will typically be the encounter the event occurred within, but some events may be initiated prior to or after the official completion of an encounter but still be tied to the context of the encounter (e.g. pre-admission laboratory tests).",
+                "requirements": "For some observations it may be important to know the link between an observation and a particular encounter.",
+                "alias": [
+                    "Context"
+                ],
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.encounter",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Encounter"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.context"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.context"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "PV1"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "inboundRelationship[typeCode=COMP].source[classCode=ENC, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.effective[x]",
+                "path": "Observation.effective[x]",
+                "short": "Often just a dateTime for Vital Signs",
+                "definition": "Often just a dateTime for Vital Signs.",
+                "comment": "At least a date should be present unless this observation is a historical report.  For recording imprecise or \"fuzzy\" times (For example, a blood glucose measurement taken \"after breakfast\") use the [Timing](http://hl7.org/fhir/datatypes.html#timing) datatype which allow the measurement to be tied to regular life events.",
+                "requirements": "Knowing when an observation was deemed true is important to its relevance as well as determining trends.",
+                "alias": [
+                    "Occurrence"
+                ],
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.effective[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-1"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-1",
+                        "severity": "error",
+                        "human": "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day",
+                        "expression": "($this as dateTime).toString().length() >= 8",
+                        "xpath": "f:effectiveDateTime[matches(@value, '^\\d{4}-\\d{2}-\\d{2}')]",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.occurrence[x]"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.done[x]"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-14, and/or OBX-19 after v2.4  (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "effectiveTime"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.issued",
+                "path": "Observation.issued",
+                "short": "Date/Time this version was made available",
+                "definition": "The date and time this version of the observation was made available to providers, typically after the results have been reviewed and verified.",
+                "comment": "For Observations that don’t require review and verification, it may be the same as the [`lastUpdated` ](http://hl7.org/fhir/resource-definitions.html#Meta.lastUpdated) time of the resource itself.  For Observations that do require review and verification for certain updates, it might not be the same as the `lastUpdated` time of the resource itself due to a non-clinically significant update that doesn’t require the new version to be reviewed and verified again.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.issued",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "instant"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.recorded"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBR.22 (or MSH.7), or perhaps OBX-19 (depends on who observation made)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=AUT].time"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.performer",
+                "path": "Observation.performer",
+                "short": "Who is responsible for the observation",
+                "definition": "Who was responsible for asserting the observed value as \"true\".",
+                "requirements": "May give a degree of confidence in the observation and also indicates where follow-up questions should be directed.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.performer",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Practitioner",
+                            "http://hl7.org/fhir/StructureDefinition/PractitionerRole",
+                            "http://hl7.org/fhir/StructureDefinition/Organization",
+                            "http://hl7.org/fhir/StructureDefinition/CareTeam",
+                            "http://hl7.org/fhir/StructureDefinition/Patient",
+                            "http://hl7.org/fhir/StructureDefinition/RelatedPerson"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "workflow",
+                        "map": "Event.performer.actor"
+                    },
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.actor"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.15 / (Practitioner)  OBX-16,  PRT-5:PRT-4='RO' /  (Device)  OBX-18 , PRT-10:PRT-4='EQUIP' / (Organization)  OBX-23,  PRT-8:PRT-4='PO'"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=PRF]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.value[x]",
+                "path": "Observation.value[x]",
+                "short": "Vital Signs Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type.",
+                "comment": "An observation may have; 1)  a single value here, 2)  both a value and a set of related or component values,  or 3)  only a set of related or component values. If a value is present, the datatype for this element should be determined by Observation.code.  A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "obs-7",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.dataAbsentReason",
+                "path": "Observation.dataAbsentReason",
+                "short": "Why the result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.value[x] is missing.",
+                "comment": "Null or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"specimen unsatisfactory\".   \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed. Note that an observation may only be reported if there are values to report. For example differential cell counts values may be reported only when > 0.  Because of these options, use-case agreements are required to interpret general observations for null or exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-2"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.interpretation",
+                "path": "Observation.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.note",
+                "path": "Observation.note",
+                "short": "Comments about the observation",
+                "definition": "Comments about the observation or the results.",
+                "comment": "May include general statements about the observation, or statements about significant, unexpected or unreliable results values, or information about its source when relevant to its interpretation.",
+                "requirements": "Need to be able to provide free text additional information.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.note",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Annotation"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "NTE.3 (partner NTE to OBX, or sometimes another (child?) OBX)"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "subjectOf.observationEvent[code=\"annotation\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.bodySite",
+                "path": "Observation.bodySite",
+                "short": "Observed body part",
+                "definition": "Indicates the site on the subject's body where the observation was made (i.e. the target site).",
+                "comment": "Only used if not implicit in code found in Observation.code.  In many systems, this may be represented as a related observation instead of an inline component.   \n\nIf the use case requires BodySite to be handled as a separate resource (e.g. to identify and track separately) then use the standard extension[ bodySite](http://hl7.org/fhir/extension-bodysite.html).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.bodySite",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "BodySite"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes describing anatomical locations. May include laterality.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/body-site"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123037004 |Body structure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-20"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "targetSiteCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "718497002 |Inherent location|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.method",
+                "path": "Observation.method",
+                "short": "How it was done",
+                "definition": "Indicates the mechanism used to perform the observation.",
+                "comment": "Only used if not implicit in code for Observation.code.",
+                "requirements": "In some cases, method can impact results and is thus used for determining whether results can be compared or determining significance of results.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.method",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationMethod"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Methods for simple observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-methods"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "methodCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.specimen",
+                "path": "Observation.specimen",
+                "short": "Specimen used for this observation",
+                "definition": "The specimen that was used when this observation was made.",
+                "comment": "Should only be used if not implicit in code found in `Observation.code`.  Observations are not made on specimens themselves; they are made on a subject, but in many cases by the means of a specimen. Note that although specimens are often involved, they are not always tracked and reported explicitly. Also note that observation resources may be used in contexts that track the specimen explicitly (e.g. Diagnostic Report).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.specimen",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Specimen"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 123038009 |Specimen|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "SPM segment"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=SPC].specimen"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "704319004 |Inherent in|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.device",
+                "path": "Observation.device",
+                "short": "(Measurement) Device",
+                "definition": "The device used to generate the observation data.",
+                "comment": "Note that this is not meant to represent a device involved in the transmission of the result, e.g., a gateway.  Such devices may be documented using the Provenance resource where relevant.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.device",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/Device",
+                            "http://hl7.org/fhir/StructureDefinition/DeviceMetric"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 49062001 |Device|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-17 / PRT -10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "participation[typeCode=DEV]"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "424226004 |Using device|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange",
+                "path": "Observation.referenceRange",
+                "short": "Provides guide for interpretation",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.  Multiple reference ranges are interpreted as an \"OR\".   In other words, to represent two distinct target populations, two `referenceRange` elements would be used.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "obs-3",
+                        "severity": "error",
+                        "human": "Must have at least a low or a high or text",
+                        "expression": "low.exists() or high.exists() or text.exists()",
+                        "xpath": "(exists(f:low) or exists(f:high)or exists(f:text))"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.id",
+                "path": "Observation.referenceRange.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.extension",
+                "path": "Observation.referenceRange.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.modifierExtension",
+                "path": "Observation.referenceRange.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.low",
+                "path": "Observation.referenceRange.low",
+                "short": "Low Range, if relevant",
+                "definition": "The value of the low bound of the reference range.  The low bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the low bound is omitted,  it is assumed to be meaningless (e.g. reference range is <=2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.low",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.low"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.high",
+                "path": "Observation.referenceRange.high",
+                "short": "High Range, if relevant",
+                "definition": "The value of the high bound of the reference range.  The high bound of the reference range endpoint is inclusive of the value (e.g.  reference range is >=5 - <=9). If the high bound is omitted,  it is assumed to be meaningless (e.g. reference range is >= 2.3).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.high",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Quantity",
+                        "profile": [
+                            "http://hl7.org/fhir/StructureDefinition/SimpleQuantity"
+                        ]
+                    }
+                ],
+                "condition": [
+                    "obs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:IVL_PQ.high"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.type",
+                "path": "Observation.referenceRange.type",
+                "short": "Reference range qualifier",
+                "definition": "Codes to indicate the what part of the targeted reference population it applies to. For example, the normal or therapeutic range.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal range is assumed.",
+                "requirements": "Need to be able to say what kind of reference range this is - normal, recommended, therapeutic, etc.,  - for proper interpretation.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.type",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeMeaning"
+                        }
+                    ],
+                    "strength": "preferred",
+                    "description": "Code for the meaning of a reference range.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-meaning"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.appliesTo",
+                "path": "Observation.referenceRange.appliesTo",
+                "short": "Reference range population",
+                "definition": "Codes to indicate the target population this reference range applies to.  For example, a reference range may be based on the normal population or a particular sex or race.  Multiple `appliesTo`  are interpreted as an \"AND\" of the target populations.  For example, to represent a target population of African American females, both a code of female and a code for African American would be used.",
+                "comment": "This SHOULD be populated if there is more than one range.  If this element is not present then the normal population is assumed.",
+                "requirements": "Need to be able to identify the target population for proper interpretation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.referenceRange.appliesTo",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationRangeType"
+                        }
+                    ],
+                    "strength": "example",
+                    "description": "Codes identifying the population the reference range applies to.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/referencerange-appliesto"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values| OR  \r< 365860008 |General clinical state finding| \rOR \r< 250171008 |Clinical history or observation findings| OR  \r< 415229000 |Racial group| OR \r< 365400002 |Finding of puberty stage| OR\r< 443938003 |Procedure carried out on subject|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-10"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.age",
+                "path": "Observation.referenceRange.age",
+                "short": "Applicable age range, if relevant",
+                "definition": "The age at which this reference range is applicable. This is a neonatal age (e.g. number of weeks at term) if the meaning says so.",
+                "requirements": "Some analytes vary greatly over age.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.age",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "Range"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=PRCN].targetObservationCriterion[code=\"age\"].value"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.referenceRange.text",
+                "path": "Observation.referenceRange.text",
+                "short": "Text based reference range in an observation",
+                "definition": "Text based reference range in an observation which may be used when a quantitative range is not appropriate for an observation.  An example would be a reference value of \"Negative\" or a list or table of \"normals\".",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.referenceRange.text",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "string"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX-7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value:ST"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.hasMember",
+                "path": "Observation.hasMember",
+                "short": "Used when reporting vital signs panel components",
+                "definition": "Used when reporting vital signs panel components.",
+                "comment": "When using this element, an observation will typically have either a value or a set of related resources, although both may be present in some cases.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.  Note that a system may calculate results from [QuestionnaireResponse](http://hl7.org/fhir/questionnaireresponse.html)  into a final score and represent the score as an Observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.hasMember",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.derivedFrom",
+                "path": "Observation.derivedFrom",
+                "short": "Related measurements the observation is made from",
+                "definition": "The target resource that represents a measurement from which this observation value is derived. For example, a calculated anion gap or a fetal measurement based on an ultrasound image.",
+                "comment": "All the reference choices that are listed in this element can represent clinical observations and other measurements that may be the source for a derived value.  The most common reference will be another Observation.  For a discussion on the ways Observations can assembled in groups together, see [Notes](http://hl7.org/fhir/observation.html#obsgrouping) below.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.derivedFrom",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/StructureDefinition/DocumentReference",
+                            "http://hl7.org/fhir/StructureDefinition/ImagingStudy",
+                            "http://hl7.org/fhir/StructureDefinition/Media",
+                            "http://hl7.org/fhir/StructureDefinition/QuestionnaireResponse",
+                            "http://hl7.org/fhir/StructureDefinition/MolecularSequence",
+                            "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                        ]
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "Relationships established by OBX-4 usage"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": ".targetObservation"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component",
+                "path": "Observation.component",
+                "short": "Component observations",
+                "definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
+                "comment": "For a discussion on the ways Observations can be assembled in groups together see [Notes](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "Component observations share the same attributes in the Observation resource as the primary observation and are always treated a part of a single observation (they are not separable).   However, the reference range for the primary observation value is not inherited by the component values and is required when appropriate for each component observation.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "BackboneElement"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "vs-3",
+                        "severity": "error",
+                        "human": "If there is no a value a data absent reason must be present",
+                        "expression": "value.exists() or dataAbsentReason.exists()",
+                        "xpath": "f:*[starts-with(local-name(.), 'value')] or f:dataAbsentReason",
+                        "source": "http://hl7.org/fhir/StructureDefinition/vitalsigns"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "containment by OBX-4?"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outBoundRelationship[typeCode=COMP]"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.id",
+                "path": "Observation.component.id",
+                "representation": [
+                    "xmlAttr"
+                ],
+                "short": "Unique id for inter-element referencing",
+                "definition": "Unique id for the element within a resource (for internal references). This may be any string value that does not contain spaces.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Element.id",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-fhir-type",
+                                "valueUrl": "string"
+                            }
+                        ],
+                        "code": "http://hl7.org/fhirpath/System.String"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.extension",
+                "path": "Observation.component.extension",
+                "short": "Additional content defined by implementations",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element. To make the use of extensions safe and manageable, there is a strict set of governance  applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension.",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "alias": [
+                    "extensions",
+                    "user content"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Element.extension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "n/a"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.modifierExtension",
+                "path": "Observation.component.modifierExtension",
+                "short": "Extensions that cannot be ignored even if unrecognized",
+                "definition": "May be used to represent additional information that is not part of the basic definition of the element and that modifies the understanding of the element in which it is contained and/or the understanding of the containing element's descendants. Usually modifier elements provide negation or qualification. To make the use of extensions safe and manageable, there is a strict set of governance applied to the definition and use of extensions. Though any implementer can define an extension, there is a set of requirements that SHALL be met as part of the definition of the extension. Applications processing a resource are required to check for modifier extensions.\n\nModifier extensions SHALL NOT change the meaning of any elements on Resource or DomainResource (including cannot change the meaning of modifierExtension itself).",
+                "comment": "There can be no stigma associated with the use of extensions by any application, project, or standard - regardless of the institution or jurisdiction that uses or defines the extensions.  The use of extensions is what allows the FHIR specification to retain a core level of simplicity for everyone.",
+                "requirements": "Modifier extensions allow for extensions that *cannot* be safely ignored to be clearly distinguished from the vast majority of extensions which can be safely ignored.  This promotes interoperability by eliminating the need for implementers to prohibit the presence of extensions. For further information, see the [definition of modifier extensions](http://hl7.org/fhir/extensibility.html#modifierExtension).",
+                "alias": [
+                    "extensions",
+                    "user content",
+                    "modifiers"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "BackboneElement.modifierExtension",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "Extension"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    },
+                    {
+                        "key": "ext-1",
+                        "severity": "error",
+                        "human": "Must have either extensions or value[x], not both",
+                        "expression": "extension.exists() != value.exists()",
+                        "xpath": "exists(f:extension)!=exists(f:*[starts-with(local-name(.), \"value\")])",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Extension"
+                    }
+                ],
+                "isModifier": true,
+                "isModifierReason": "Modifier extensions are expected to modify the meaning or interpretation of the element that contains them",
+                "isSummary": true,
+                "mapping": [
+                    {
+                        "identity": "rim",
+                        "map": "N/A"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.code",
+                "path": "Observation.component.code",
+                "short": "Type of component observation (code / type)",
+                "definition": "Describes what was observed. Sometimes this is called the observation \"code\".",
+                "comment": "*All* code-value and  component.code-component.value pairs need to be taken into account to correctly understand the meaning of the observation.",
+                "requirements": "Knowing what kind of observation is being made is essential to understanding the observation.",
+                "min": 1,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.code",
+                    "min": 1,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                },
+                "mapping": [
+                    {
+                        "identity": "w5",
+                        "map": "FiveWs.what[x]"
+                    },
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 363787002 |Observable entity| OR \r< 386053000 |Evaluation procedure|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-3"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "code"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.value[x]",
+                "path": "Observation.component.value[x]",
+                "short": "Vital Sign Component Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
+                "comment": "Used when observation has a set of component observations. An observation may have both a value (e.g. an  Apgar score)  and component observations (the observations from which the Apgar score was derived). If a value is present, the datatype for this element should be determined by Observation.code. A CodeableConcept with just a text would be used instead of a string if the field was usually coded, or if the type associated with the Observation.code defines a coded value.  For additional guidance, see the [Notes section](http://hl7.org/fhir/observation.html#notes) below.",
+                "requirements": "9. SHALL contain exactly one [1..1] value with @xsi:type=\"PQ\" (CONF:7305).",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.value[x]",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "condition": [
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "363714003 |Interprets| < 441742003 |Evaluation finding|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX.2, OBX.5, OBX.6"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363714003 |Interprets|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.dataAbsentReason",
+                "path": "Observation.component.dataAbsentReason",
+                "short": "Why the component result is missing",
+                "definition": "Provides a reason why the expected value in the element Observation.component.value[x] is missing.",
+                "comment": "\"Null\" or exceptional values can be represented two ways in FHIR Observations.  One way is to simply include them in the value set and represent the exceptions in the value.  For example, measurement values for a serology test could be  \"detected\", \"not detected\", \"inconclusive\", or  \"test not done\". \n\nThe alternate way is to use the value element for actual observations and use the explicit dataAbsentReason element to record exceptional values.  For example, the dataAbsentReason code \"error\" could be used when the measurement was not completed.  Because of these options, use-case agreements are required to interpret general observations for exceptional values.",
+                "requirements": "For many results it is necessary to handle exceptional values in measurements.",
+                "min": 0,
+                "max": "1",
+                "base": {
+                    "path": "Observation.component.dataAbsentReason",
+                    "min": 0,
+                    "max": "1"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "condition": [
+                    "obs-6",
+                    "vs-3"
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "mustSupport": true,
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationValueAbsentReason"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes specifying why the result (`Observation.value[x]`) is missing.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/data-absent-reason"
+                },
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "N/A"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "value.nullFlavor"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.interpretation",
+                "path": "Observation.component.interpretation",
+                "short": "High, low, normal, etc.",
+                "definition": "A categorical assessment of an observation value.  For example, high, low, normal.",
+                "comment": "Historically used for laboratory results (known as 'abnormal flag' ),  its use extends to other use cases where coded interpretations  are relevant.  Often reported as one or more simple compact codes this element is often placed adjacent to the result value in reports and flow sheets to signal the meaning/normalcy status of the result.",
+                "requirements": "For some results, particularly numeric results, an interpretation is necessary to fully understand the significance of a result.",
+                "alias": [
+                    "Abnormal Flag"
+                ],
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.interpretation",
+                    "min": 0,
+                    "max": "*"
+                },
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "binding": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-bindingName",
+                            "valueString": "ObservationInterpretation"
+                        }
+                    ],
+                    "strength": "extensible",
+                    "description": "Codes identifying interpretations of observations.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/observation-interpretation"
+                },
+                "mapping": [
+                    {
+                        "identity": "sct-concept",
+                        "map": "< 260245000 |Findings values|"
+                    },
+                    {
+                        "identity": "v2",
+                        "map": "OBX-8"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "interpretationCode"
+                    },
+                    {
+                        "identity": "sct-attr",
+                        "map": "363713009 |Has interpretation|"
+                    }
+                ]
+            },
+            {
+                "id": "Observation.component.referenceRange",
+                "path": "Observation.component.referenceRange",
+                "short": "Provides guide for interpretation of component result",
+                "definition": "Guidance on how to interpret the value by comparison to a normal or recommended range.",
+                "comment": "Most observations only have one generic reference range. Systems MAY choose to restrict to only supplying the relevant reference range based on knowledge about the patient (e.g., specific to the patient's age, gender, weight and other factors), but this might not be possible or appropriate. Whenever more than one reference range is supplied, the differences between them SHOULD be provided in the reference range and/or age properties.",
+                "requirements": "Knowing what values are considered \"normal\" can help evaluate the significance of a particular result. Need to be able to provide multiple reference ranges for different contexts.",
+                "min": 0,
+                "max": "*",
+                "base": {
+                    "path": "Observation.component.referenceRange",
+                    "min": 0,
+                    "max": "*"
+                },
+                "contentReference": "http://hl7.org/fhir/StructureDefinition/Observation#Observation.referenceRange",
+                "constraint": [
+                    {
+                        "key": "ele-1",
+                        "severity": "error",
+                        "human": "All FHIR elements must have a @value or children",
+                        "expression": "hasValue() or (children().count() > id.count())",
+                        "xpath": "@value|f:*|h:div",
+                        "source": "http://hl7.org/fhir/StructureDefinition/Element"
+                    }
+                ],
+                "isModifier": false,
+                "isSummary": false,
+                "mapping": [
+                    {
+                        "identity": "v2",
+                        "map": "OBX.7"
+                    },
+                    {
+                        "identity": "rim",
+                        "map": "outboundRelationship[typeCode=REFV]/target[classCode=OBS, moodCode=EVN]"
+                    }
+                ]
+            }
+        ]
+    },
+    "differential": {
+        "element": [
+            {
+                "id": "Observation",
+                "path": "Observation",
+                "short": "US Core Vital Signs Profile",
+                "definition": "Defines constraints on the Observation resource to represent vital signs observation.  This profile is used as the base definition for the other US Core Vital Signs Profiles and based on the FHIR VitalSigns Profile."
+            },
+            {
+                "id": "Observation.status",
+                "path": "Observation.status",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.category",
+                "path": "Observation.category",
+                "slicing": {
+                    "discriminator": [
+                        {
+                            "type": "value",
+                            "path": "coding.code"
+                        },
+                        {
+                            "type": "value",
+                            "path": "coding.system"
+                        }
+                    ],
+                    "ordered": false,
+                    "rules": "open"
+                },
+                "min": 1,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.category:VSCat",
+                "path": "Observation.category",
+                "sliceName": "VSCat",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "CodeableConcept"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.category:VSCat.coding",
+                "path": "Observation.category.coding",
+                "min": 1,
+                "max": "*",
+                "type": [
+                    {
+                        "code": "Coding"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.category:VSCat.coding.system",
+                "path": "Observation.category.coding.system",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "uri"
+                    }
+                ],
+                "fixedUri": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.category:VSCat.coding.code",
+                "path": "Observation.category.coding.code",
+                "min": 1,
+                "max": "1",
+                "type": [
+                    {
+                        "code": "code"
+                    }
+                ],
+                "fixedCode": "vital-signs",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.code",
+                "path": "Observation.code",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                }
+            },
+            {
+                "id": "Observation.subject",
+                "path": "Observation.subject",
+                "type": [
+                    {
+                        "code": "Reference",
+                        "targetProfile": [
+                            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+                        ]
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.effective[x]",
+                "path": "Observation.effective[x]",
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.value[x]",
+                "path": "Observation.value[x]",
+                "short": "Vital Signs Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type.",
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                }
+            },
+            {
+                "id": "Observation.dataAbsentReason",
+                "path": "Observation.dataAbsentReason",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component",
+                "path": "Observation.component",
+                "short": "Component observations",
+                "definition": "Used when reporting component observation such as systolic and diastolic blood pressure.",
+                "mustSupport": true
+            },
+            {
+                "id": "Observation.component.code",
+                "path": "Observation.component.code",
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs"
+                }
+            },
+            {
+                "id": "Observation.component.value[x]",
+                "path": "Observation.component.value[x]",
+                "short": "Vital Sign Component Value",
+                "definition": "Vital Signs value are typically recorded using the Quantity data type. For supporting observations such as cuff size could use other datatypes such as CodeableConcept.",
+                "type": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                                "valueBoolean": true
+                            }
+                        ],
+                        "code": "Quantity"
+                    },
+                    {
+                        "code": "CodeableConcept"
+                    },
+                    {
+                        "code": "string"
+                    },
+                    {
+                        "code": "boolean"
+                    },
+                    {
+                        "code": "integer"
+                    },
+                    {
+                        "code": "Range"
+                    },
+                    {
+                        "code": "Ratio"
+                    },
+                    {
+                        "code": "SampledData"
+                    },
+                    {
+                        "code": "time"
+                    },
+                    {
+                        "code": "dateTime"
+                    },
+                    {
+                        "code": "Period"
+                    }
+                ],
+                "mustSupport": true,
+                "binding": {
+                    "strength": "extensible",
+                    "description": "Common UCUM units for recording Vital Signs.",
+                    "valueSet": "http://hl7.org/fhir/ValueSet/ucum-vitals-common|4.0.1"
+                }
+            },
+            {
+                "id": "Observation.component.dataAbsentReason",
+                "path": "Observation.component.dataAbsentReason",
+                "mustSupport": true
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-birthsex.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-birthsex.json
@@ -1,70 +1,70 @@
 {
-	"resourceType": "ValueSet",
-	"id": "birthsex",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This value set includes codes based on the following rules:</p><ul><li>Include these codes as defined in <a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-v3-AdministrativeGender.html\"><code>http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td><td><b>Definition</b></td></tr><tr><td><a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-v3-AdministrativeGender.html#v3-AdministrativeGender-F\">F</a></td><td>Female</td><td>Female</td></tr><tr><td><a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-v3-AdministrativeGender.html#v3-AdministrativeGender-M\">M</a></td><td>Male</td><td>Male</td></tr></table></li><li>Include these codes as defined in <a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-v3-NullFlavor.html\"><code>http://terminology.hl7.org/CodeSystem/v3-NullFlavor</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td><td><b>Definition</b></td></tr><tr><td><a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-v3-NullFlavor.html#v3-NullFlavor-UNK\">UNK</a></td><td>Unknown</td><td>**Description:**A proper value is applicable, but not known.<br/><br/>**Usage Notes**: This means the actual value is not known. If the only thing that is unknown is how to properly express the value in the necessary constraints (value set, datatype, etc.), then the OTH or UNC flavor should be used. No properties should be included for a datatype with this property unless:<br/><br/>1.  Those properties themselves directly translate to a semantic of &quot;unknown&quot;. (E.g. a local code sent as a translation that conveys 'unknown')<br/>2.  Those properties further qualify the nature of what is unknown. (E.g. specifying a use code of &quot;H&quot; and a URL prefix of &quot;tel:&quot; to convey that it is the home phone number that is unknown.)</td></tr></table></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/birthsex",
-	"identifier": [
-		{
-			"system": "urn:ietf:rfc:3986",
-			"value": "urn:oid:2.16.840.1.113762.1.4.1021.24"
-		}
-	],
-	"version": "4.0.0",
-	"name": "BirthSex",
-	"title": "Birth Sex",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Codes for assigning sex at birth as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc)",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"compose": {
-		"include": [
-			{
-				"system": "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender",
-				"concept": [
-					{
-						"code": "F",
-						"display": "Female"
-					},
-					{
-						"code": "M",
-						"display": "Male"
-					}
-				]
-			},
-			{
-				"system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
-				"concept": [
-					{
-						"code": "UNK",
-						"display": "Unknown"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "birthsex",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/birthsex",
+    "identifier": [
+        {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:oid:2.16.840.1.113762.1.4.1021.24"
+        }
+    ],
+    "version": "4.0.0",
+    "name": "BirthSex",
+    "title": "Birth Sex",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Codes for assigning sex at birth as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc)",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "compose": {
+        "include": [
+            {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender",
+                "concept": [
+                    {
+                        "code": "F",
+                        "display": "Female"
+                    },
+                    {
+                        "code": "M",
+                        "display": "Male"
+                    }
+                ]
+            },
+            {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                "concept": [
+                    {
+                        "code": "UNK",
+                        "display": "Unknown"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-detailed-ethnicity.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-detailed-ethnicity.json
@@ -1,65 +1,65 @@
 {
-	"resourceType": "ValueSet",
-	"id": "detailed-ethnicity",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This value set includes codes based on the following rules:</p><ul><li>Include codes from <a href=\"CodeSystem-cdcrec.html\"><code>urn:oid:2.16.840.1.113883.6.238</code></a> where concept  is-a  <a href=\"CodeSystem-cdcrec.html#cdcrec-2133-7\">2133-7</a></li></ul><p>This value set excludes codes based on the following rules:</p><ul><li>Exclude these codes as defined in <a href=\"CodeSystem-cdcrec.html\"><code>urn:oid:2.16.840.1.113883.6.238</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td><td><b>Definition</b></td></tr><tr><td><a href=\"CodeSystem-cdcrec.html#cdcrec-2135-2\">2135-2</a></td><td>Hispanic or Latino</td><td>Hispanic or Latino</td></tr><tr><td><a href=\"CodeSystem-cdcrec.html#cdcrec-2186-5\">2186-5</a></td><td>Not Hispanic or Latino</td><td>Note that this term remains in the table for completeness, even though within HL7, the notion of &quot;not otherwise coded&quot; term is deprecated.</td></tr></table></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/detailed-ethnicity",
-	"version": "4.0.0",
-	"name": "DetailedEthnicity",
-	"title": "Detailed ethnicity",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The 41 [CDC ethnicity codes](http://www.cdc.gov/phin/resources/vocabulary/index.html) that are grouped under one of the 2 OMB ethnicity category codes.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"compose": {
-		"include": [
-			{
-				"system": "urn:oid:2.16.840.1.113883.6.238",
-				"filter": [
-					{
-						"property": "concept",
-						"op": "is-a",
-						"value": "2133-7"
-					}
-				]
-			}
-		],
-		"exclude": [
-			{
-				"system": "urn:oid:2.16.840.1.113883.6.238",
-				"concept": [
-					{
-						"code": "2135-2"
-					},
-					{
-						"code": "2186-5"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "detailed-ethnicity",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/detailed-ethnicity",
+    "version": "4.0.0",
+    "name": "DetailedEthnicity",
+    "title": "Detailed ethnicity",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The 41 [CDC ethnicity codes](http://www.cdc.gov/phin/resources/vocabulary/index.html) that are grouped under one of the 2 OMB ethnicity category codes.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "compose": {
+        "include": [
+            {
+                "system": "urn:oid:2.16.840.1.113883.6.238",
+                "filter": [
+                    {
+                        "property": "concept",
+                        "op": "is-a",
+                        "value": "2133-7"
+                    }
+                ]
+            }
+        ],
+        "exclude": [
+            {
+                "system": "urn:oid:2.16.840.1.113883.6.238",
+                "concept": [
+                    {
+                        "code": "2135-2"
+                    },
+                    {
+                        "code": "2186-5"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-detailed-race.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-detailed-race.json
@@ -1,74 +1,74 @@
 {
-	"resourceType": "ValueSet",
-	"id": "detailed-race",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This value set includes codes based on the following rules:</p><ul><li>Include codes from <a href=\"CodeSystem-cdcrec.html\"><code>urn:oid:2.16.840.1.113883.6.238</code></a> where concept  is-a  <a href=\"CodeSystem-cdcrec.html#cdcrec-1000-9\">1000-9</a></li></ul><p>This value set excludes codes based on the following rules:</p><ul><li>Exclude these codes as defined in <a href=\"CodeSystem-cdcrec.html\"><code>urn:oid:2.16.840.1.113883.6.238</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td><td><b>Definition</b></td></tr><tr><td><a href=\"CodeSystem-cdcrec.html#cdcrec-1002-5\">1002-5</a></td><td>American Indian or Alaska Native</td><td>American Indian or Alaska Native</td></tr><tr><td><a href=\"CodeSystem-cdcrec.html#cdcrec-2028-9\">2028-9</a></td><td>Asian</td><td>Asian</td></tr><tr><td><a href=\"CodeSystem-cdcrec.html#cdcrec-2054-5\">2054-5</a></td><td>Black or African American</td><td>Black or African American</td></tr><tr><td><a href=\"CodeSystem-cdcrec.html#cdcrec-2076-8\">2076-8</a></td><td>Native Hawaiian or Other Pacific Islander</td><td>Native Hawaiian or Other Pacific Islander</td></tr><tr><td><a href=\"CodeSystem-cdcrec.html#cdcrec-2106-3\">2106-3</a></td><td>White</td><td>White</td></tr></table></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/detailed-race",
-	"version": "4.0.0",
-	"name": "DetailedRace",
-	"title": "Detailed Race",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The 900+ [CDC Race codes](http://www.cdc.gov/phin/resources/vocabulary/index.html) that are grouped under one of the 5 OMB race category codes.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"compose": {
-		"include": [
-			{
-				"system": "urn:oid:2.16.840.1.113883.6.238",
-				"filter": [
-					{
-						"property": "concept",
-						"op": "is-a",
-						"value": "1000-9"
-					}
-				]
-			}
-		],
-		"exclude": [
-			{
-				"system": "urn:oid:2.16.840.1.113883.6.238",
-				"concept": [
-					{
-						"code": "1002-5"
-					},
-					{
-						"code": "2028-9"
-					},
-					{
-						"code": "2054-5"
-					},
-					{
-						"code": "2076-8"
-					},
-					{
-						"code": "2106-3"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "detailed-race",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/detailed-race",
+    "version": "4.0.0",
+    "name": "DetailedRace",
+    "title": "Detailed Race",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The 900+ [CDC Race codes](http://www.cdc.gov/phin/resources/vocabulary/index.html) that are grouped under one of the 5 OMB race category codes.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "compose": {
+        "include": [
+            {
+                "system": "urn:oid:2.16.840.1.113883.6.238",
+                "filter": [
+                    {
+                        "property": "concept",
+                        "op": "is-a",
+                        "value": "1000-9"
+                    }
+                ]
+            }
+        ],
+        "exclude": [
+            {
+                "system": "urn:oid:2.16.840.1.113883.6.238",
+                "concept": [
+                    {
+                        "code": "1002-5"
+                    },
+                    {
+                        "code": "2028-9"
+                    },
+                    {
+                        "code": "2054-5"
+                    },
+                    {
+                        "code": "2076-8"
+                    },
+                    {
+                        "code": "2106-3"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-omb-ethnicity-category.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-omb-ethnicity-category.json
@@ -1,55 +1,55 @@
 {
-	"resourceType": "ValueSet",
-	"id": "omb-ethnicity-category",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include these codes as defined in <a href=\"CodeSystem-cdcrec.html\"><code>urn:oid:2.16.840.1.113883.6.238</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td><td><b>Definition</b></td></tr><tr><td><a href=\"CodeSystem-cdcrec.html#cdcrec-2135-2\">2135-2</a></td><td>Hispanic or Latino</td><td>Hispanic or Latino</td></tr><tr><td><a href=\"CodeSystem-cdcrec.html#cdcrec-2186-5\">2186-5</a></td><td>Non Hispanic or Latino</td><td>Note that this term remains in the table for completeness, even though within HL7, the notion of &quot;not otherwise coded&quot; term is deprecated.</td></tr></table></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/omb-ethnicity-category",
-	"version": "4.0.0",
-	"name": "OmbEthnicityCategories",
-	"title": "OMB Ethnicity Categories",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The codes for the ethnicity categories - 'Hispanic or Latino' and 'Non Hispanic or Latino' - as defined by the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"compose": {
-		"include": [
-			{
-				"system": "urn:oid:2.16.840.1.113883.6.238",
-				"concept": [
-					{
-						"code": "2135-2",
-						"display": "Hispanic or Latino"
-					},
-					{
-						"code": "2186-5",
-						"display": "Non Hispanic or Latino"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "omb-ethnicity-category",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/omb-ethnicity-category",
+    "version": "4.0.0",
+    "name": "OmbEthnicityCategories",
+    "title": "OMB Ethnicity Categories",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The codes for the ethnicity categories - 'Hispanic or Latino' and 'Non Hispanic or Latino' - as defined by the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "compose": {
+        "include": [
+            {
+                "system": "urn:oid:2.16.840.1.113883.6.238",
+                "concept": [
+                    {
+                        "code": "2135-2",
+                        "display": "Hispanic or Latino"
+                    },
+                    {
+                        "code": "2186-5",
+                        "display": "Non Hispanic or Latino"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-omb-race-category.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-omb-race-category.json
@@ -1,86 +1,86 @@
 {
-	"resourceType": "ValueSet",
-	"id": "omb-race-category",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This value set includes codes based on the following rules:</p><ul><li>Include these codes as defined in <a href=\"CodeSystem-cdcrec.html\"><code>urn:oid:2.16.840.1.113883.6.238</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td><td><b>Definition</b></td></tr><tr><td><a href=\"CodeSystem-cdcrec.html#cdcrec-1002-5\">1002-5</a></td><td>American Indian or Alaska Native</td><td>American Indian or Alaska Native</td></tr><tr><td><a href=\"CodeSystem-cdcrec.html#cdcrec-2028-9\">2028-9</a></td><td>Asian</td><td>Asian</td></tr><tr><td><a href=\"CodeSystem-cdcrec.html#cdcrec-2054-5\">2054-5</a></td><td>Black or African American</td><td>Black or African American</td></tr><tr><td><a href=\"CodeSystem-cdcrec.html#cdcrec-2076-8\">2076-8</a></td><td>Native Hawaiian or Other Pacific Islander</td><td>Native Hawaiian or Other Pacific Islander</td></tr><tr><td><a href=\"CodeSystem-cdcrec.html#cdcrec-2106-3\">2106-3</a></td><td>White</td><td>White</td></tr></table></li><li>Include these codes as defined in <a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-v3-NullFlavor.html\"><code>http://terminology.hl7.org/CodeSystem/v3-NullFlavor</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td><td><b>Definition</b></td></tr><tr><td><a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-v3-NullFlavor.html#v3-NullFlavor-UNK\">UNK</a></td><td>Unknown</td><td>**Description:**A proper value is applicable, but not known.<br/><br/>**Usage Notes**: This means the actual value is not known. If the only thing that is unknown is how to properly express the value in the necessary constraints (value set, datatype, etc.), then the OTH or UNC flavor should be used. No properties should be included for a datatype with this property unless:<br/><br/>1.  Those properties themselves directly translate to a semantic of &quot;unknown&quot;. (E.g. a local code sent as a translation that conveys 'unknown')<br/>2.  Those properties further qualify the nature of what is unknown. (E.g. specifying a use code of &quot;H&quot; and a URL prefix of &quot;tel:&quot; to convey that it is the home phone number that is unknown.)</td></tr><tr><td><a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-v3-NullFlavor.html#v3-NullFlavor-ASKU\">ASKU</a></td><td>Asked but no answer</td><td>Information was sought but not found (e.g., patient was asked but didn't know)</td></tr></table></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/omb-race-category",
-	"identifier": [
-		{
-			"system": "urn:ietf:rfc:3986",
-			"value": "urn:oid:2.16.840.1.113883.4.642.2.575"
-		}
-	],
-	"version": "4.0.0",
-	"name": "OmbRaceCategories",
-	"title": "OMB Race Categories",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The codes for the concepts 'Unknown' and  'Asked but no answer' and the the codes for the five race categories - 'American Indian' or 'Alaska Native', 'Asian', 'Black or African American', 'Native Hawaiian or Other Pacific Islander', and 'White' - as defined by the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf) .",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"compose": {
-		"include": [
-			{
-				"system": "urn:oid:2.16.840.1.113883.6.238",
-				"concept": [
-					{
-						"code": "1002-5",
-						"display": "American Indian or Alaska Native"
-					},
-					{
-						"code": "2028-9",
-						"display": "Asian"
-					},
-					{
-						"code": "2054-5",
-						"display": "Black or African American"
-					},
-					{
-						"code": "2076-8",
-						"display": "Native Hawaiian or Other Pacific Islander"
-					},
-					{
-						"code": "2106-3",
-						"display": "White"
-					}
-				]
-			},
-			{
-				"system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
-				"concept": [
-					{
-						"code": "UNK",
-						"display": "Unknown"
-					},
-					{
-						"code": "ASKU",
-						"display": "Asked but no answer"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "omb-race-category",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/omb-race-category",
+    "identifier": [
+        {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:oid:2.16.840.1.113883.4.642.2.575"
+        }
+    ],
+    "version": "4.0.0",
+    "name": "OmbRaceCategories",
+    "title": "OMB Race Categories",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The codes for the concepts 'Unknown' and  'Asked but no answer' and the the codes for the five race categories - 'American Indian' or 'Alaska Native', 'Asian', 'Black or African American', 'Native Hawaiian or Other Pacific Islander', and 'White' - as defined by the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf) .",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "compose": {
+        "include": [
+            {
+                "system": "urn:oid:2.16.840.1.113883.6.238",
+                "concept": [
+                    {
+                        "code": "1002-5",
+                        "display": "American Indian or Alaska Native"
+                    },
+                    {
+                        "code": "2028-9",
+                        "display": "Asian"
+                    },
+                    {
+                        "code": "2054-5",
+                        "display": "Black or African American"
+                    },
+                    {
+                        "code": "2076-8",
+                        "display": "Native Hawaiian or Other Pacific Islander"
+                    },
+                    {
+                        "code": "2106-3",
+                        "display": "White"
+                    }
+                ]
+            },
+            {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                "concept": [
+                    {
+                        "code": "UNK",
+                        "display": "Unknown"
+                    },
+                    {
+                        "code": "ASKU",
+                        "display": "Asked but no answer"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-simple-language.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-simple-language.json
@@ -1,72 +1,72 @@
 {
-	"resourceType": "ValueSet",
-	"id": "simple-language",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include codes from <a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-v3-ietf3066.html\"><code>urn:ietf:bcp:47</code></a> where ext-lang doesn't exist, script doesn't exist, variant doesn't exist, extension doesn't exist and private-use doesn't exist</li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/simple-language",
-	"version": "4.0.0",
-	"name": "LanguageCodesWithLanguageAndOptionallyARegionModifier",
-	"title": "Language codes with language and optionally a region modifier",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "This value set includes codes from [BCP-47](http://tools.ietf.org/html/bcp47). This value set matches the ONC 2015 Edition LanguageCommunication data element value set within C-CDA to use a 2 character language code if one exists,   and a 3 character code if a 2 character code does not exist. It points back to [RFC 5646](https://tools.ietf.org/html/rfc5646), however only the language codes are required, all other elements are optional.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "ISO Maintains the copyright on the country codes and controls it's use carefully. For further details, see the [ISO 3166 Home Page](http://www.iso.org/iso/country_codes.htm)",
-	"compose": {
-		"include": [
-			{
-				"system": "urn:ietf:bcp:47",
-				"filter": [
-					{
-						"property": "ext-lang",
-						"op": "exists",
-						"value": "false"
-					},
-					{
-						"property": "script",
-						"op": "exists",
-						"value": "false"
-					},
-					{
-						"property": "variant",
-						"op": "exists",
-						"value": "false"
-					},
-					{
-						"property": "extension",
-						"op": "exists",
-						"value": "false"
-					},
-					{
-						"property": "private-use",
-						"op": "exists",
-						"value": "false"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "simple-language",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/simple-language",
+    "version": "4.0.0",
+    "name": "LanguageCodesWithLanguageAndOptionallyARegionModifier",
+    "title": "Language codes with language and optionally a region modifier",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "This value set includes codes from [BCP-47](http://tools.ietf.org/html/bcp47). This value set matches the ONC 2015 Edition LanguageCommunication data element value set within C-CDA to use a 2 character language code if one exists,   and a 3 character code if a 2 character code does not exist. It points back to [RFC 5646](https://tools.ietf.org/html/rfc5646), however only the language codes are required, all other elements are optional.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "ISO Maintains the copyright on the country codes and controls it's use carefully. For further details, see the [ISO 3166 Home Page](http://www.iso.org/iso/country_codes.htm)",
+    "compose": {
+        "include": [
+            {
+                "system": "urn:ietf:bcp:47",
+                "filter": [
+                    {
+                        "property": "ext-lang",
+                        "op": "exists",
+                        "value": "false"
+                    },
+                    {
+                        "property": "script",
+                        "op": "exists",
+                        "value": "false"
+                    },
+                    {
+                        "property": "variant",
+                        "op": "exists",
+                        "value": "false"
+                    },
+                    {
+                        "property": "extension",
+                        "op": "exists",
+                        "value": "false"
+                    },
+                    {
+                        "property": "private-use",
+                        "op": "exists",
+                        "value": "false"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-clinical-note-type.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-clinical-note-type.json
@@ -1,62 +1,62 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-clinical-note-type",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include these codes as defined in <a href=\"http://loinc.org\"><code>http://loinc.org</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/18842-5.html\">18842-5</a></td><td>Discharge summary</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/11488-4.html\">11488-4</a></td><td>Consult note</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/34117-2.html\">34117-2</a></td><td>History and physical note</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/11506-3.html\">11506-3</a></td><td>Progress note</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/28570-0.html\">28570-0</a></td><td>Procedure note</td></tr></table></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-clinical-note-type",
-	"version": "4.0.0",
-	"name": "USCoreClinicalNoteType",
-	"title": "US Core Clinical Note Type",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The US Core Clinical Note Type Value Set is a 'starter set' of types supported for fetching and storing clinical notes.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "This material contains content from LOINC (http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc",
-	"compose": {
-		"include": [
-			{
-				"system": "http://loinc.org",
-				"concept": [
-					{
-						"code": "18842-5"
-					},
-					{
-						"code": "11488-4"
-					},
-					{
-						"code": "34117-2"
-					},
-					{
-						"code": "11506-3"
-					},
-					{
-						"code": "28570-0"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-clinical-note-type",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-clinical-note-type",
+    "version": "4.0.0",
+    "name": "USCoreClinicalNoteType",
+    "title": "US Core Clinical Note Type",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The US Core Clinical Note Type Value Set is a 'starter set' of types supported for fetching and storing clinical notes.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "This material contains content from LOINC (http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc",
+    "compose": {
+        "include": [
+            {
+                "system": "http://loinc.org",
+                "concept": [
+                    {
+                        "code": "18842-5"
+                    },
+                    {
+                        "code": "11488-4"
+                    },
+                    {
+                        "code": "34117-2"
+                    },
+                    {
+                        "code": "11506-3"
+                    },
+                    {
+                        "code": "28570-0"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-condition-category.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-condition-category.json
@@ -1,70 +1,70 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-condition-category",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This value set includes codes based on the following rules:</p><ul><li>Include all codes defined in <a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-condition-category.html\"><code>http://terminology.hl7.org/CodeSystem/condition-category</code></a></li><li>Include these codes as defined in <a href=\"CodeSystem-condition-category.html\"><code>http://hl7.org/fhir/us/core/CodeSystem/condition-category</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td><td><b>Definition</b></td></tr><tr><td><a href=\"CodeSystem-condition-category.html#condition-category-health-concern\">health-concern</a></td><td>Health Concern</td><td>Additional health concerns from other stakeholders which are outside the provider’s problem list.</td></tr></table></li><li>Include these codes as defined in <a href=\"http://www.snomed.org/\"><code>http://snomed.info/sct</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td><td><b>Definition</b></td></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=16100001\">16100001</a></td><td>Death diagnosis</td><td>Death diagnosis, or cause of death is a contextual qualifier indicating the problem represented caused the patient's death.</td></tr></table></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category",
-	"version": "4.0.0",
-	"name": "USCoreConditionCategoryCodes",
-	"title": "US Core Condition Category Codes",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The US Core Condition Category Codes support the separate concepts of problems and health concerns in Condition.category in order for API consumers to be able to separate health concerns and problems. However this is not mandatory for 2015 certification",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"purpose": "So API consumers can separate health concerns and problems.",
-	"copyright": "This value set includes content from SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement",
-	"compose": {
-		"include": [
-			{
-				"system": "http://terminology.hl7.org/CodeSystem/condition-category"
-			},
-			{
-				"system": "http://hl7.org/fhir/us/core/CodeSystem/condition-category",
-				"concept": [
-					{
-						"code": "health-concern",
-						"display": "Health Concern"
-					}
-				]
-			},
-			{
-				"system": "http://snomed.info/sct",
-				"concept": [
-					{
-						"extension": [
-							{
-								"url": "http://hl7.org/fhir/StructureDefinition/valueset-concept-definition",
-								"valueString": "Death diagnosis, or cause of death is a contextual qualifier indicating the problem represented caused the patient's death."
-							}
-						],
-						"code": "16100001",
-						"display": "Death diagnosis"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-condition-category",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category",
+    "version": "4.0.0",
+    "name": "USCoreConditionCategoryCodes",
+    "title": "US Core Condition Category Codes",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The US Core Condition Category Codes support the separate concepts of problems and health concerns in Condition.category in order for API consumers to be able to separate health concerns and problems. However this is not mandatory for 2015 certification",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "purpose": "So API consumers can separate health concerns and problems.",
+    "copyright": "This value set includes content from SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement",
+    "compose": {
+        "include": [
+            {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category"
+            },
+            {
+                "system": "http://hl7.org/fhir/us/core/CodeSystem/condition-category",
+                "concept": [
+                    {
+                        "code": "health-concern",
+                        "display": "Health Concern"
+                    }
+                ]
+            },
+            {
+                "system": "http://snomed.info/sct",
+                "concept": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/valueset-concept-definition",
+                                "valueString": "Death diagnosis, or cause of death is a contextual qualifier indicating the problem represented caused the patient's death."
+                            }
+                        ],
+                        "code": "16100001",
+                        "display": "Death diagnosis"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-condition-code.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-condition-code.json
@@ -1,86 +1,86 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-condition-code",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This value set includes codes based on the following rules:</p><ul><li>Include these codes as defined in <a href=\"http://www.snomed.org/\"><code>http://snomed.info/sct</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td></tr><tr><td><a href=\"http://browser.ihtsdotools.org/?perspective=full&amp;conceptId1=160245001\">160245001</a></td><td>No current problems or disability</td></tr></table></li><li>Include codes from <a href=\"http://www.snomed.org/\"><code>http://snomed.info/sct</code></a> where concept  is-a  404684003 (Clinical finding (finding))</li><li>Include codes from <a href=\"http://www.snomed.org/\"><code>http://snomed.info/sct</code></a> where concept  is-a  243796009 (Context-dependent categories)</li><li>Include codes from <a href=\"http://www.snomed.org/\"><code>http://snomed.info/sct</code></a> where concept  is-a  272379006 (Events)</li><li>Include all codes defined in <a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-icd10CM.html\"><code>http://hl7.org/fhir/sid/icd-10-cm</code></a></li><li>Include all codes defined in <code>http://hl7.org/fhir/sid/icd-9-cm</code></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-code",
-	"version": "4.0.0",
-	"name": "USCoreConditionCode",
-	"title": "US Core Condition Code",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "This describes the problem. Diagnosis/Problem List is broadly defined as a series of brief statements that catalog a patient's medical, nursing, dental, social, preventative and psychiatric events and issues that are relevant to that patient's healthcare (e.g., signs, symptoms, and defined conditions).   ICD-10 is appropriate for Diagnosis information, and ICD-9 for historical information.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "This value set includes content from:\n  1. SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.\n  2. ICD-9 and ICD-10 are copyrighted by the World Health Organization (WHO) which owns and publishes the classification. See https://www.who.int/classifications/icd/en. WHO has authorized the development of an adaptation of ICD-9 and ICD-10 to ICD-9-CM to ICD-10-CM for use in the United States for U.S. government purposes.\n",
-	"compose": {
-		"include": [
-			{
-				"system": "http://snomed.info/sct",
-				"concept": [
-					{
-						"code": "160245001"
-					}
-				]
-			},
-			{
-				"system": "http://snomed.info/sct",
-				"filter": [
-					{
-						"property": "concept",
-						"op": "is-a",
-						"value": "404684003"
-					}
-				]
-			},
-			{
-				"system": "http://snomed.info/sct",
-				"filter": [
-					{
-						"property": "concept",
-						"op": "is-a",
-						"value": "243796009"
-					}
-				]
-			},
-			{
-				"system": "http://snomed.info/sct",
-				"filter": [
-					{
-						"property": "concept",
-						"op": "is-a",
-						"value": "272379006"
-					}
-				]
-			},
-			{
-				"system": "http://hl7.org/fhir/sid/icd-10-cm"
-			},
-			{
-				"system": "http://hl7.org/fhir/sid/icd-9-cm"
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-condition-code",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-code",
+    "version": "4.0.0",
+    "name": "USCoreConditionCode",
+    "title": "US Core Condition Code",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "This describes the problem. Diagnosis/Problem List is broadly defined as a series of brief statements that catalog a patient's medical, nursing, dental, social, preventative and psychiatric events and issues that are relevant to that patient's healthcare (e.g., signs, symptoms, and defined conditions).   ICD-10 is appropriate for Diagnosis information, and ICD-9 for historical information.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "This value set includes content from:\n  1. SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.\n  2. ICD-9 and ICD-10 are copyrighted by the World Health Organization (WHO) which owns and publishes the classification. See https://www.who.int/classifications/icd/en. WHO has authorized the development of an adaptation of ICD-9 and ICD-10 to ICD-9-CM to ICD-10-CM for use in the United States for U.S. government purposes.\n",
+    "compose": {
+        "include": [
+            {
+                "system": "http://snomed.info/sct",
+                "concept": [
+                    {
+                        "code": "160245001"
+                    }
+                ]
+            },
+            {
+                "system": "http://snomed.info/sct",
+                "filter": [
+                    {
+                        "property": "concept",
+                        "op": "is-a",
+                        "value": "404684003"
+                    }
+                ]
+            },
+            {
+                "system": "http://snomed.info/sct",
+                "filter": [
+                    {
+                        "property": "concept",
+                        "op": "is-a",
+                        "value": "243796009"
+                    }
+                ]
+            },
+            {
+                "system": "http://snomed.info/sct",
+                "filter": [
+                    {
+                        "property": "concept",
+                        "op": "is-a",
+                        "value": "272379006"
+                    }
+                ]
+            },
+            {
+                "system": "http://hl7.org/fhir/sid/icd-10-cm"
+            },
+            {
+                "system": "http://hl7.org/fhir/sid/icd-9-cm"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-diagnosticreport-category.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-diagnosticreport-category.json
@@ -1,59 +1,59 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-diagnosticreport-category",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include these codes as defined in <a href=\"http://loinc.org\"><code>http://loinc.org</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/LP29684-5.html\">LP29684-5</a></td><td>Radiology</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/LP29708-2.html\">LP29708-2</a></td><td>Cardiology</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/LP7839-6.html\">LP7839-6</a></td><td>Pathology</td></tr></table></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-category",
-	"version": "4.0.0",
-	"name": "USCoreDiagnosticReportCategory",
-	"title": "US Core DiagnosticReport Category",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The US Core Diagnostic Report Category Value Set is a 'starter set' of categories supported for fetching and Diagnostic Reports and notes.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "This material contains content from LOINC (http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc",
-	"compose": {
-		"include": [
-			{
-				"system": "http://loinc.org",
-				"concept": [
-					{
-						"code": "LP29684-5",
-						"display": "Radiology"
-					},
-					{
-						"code": "LP29708-2",
-						"display": "Cardiology"
-					},
-					{
-						"code": "LP7839-6",
-						"display": "Pathology"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-diagnosticreport-category",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-category",
+    "version": "4.0.0",
+    "name": "USCoreDiagnosticReportCategory",
+    "title": "US Core DiagnosticReport Category",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The US Core Diagnostic Report Category Value Set is a 'starter set' of categories supported for fetching and Diagnostic Reports and notes.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "This material contains content from LOINC (http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc",
+    "compose": {
+        "include": [
+            {
+                "system": "http://loinc.org",
+                "concept": [
+                    {
+                        "code": "LP29684-5",
+                        "display": "Radiology"
+                    },
+                    {
+                        "code": "LP29708-2",
+                        "display": "Cardiology"
+                    },
+                    {
+                        "code": "LP7839-6",
+                        "display": "Pathology"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-diagnosticreport-lab-codes.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-diagnosticreport-lab-codes.json
@@ -1,52 +1,52 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-diagnosticreport-lab-codes",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include codes from <a href=\"http://loinc.org\"><code>http://loinc.org</code></a> where CLASSTYPE  =  1</li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-lab-codes",
-	"version": "4.0.0",
-	"name": "USCoreDiagnosticReportLabCodes",
-	"title": "US Core Diagnostic Report Laboratory Codes",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The Document Type value set includes all LOINC  values whose CLASSTYPE is LABORATORY in the LOINC database",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "This material contains content from LOINC (http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc",
-	"compose": {
-		"include": [
-			{
-				"system": "http://loinc.org",
-				"filter": [
-					{
-						"property": "CLASSTYPE",
-						"op": "=",
-						"value": "1"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-diagnosticreport-lab-codes",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-lab-codes",
+    "version": "4.0.0",
+    "name": "USCoreDiagnosticReportLabCodes",
+    "title": "US Core Diagnostic Report Laboratory Codes",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The Document Type value set includes all LOINC  values whose CLASSTYPE is LABORATORY in the LOINC database",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "This material contains content from LOINC (http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc",
+    "compose": {
+        "include": [
+            {
+                "system": "http://loinc.org",
+                "filter": [
+                    {
+                        "property": "CLASSTYPE",
+                        "op": "=",
+                        "value": "1"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-diagnosticreport-report-and-note-codes.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-diagnosticreport-report-and-note-codes.json
@@ -1,46 +1,46 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-diagnosticreport-report-and-note-codes",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include all codes defined in <a href=\"http://loinc.org\"><code>http://loinc.org</code></a></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-report-and-note-codes",
-	"version": "4.0.0",
-	"name": "USCoreDiagnosticReportReportAndNoteCodes",
-	"title": "US Core DiagnosticReport Report And Note Codes",
-	"status": "active",
-	"experimental": false,
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "This value set currently contains all of LOINC. The codes selected should represent discrete and narrative diagnostic observations and reports",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "This material contains content from LOINC (http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc",
-	"compose": {
-		"include": [
-			{
-				"system": "http://loinc.org"
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-diagnosticreport-report-and-note-codes",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-report-and-note-codes",
+    "version": "4.0.0",
+    "name": "USCoreDiagnosticReportReportAndNoteCodes",
+    "title": "US Core DiagnosticReport Report And Note Codes",
+    "status": "active",
+    "experimental": false,
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "This value set currently contains all of LOINC. The codes selected should represent discrete and narrative diagnostic observations and reports",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "This material contains content from LOINC (http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc",
+    "compose": {
+        "include": [
+            {
+                "system": "http://loinc.org"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-documentreference-category.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-documentreference-category.json
@@ -1,45 +1,45 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-documentreference-category",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include all codes defined in <a href=\"CodeSystem-us-core-documentreference-category.html\"><code>http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category</code></a></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-category",
-	"version": "4.0.0",
-	"name": "USCoreDocumentReferenceCategory",
-	"title": "US Core DocumentReference Category",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The US Core DocumentReferences Category Value Set is a 'starter set' of categories supported for fetching and storing clinical notes.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"compose": {
-		"include": [
-			{
-				"system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category"
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-documentreference-category",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-category",
+    "version": "4.0.0",
+    "name": "USCoreDocumentReferenceCategory",
+    "title": "US Core DocumentReference Category",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The US Core DocumentReferences Category Value Set is a 'starter set' of categories supported for fetching and storing clinical notes.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "compose": {
+        "include": [
+            {
+                "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-documentreference-type.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-documentreference-type.json
@@ -1,61 +1,61 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-documentreference-type",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This value set includes codes based on the following rules:</p><ul><li>Include these codes as defined in <a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-v3-NullFlavor.html\"><code>http://terminology.hl7.org/CodeSystem/v3-NullFlavor</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td><td><b>Definition</b></td></tr><tr><td><a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-v3-NullFlavor.html#v3-NullFlavor-UNK\">UNK</a></td><td>unknown</td><td>**Description:**A proper value is applicable, but not known.<br/><br/>**Usage Notes**: This means the actual value is not known. If the only thing that is unknown is how to properly express the value in the necessary constraints (value set, datatype, etc.), then the OTH or UNC flavor should be used. No properties should be included for a datatype with this property unless:<br/><br/>1.  Those properties themselves directly translate to a semantic of &quot;unknown&quot;. (E.g. a local code sent as a translation that conveys 'unknown')<br/>2.  Those properties further qualify the nature of what is unknown. (E.g. specifying a use code of &quot;H&quot; and a URL prefix of &quot;tel:&quot; to convey that it is the home phone number that is unknown.)</td></tr></table></li><li>Include codes from <a href=\"http://loinc.org\"><code>http://loinc.org</code></a> where SCALE_TYP  =  DOC</li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-type",
-	"version": "4.0.0",
-	"name": "USCoreDocumentReferenceType",
-	"title": "US Core DocumentReference Type",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The US Core DocumentReference Type Value Set includes all LOINC  values whose SCALE is DOC in the LOINC database and the HL7 v3 Code System NullFlavor concept 'unknown'",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "This material contains content from LOINC (http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc",
-	"compose": {
-		"include": [
-			{
-				"system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
-				"concept": [
-					{
-						"code": "UNK",
-						"display": "unknown"
-					}
-				]
-			},
-			{
-				"system": "http://loinc.org",
-				"filter": [
-					{
-						"property": "SCALE_TYP",
-						"op": "=",
-						"value": "DOC"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-documentreference-type",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-type",
+    "version": "4.0.0",
+    "name": "USCoreDocumentReferenceType",
+    "title": "US Core DocumentReference Type",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The US Core DocumentReference Type Value Set includes all LOINC  values whose SCALE is DOC in the LOINC database and the HL7 v3 Code System NullFlavor concept 'unknown'",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "This material contains content from LOINC (http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc",
+    "compose": {
+        "include": [
+            {
+                "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                "concept": [
+                    {
+                        "code": "UNK",
+                        "display": "unknown"
+                    }
+                ]
+            },
+            {
+                "system": "http://loinc.org",
+                "filter": [
+                    {
+                        "property": "SCALE_TYP",
+                        "op": "=",
+                        "value": "DOC"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-encounter-type.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-encounter-type.json
@@ -1,55 +1,55 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-encounter-type",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This value set includes codes based on the following rules:</p><ul><li>Include codes from <a href=\"http://www.snomed.org/\"><code>http://snomed.info/sct</code></a> where concept  is-a  308335008 (Patient encounter procedure)</li><li>Include all codes defined in <a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-v3-cpt-4.html\"><code>http://www.ama-assn.org/go/cpt</code></a></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-encounter-type",
-	"version": "4.0.0",
-	"name": "USCoreEncounterType",
-	"title": "US Core Encounter Type",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The type of encounter: a specific code indicating type of service provided. This value set includes codes from SNOMED CT decending from the concept 308335008 (Patient encounter procedure (procedure)) and codes from the Current Procedure and Terminology (CPT) found in the following CPT sections:\n  - 99201-99499 E/M\n - 99500-99600 home health (mainly nonphysician, such as newborn care in home)\n - 99605-99607 medication management\n - 98966-98968 non physician telephone services\n \n (subscription to AMA Required)",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "This value set includes content from:\n 1. SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.\n  2. CPT © Copyright 2020 American Medical Association. All rights reserved. AMA and CPT are registered trademarks of the American Medical Association.",
-	"compose": {
-		"include": [
-			{
-				"system": "http://snomed.info/sct",
-				"filter": [
-					{
-						"property": "concept",
-						"op": "is-a",
-						"value": "308335008"
-					}
-				]
-			},
-			{
-				"system": "http://www.ama-assn.org/go/cpt"
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-encounter-type",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-encounter-type",
+    "version": "4.0.0",
+    "name": "USCoreEncounterType",
+    "title": "US Core Encounter Type",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The type of encounter: a specific code indicating type of service provided. This value set includes codes from SNOMED CT decending from the concept 308335008 (Patient encounter procedure (procedure)) and codes from the Current Procedure and Terminology (CPT) found in the following CPT sections:\n  - 99201-99499 E/M\n - 99500-99600 home health (mainly nonphysician, such as newborn care in home)\n - 99605-99607 medication management\n - 98966-98968 non physician telephone services\n \n (subscription to AMA Required)",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "This value set includes content from:\n 1. SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.\n  2. CPT © Copyright 2020 American Medical Association. All rights reserved. AMA and CPT are registered trademarks of the American Medical Association.",
+    "compose": {
+        "include": [
+            {
+                "system": "http://snomed.info/sct",
+                "filter": [
+                    {
+                        "property": "concept",
+                        "op": "is-a",
+                        "value": "308335008"
+                    }
+                ]
+            },
+            {
+                "system": "http://www.ama-assn.org/go/cpt"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-narrative-status.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-narrative-status.json
@@ -1,55 +1,55 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-narrative-status",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include these codes as defined in <a href=\"http://hl7.org/fhir/R4/codesystem-narrative-status.html\"><code>http://hl7.org/fhir/narrative-status</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td><td><b>Definition</b></td></tr><tr><td><a href=\"http://hl7.org/fhir/R4/codesystem-narrative-status.html#narrative-status-additional\">additional</a></td><td>additional</td><td>The contents of the narrative may contain additional information not found in the structured data. Note that there is no computable way to determine what the extra information is, other than by human inspection.</td></tr><tr><td><a href=\"http://hl7.org/fhir/R4/codesystem-narrative-status.html#narrative-status-generated\">generated</a></td><td>generated</td><td>The contents of the narrative are entirely generated from the core elements in the content.</td></tr></table></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-narrative-status",
-	"version": "4.0.0",
-	"name": "NarrativeStatus",
-	"title": "US Core Narrative Status",
-	"status": "active",
-	"date": "2021-06-28T19:10:06+00:00",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The US Core Narrative Status Value Set limits the text status for the resource narrative.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "HL7",
-	"compose": {
-		"include": [
-			{
-				"system": "http://hl7.org/fhir/narrative-status",
-				"concept": [
-					{
-						"code": "additional",
-						"display": "additional"
-					},
-					{
-						"code": "generated",
-						"display": "generated"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-narrative-status",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-narrative-status",
+    "version": "4.0.0",
+    "name": "NarrativeStatus",
+    "title": "US Core Narrative Status",
+    "status": "active",
+    "date": "2021-06-28T19:10:06+00:00",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The US Core Narrative Status Value Set limits the text status for the resource narrative.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "HL7",
+    "compose": {
+        "include": [
+            {
+                "system": "http://hl7.org/fhir/narrative-status",
+                "concept": [
+                    {
+                        "code": "additional",
+                        "display": "additional"
+                    },
+                    {
+                        "code": "generated",
+                        "display": "generated"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-observation-smoking-status-status.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-observation-smoking-status-status.json
@@ -1,53 +1,53 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-observation-smoking-status-status",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include these codes as defined in <a href=\"http://hl7.org/fhir/R4/codesystem-observation-status.html\"><code>http://hl7.org/fhir/observation-status</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td><td><b>Definition</b></td></tr><tr><td><a href=\"http://hl7.org/fhir/R4/codesystem-observation-status.html#observation-status-final\">final</a></td><td>Final</td><td>The observation is complete and there are no further actions needed. Additional information such &quot;released&quot;, &quot;signed&quot;, etc would be represented using [Provenance](provenance.html) which provides not only the act but also the actors and dates and other related data. These act states would be associated with an observation status of `preliminary` until they are all completed and then a status of `final` would be applied.</td></tr><tr><td><a href=\"http://hl7.org/fhir/R4/codesystem-observation-status.html#observation-status-entered-in-error\">entered-in-error</a></td><td>Entered in Error</td><td>The observation has been withdrawn following previous final release.  This electronic record should never have existed, though it is possible that real-world decisions were based on it. (If real-world activity has occurred, the status should be &quot;cancelled&quot; rather than &quot;entered-in-error&quot;.).</td></tr></table></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smoking-status-status",
-	"version": "4.0.0",
-	"name": "USCoreObservationSmokingStatusStatus",
-	"title": "US Core Status for Smoking Status Observation",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Codes providing the status of an observation for smoking status. Constrained to `final`and `entered-in-error`.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"compose": {
-		"include": [
-			{
-				"system": "http://hl7.org/fhir/observation-status",
-				"concept": [
-					{
-						"code": "final"
-					},
-					{
-						"code": "entered-in-error"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-observation-smoking-status-status",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smoking-status-status",
+    "version": "4.0.0",
+    "name": "USCoreObservationSmokingStatusStatus",
+    "title": "US Core Status for Smoking Status Observation",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Codes providing the status of an observation for smoking status. Constrained to `final`and `entered-in-error`.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "compose": {
+        "include": [
+            {
+                "system": "http://hl7.org/fhir/observation-status",
+                "concept": [
+                    {
+                        "code": "final"
+                    },
+                    {
+                        "code": "entered-in-error"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-observation-smokingstatus-max.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-observation-smokingstatus-max.json
@@ -1,45 +1,45 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-observation-smokingstatus-max",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include all codes defined in <a href=\"http://www.snomed.org/\"><code>http://snomed.info/sct</code></a></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smokingstatus-max",
-	"version": "4.0.0",
-	"name": "USCoreSmokingStatusmaxValueSet",
-	"title": "US Core Smoking Status Max-Binding",
-	"status": "active",
-	"date": "2020-06-29",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Representing a patient’s smoking behavior using concepts from SNOMED CT.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "This value set includes content from SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement",
-	"compose": {
-		"include": [
-			{
-				"system": "http://snomed.info/sct"
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-observation-smokingstatus-max",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smokingstatus-max",
+    "version": "4.0.0",
+    "name": "USCoreSmokingStatusmaxValueSet",
+    "title": "US Core Smoking Status Max-Binding",
+    "status": "active",
+    "date": "2020-06-29",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Representing a patient’s smoking behavior using concepts from SNOMED CT.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "This value set includes content from SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement",
+    "compose": {
+        "include": [
+            {
+                "system": "http://snomed.info/sct"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-observation-value-codes.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-observation-value-codes.json
@@ -1,45 +1,45 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-observation-value-codes",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include all codes defined in <a href=\"http://www.snomed.org/\"><code>http://snomed.info/sct</code></a></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-value-codes",
-	"version": "4.0.0",
-	"name": "USCoreObservationValueCodes",
-	"title": "US Core Observation Value Codes (SNOMED-CT)",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "[Snomed-CT](http://www.ihtsdo.org/) concept codes for coded results",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "This value set includes content from SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement",
-	"compose": {
-		"include": [
-			{
-				"system": "http://snomed.info/sct"
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-observation-value-codes",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-observation-value-codes",
+    "version": "4.0.0",
+    "name": "USCoreObservationValueCodes",
+    "title": "US Core Observation Value Codes (SNOMED-CT)",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "[Snomed-CT](http://www.ihtsdo.org/) concept codes for coded results",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "This value set includes content from SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement",
+    "compose": {
+        "include": [
+            {
+                "system": "http://snomed.info/sct"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-procedure-code.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-procedure-code.json
@@ -1,67 +1,67 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-procedure-code",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This value set includes codes based on the following rules:</p><ul><li>Include all codes defined in <a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-v3-cpt-4.html\"><code>http://www.ama-assn.org/go/cpt</code></a></li><li>Include codes from <a href=\"http://www.snomed.org/\"><code>http://snomed.info/sct</code></a> where concept  is-a  71388002 (Procedure)</li><li>Include all codes defined in <code>http://www.cms.gov/Medicare/Coding/HCPCSReleaseCodeSets</code></li><li>Include all codes defined in <a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-icd10PCS.html\"><code>http://www.cms.gov/Medicare/Coding/ICD10</code></a></li><li>Include all codes defined in <code>http://ada.org/cdt</code></li><li>Include all codes defined in <a href=\"http://loinc.org\"><code>http://loinc.org</code></a></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-code",
-	"version": "4.0.0",
-	"name": "USCoreProcedureCodes",
-	"title": "US Core Procedure Codes",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Concepts from CPT, SNOMED CT, HCPCS Level II Alphanumeric Codes, ICD-10-PCS,CDT and LOINC code systems that can be used to indicate the type of procedure performed.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "This value set includes content from:\n  1. CPT copyright 2014 American Medical Association. All rights reserved.\n  2. SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.\n  3. HCPCS Level II Alphanumeric Codes codes are maintained by the US Centers for Medicare and Medicaid Services (CMS) available for public use.\n  4. The International Classification of Diseases, Tenth Revision, Procedure Coding System (ICD-10-PCS) was developed for the Centers for Medicare and Medicaid Services (CMS) available for public use.  CMS is the U.S. governmental agency responsible for overseeing all changes and modifications to the ICD-10-PCS.\n  5. The ADA is the exclusive copyright owner of CDT, the Code on Dental Procedures and Nomenclature (the Code), and the ADA Dental Claim Form. Except as permitted by law, all use, copying or distribution of CDT, or any portion thereof (including the Code on Dental Procedures and Nomenclature) in any product or services (including works prepared for clients by consultants and other professionals), whether in printed, electronic or other format, requires a valid commercial user license from the ADA. CDT® is a registered trademark of the American Dental Association. All Rights Reserved.\n  6. LOINC (http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc",
-	"compose": {
-		"include": [
-			{
-				"system": "http://www.ama-assn.org/go/cpt"
-			},
-			{
-				"system": "http://snomed.info/sct",
-				"filter": [
-					{
-						"property": "concept",
-						"op": "is-a",
-						"value": "71388002"
-					}
-				]
-			},
-			{
-				"system": "http://www.cms.gov/Medicare/Coding/HCPCSReleaseCodeSets"
-			},
-			{
-				"system": "http://www.cms.gov/Medicare/Coding/ICD10"
-			},
-			{
-				"system": "http://ada.org/cdt"
-			},
-			{
-				"system": "http://loinc.org"
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-procedure-code",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-code",
+    "version": "4.0.0",
+    "name": "USCoreProcedureCodes",
+    "title": "US Core Procedure Codes",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Concepts from CPT, SNOMED CT, HCPCS Level II Alphanumeric Codes, ICD-10-PCS,CDT and LOINC code systems that can be used to indicate the type of procedure performed.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "This value set includes content from:\n  1. CPT copyright 2014 American Medical Association. All rights reserved.\n  2. SNOMED CT, which is copyright © 2002+ International Health Terminology Standards Development Organisation (IHTSDO), and distributed by agreement between IHTSDO and HL7. Implementer use of SNOMED CT is not covered by this agreement.\n  3. HCPCS Level II Alphanumeric Codes codes are maintained by the US Centers for Medicare and Medicaid Services (CMS) available for public use.\n  4. The International Classification of Diseases, Tenth Revision, Procedure Coding System (ICD-10-PCS) was developed for the Centers for Medicare and Medicaid Services (CMS) available for public use.  CMS is the U.S. governmental agency responsible for overseeing all changes and modifications to the ICD-10-PCS.\n  5. The ADA is the exclusive copyright owner of CDT, the Code on Dental Procedures and Nomenclature (the Code), and the ADA Dental Claim Form. Except as permitted by law, all use, copying or distribution of CDT, or any portion thereof (including the Code on Dental Procedures and Nomenclature) in any product or services (including works prepared for clients by consultants and other professionals), whether in printed, electronic or other format, requires a valid commercial user license from the ADA. CDT® is a registered trademark of the American Dental Association. All Rights Reserved.\n  6. LOINC (http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc",
+    "compose": {
+        "include": [
+            {
+                "system": "http://www.ama-assn.org/go/cpt"
+            },
+            {
+                "system": "http://snomed.info/sct",
+                "filter": [
+                    {
+                        "property": "concept",
+                        "op": "is-a",
+                        "value": "71388002"
+                    }
+                ]
+            },
+            {
+                "system": "http://www.cms.gov/Medicare/Coding/HCPCSReleaseCodeSets"
+            },
+            {
+                "system": "http://www.cms.gov/Medicare/Coding/ICD10"
+            },
+            {
+                "system": "http://ada.org/cdt"
+            },
+            {
+                "system": "http://loinc.org"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-provenance-participant-type.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-provenance-participant-type.json
@@ -1,49 +1,49 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-provenance-participant-type",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This value set includes codes based on the following rules:</p><ul><li>Include all codes defined in <a href=\"CodeSystem-us-core-provenance-participant-type.html\"><code>http://hl7.org/fhir/us/core/CodeSystem/us-core-provenance-participant-type</code></a></li><li>Include all codes defined in <a href=\"https://terminology.hl7.org/1.0.0//CodeSystem-provenance-participant-type.html\"><code>http://terminology.hl7.org/CodeSystem/provenance-participant-type</code></a></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-provenance-participant-type",
-	"version": "4.0.0",
-	"name": "USCoreProvenancePaticipantTypeCodes",
-	"title": "US Core Provenance Participant Type Codes",
-	"status": "active",
-	"date": "2019-08-28",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The type of participation a provenance agent played for a given target.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"purpose": "So API consumers can identify the provenance participant type.",
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"compose": {
-		"include": [
-			{
-				"system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-provenance-participant-type"
-			},
-			{
-				"system": "http://terminology.hl7.org/CodeSystem/provenance-participant-type"
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-provenance-participant-type",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-provenance-participant-type",
+    "version": "4.0.0",
+    "name": "USCoreProvenancePaticipantTypeCodes",
+    "title": "US Core Provenance Participant Type Codes",
+    "status": "active",
+    "date": "2019-08-28",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The type of participation a provenance agent played for a given target.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "purpose": "So API consumers can identify the provenance participant type.",
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "compose": {
+        "include": [
+            {
+                "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-provenance-participant-type"
+            },
+            {
+                "system": "http://terminology.hl7.org/CodeSystem/provenance-participant-type"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-provider-role.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-provider-role.json
@@ -1,45 +1,45 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-provider-role",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include all codes defined in <code>http://nucc.org/provider-taxonomy</code></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-provider-role",
-	"version": "4.0.0",
-	"name": "USCoreProviderRoleNucc",
-	"title": "US Core Provider Role (NUCC)",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "Provider roles codes which are composed of the NUCC Health Care Provider Taxonomy Code Set classification codes for providers. Only concepts with a classification and no specialization are included.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "This value set includes content from NUCC Health Care Provider Taxonomy Code Set for providers which is copyright © 2016+ American Medical Association.  For commercial use, including sales or licensing, a license must be obtained.",
-	"compose": {
-		"include": [
-			{
-				"system": "http://nucc.org/provider-taxonomy"
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-provider-role",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-provider-role",
+    "version": "4.0.0",
+    "name": "USCoreProviderRoleNucc",
+    "title": "US Core Provider Role (NUCC)",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "Provider roles codes which are composed of the NUCC Health Care Provider Taxonomy Code Set classification codes for providers. Only concepts with a classification and no specialization are included.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "This value set includes content from NUCC Health Care Provider Taxonomy Code Set for providers which is copyright © 2016+ American Medical Association.  For commercial use, including sales or licensing, a license must be obtained.",
+    "compose": {
+        "include": [
+            {
+                "system": "http://nucc.org/provider-taxonomy"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-smoking-status-observation-codes.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-smoking-status-observation-codes.json
@@ -1,51 +1,51 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-smoking-status-observation-codes",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include these codes as defined in <a href=\"http://loinc.org\"><code>http://loinc.org</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/72166-2.html\">72166-2</a></td><td>Tobacco smoking status NHIS</td></tr></table></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-smoking-status-observation-codes",
-	"version": "4.0.0",
-	"name": "USCoreSmokingStatusObservationCodes",
-	"title": "US Core Smoking Status Observation Codes",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The US Core Smoking Status Observation Codes Value Set is a 'starter set' of concepts to capture smoking status.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "This material contains content from LOINC (http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc",
-	"compose": {
-		"include": [
-			{
-				"system": "http://loinc.org",
-				"concept": [
-					{
-						"code": "72166-2",
-						"display": "Tobacco smoking status NHIS"
-					}
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-smoking-status-observation-codes",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-smoking-status-observation-codes",
+    "version": "4.0.0",
+    "name": "USCoreSmokingStatusObservationCodes",
+    "title": "US Core Smoking Status Observation Codes",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The US Core Smoking Status Observation Codes Value Set is a 'starter set' of concepts to capture smoking status.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "This material contains content from LOINC (http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc",
+    "compose": {
+        "include": [
+            {
+                "system": "http://loinc.org",
+                "concept": [
+                    {
+                        "code": "72166-2",
+                        "display": "Tobacco smoking status NHIS"
+                    }
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-usps-state.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-usps-state.json
@@ -1,51 +1,51 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-usps-state",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><ul><li>Include all codes defined in <code>https://www.usps.com/</code></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state",
-	"identifier": [
-		{
-			"system": "urn:ietf:rfc:3986",
-			"value": "urn:oid:2.16.840.1.113883.4.642.3.40"
-		}
-	],
-	"version": "4.0.0",
-	"name": "UspsTwoLetterAlphabeticCodes",
-	"title": "USPS Two Letter Alphabetic Codes",
-	"status": "active",
-	"date": "2019-05-21",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "This value set defines two letter USPS alphabetic codes.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "On July 1, 1963, the Post Office Department implemented the five-digit ZIP Code, which was placed after the state name in the last line of an address. To provide room for the ZIP Code, the Department issued two-letter abbreviations for all states and territories. Publication 59, Abbreviations for Use with ZIP Code, issued by the Department in October 1963. There is no copyright restriction on this value set.",
-	"compose": {
-		"include": [
-			{
-				"system": "https://www.usps.com/"
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-usps-state",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state",
+    "identifier": [
+        {
+            "system": "urn:ietf:rfc:3986",
+            "value": "urn:oid:2.16.840.1.113883.4.642.3.40"
+        }
+    ],
+    "version": "4.0.0",
+    "name": "UspsTwoLetterAlphabeticCodes",
+    "title": "USPS Two Letter Alphabetic Codes",
+    "status": "active",
+    "date": "2019-05-21",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "This value set defines two letter USPS alphabetic codes.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "On July 1, 1963, the Post Office Department implemented the five-digit ZIP Code, which was placed after the state name in the last line of an address. To provide room for the ZIP Code, the Department issued two-letter abbreviations for all states and territories. Publication 59, Abbreviations for Use with ZIP Code, issued by the Department in October 1963. There is no copyright restriction on this value set.",
+    "compose": {
+        "include": [
+            {
+                "system": "https://www.usps.com/"
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-vital-signs.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ValueSet-us-core-vital-signs.json
@@ -1,71 +1,71 @@
 {
-	"resourceType": "ValueSet",
-	"id": "us-core-vital-signs",
-	"text": {
-		"status": "generated",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p>This value set includes codes based on the following rules:</p><ul><li>Include these codes as defined in <a href=\"http://loinc.org\"><code>http://loinc.org</code></a><table class=\"none\"><tr><td style=\"white-space:nowrap\"><b>Code</b></td><td><b>Display</b></td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/59576-9.html\">59576-9</a></td><td>Body mass index (BMI) [Percentile] Per age and sex</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/8289-1.html\">8289-1</a></td><td>Head Occipital-frontal circumference Percentile</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/77606-2.html\">77606-2</a></td><td>Weight-for-length Per age and sex</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/59408-5.html\">59408-5</a></td><td>Oxygen saturation in Arterial blood by Pulse oximetry</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/3150-0.html\">3150-0</a></td><td>Inhaled oxygen concentration</td></tr><tr><td><a href=\"http://details.loinc.org/LOINC/3151-8.html\">3151-8</a></td><td>Inhaled oxygen flow rate</td></tr></table></li><li>Import all the codes that are contained in <a href=\"http://hl7.org/fhir/R4/valueset-observation-vitalsignresult.html\">http://hl7.org/fhir/ValueSet/observation-vitalsignresult</a></li></ul></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs",
-	"version": "4.0.0",
-	"name": "UsCoreVitalSigns",
-	"title": "US Core Vital Signs ValueSet",
-	"status": "active",
-	"experimental": false,
-	"date": "2020-11-17",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "This material contains content from LOINC (http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc",
-	"compose": {
-		"include": [
-			{
-				"system": "http://loinc.org",
-				"concept": [
-					{
-						"code": "59576-9"
-					},
-					{
-						"code": "8289-1"
-					},
-					{
-						"code": "77606-2"
-					},
-					{
-						"code": "59408-5"
-					},
-					{
-						"code": "3150-0"
-					},
-					{
-						"code": "3151-8"
-					}
-				]
-			},
-			{
-				"valueSet": [
-					"http://hl7.org/fhir/ValueSet/observation-vitalsignresult"
-				]
-			}
-		]
-	}
+    "resourceType": "ValueSet",
+    "id": "us-core-vital-signs",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ValueSet/us-core-vital-signs",
+    "version": "4.0.0",
+    "name": "UsCoreVitalSigns",
+    "title": "US Core Vital Signs ValueSet",
+    "status": "active",
+    "experimental": false,
+    "date": "2020-11-17",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "This material contains content from LOINC (http://loinc.org). LOINC is copyright © 1995-2020, Regenstrief Institute, Inc. and the Logical Observation Identifiers Names and Codes (LOINC) Committee and is available at no cost under the license at http://loinc.org/license. LOINC® is a registered United States trademark of Regenstrief Institute, Inc",
+    "compose": {
+        "include": [
+            {
+                "system": "http://loinc.org",
+                "concept": [
+                    {
+                        "code": "59576-9"
+                    },
+                    {
+                        "code": "8289-1"
+                    },
+                    {
+                        "code": "77606-2"
+                    },
+                    {
+                        "code": "59408-5"
+                    },
+                    {
+                        "code": "3150-0"
+                    },
+                    {
+                        "code": "3151-8"
+                    }
+                ]
+            },
+            {
+                "valueSet": [
+                    "http://hl7.org/fhir/ValueSet/observation-vitalsignresult"
+                ]
+            }
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ig-r4.json
+++ b/conformance/fhir-ig-us-core/src/main/resources/hl7/fhir/us/core/400/package/ig-r4.json
@@ -1,3372 +1,3372 @@
 {
-	"resourceType": "ImplementationGuide",
-	"id": "hl7.fhir.us.core",
-	"text": {
-		"status": "extensions",
-		"div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2>USCore</h2><p>The official URL for this implementation guide is: </p><pre>http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core</pre><div><p>The US Core Implementation Guide is based on FHIR Version R4 and defines the minimum conformance requirements for accessing patient data. The Argonaut pilot implementations, ONC 2015 Edition Common Clinical Data Set (CCDS), and ONC U.S. Core Data for Interoperability (USCDI) v1 provided the requirements for this guide. The prior Argonaut search and vocabulary requirements, based on FHIR DSTU2, are updated in this guide to support FHIR Version R4. This guide was used as the basis for further testing and guidance by the Argonaut Project Team to provide additional content and guidance specific to Data Query Access for purpose of ONC Certification testing. These profiles are the foundation for future US Realm FHIR implementation guides. In addition to Argonaut, they are used by DAF-Research, QI-Core, and CIMI. Under the guidance of HL7 and the HL7 US Realm Steering Committee, the content will expand in future versions to meet the needs specific to the US Realm.\nThese requirements were originally developed, balloted, and published in FHIR DSTU2 as part of the Office of the National Coordinator for Health Information Technology (ONC) sponsored Data Access Framework (DAF) project. For more information on how DAF became US Core see the US Core change notes.</p>\n</div></div>"
-	},
-	"url": "http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core",
-	"version": "4.0.0",
-	"name": "USCore",
-	"title": "US Core Implementation Guide",
-	"status": "active",
-	"date": "2021-06-16",
-	"publisher": "HL7 International - US Realm Steering Committee",
-	"contact": [
-		{
-			"name": "HL7 International - US Realm Steering Committee",
-			"telecom": [
-				{
-					"system": "url",
-					"value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
-				}
-			]
-		}
-	],
-	"description": "The US Core Implementation Guide is based on FHIR Version R4 and defines the minimum conformance requirements for accessing patient data. The Argonaut pilot implementations, ONC 2015 Edition Common Clinical Data Set (CCDS), and ONC U.S. Core Data for Interoperability (USCDI) v1 provided the requirements for this guide. The prior Argonaut search and vocabulary requirements, based on FHIR DSTU2, are updated in this guide to support FHIR Version R4. This guide was used as the basis for further testing and guidance by the Argonaut Project Team to provide additional content and guidance specific to Data Query Access for purpose of ONC Certification testing. These profiles are the foundation for future US Realm FHIR implementation guides. In addition to Argonaut, they are used by DAF-Research, QI-Core, and CIMI. Under the guidance of HL7 and the HL7 US Realm Steering Committee, the content will expand in future versions to meet the needs specific to the US Realm.\nThese requirements were originally developed, balloted, and published in FHIR DSTU2 as part of the Office of the National Coordinator for Health Information Technology (ONC) sponsored Data Access Framework (DAF) project. For more information on how DAF became US Core see the US Core change notes.",
-	"jurisdiction": [
-		{
-			"coding": [
-				{
-					"system": "urn:iso:std:iso:3166",
-					"code": "US"
-				}
-			]
-		}
-	],
-	"copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
-	"packageId": "hl7.fhir.us.core",
-	"license": "CC0-1.0",
-	"fhirVersion": [
-		"4.0.1"
-	],
-	"dependsOn": [
-		{
-			"id": "hl7_fhir_uv_bulkdata",
-			"uri": "http://hl7.org/fhir/uv/bulkdata/ImplementationGuide/hl7.fhir.uv.bulkdata",
-			"packageId": "hl7.fhir.uv.bulkdata",
-			"version": "1.0.1"
-		},
-		{
-			"id": "vsac",
-			"uri": "http://fhir.org/packages/us.nlm.vsac/ImplementationGuide/us.nlm.vsac",
-			"packageId": "us.nlm.vsac",
-			"version": "0.3.0"
-		}
-	],
-	"definition": {
-		"resource": [
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/head-occipital-frontal-circumference-percentile"
-				},
-				"name": "US Core Pediatric Head Occipital-frontal Circumference Percentile Profile",
-				"description": "Defines constraints on the Observation resource to represent head occipital-frontal circumference percentile for patients from birth to 36 months of age in FHIR using a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-allergyintolerance"
-				},
-				"name": "US Core AllergyIntolerance Profile",
-				"description": "Defines constraints and extensions on the AllergyIntolerance resource for the minimal set of data to query and retrieve allergy information.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:extension"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-birthsex"
-				},
-				"name": "US Core Birth Sex Extension",
-				"description": "A code classifying the person's sex assigned at birth  as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc). This extension aligns with the C-CDA Birth Sex Observation (LOINC 76689-9).",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-blood-pressure"
-				},
-				"name": "US Core Blood Pressure Profile",
-				"description": "Defines constraints on Observation to represent diastolic and systolic blood pressure observations with standard LOINC codes and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-bmi"
-				},
-				"name": "US Core BMI Profile",
-				"description": "Defines constraints on Observation to represent Body Mass Index (BMI) observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-body-height"
-				},
-				"name": "US Core Body Height Profile",
-				"description": "Defines constraints on Observation to represent body height observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-body-temperature"
-				},
-				"name": "US Core Body Temperature Profile",
-				"description": "Defines constraints on Observation to represent body temperature observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-body-weight"
-				},
-				"name": "US Core Body Weight Profile",
-				"description": "Defines constraints on Observation to represent body weight observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-careplan"
-				},
-				"name": "US Core CarePlan Profile",
-				"description": "Defines constraints and extensions on the CarePlan resource for the minimal set of data to query and retrieve a patient's Care Plan.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-careteam"
-				},
-				"name": "US Core CareTeam Profile",
-				"description": "Defines constraints and extensions on the CareTeam resource for the minimal set of data to query and retrieve a patient's Care Team.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-condition"
-				},
-				"name": "US Core Condition Profile",
-				"description": "Defines constraints and extensions on the Condition resource for the minimal set of data to query and retrieve problems and health concerns information.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-diagnosticreport-lab"
-				},
-				"name": "US Core DiagnosticReport Profile for Laboratory Results Reporting",
-				"description": "Defines constraints and extensions on the DiagnosticReport resource  for the minimal set of data to query and retrieve diagnostic reports associated with laboratory results for a patient",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-diagnosticreport-note"
-				},
-				"name": "US Core DiagnosticReport Profile for Report and Note exchange",
-				"description": "Defines constraints and extensions on the DiagnosticReport resource  for the minimal set of data to query and retrieve diagnostic reports associated with clinical notes for a patient",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:extension"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-direct"
-				},
-				"name": "US Core Direct email Extension",
-				"description": "This email address is associated with a [direct](http://wiki.directproject.org/Addressing+Specification) service.  This extension can only be used on contact points where the system = 'email'",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-documentreference"
-				},
-				"name": "US Core DocumentReference Profile",
-				"description": "The document reference profile used in US Core.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-encounter"
-				},
-				"name": "US Core Encounter Profile",
-				"description": "The Encounter referenced in the US Core profiles.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:extension"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-ethnicity"
-				},
-				"name": "US Core Ethnicity Extension",
-				"description": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-goal"
-				},
-				"name": "US Core Goal Profile",
-				"description": "Defines constraints and extensions on the Goal resource for the minimal set of data to query and retrieve a patient's goal(s).",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-head-circumference"
-				},
-				"name": "US Core Head Circumference Profile",
-				"description": "Defines constraints on Observation to represent head circumference observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-heart-rate"
-				},
-				"name": "US Core Heart Rate Profile",
-				"description": "Defines constraints on Observation to represent heart rate observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-immunization"
-				},
-				"name": "US Core Immunization Profile",
-				"description": "Defines constraints and extensions on the Immunization resource for the minimal set of data to query and retrieve  patient's immunization information.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-implantable-device"
-				},
-				"name": "US Core Implantable Device Profile",
-				"description": "Defines constraints and extensions on the Device resource for the minimal set of data to query and retrieve a patient's implantable device(s).",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-location"
-				},
-				"name": "US Core Location Profile",
-				"description": "Defines basic constraints and extensions on the Location resource for use with other US Core resources",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-medication"
-				},
-				"name": "US Core Medication Profile",
-				"description": "Defines constraints and extensions on the Medication resource for the minimal set of data to query and retrieve patient retrieving patient's medication information.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-medicationrequest"
-				},
-				"name": "US Core MedicationRequest Profile",
-				"description": "Defines constraints and extensions on the MedicationRequest resource for the minimal set of data to query and retrieve prescription information.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-observation-lab"
-				},
-				"name": "US Core Laboratory Result Observation Profile",
-				"description": "Defines constraints and extensions on the Observation resource for the minimal set of data to query and retrieve laboratory test results",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-organization"
-				},
-				"name": "US Core Organization Profile",
-				"description": "Defines basic constraints and extensions on the Organization resource for use with other US Core resources",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/pediatric-bmi-for-age"
-				},
-				"name": "US Core Pediatric BMI for Age Observation Profile",
-				"description": "Defines constraints on Observation to represent to represent BMI percentile per age and sex for youth 2-20 observations in FHIR using a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/pediatric-weight-for-height"
-				},
-				"name": "US Core Pediatric Weight for Height Observation Profile",
-				"description": "Defines constraints on the Observation resource to represent pediatric Weight-for-length per age and gender observations in FHIR with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-practitioner"
-				},
-				"name": "US Core Practitioner Profile",
-				"description": "The practitioner(s) referenced in US Core profiles.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-practitionerrole"
-				},
-				"name": "US Core PractitionerRole Profile",
-				"description": "The practitioner roles referenced in the US Core profiles.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-procedure"
-				},
-				"name": "US Core Procedure Profile",
-				"description": "Defines constraints and extensions on the Procedure resource for the minimal set of data to query and retrieve patient's procedure information.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-provenance"
-				},
-				"name": "US Core Provenance Profile",
-				"description": "Draft set of requirements to satisfy Basic Provenance Requirements.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-pulse-oximetry"
-				},
-				"name": "US Core Pulse Oximetry Profile",
-				"description": "Defines constraints on the Observation resource to represent inspired O2 by pulse oximetry and inspired oxygen concentration observations with a standard LOINC codes and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:extension"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-race"
-				},
-				"name": "US Core Race Extension",
-				"description": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\n - American Indian or Alaska Native\n - Asian\n - Black or African American\n - Native Hawaiian or Other Pacific Islander\n - White.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-respiratory-rate"
-				},
-				"name": "US Core Respiratory Rate Profile",
-				"description": "Defines constraints on Observation to represent respiratory rate observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-smokingstatus"
-				},
-				"name": "US Core Smoking Status Observation Profile",
-				"description": "Defines constraints and extensions on the Observation  resource for the minimal set of data to query and retrieve patient's Smoking Status information.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-vital-signs"
-				},
-				"name": "US Core Vital Signs Profile",
-				"description": "Defines constraints on the Observation resource to represent vital signs observations.  This profile is used as the base definition for the other US Core Vital Signs Profiles and based on the FHIR VitalSigns Profile.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CapabilityStatement"
-					}
-				],
-				"reference": {
-					"reference": "CapabilityStatement/us-core-client"
-				},
-				"name": "US Core Client CapabilityStatement",
-				"description": "This Section describes the expected capabilities of the US Core Client which is responsible for creating and initiating the queries for information about an individual patient. The complete list of FHIR profiles, RESTful operations, and search parameters supported by US Core Servers are defined in the [Conformance Requirements for Server](CapabilityStatement-us-core-server.html). US Core Clients have the option of choosing from this list to access necessary data based on their local use cases and other contextual requirements.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CapabilityStatement"
-					}
-				],
-				"reference": {
-					"reference": "CapabilityStatement/us-core-server"
-				},
-				"name": "US Core Server CapabilityStatement",
-				"description": "This Section describes the expected capabilities of the US Core Server actor which is responsible for providing responses to the queries submitted by the US Core Requestors. The complete list of FHIR profiles, RESTful operations, and search parameters supported by US Core Servers are defined. Systems implementing this capability statement should meet the ONC 2015 Common Clinical Data Set (CCDS) access requirement for Patient Selection 170.315(g)(7) and Application Access - Data Category Request 170.315(g)(8) and and the ONC [U.S. Core Data for Interoperability (USCDI)](https://www.healthit.gov/isa/sites/isa/files/2020-03/USCDI-Version1-2020-Final-Standard.pdf).  US Core Clients have the option of choosing from this list to access necessary data based on their local use cases and other contextual requirements.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CodeSystem"
-					}
-				],
-				"reference": {
-					"reference": "CodeSystem/careplan-category"
-				},
-				"name": "US Core CarePlan Category Extension Codes",
-				"description": "Set of codes that are needed for implementation of the US-Core CarePlan Profile. These codes are used as extensions to the FHIR ValueSet.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CodeSystem"
-					}
-				],
-				"reference": {
-					"reference": "CodeSystem/cdcrec"
-				},
-				"name": "Race & Ethnicity - CDC",
-				"description": "The U.S. Centers for Disease Control and Prevention (CDC) has prepared a code set for use in codingrace and ethnicity data. This code set is based on current federal standards for classifying data onrace and ethnicity, specifically the minimum race and ethnicity categories defined by the U.S. Office ofManagement and Budget (OMB) and a more detailed set of race and ethnicity categories maintainedby the U.S. Bureau of the Census (BC). The main purpose of the code set is to facilitate use of federalstandards for classifying data on race and ethnicity when these data are exchanged, stored, retrieved,or analyzed in electronic form. At the same time, the code set can be applied to paper-based recordsystems to the extent that these systems are used to collect, maintain, and report data on race andethnicity in accordance with current federal standards. Source: [Race and Ethnicity Code Set Version 1.0](https://www.cdc.gov/phin/resources/vocabulary/documents/cdc-race--ethnicity-background-and-purpose.pdf).",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CodeSystem"
-					}
-				],
-				"reference": {
-					"reference": "CodeSystem/condition-category"
-				},
-				"name": "US Core Condition Category Extension Codes",
-				"description": "Set of codes that are needed for implementation of the US-Core Condition Profile. These codes are used as extensions to the FHIR and US Core value sets.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CodeSystem"
-					}
-				],
-				"reference": {
-					"reference": "CodeSystem/us-core-documentreference-category"
-				},
-				"name": "US Core DocumentReferences Category Codes",
-				"description": "The US Core DocumentReferences Type Code System is a 'starter set' of categories supported for fetching and storing DocumentReference Resources.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CodeSystem"
-					}
-				],
-				"reference": {
-					"reference": "CodeSystem/us-core-provenance-participant-type"
-				},
-				"name": "US Core Provenance Participant Type Extension Codes",
-				"description": "Set of codes that are needed for implementation of the US-Core Provenance Profile. These codes are used as extensions to the FHIR value sets.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "OperationDefinition"
-					}
-				],
-				"reference": {
-					"reference": "OperationDefinition/docref"
-				},
-				"name": "US Core Fetch DocumentReference",
-				"description": "This operation is used to return all the references to documents related to a patient. \n\n The operation requires a patient id and takes the optional input parameters: \n  - start date\n  - end date\n  - document type \n\n and returns a [Bundle](http://hl7.org/fhir/bundle.html) of type \"searchset\" containing [DocumentReference](http://hl7.org/fhir/documentreference.html) resources for the patient. The DocumentReference resources **SHOULD** conform to the [US Core DocumentReference\n Profiles](http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference). If the server has or can create documents that are related to the patient, and that are available for the given user, the server returns the DocumentReference resources needed to support the records.  The principle intended use for this operation is to provide a provider or patient with access to their available document information. \n\n This operation is *different* from a search by patient and type and date range because: \n\n 1. It is used to request a server *generate* a document based on the specified parameters. \n\n 1. If no parameters are specified, the server SHALL return a DocumentReference to the patient's most current CCD \n\n 1. If the server cannot *generate* a document based on the specified parameters, the operation will return an empty search bundle. \n\n This operation is the *same* as a FHIR RESTful search by patient,type and date range because: \n\n 1. References for *existing* documents that meet the requirements of the request SHOULD also be returned unless the client indicates they are only interested in 'on-demand' documents using the *on-demand* parameter.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-allergyintolerance-clinical-status"
-				},
-				"name": "USCoreAllergyIntoleranceClinicalStatus",
-				"description": "**active | inactive | resolved**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-allergyintolerance-patient"
-				},
-				"name": "USCoreAllergyIntolerancePatient",
-				"description": "**Who the sensitivity is for**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-careplan-category"
-				},
-				"name": "USCoreCarePlanCategory",
-				"description": "**Type of plan**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-careplan-date"
-				},
-				"name": "USCoreCarePlanDate",
-				"description": "**Time period plan covers**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-careplan-patient"
-				},
-				"name": "USCoreCarePlanPatient",
-				"description": "**Who the care plan is for**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-careplan-status"
-				},
-				"name": "USCoreCarePlanStatus",
-				"description": "**draft | active | on-hold | revoked | completed | entered-in-error | unknown**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-careteam-patient"
-				},
-				"name": "USCoreCareTeamPatient",
-				"description": "**Who care team is for**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-careteam-status"
-				},
-				"name": "USCoreCareTeamStatus",
-				"description": "**proposed | active | suspended | inactive | entered-in-error**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-condition-category"
-				},
-				"name": "USCoreConditionCategory",
-				"description": "**The category of the condition**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-condition-clinical-status"
-				},
-				"name": "USCoreConditionClinicalStatus",
-				"description": "**The clinical status of the condition**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-condition-code"
-				},
-				"name": "USCoreConditionCode",
-				"description": "**Code for the condition**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-condition-onset-date"
-				},
-				"name": "USCoreConditionOnsetDate",
-				"description": "**Date related onsets (dateTime and Period)**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-condition-patient"
-				},
-				"name": "USCoreConditionPatient",
-				"description": "**Who has the condition?**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-device-patient"
-				},
-				"name": "USCoreDevicePatient",
-				"description": "**Patient information, if the resource is affixed to a person**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-device-type"
-				},
-				"name": "USCoreDeviceType",
-				"description": "**The type of the device**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-diagnosticreport-category"
-				},
-				"name": "USCoreDiagnosticReportCategory",
-				"description": "**Which diagnostic discipline/department created the report**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-diagnosticreport-code"
-				},
-				"name": "USCoreDiagnosticReportCode",
-				"description": "**The code for the report, as opposed to codes for the atomic results, which are the names on the observation resource referred to from the result**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-diagnosticreport-date"
-				},
-				"name": "USCoreDiagnosticReportDate",
-				"description": "**The clinically relevant time of the report**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-diagnosticreport-patient"
-				},
-				"name": "USCoreDiagnosticReportPatient",
-				"description": "**The subject of the report if a patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-diagnosticreport-status"
-				},
-				"name": "USCoreDiagnosticReportStatus",
-				"description": "**The status of the report**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-documentreference-category"
-				},
-				"name": "USCoreDocumentReferenceCategory",
-				"description": "**Categorization of document**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-documentreference-date"
-				},
-				"name": "USCoreDocumentReferenceDate",
-				"description": "**When this document reference was created**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-documentreference-id"
-				},
-				"name": "USCoreDocumentReferenceId",
-				"description": "**Logical id of this artifact**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-documentreference-patient"
-				},
-				"name": "USCoreDocumentReferencePatient",
-				"description": "**Who/what is the subject of the document**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-documentreference-period"
-				},
-				"name": "USCoreDocumentReferencePeriod",
-				"description": "**Time of service that is being documented**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-documentreference-status"
-				},
-				"name": "USCoreDocumentReferenceStatus",
-				"description": "**current | superseded | entered-in-error**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-documentreference-type"
-				},
-				"name": "USCoreDocumentReferenceType",
-				"description": "**Kind of document (LOINC if possible)**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-encounter-class"
-				},
-				"name": "USCoreEncounterClass",
-				"description": "**Classification of patient encounter**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-encounter-date"
-				},
-				"name": "USCoreEncounterDate",
-				"description": "**A date within the period the Encounter lasted**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-encounter-id"
-				},
-				"name": "USCoreEncounterId",
-				"description": "**Logical id of this artifact**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-encounter-identifier"
-				},
-				"name": "USCoreEncounterIdentifier",
-				"description": "**Identifier(s) by which this encounter is known**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-encounter-patient"
-				},
-				"name": "USCoreEncounterPatient",
-				"description": "**The patient or group present at the encounter**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-encounter-status"
-				},
-				"name": "USCoreEncounterStatus",
-				"description": "**planned | arrived | triaged | in-progress | onleave | finished | cancelled +**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-encounter-type"
-				},
-				"name": "USCoreEncounterType",
-				"description": "**Specific type of encounter**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-ethnicity"
-				},
-				"name": "USCoreEthnicity",
-				"description": "Returns patients with an ethnicity extension matching the specified code.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-goal-lifecycle-status"
-				},
-				"name": "USCoreGoalLifecycleStatus",
-				"description": "**proposed | planned | accepted | active | on-hold | completed | cancelled | entered-in-error | rejected**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-goal-patient"
-				},
-				"name": "USCoreGoalPatient",
-				"description": "**Who this goal is intended for**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-goal-target-date"
-				},
-				"name": "USCoreGoalTargetDate",
-				"description": "**Reach goal on or before**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-immunization-date"
-				},
-				"name": "USCoreImmunizationDate",
-				"description": "**Vaccination  (non)-Administration Date**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-immunization-patient"
-				},
-				"name": "USCoreImmunizationPatient",
-				"description": "**The patient for the vaccination record**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-immunization-status"
-				},
-				"name": "USCoreImmunizationStatus",
-				"description": "**Immunization event status**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-location-address-city"
-				},
-				"name": "USCoreLocationAddressCity",
-				"description": "**A city specified in an address**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-location-address-postalcode"
-				},
-				"name": "USCoreLocationAddressPostalcode",
-				"description": "**A postal code specified in an address**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-location-address-state"
-				},
-				"name": "USCoreLocationAddressState",
-				"description": "**A state specified in an address**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-location-address"
-				},
-				"name": "USCoreLocationAddress",
-				"description": "**A (part of the) address of the location**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-location-name"
-				},
-				"name": "USCoreLocationName",
-				"description": "**A portion of the location's name or alias**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-medicationrequest-authoredon"
-				},
-				"name": "USCoreMedicationRequestAuthoredon",
-				"description": "**Return prescriptions written on this date**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-medicationrequest-encounter"
-				},
-				"name": "USCoreMedicationRequestEncounter",
-				"description": "**Return prescriptions with this encounter identifier**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-medicationrequest-intent"
-				},
-				"name": "USCoreMedicationRequestIntent",
-				"description": "**Returns prescriptions with different intents**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-medicationrequest-patient"
-				},
-				"name": "USCoreMedicationRequestPatient",
-				"description": "**Returns prescriptions for a specific patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-medicationrequest-status"
-				},
-				"name": "USCoreMedicationRequestStatus",
-				"description": "**Status of the prescription**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-observation-category"
-				},
-				"name": "USCoreObservationCategory",
-				"description": "**The classification of the type of observation**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-observation-code"
-				},
-				"name": "USCoreObservationCode",
-				"description": "**The code of the observation type**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-observation-date"
-				},
-				"name": "USCoreObservationDate",
-				"description": "**Obtained date/time. If the obtained element is a period, a date that falls in the period**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-observation-patient"
-				},
-				"name": "USCoreObservationPatient",
-				"description": "**The subject that the observation is about (if patient)**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-observation-status"
-				},
-				"name": "USCoreObservationStatus",
-				"description": "**The status of the observation**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-organization-address"
-				},
-				"name": "USCoreOrganizationAddress",
-				"description": "**A server defined search that may match any of the string fields in the Address, including line, city, district, state, country, postalCode, and/or text**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-organization-name"
-				},
-				"name": "USCoreOrganizationName",
-				"description": "**A portion of the organization's name or alias**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-patient-birthdate"
-				},
-				"name": "USCorePatientBirthdate",
-				"description": "**The patient's date of birth**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-patient-family"
-				},
-				"name": "USCorePatientFamily",
-				"description": "**A portion of the family name of the patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-patient-gender"
-				},
-				"name": "USCorePatientGender",
-				"description": "**Gender of the patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-patient-given"
-				},
-				"name": "USCorePatientGiven",
-				"description": "**A portion of the given name of the patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-patient-id"
-				},
-				"name": "USCorePatientId",
-				"description": "**Logical id of this artifact**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-patient-identifier"
-				},
-				"name": "USCorePatientIdentifier",
-				"description": "**A patient identifier**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-patient-name"
-				},
-				"name": "USCorePatientName",
-				"description": "**A server defined search that may match any of the string fields in the HumanName, including family, give, prefix, suffix, suffix, and/or text**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-practitioner-identifier"
-				},
-				"name": "USCorePractitionerIdentifier",
-				"description": "**A practitioner's Identifier**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-practitioner-name"
-				},
-				"name": "USCorePractitionerName",
-				"description": "**A server defined search that may match any of the string fields in the HumanName, including family, give, prefix, suffix, suffix, and/or text**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-practitionerrole-practitioner"
-				},
-				"name": "USCorePractitionerRolePractitioner",
-				"description": "**Practitioner that is able to provide the defined services for the organization**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-practitionerrole-specialty"
-				},
-				"name": "USCorePractitionerRoleSpecialty",
-				"description": "**The practitioner has this specialty at an organization**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-procedure-code"
-				},
-				"name": "USCoreProcedureCode",
-				"description": "**A code to identify a  procedure**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-procedure-date"
-				},
-				"name": "USCoreProcedureDate",
-				"description": "**When the procedure was performed**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-procedure-patient"
-				},
-				"name": "USCoreProcedurePatient",
-				"description": "**Search by subject - a patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-procedure-status"
-				},
-				"name": "USCoreProcedureStatus",
-				"description": "**preparation | in-progress | not-done | on-hold | stopped | completed | entered-in-error | unknown**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "SearchParameter"
-					}
-				],
-				"reference": {
-					"reference": "SearchParameter/us-core-race"
-				},
-				"name": "USCoreRace",
-				"description": "Returns patients with a race extension matching the specified code.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "StructureDefinition:resource"
-					}
-				],
-				"reference": {
-					"reference": "StructureDefinition/us-core-patient"
-				},
-				"name": "US Core Patient Profile",
-				"description": "Defines constraints and extensions on the patient resource for the minimal set of data to query and retrieve patient demographic information.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/detailed-ethnicity"
-				},
-				"name": "Detailed ethnicity",
-				"description": "The 41 [CDC ethnicity codes](http://www.cdc.gov/phin/resources/vocabulary/index.html) that are grouped under one of the 2 OMB ethnicity category codes.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/detailed-race"
-				},
-				"name": "Detailed Race",
-				"description": "The 900+ [CDC Race codes](http://www.cdc.gov/phin/resources/vocabulary/index.html) that are grouped under one of the 5 OMB race category codes.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/omb-ethnicity-category"
-				},
-				"name": "OMB Ethnicity Categories",
-				"description": "The codes for the ethnicity categories - 'Hispanic or Latino' and 'Non Hispanic or Latino' - as defined by the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/omb-race-category"
-				},
-				"name": "OMB Race Categories",
-				"description": "The codes for the concepts 'Unknown' and  'Asked but no answer' and the the codes for the five race categories - 'American Indian' or 'Alaska Native', 'Asian', 'Black or African American', 'Native Hawaiian or Other Pacific Islander', and 'White' - as defined by the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf) .",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/simple-language"
-				},
-				"name": "Language codes with language and optionally a region modifier",
-				"description": "This value set includes codes from [BCP-47](http://tools.ietf.org/html/bcp47). This value set matches the ONC 2015 Edition LanguageCommunication data element value set within C-CDA to use a 2 character language code if one exists,   and a 3 character code if a 2 character code does not exist. It points back to [RFC 5646](https://tools.ietf.org/html/rfc5646), however only the language codes are required, all other elements are optional.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/birthsex"
-				},
-				"name": "Birth Sex",
-				"description": "Codes for assigning sex at birth as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc)",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-clinical-note-type"
-				},
-				"name": "US Core Clinical Note Type",
-				"description": "The US Core Clinical Note Type Value Set is a 'starter set' of types supported for fetching and storing clinical notes.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-condition-category"
-				},
-				"name": "US Core Condition Category Codes",
-				"description": "The US Core Condition Category Codes support the separate concepts of problems and health concerns in Condition.category in order for API consumers to be able to separate health concerns and problems. However this is not mandatory for 2015 certification",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-condition-code"
-				},
-				"name": "US Core Condition Code",
-				"description": "This describes the problem. Diagnosis/Problem List is broadly defined as a series of brief statements that catalog a patient's medical, nursing, dental, social, preventative and psychiatric events and issues that are relevant to that patient's healthcare (e.g., signs, symptoms, and defined conditions).   ICD-10 is appropriate for Diagnosis information, and ICD-9 for historical information.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-diagnosticreport-category"
-				},
-				"name": "US Core DiagnosticReport Category",
-				"description": "The US Core Diagnostic Report Category Value Set is a 'starter set' of categories supported for fetching and Diagnostic Reports and notes.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-diagnosticreport-lab-codes"
-				},
-				"name": "US Core Diagnostic Report Laboratory Codes",
-				"description": "The Document Type value set includes all LOINC  values whose CLASSTYPE is LABORATORY in the LOINC database",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-diagnosticreport-report-and-note-codes"
-				},
-				"name": "US Core DiagnosticReport Report And Note Codes",
-				"description": "This value set currently contains all of LOINC. The codes selected should represent discrete and narrative diagnostic observations and reports",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-documentreference-category"
-				},
-				"name": "US Core DocumentReference Category",
-				"description": "The US Core DocumentReferences Category Value Set is a 'starter set' of categories supported for fetching and storing clinical notes.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-documentreference-type"
-				},
-				"name": "US Core DocumentReference Type",
-				"description": "The US Core DocumentReference Type Value Set includes all LOINC  values whose SCALE is DOC in the LOINC database and the HL7 v3 Code System NullFlavor concept 'unknown'",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-encounter-type"
-				},
-				"name": "US Core Encounter Type",
-				"description": "The type of encounter: a specific code indicating type of service provided. This value set includes codes from SNOMED CT decending from the concept 308335008 (Patient encounter procedure (procedure)) and codes from the Current Procedure and Terminology (CPT) found in the following CPT sections:\n\n\n- 99201-99499 E/M\n\n- 99500-99600 home health (mainly nonphysician, such as newborn care in home)\n\n- 99605-99607 medication management\n\n- 98966-98968 non physician telephone services\n\n\n\n(subscription to AMA Required)",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-narrative-status"
-				},
-				"name": "US Core Narrative Status",
-				"description": "The US Core Narrative Status Value Set limits the text status for the resource narrative.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-observation-smokingstatus-max"
-				},
-				"name": "US Core Smoking Status Max-Binding",
-				"description": "Representing a patient’s smoking behavior using concepts from SNOMED CT.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-observation-smoking-status-status"
-				},
-				"name": "US Core Status for Smoking Status Observation",
-				"description": "Codes providing the status of an observation for smoking status. Constrained to `final`and `entered-in-error`.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-observation-value-codes"
-				},
-				"name": "US Core Observation Value Codes (SNOMED-CT)",
-				"description": "[Snomed-CT](http://www.ihtsdo.org/) concept codes for coded results",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-procedure-code"
-				},
-				"name": "US Core Procedure Codes",
-				"description": "Concepts from CPT, SNOMED CT, HCPCS Level II Alphanumeric Codes, ICD-10-PCS,CDT and LOINC code systems that can be used to indicate the type of procedure performed.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-provenance-participant-type"
-				},
-				"name": "US Core Provenance Participant Type Codes",
-				"description": "The type of participation a provenance agent played for a given target.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-provider-role"
-				},
-				"name": "US Core Provider Role (NUCC)",
-				"description": "Provider roles codes which are composed of the NUCC Health Care Provider Taxonomy Code Set classification codes for providers. Only concepts with a classification and no specialization are included.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-smoking-status-observation-codes"
-				},
-				"name": "US Core Smoking Status Observation Codes",
-				"description": "The US Core Smoking Status Observation Codes Value Set is a 'starter set' of concepts to capture smoking status.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-usps-state"
-				},
-				"name": "USPS Two Letter Alphabetic Codes",
-				"description": "This value set defines two letter USPS alphabetic codes.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "ValueSet"
-					}
-				],
-				"reference": {
-					"reference": "ValueSet/us-core-vital-signs"
-				},
-				"name": "US Core Vital Signs ValueSet",
-				"description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
-				"exampleBoolean": false
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Device"
-					}
-				],
-				"reference": {
-					"reference": "Device/udi-2"
-				},
-				"name": "Device Defib Example",
-				"description": "This is a Device defib example for the *US Core Implantable Device Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Device"
-					}
-				],
-				"reference": {
-					"reference": "Device/udi-3"
-				},
-				"name": "Device Knee Example",
-				"description": "This is a Device knee example for the *US Core Implantable Device Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "DiagnosticReport"
-					}
-				],
-				"reference": {
-					"reference": "DiagnosticReport/cardiology-report"
-				},
-				"name": "DiagnosticReport Cardiology Report Example",
-				"description": "This is a DiagnosticReport cardiology report example for the *US Core DiagnosticReport Note Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "DiagnosticReport"
-					}
-				],
-				"reference": {
-					"reference": "DiagnosticReport/chest-xray-report"
-				},
-				"name": "DiagnosticReport Chest Xray Report Example",
-				"description": "This is a DiagnosticReport chest xray report example for the *US Core DiagnosticReport Note Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Bundle"
-					}
-				],
-				"reference": {
-					"reference": "Bundle/66c8856b-ba11-4876-8aa8-467aad8c11a2"
-				},
-				"name": "PractitionerRole_Practitioner_Endpoint_Bundle_Example Example",
-				"description": "This is a PractitionerRole_Practitioner_Endpoint_Bundle_Example example for the *Bundle Profile*.",
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Procedure"
-					}
-				],
-				"reference": {
-					"reference": "Procedure/defib-implant"
-				},
-				"name": "Procedure R4 Defib Implant Example",
-				"description": "This is a Procedure R4 defib implant example for the *US Core Procedure Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Organization"
-					}
-				],
-				"reference": {
-					"reference": "Organization/acme-lab"
-				},
-				"name": "Acme Lab Example",
-				"description": "This is a acme lab example for the *US Core Organization Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "AllergyIntolerance"
-					}
-				],
-				"reference": {
-					"reference": "AllergyIntolerance/example"
-				},
-				"name": "AllergyIntolerance Example",
-				"description": "This is a allergyintolerance example for the *US Core AllergyIntolerance Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Bundle"
-					}
-				],
-				"reference": {
-					"reference": "Bundle/c887e62f-6166-419f-8268-b5ecd6c7b901"
-				},
-				"name": "AllergyIntolerance Provenance Example",
-				"description": "This is a allergyintolerance provenance example for the *Bundle Profile*.",
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/blood-glucose"
-				},
-				"name": "Blood Glucose Example",
-				"description": "This is a blood glucose example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/blood-pressure"
-				},
-				"name": "Blood Pressure Example",
-				"description": "This is a blood pressure example for the *Vitalsigns Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/bmi"
-				},
-				"name": "BMI Example",
-				"description": "This is a BMI example for the *Vitalsigns Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-bmi"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/bp-data-absent"
-				},
-				"name": "BP Data Absent Example",
-				"description": "This is a bp data absent example for the *Vitalsigns Profile* showing how to reprsesent blood pressure with a missing diastolic measurement.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/bun"
-				},
-				"name": "BUN Example",
-				"description": "This is a BUN example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CareTeam"
-					}
-				],
-				"reference": {
-					"reference": "CareTeam/example"
-				},
-				"name": "CareTeam Example",
-				"description": "This is a careteam example for the *US Core CareTeam Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "DiagnosticReport"
-					}
-				],
-				"reference": {
-					"reference": "DiagnosticReport/cbc"
-				},
-				"name": "CBC Example",
-				"description": "This is a CBC example for the *US Core DiagnosticReport Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "CarePlan"
-					}
-				],
-				"reference": {
-					"reference": "CarePlan/colonoscopy"
-				},
-				"name": "Colonoscopy Example",
-				"description": "This is a colonoscopy example for the *US Core CarePlan Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Condition"
-					}
-				],
-				"reference": {
-					"reference": "Condition/example"
-				},
-				"name": "Condition Example",
-				"description": "This is a condition example for the *US Core Condition Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Encounter"
-					}
-				],
-				"reference": {
-					"reference": "Encounter/1036"
-				},
-				"name": "Encounter 1036 Example",
-				"description": "This is a encounter 1036 example for the *Encounter Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Encounter"
-					}
-				],
-				"reference": {
-					"reference": "Encounter/example-1"
-				},
-				"name": "Encounter 1 Example",
-				"description": "This is a encounter 1 example for the *US Core Encounter Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "DocumentReference"
-					}
-				],
-				"reference": {
-					"reference": "DocumentReference/episode-summary"
-				},
-				"name": "Episode Summary Example",
-				"description": "This is a episode summary example for the *US Core DocumentReference Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/erythrocytes"
-				},
-				"name": "Erythrocytes Example",
-				"description": "This is a erythrocytes example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Organization"
-					}
-				],
-				"reference": {
-					"reference": "Organization/example-organization-2"
-				},
-				"name": "Organization 2 Example",
-				"description": "This is a organization 2 example for the *US Core Organization Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Goal"
-					}
-				],
-				"reference": {
-					"reference": "Goal/goal-1"
-				},
-				"name": "Goal 1 Example",
-				"description": "This is a goal 1 example for the *US Core Goal Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Condition"
-					}
-				],
-				"reference": {
-					"reference": "Condition/hc1"
-				},
-				"name": "HC1 Example",
-				"description": "This is a hc1 example for the *US Core Condition Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/head-circumference"
-				},
-				"name": "Head Circumference Example",
-				"description": "This is a head circumference example for the *US Core Head Circumference Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-head-circumference"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/heart-rate"
-				},
-				"name": "Heart Rate Example",
-				"description": "This is a heart rate example for the *Vitalsigns Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/height"
-				},
-				"name": "Height Example",
-				"description": "This is a height example for the *Vitalsigns Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-height"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/hemoglobin"
-				},
-				"name": "Hemoglobin Example",
-				"description": "This is a hemoglobin example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Location"
-					}
-				],
-				"reference": {
-					"reference": "Location/hl7east"
-				},
-				"name": "HL7East Example",
-				"description": "This is a HL7East example for the *US Core Location Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-location"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Immunization"
-					}
-				],
-				"reference": {
-					"reference": "Immunization/imm-1"
-				},
-				"name": "Imm 1 Example",
-				"description": "This is a imm 1 example for the *US Core Immunization Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/length"
-				},
-				"name": "Length Example",
-				"description": "This is a length example for the *Vitalsigns Profile* which shows how body length (typically used for infants) is represented using 8306-3 -*Body height - lying* as an additional observation code.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-height"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/mchc"
-				},
-				"name": "MCHC Example",
-				"description": "This is a MCHC example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "DiagnosticReport"
-					}
-				],
-				"reference": {
-					"reference": "DiagnosticReport/metabolic-panel"
-				},
-				"name": "Metabolic Panel Example",
-				"description": "This is a metabolic panel example for the *US Core DiagnosticReport Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/neutrophils"
-				},
-				"name": "Neutrophils Example",
-				"description": "This is a neutrophils example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/satO2-fiO2"
-				},
-				"name": "Observation SatO2 FiO2 Example",
-				"description": "This is a observation satO2 fiO2 example for the *US Core Pulse Oximetry Profile* representing a spO2 value with a for a patient on 6 l/min of O2 suppplemental oxygen.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/ofc-percentile"
-				},
-				"name": "OFC Percentile Example",
-				"description": "This is a OFC percentile example for the *Head Occipital Frontal Circumference Percentile Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/oxygen-saturation"
-				},
-				"name": "Oxygen Saturation Example",
-				"description": "This is a typical oxygen saturation example for the *US Core Pulse Oximetry Profile* on room air where no oxygen concentration is recorded.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Patient"
-					}
-				],
-				"reference": {
-					"reference": "Patient/child-example"
-				},
-				"name": "Patient Child Example",
-				"description": "This is a patient child example for the *US Core Patient Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Patient"
-					}
-				],
-				"reference": {
-					"reference": "Patient/example"
-				},
-				"name": "Patient Example",
-				"description": "This is a patient example for the *US Core Patient Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Patient"
-					}
-				],
-				"reference": {
-					"reference": "Patient/infant-example"
-				},
-				"name": "Patient Infant Example",
-				"description": "This is a patient infant example for the *US Core Patient Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/pediatric-bmi-example"
-				},
-				"name": "Pediatric BMI Example",
-				"description": "This is a pediatric BMI example for the *Pediatric BMI For Age Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/pediatric-wt-example"
-				},
-				"name": "Pediatric Wt Example",
-				"description": "This is a pediatric wt example for the *Pediatric Weight For Height Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Practitioner"
-					}
-				],
-				"reference": {
-					"reference": "Practitioner/practitioner-1"
-				},
-				"name": "Practitioner 1 Example",
-				"description": "This is a practitioner 1 example for the *US Core Practitioner Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Practitioner"
-					}
-				],
-				"reference": {
-					"reference": "Practitioner/practitioner-2"
-				},
-				"name": "Practitioner 2 Example",
-				"description": "This is a practitioner 2 example for the *US Core Practitioner Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Procedure"
-					}
-				],
-				"reference": {
-					"reference": "Procedure/rehab"
-				},
-				"name": "Rehab Example",
-				"description": "This is a rehab example for the *US Core Procedure Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/respiratory-rate"
-				},
-				"name": "Respiratory Rate Example",
-				"description": "This is a respiratory rate example for the *Vitalsigns Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-respiratory-rate"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Organization"
-					}
-				],
-				"reference": {
-					"reference": "Organization/saint-luke-w-endpoint"
-				},
-				"name": "Saint Luke W Endpoint Example",
-				"description": "This is a saint luke w endpoint example for the *US Core Organization Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "MedicationRequest"
-					}
-				],
-				"reference": {
-					"reference": "MedicationRequest/self-tylenol"
-				},
-				"name": "Self Tylenol Example",
-				"description": "This is a self tylenol example for the *MedicationRequest Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/serum-calcium"
-				},
-				"name": "Serum Calcium Example",
-				"description": "This is a serum calcium example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/serum-chloride"
-				},
-				"name": "Serum Chloride Example",
-				"description": "This is a serum chloride example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/serum-co2"
-				},
-				"name": "Serum CO2 Example",
-				"description": "This is a serum CO2 example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/serum-creatinine"
-				},
-				"name": "Serum Creatinine Example",
-				"description": "This is a serum creatinine example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/serum-potassium"
-				},
-				"name": "Serum Potassium Example",
-				"description": "This is a serum potassium example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/serum-sodium"
-				},
-				"name": "Serum Sodium Example",
-				"description": "This is a serum sodium example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/serum-total-bilirubin"
-				},
-				"name": "Serum Total Bilirubin Example",
-				"description": "This is a serum total bilirubin example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/some-day-smoker"
-				},
-				"name": "Some Day Smoker Example",
-				"description": "This is a some day smoker example for the *US Core Smokingstatus Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/temperature"
-				},
-				"name": "Temperature Example",
-				"description": "This is a temperature example for the *Vitalsigns Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-temperature"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Device"
-					}
-				],
-				"reference": {
-					"reference": "Device/udi-1"
-				},
-				"name": "UDI 1 Example",
-				"description": "This is a UDI 1 example for the *US Core Implantable Device Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "DiagnosticReport"
-					}
-				],
-				"reference": {
-					"reference": "DiagnosticReport/urinalysis"
-				},
-				"name": "Urinalysis Example",
-				"description": "This is a urinalysis example for the *US Core DiagnosticReport Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-bacteria"
-				},
-				"name": "Urine Bacteria Example",
-				"description": "This is a urine bacteria example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-bilirubin"
-				},
-				"name": "Urine Bilirubin Example",
-				"description": "This is a urine bilirubin example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-cells"
-				},
-				"name": "Urine Cells Example",
-				"description": "This is a urine cells example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-clarity"
-				},
-				"name": "Urine Clarity Example",
-				"description": "This is a urine clarity example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-color"
-				},
-				"name": "Urine Color Example",
-				"description": "This is a urine color example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-epi-cells"
-				},
-				"name": "Urine Epi Cells Example",
-				"description": "This is a urine epi cells example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-glucose"
-				},
-				"name": "Urine Glucose Example",
-				"description": "This is a urine glucose example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-hemoglobin"
-				},
-				"name": "Urine Hemoglobin Example",
-				"description": "This is a urine hemoglobin example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-ketone"
-				},
-				"name": "Urine Ketone Example",
-				"description": "This is a urine ketone example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-leukocyte-esterase"
-				},
-				"name": "Urine Leukocyte Esterase Example",
-				"description": "This is a urine leukocyte esterase example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-nitrite"
-				},
-				"name": "Urine Nitrite Example",
-				"description": "This is a urine nitrite example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-ph"
-				},
-				"name": "Urine pH Example",
-				"description": "This is a urine pH example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-protein"
-				},
-				"name": "Urine Protein Example",
-				"description": "This is a urine protein example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-rbcs"
-				},
-				"name": "Urine RBCsExample",
-				"description": "This is a urine RBCsexample for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-sediment"
-				},
-				"name": "Urine Sediment Example",
-				"description": "This is a urine sediment example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urine-wbcs"
-				},
-				"name": "Urine WBCsExample",
-				"description": "This is a urine WBCsexample for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/urobilinogen"
-				},
-				"name": "Urobilinogen Example",
-				"description": "This is a urobilinogen example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Medication"
-					}
-				],
-				"reference": {
-					"reference": "Medication/uscore-med1"
-				},
-				"name": "Uscore Med1 Example",
-				"description": "This is a uscore med1 example for the *US Core Medication Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Medication"
-					}
-				],
-				"reference": {
-					"reference": "Medication/uscore-med2"
-				},
-				"name": "Uscore Med2 Example",
-				"description": "This is a uscore med2 example for the *US Core Medication Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "MedicationRequest"
-					}
-				],
-				"reference": {
-					"reference": "MedicationRequest/uscore-mo1"
-				},
-				"name": "Uscore MO1 Example",
-				"description": "This is a uscore mo1 example for the *US Core MedicationRequest Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "MedicationRequest"
-					}
-				],
-				"reference": {
-					"reference": "MedicationRequest/uscore-mo2"
-				},
-				"name": "Uscore MO2 Example",
-				"description": "This is a uscore MO2 example for the *US Core MedicationRequest Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Bundle"
-					}
-				],
-				"reference": {
-					"reference": "Bundle/uscore-mo3"
-				},
-				"name": "Uscore MO3 Example",
-				"description": "This is a uscore mo3 example for the *Bundle Profile*.",
-				"exampleBoolean": true
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/usg"
-				},
-				"name": "USG Example",
-				"description": "This is a USG example for the *US Core Observation Lab Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
-			},
-			{
-				"extension": [
-					{
-						"url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
-						"valueString": "Observation"
-					}
-				],
-				"reference": {
-					"reference": "Observation/weight"
-				},
-				"name": "Weight Example",
-				"description": "This is a weight example for the *Vitalsigns Profile*.",
-				"exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-weight"
-			}
-		],
-		"page": {
-			"nameUrl": "toc.html",
-			"title": "Table of Contents",
-			"generation": "html",
-			"page": [
-				{
-					"nameUrl": "index.html",
-					"title": "Index",
-					"generation": "markdown"
-				},
-				{
-					"nameUrl": "guidance.html",
-					"title": "Guidance",
-					"generation": "markdown",
-					"page": [
-						{
-							"nameUrl": "general-guidance.html",
-							"title": "General Guidance",
-							"generation": "markdown"
-						},
-						{
-							"nameUrl": "conformance-expectations.html",
-							"title": "Conformance Expectations",
-							"generation": "markdown"
-						},
-						{
-							"nameUrl": "clinical-notes-guidance.html",
-							"title": "Clinical Notes Guidance",
-							"generation": "markdown"
-						},
-						{
-							"nameUrl": "medication-list-guidance.html",
-							"title": "Medication List Guidance",
-							"generation": "markdown"
-						},
-						{
-							"nameUrl": "basic-provenance.html",
-							"title": "Basic Provenance",
-							"generation": "markdown"
-						},
-						{
-							"nameUrl": "DSTU2-to-R4-conversion.html",
-							"title": "DSTU2 to R4 Conversion",
-							"generation": "markdown"
-						},
-						{
-							"nameUrl": "future-of-US-core.html",
-							"title": "Future of US Core",
-							"generation": "markdown"
-						}
-					]
-				},
-				{
-					"nameUrl": "profiles-and-extensions.html",
-					"title": "Profiles and Extensions",
-					"generation": "markdown"
-				},
-				{
-					"nameUrl": "capability-statements.html",
-					"title": "Capability Statements",
-					"generation": "markdown"
-				},
-				{
-					"nameUrl": "search-parameters-and-operations.html",
-					"title": "Search Parameters and Operations",
-					"generation": "markdown"
-				},
-				{
-					"nameUrl": "terminology.html",
-					"title": "Terminology",
-					"generation": "markdown"
-				},
-				{
-					"nameUrl": "security.html",
-					"title": "Security",
-					"generation": "markdown"
-				},
-				{
-					"nameUrl": "examples.html",
-					"title": "Examples",
-					"generation": "markdown"
-				},
-				{
-					"nameUrl": "downloads.html",
-					"title": "Downloads",
-					"generation": "markdown"
-				}
-			]
-		},
-		"parameter": [
-		]
-	}
+    "resourceType": "ImplementationGuide",
+    "id": "hl7.fhir.us.core",
+    "text": {
+        "status": "empty",
+        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>"
+    },
+    "url": "http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core",
+    "version": "4.0.0",
+    "name": "USCore",
+    "title": "US Core Implementation Guide",
+    "status": "active",
+    "date": "2021-06-16",
+    "publisher": "HL7 International - US Realm Steering Committee",
+    "contact": [
+        {
+            "name": "HL7 International - US Realm Steering Committee",
+            "telecom": [
+                {
+                    "system": "url",
+                    "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+                }
+            ]
+        }
+    ],
+    "description": "The US Core Implementation Guide is based on FHIR Version R4 and defines the minimum conformance requirements for accessing patient data. The Argonaut pilot implementations, ONC 2015 Edition Common Clinical Data Set (CCDS), and ONC U.S. Core Data for Interoperability (USCDI) v1 provided the requirements for this guide. The prior Argonaut search and vocabulary requirements, based on FHIR DSTU2, are updated in this guide to support FHIR Version R4. This guide was used as the basis for further testing and guidance by the Argonaut Project Team to provide additional content and guidance specific to Data Query Access for purpose of ONC Certification testing. These profiles are the foundation for future US Realm FHIR implementation guides. In addition to Argonaut, they are used by DAF-Research, QI-Core, and CIMI. Under the guidance of HL7 and the HL7 US Realm Steering Committee, the content will expand in future versions to meet the needs specific to the US Realm.\nThese requirements were originally developed, balloted, and published in FHIR DSTU2 as part of the Office of the National Coordinator for Health Information Technology (ONC) sponsored Data Access Framework (DAF) project. For more information on how DAF became US Core see the US Core change notes.",
+    "jurisdiction": [
+        {
+            "coding": [
+                {
+                    "system": "urn:iso:std:iso:3166",
+                    "code": "US"
+                }
+            ]
+        }
+    ],
+    "copyright": "Used by permission of HL7 International, all rights reserved Creative Commons License",
+    "packageId": "hl7.fhir.us.core",
+    "license": "CC0-1.0",
+    "fhirVersion": [
+        "4.0.1"
+    ],
+    "dependsOn": [
+        {
+            "id": "hl7_fhir_uv_bulkdata",
+            "uri": "http://hl7.org/fhir/uv/bulkdata/ImplementationGuide/hl7.fhir.uv.bulkdata",
+            "packageId": "hl7.fhir.uv.bulkdata",
+            "version": "1.0.1"
+        },
+        {
+            "id": "vsac",
+            "uri": "http://fhir.org/packages/us.nlm.vsac/ImplementationGuide/us.nlm.vsac",
+            "packageId": "us.nlm.vsac",
+            "version": "0.3.0"
+        }
+    ],
+    "definition": {
+        "resource": [
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/head-occipital-frontal-circumference-percentile"
+                },
+                "name": "US Core Pediatric Head Occipital-frontal Circumference Percentile Profile",
+                "description": "Defines constraints on the Observation resource to represent head occipital-frontal circumference percentile for patients from birth to 36 months of age in FHIR using a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-allergyintolerance"
+                },
+                "name": "US Core AllergyIntolerance Profile",
+                "description": "Defines constraints and extensions on the AllergyIntolerance resource for the minimal set of data to query and retrieve allergy information.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:extension"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-birthsex"
+                },
+                "name": "US Core Birth Sex Extension",
+                "description": "A code classifying the person's sex assigned at birth  as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc). This extension aligns with the C-CDA Birth Sex Observation (LOINC 76689-9).",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-blood-pressure"
+                },
+                "name": "US Core Blood Pressure Profile",
+                "description": "Defines constraints on Observation to represent diastolic and systolic blood pressure observations with standard LOINC codes and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-bmi"
+                },
+                "name": "US Core BMI Profile",
+                "description": "Defines constraints on Observation to represent Body Mass Index (BMI) observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-body-height"
+                },
+                "name": "US Core Body Height Profile",
+                "description": "Defines constraints on Observation to represent body height observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-body-temperature"
+                },
+                "name": "US Core Body Temperature Profile",
+                "description": "Defines constraints on Observation to represent body temperature observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-body-weight"
+                },
+                "name": "US Core Body Weight Profile",
+                "description": "Defines constraints on Observation to represent body weight observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-careplan"
+                },
+                "name": "US Core CarePlan Profile",
+                "description": "Defines constraints and extensions on the CarePlan resource for the minimal set of data to query and retrieve a patient's Care Plan.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-careteam"
+                },
+                "name": "US Core CareTeam Profile",
+                "description": "Defines constraints and extensions on the CareTeam resource for the minimal set of data to query and retrieve a patient's Care Team.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-condition"
+                },
+                "name": "US Core Condition Profile",
+                "description": "Defines constraints and extensions on the Condition resource for the minimal set of data to query and retrieve problems and health concerns information.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-diagnosticreport-lab"
+                },
+                "name": "US Core DiagnosticReport Profile for Laboratory Results Reporting",
+                "description": "Defines constraints and extensions on the DiagnosticReport resource  for the minimal set of data to query and retrieve diagnostic reports associated with laboratory results for a patient",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-diagnosticreport-note"
+                },
+                "name": "US Core DiagnosticReport Profile for Report and Note exchange",
+                "description": "Defines constraints and extensions on the DiagnosticReport resource  for the minimal set of data to query and retrieve diagnostic reports associated with clinical notes for a patient",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:extension"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-direct"
+                },
+                "name": "US Core Direct email Extension",
+                "description": "This email address is associated with a [direct](http://wiki.directproject.org/Addressing+Specification) service.  This extension can only be used on contact points where the system = 'email'",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-documentreference"
+                },
+                "name": "US Core DocumentReference Profile",
+                "description": "The document reference profile used in US Core.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-encounter"
+                },
+                "name": "US Core Encounter Profile",
+                "description": "The Encounter referenced in the US Core profiles.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:extension"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-ethnicity"
+                },
+                "name": "US Core Ethnicity Extension",
+                "description": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-goal"
+                },
+                "name": "US Core Goal Profile",
+                "description": "Defines constraints and extensions on the Goal resource for the minimal set of data to query and retrieve a patient's goal(s).",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-head-circumference"
+                },
+                "name": "US Core Head Circumference Profile",
+                "description": "Defines constraints on Observation to represent head circumference observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-heart-rate"
+                },
+                "name": "US Core Heart Rate Profile",
+                "description": "Defines constraints on Observation to represent heart rate observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-immunization"
+                },
+                "name": "US Core Immunization Profile",
+                "description": "Defines constraints and extensions on the Immunization resource for the minimal set of data to query and retrieve  patient's immunization information.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-implantable-device"
+                },
+                "name": "US Core Implantable Device Profile",
+                "description": "Defines constraints and extensions on the Device resource for the minimal set of data to query and retrieve a patient's implantable device(s).",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-location"
+                },
+                "name": "US Core Location Profile",
+                "description": "Defines basic constraints and extensions on the Location resource for use with other US Core resources",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-medication"
+                },
+                "name": "US Core Medication Profile",
+                "description": "Defines constraints and extensions on the Medication resource for the minimal set of data to query and retrieve patient retrieving patient's medication information.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-medicationrequest"
+                },
+                "name": "US Core MedicationRequest Profile",
+                "description": "Defines constraints and extensions on the MedicationRequest resource for the minimal set of data to query and retrieve prescription information.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-observation-lab"
+                },
+                "name": "US Core Laboratory Result Observation Profile",
+                "description": "Defines constraints and extensions on the Observation resource for the minimal set of data to query and retrieve laboratory test results",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-organization"
+                },
+                "name": "US Core Organization Profile",
+                "description": "Defines basic constraints and extensions on the Organization resource for use with other US Core resources",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/pediatric-bmi-for-age"
+                },
+                "name": "US Core Pediatric BMI for Age Observation Profile",
+                "description": "Defines constraints on Observation to represent to represent BMI percentile per age and sex for youth 2-20 observations in FHIR using a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/pediatric-weight-for-height"
+                },
+                "name": "US Core Pediatric Weight for Height Observation Profile",
+                "description": "Defines constraints on the Observation resource to represent pediatric Weight-for-length per age and gender observations in FHIR with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-practitioner"
+                },
+                "name": "US Core Practitioner Profile",
+                "description": "The practitioner(s) referenced in US Core profiles.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-practitionerrole"
+                },
+                "name": "US Core PractitionerRole Profile",
+                "description": "The practitioner roles referenced in the US Core profiles.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-procedure"
+                },
+                "name": "US Core Procedure Profile",
+                "description": "Defines constraints and extensions on the Procedure resource for the minimal set of data to query and retrieve patient's procedure information.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-provenance"
+                },
+                "name": "US Core Provenance Profile",
+                "description": "Draft set of requirements to satisfy Basic Provenance Requirements.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-pulse-oximetry"
+                },
+                "name": "US Core Pulse Oximetry Profile",
+                "description": "Defines constraints on the Observation resource to represent inspired O2 by pulse oximetry and inspired oxygen concentration observations with a standard LOINC codes and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:extension"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-race"
+                },
+                "name": "US Core Race Extension",
+                "description": "Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\n - American Indian or Alaska Native\n - Asian\n - Black or African American\n - Native Hawaiian or Other Pacific Islander\n - White.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-respiratory-rate"
+                },
+                "name": "US Core Respiratory Rate Profile",
+                "description": "Defines constraints on Observation to represent respiratory rate observations with a standard LOINC code and UCUM units of measure. This profile is derived from the US Core Vital Signs Profile.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-smokingstatus"
+                },
+                "name": "US Core Smoking Status Observation Profile",
+                "description": "Defines constraints and extensions on the Observation  resource for the minimal set of data to query and retrieve patient's Smoking Status information.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-vital-signs"
+                },
+                "name": "US Core Vital Signs Profile",
+                "description": "Defines constraints on the Observation resource to represent vital signs observations.  This profile is used as the base definition for the other US Core Vital Signs Profiles and based on the FHIR VitalSigns Profile.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CapabilityStatement"
+                    }
+                ],
+                "reference": {
+                    "reference": "CapabilityStatement/us-core-client"
+                },
+                "name": "US Core Client CapabilityStatement",
+                "description": "This Section describes the expected capabilities of the US Core Client which is responsible for creating and initiating the queries for information about an individual patient. The complete list of FHIR profiles, RESTful operations, and search parameters supported by US Core Servers are defined in the [Conformance Requirements for Server](CapabilityStatement-us-core-server.html). US Core Clients have the option of choosing from this list to access necessary data based on their local use cases and other contextual requirements.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CapabilityStatement"
+                    }
+                ],
+                "reference": {
+                    "reference": "CapabilityStatement/us-core-server"
+                },
+                "name": "US Core Server CapabilityStatement",
+                "description": "This Section describes the expected capabilities of the US Core Server actor which is responsible for providing responses to the queries submitted by the US Core Requestors. The complete list of FHIR profiles, RESTful operations, and search parameters supported by US Core Servers are defined. Systems implementing this capability statement should meet the ONC 2015 Common Clinical Data Set (CCDS) access requirement for Patient Selection 170.315(g)(7) and Application Access - Data Category Request 170.315(g)(8) and and the ONC [U.S. Core Data for Interoperability (USCDI)](https://www.healthit.gov/isa/sites/isa/files/2020-03/USCDI-Version1-2020-Final-Standard.pdf).  US Core Clients have the option of choosing from this list to access necessary data based on their local use cases and other contextual requirements.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CodeSystem"
+                    }
+                ],
+                "reference": {
+                    "reference": "CodeSystem/careplan-category"
+                },
+                "name": "US Core CarePlan Category Extension Codes",
+                "description": "Set of codes that are needed for implementation of the US-Core CarePlan Profile. These codes are used as extensions to the FHIR ValueSet.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CodeSystem"
+                    }
+                ],
+                "reference": {
+                    "reference": "CodeSystem/cdcrec"
+                },
+                "name": "Race & Ethnicity - CDC",
+                "description": "The U.S. Centers for Disease Control and Prevention (CDC) has prepared a code set for use in codingrace and ethnicity data. This code set is based on current federal standards for classifying data onrace and ethnicity, specifically the minimum race and ethnicity categories defined by the U.S. Office ofManagement and Budget (OMB) and a more detailed set of race and ethnicity categories maintainedby the U.S. Bureau of the Census (BC). The main purpose of the code set is to facilitate use of federalstandards for classifying data on race and ethnicity when these data are exchanged, stored, retrieved,or analyzed in electronic form. At the same time, the code set can be applied to paper-based recordsystems to the extent that these systems are used to collect, maintain, and report data on race andethnicity in accordance with current federal standards. Source: [Race and Ethnicity Code Set Version 1.0](https://www.cdc.gov/phin/resources/vocabulary/documents/cdc-race--ethnicity-background-and-purpose.pdf).",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CodeSystem"
+                    }
+                ],
+                "reference": {
+                    "reference": "CodeSystem/condition-category"
+                },
+                "name": "US Core Condition Category Extension Codes",
+                "description": "Set of codes that are needed for implementation of the US-Core Condition Profile. These codes are used as extensions to the FHIR and US Core value sets.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CodeSystem"
+                    }
+                ],
+                "reference": {
+                    "reference": "CodeSystem/us-core-documentreference-category"
+                },
+                "name": "US Core DocumentReferences Category Codes",
+                "description": "The US Core DocumentReferences Type Code System is a 'starter set' of categories supported for fetching and storing DocumentReference Resources.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CodeSystem"
+                    }
+                ],
+                "reference": {
+                    "reference": "CodeSystem/us-core-provenance-participant-type"
+                },
+                "name": "US Core Provenance Participant Type Extension Codes",
+                "description": "Set of codes that are needed for implementation of the US-Core Provenance Profile. These codes are used as extensions to the FHIR value sets.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "OperationDefinition"
+                    }
+                ],
+                "reference": {
+                    "reference": "OperationDefinition/docref"
+                },
+                "name": "US Core Fetch DocumentReference",
+                "description": "This operation is used to return all the references to documents related to a patient. \n\n The operation requires a patient id and takes the optional input parameters: \n  - start date\n  - end date\n  - document type \n\n and returns a [Bundle](http://hl7.org/fhir/bundle.html) of type \"searchset\" containing [DocumentReference](http://hl7.org/fhir/documentreference.html) resources for the patient. The DocumentReference resources **SHOULD** conform to the [US Core DocumentReference\n Profiles](http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference). If the server has or can create documents that are related to the patient, and that are available for the given user, the server returns the DocumentReference resources needed to support the records.  The principle intended use for this operation is to provide a provider or patient with access to their available document information. \n\n This operation is *different* from a search by patient and type and date range because: \n\n 1. It is used to request a server *generate* a document based on the specified parameters. \n\n 1. If no parameters are specified, the server SHALL return a DocumentReference to the patient's most current CCD \n\n 1. If the server cannot *generate* a document based on the specified parameters, the operation will return an empty search bundle. \n\n This operation is the *same* as a FHIR RESTful search by patient,type and date range because: \n\n 1. References for *existing* documents that meet the requirements of the request SHOULD also be returned unless the client indicates they are only interested in 'on-demand' documents using the *on-demand* parameter.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-allergyintolerance-clinical-status"
+                },
+                "name": "USCoreAllergyIntoleranceClinicalStatus",
+                "description": "**active | inactive | resolved**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-allergyintolerance-patient"
+                },
+                "name": "USCoreAllergyIntolerancePatient",
+                "description": "**Who the sensitivity is for**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-careplan-category"
+                },
+                "name": "USCoreCarePlanCategory",
+                "description": "**Type of plan**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-careplan-date"
+                },
+                "name": "USCoreCarePlanDate",
+                "description": "**Time period plan covers**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-careplan-patient"
+                },
+                "name": "USCoreCarePlanPatient",
+                "description": "**Who the care plan is for**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-careplan-status"
+                },
+                "name": "USCoreCarePlanStatus",
+                "description": "**draft | active | on-hold | revoked | completed | entered-in-error | unknown**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-careteam-patient"
+                },
+                "name": "USCoreCareTeamPatient",
+                "description": "**Who care team is for**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-careteam-status"
+                },
+                "name": "USCoreCareTeamStatus",
+                "description": "**proposed | active | suspended | inactive | entered-in-error**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-condition-category"
+                },
+                "name": "USCoreConditionCategory",
+                "description": "**The category of the condition**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-condition-clinical-status"
+                },
+                "name": "USCoreConditionClinicalStatus",
+                "description": "**The clinical status of the condition**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-condition-code"
+                },
+                "name": "USCoreConditionCode",
+                "description": "**Code for the condition**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-condition-onset-date"
+                },
+                "name": "USCoreConditionOnsetDate",
+                "description": "**Date related onsets (dateTime and Period)**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-condition-patient"
+                },
+                "name": "USCoreConditionPatient",
+                "description": "**Who has the condition?**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-device-patient"
+                },
+                "name": "USCoreDevicePatient",
+                "description": "**Patient information, if the resource is affixed to a person**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-device-type"
+                },
+                "name": "USCoreDeviceType",
+                "description": "**The type of the device**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-diagnosticreport-category"
+                },
+                "name": "USCoreDiagnosticReportCategory",
+                "description": "**Which diagnostic discipline/department created the report**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-diagnosticreport-code"
+                },
+                "name": "USCoreDiagnosticReportCode",
+                "description": "**The code for the report, as opposed to codes for the atomic results, which are the names on the observation resource referred to from the result**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-diagnosticreport-date"
+                },
+                "name": "USCoreDiagnosticReportDate",
+                "description": "**The clinically relevant time of the report**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-diagnosticreport-patient"
+                },
+                "name": "USCoreDiagnosticReportPatient",
+                "description": "**The subject of the report if a patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-diagnosticreport-status"
+                },
+                "name": "USCoreDiagnosticReportStatus",
+                "description": "**The status of the report**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-documentreference-category"
+                },
+                "name": "USCoreDocumentReferenceCategory",
+                "description": "**Categorization of document**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-documentreference-date"
+                },
+                "name": "USCoreDocumentReferenceDate",
+                "description": "**When this document reference was created**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-documentreference-id"
+                },
+                "name": "USCoreDocumentReferenceId",
+                "description": "**Logical id of this artifact**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-documentreference-patient"
+                },
+                "name": "USCoreDocumentReferencePatient",
+                "description": "**Who/what is the subject of the document**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-documentreference-period"
+                },
+                "name": "USCoreDocumentReferencePeriod",
+                "description": "**Time of service that is being documented**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-documentreference-status"
+                },
+                "name": "USCoreDocumentReferenceStatus",
+                "description": "**current | superseded | entered-in-error**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-documentreference-type"
+                },
+                "name": "USCoreDocumentReferenceType",
+                "description": "**Kind of document (LOINC if possible)**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-encounter-class"
+                },
+                "name": "USCoreEncounterClass",
+                "description": "**Classification of patient encounter**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-encounter-date"
+                },
+                "name": "USCoreEncounterDate",
+                "description": "**A date within the period the Encounter lasted**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-encounter-id"
+                },
+                "name": "USCoreEncounterId",
+                "description": "**Logical id of this artifact**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-encounter-identifier"
+                },
+                "name": "USCoreEncounterIdentifier",
+                "description": "**Identifier(s) by which this encounter is known**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-encounter-patient"
+                },
+                "name": "USCoreEncounterPatient",
+                "description": "**The patient or group present at the encounter**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-encounter-status"
+                },
+                "name": "USCoreEncounterStatus",
+                "description": "**planned | arrived | triaged | in-progress | onleave | finished | cancelled +**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-encounter-type"
+                },
+                "name": "USCoreEncounterType",
+                "description": "**Specific type of encounter**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-ethnicity"
+                },
+                "name": "USCoreEthnicity",
+                "description": "Returns patients with an ethnicity extension matching the specified code.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-goal-lifecycle-status"
+                },
+                "name": "USCoreGoalLifecycleStatus",
+                "description": "**proposed | planned | accepted | active | on-hold | completed | cancelled | entered-in-error | rejected**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-goal-patient"
+                },
+                "name": "USCoreGoalPatient",
+                "description": "**Who this goal is intended for**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-goal-target-date"
+                },
+                "name": "USCoreGoalTargetDate",
+                "description": "**Reach goal on or before**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-immunization-date"
+                },
+                "name": "USCoreImmunizationDate",
+                "description": "**Vaccination  (non)-Administration Date**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-immunization-patient"
+                },
+                "name": "USCoreImmunizationPatient",
+                "description": "**The patient for the vaccination record**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-immunization-status"
+                },
+                "name": "USCoreImmunizationStatus",
+                "description": "**Immunization event status**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-location-address-city"
+                },
+                "name": "USCoreLocationAddressCity",
+                "description": "**A city specified in an address**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-location-address-postalcode"
+                },
+                "name": "USCoreLocationAddressPostalcode",
+                "description": "**A postal code specified in an address**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-location-address-state"
+                },
+                "name": "USCoreLocationAddressState",
+                "description": "**A state specified in an address**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-location-address"
+                },
+                "name": "USCoreLocationAddress",
+                "description": "**A (part of the) address of the location**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-location-name"
+                },
+                "name": "USCoreLocationName",
+                "description": "**A portion of the location's name or alias**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-medicationrequest-authoredon"
+                },
+                "name": "USCoreMedicationRequestAuthoredon",
+                "description": "**Return prescriptions written on this date**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-medicationrequest-encounter"
+                },
+                "name": "USCoreMedicationRequestEncounter",
+                "description": "**Return prescriptions with this encounter identifier**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-medicationrequest-intent"
+                },
+                "name": "USCoreMedicationRequestIntent",
+                "description": "**Returns prescriptions with different intents**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-medicationrequest-patient"
+                },
+                "name": "USCoreMedicationRequestPatient",
+                "description": "**Returns prescriptions for a specific patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-medicationrequest-status"
+                },
+                "name": "USCoreMedicationRequestStatus",
+                "description": "**Status of the prescription**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-observation-category"
+                },
+                "name": "USCoreObservationCategory",
+                "description": "**The classification of the type of observation**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-observation-code"
+                },
+                "name": "USCoreObservationCode",
+                "description": "**The code of the observation type**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-observation-date"
+                },
+                "name": "USCoreObservationDate",
+                "description": "**Obtained date/time. If the obtained element is a period, a date that falls in the period**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-observation-patient"
+                },
+                "name": "USCoreObservationPatient",
+                "description": "**The subject that the observation is about (if patient)**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-observation-status"
+                },
+                "name": "USCoreObservationStatus",
+                "description": "**The status of the observation**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-organization-address"
+                },
+                "name": "USCoreOrganizationAddress",
+                "description": "**A server defined search that may match any of the string fields in the Address, including line, city, district, state, country, postalCode, and/or text**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-organization-name"
+                },
+                "name": "USCoreOrganizationName",
+                "description": "**A portion of the organization's name or alias**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-patient-birthdate"
+                },
+                "name": "USCorePatientBirthdate",
+                "description": "**The patient's date of birth**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-patient-family"
+                },
+                "name": "USCorePatientFamily",
+                "description": "**A portion of the family name of the patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-patient-gender"
+                },
+                "name": "USCorePatientGender",
+                "description": "**Gender of the patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-patient-given"
+                },
+                "name": "USCorePatientGiven",
+                "description": "**A portion of the given name of the patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-patient-id"
+                },
+                "name": "USCorePatientId",
+                "description": "**Logical id of this artifact**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-patient-identifier"
+                },
+                "name": "USCorePatientIdentifier",
+                "description": "**A patient identifier**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-patient-name"
+                },
+                "name": "USCorePatientName",
+                "description": "**A server defined search that may match any of the string fields in the HumanName, including family, give, prefix, suffix, suffix, and/or text**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-practitioner-identifier"
+                },
+                "name": "USCorePractitionerIdentifier",
+                "description": "**A practitioner's Identifier**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-practitioner-name"
+                },
+                "name": "USCorePractitionerName",
+                "description": "**A server defined search that may match any of the string fields in the HumanName, including family, give, prefix, suffix, suffix, and/or text**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-practitionerrole-practitioner"
+                },
+                "name": "USCorePractitionerRolePractitioner",
+                "description": "**Practitioner that is able to provide the defined services for the organization**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-practitionerrole-specialty"
+                },
+                "name": "USCorePractitionerRoleSpecialty",
+                "description": "**The practitioner has this specialty at an organization**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-procedure-code"
+                },
+                "name": "USCoreProcedureCode",
+                "description": "**A code to identify a  procedure**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-procedure-date"
+                },
+                "name": "USCoreProcedureDate",
+                "description": "**When the procedure was performed**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-procedure-patient"
+                },
+                "name": "USCoreProcedurePatient",
+                "description": "**Search by subject - a patient**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-procedure-status"
+                },
+                "name": "USCoreProcedureStatus",
+                "description": "**preparation | in-progress | not-done | on-hold | stopped | completed | entered-in-error | unknown**  \n**NOTE**: This US Core SearchParameter definition extends the usage context of the\n[Conformance expectation extension](http://hl7.org/fhir/R4/extension-capabilitystatement-expectation.html)\n - multipleAnd\n - multipleOr\n - comparator\n - modifier\n - chain",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "SearchParameter"
+                    }
+                ],
+                "reference": {
+                    "reference": "SearchParameter/us-core-race"
+                },
+                "name": "USCoreRace",
+                "description": "Returns patients with a race extension matching the specified code.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "StructureDefinition:resource"
+                    }
+                ],
+                "reference": {
+                    "reference": "StructureDefinition/us-core-patient"
+                },
+                "name": "US Core Patient Profile",
+                "description": "Defines constraints and extensions on the patient resource for the minimal set of data to query and retrieve patient demographic information.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/detailed-ethnicity"
+                },
+                "name": "Detailed ethnicity",
+                "description": "The 41 [CDC ethnicity codes](http://www.cdc.gov/phin/resources/vocabulary/index.html) that are grouped under one of the 2 OMB ethnicity category codes.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/detailed-race"
+                },
+                "name": "Detailed Race",
+                "description": "The 900+ [CDC Race codes](http://www.cdc.gov/phin/resources/vocabulary/index.html) that are grouped under one of the 5 OMB race category codes.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/omb-ethnicity-category"
+                },
+                "name": "OMB Ethnicity Categories",
+                "description": "The codes for the ethnicity categories - 'Hispanic or Latino' and 'Non Hispanic or Latino' - as defined by the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf).",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/omb-race-category"
+                },
+                "name": "OMB Race Categories",
+                "description": "The codes for the concepts 'Unknown' and  'Asked but no answer' and the the codes for the five race categories - 'American Indian' or 'Alaska Native', 'Asian', 'Black or African American', 'Native Hawaiian or Other Pacific Islander', and 'White' - as defined by the [OMB Standards for Maintaining, Collecting, and Presenting Federal Data on Race and Ethnicity, Statistical Policy Directive No. 15, as revised, October 30, 1997](https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf) .",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/simple-language"
+                },
+                "name": "Language codes with language and optionally a region modifier",
+                "description": "This value set includes codes from [BCP-47](http://tools.ietf.org/html/bcp47). This value set matches the ONC 2015 Edition LanguageCommunication data element value set within C-CDA to use a 2 character language code if one exists,   and a 3 character code if a 2 character code does not exist. It points back to [RFC 5646](https://tools.ietf.org/html/rfc5646), however only the language codes are required, all other elements are optional.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/birthsex"
+                },
+                "name": "Birth Sex",
+                "description": "Codes for assigning sex at birth as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc)",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-clinical-note-type"
+                },
+                "name": "US Core Clinical Note Type",
+                "description": "The US Core Clinical Note Type Value Set is a 'starter set' of types supported for fetching and storing clinical notes.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-condition-category"
+                },
+                "name": "US Core Condition Category Codes",
+                "description": "The US Core Condition Category Codes support the separate concepts of problems and health concerns in Condition.category in order for API consumers to be able to separate health concerns and problems. However this is not mandatory for 2015 certification",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-condition-code"
+                },
+                "name": "US Core Condition Code",
+                "description": "This describes the problem. Diagnosis/Problem List is broadly defined as a series of brief statements that catalog a patient's medical, nursing, dental, social, preventative and psychiatric events and issues that are relevant to that patient's healthcare (e.g., signs, symptoms, and defined conditions).   ICD-10 is appropriate for Diagnosis information, and ICD-9 for historical information.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-diagnosticreport-category"
+                },
+                "name": "US Core DiagnosticReport Category",
+                "description": "The US Core Diagnostic Report Category Value Set is a 'starter set' of categories supported for fetching and Diagnostic Reports and notes.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-diagnosticreport-lab-codes"
+                },
+                "name": "US Core Diagnostic Report Laboratory Codes",
+                "description": "The Document Type value set includes all LOINC  values whose CLASSTYPE is LABORATORY in the LOINC database",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-diagnosticreport-report-and-note-codes"
+                },
+                "name": "US Core DiagnosticReport Report And Note Codes",
+                "description": "This value set currently contains all of LOINC. The codes selected should represent discrete and narrative diagnostic observations and reports",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-documentreference-category"
+                },
+                "name": "US Core DocumentReference Category",
+                "description": "The US Core DocumentReferences Category Value Set is a 'starter set' of categories supported for fetching and storing clinical notes.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-documentreference-type"
+                },
+                "name": "US Core DocumentReference Type",
+                "description": "The US Core DocumentReference Type Value Set includes all LOINC  values whose SCALE is DOC in the LOINC database and the HL7 v3 Code System NullFlavor concept 'unknown'",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-encounter-type"
+                },
+                "name": "US Core Encounter Type",
+                "description": "The type of encounter: a specific code indicating type of service provided. This value set includes codes from SNOMED CT decending from the concept 308335008 (Patient encounter procedure (procedure)) and codes from the Current Procedure and Terminology (CPT) found in the following CPT sections:\n\n\n- 99201-99499 E/M\n\n- 99500-99600 home health (mainly nonphysician, such as newborn care in home)\n\n- 99605-99607 medication management\n\n- 98966-98968 non physician telephone services\n\n\n\n(subscription to AMA Required)",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-narrative-status"
+                },
+                "name": "US Core Narrative Status",
+                "description": "The US Core Narrative Status Value Set limits the text status for the resource narrative.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-observation-smokingstatus-max"
+                },
+                "name": "US Core Smoking Status Max-Binding",
+                "description": "Representing a patient’s smoking behavior using concepts from SNOMED CT.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-observation-smoking-status-status"
+                },
+                "name": "US Core Status for Smoking Status Observation",
+                "description": "Codes providing the status of an observation for smoking status. Constrained to `final`and `entered-in-error`.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-observation-value-codes"
+                },
+                "name": "US Core Observation Value Codes (SNOMED-CT)",
+                "description": "[Snomed-CT](http://www.ihtsdo.org/) concept codes for coded results",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-procedure-code"
+                },
+                "name": "US Core Procedure Codes",
+                "description": "Concepts from CPT, SNOMED CT, HCPCS Level II Alphanumeric Codes, ICD-10-PCS,CDT and LOINC code systems that can be used to indicate the type of procedure performed.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-provenance-participant-type"
+                },
+                "name": "US Core Provenance Participant Type Codes",
+                "description": "The type of participation a provenance agent played for a given target.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-provider-role"
+                },
+                "name": "US Core Provider Role (NUCC)",
+                "description": "Provider roles codes which are composed of the NUCC Health Care Provider Taxonomy Code Set classification codes for providers. Only concepts with a classification and no specialization are included.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-smoking-status-observation-codes"
+                },
+                "name": "US Core Smoking Status Observation Codes",
+                "description": "The US Core Smoking Status Observation Codes Value Set is a 'starter set' of concepts to capture smoking status.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-usps-state"
+                },
+                "name": "USPS Two Letter Alphabetic Codes",
+                "description": "This value set defines two letter USPS alphabetic codes.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "ValueSet"
+                    }
+                ],
+                "reference": {
+                    "reference": "ValueSet/us-core-vital-signs"
+                },
+                "name": "US Core Vital Signs ValueSet",
+                "description": "The vital sign codes from the base FHIR and US Core Vital Signs.",
+                "exampleBoolean": false
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Device"
+                    }
+                ],
+                "reference": {
+                    "reference": "Device/udi-2"
+                },
+                "name": "Device Defib Example",
+                "description": "This is a Device defib example for the *US Core Implantable Device Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Device"
+                    }
+                ],
+                "reference": {
+                    "reference": "Device/udi-3"
+                },
+                "name": "Device Knee Example",
+                "description": "This is a Device knee example for the *US Core Implantable Device Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "DiagnosticReport"
+                    }
+                ],
+                "reference": {
+                    "reference": "DiagnosticReport/cardiology-report"
+                },
+                "name": "DiagnosticReport Cardiology Report Example",
+                "description": "This is a DiagnosticReport cardiology report example for the *US Core DiagnosticReport Note Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "DiagnosticReport"
+                    }
+                ],
+                "reference": {
+                    "reference": "DiagnosticReport/chest-xray-report"
+                },
+                "name": "DiagnosticReport Chest Xray Report Example",
+                "description": "This is a DiagnosticReport chest xray report example for the *US Core DiagnosticReport Note Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Bundle"
+                    }
+                ],
+                "reference": {
+                    "reference": "Bundle/66c8856b-ba11-4876-8aa8-467aad8c11a2"
+                },
+                "name": "PractitionerRole_Practitioner_Endpoint_Bundle_Example Example",
+                "description": "This is a PractitionerRole_Practitioner_Endpoint_Bundle_Example example for the *Bundle Profile*.",
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Procedure"
+                    }
+                ],
+                "reference": {
+                    "reference": "Procedure/defib-implant"
+                },
+                "name": "Procedure R4 Defib Implant Example",
+                "description": "This is a Procedure R4 defib implant example for the *US Core Procedure Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Organization"
+                    }
+                ],
+                "reference": {
+                    "reference": "Organization/acme-lab"
+                },
+                "name": "Acme Lab Example",
+                "description": "This is a acme lab example for the *US Core Organization Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "AllergyIntolerance"
+                    }
+                ],
+                "reference": {
+                    "reference": "AllergyIntolerance/example"
+                },
+                "name": "AllergyIntolerance Example",
+                "description": "This is a allergyintolerance example for the *US Core AllergyIntolerance Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Bundle"
+                    }
+                ],
+                "reference": {
+                    "reference": "Bundle/c887e62f-6166-419f-8268-b5ecd6c7b901"
+                },
+                "name": "AllergyIntolerance Provenance Example",
+                "description": "This is a allergyintolerance provenance example for the *Bundle Profile*.",
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/blood-glucose"
+                },
+                "name": "Blood Glucose Example",
+                "description": "This is a blood glucose example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/blood-pressure"
+                },
+                "name": "Blood Pressure Example",
+                "description": "This is a blood pressure example for the *Vitalsigns Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/bmi"
+                },
+                "name": "BMI Example",
+                "description": "This is a BMI example for the *Vitalsigns Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-bmi"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/bp-data-absent"
+                },
+                "name": "BP Data Absent Example",
+                "description": "This is a bp data absent example for the *Vitalsigns Profile* showing how to reprsesent blood pressure with a missing diastolic measurement.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/bun"
+                },
+                "name": "BUN Example",
+                "description": "This is a BUN example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CareTeam"
+                    }
+                ],
+                "reference": {
+                    "reference": "CareTeam/example"
+                },
+                "name": "CareTeam Example",
+                "description": "This is a careteam example for the *US Core CareTeam Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "DiagnosticReport"
+                    }
+                ],
+                "reference": {
+                    "reference": "DiagnosticReport/cbc"
+                },
+                "name": "CBC Example",
+                "description": "This is a CBC example for the *US Core DiagnosticReport Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "CarePlan"
+                    }
+                ],
+                "reference": {
+                    "reference": "CarePlan/colonoscopy"
+                },
+                "name": "Colonoscopy Example",
+                "description": "This is a colonoscopy example for the *US Core CarePlan Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Condition"
+                    }
+                ],
+                "reference": {
+                    "reference": "Condition/example"
+                },
+                "name": "Condition Example",
+                "description": "This is a condition example for the *US Core Condition Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Encounter"
+                    }
+                ],
+                "reference": {
+                    "reference": "Encounter/1036"
+                },
+                "name": "Encounter 1036 Example",
+                "description": "This is a encounter 1036 example for the *Encounter Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Encounter"
+                    }
+                ],
+                "reference": {
+                    "reference": "Encounter/example-1"
+                },
+                "name": "Encounter 1 Example",
+                "description": "This is a encounter 1 example for the *US Core Encounter Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "DocumentReference"
+                    }
+                ],
+                "reference": {
+                    "reference": "DocumentReference/episode-summary"
+                },
+                "name": "Episode Summary Example",
+                "description": "This is a episode summary example for the *US Core DocumentReference Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/erythrocytes"
+                },
+                "name": "Erythrocytes Example",
+                "description": "This is a erythrocytes example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Organization"
+                    }
+                ],
+                "reference": {
+                    "reference": "Organization/example-organization-2"
+                },
+                "name": "Organization 2 Example",
+                "description": "This is a organization 2 example for the *US Core Organization Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Goal"
+                    }
+                ],
+                "reference": {
+                    "reference": "Goal/goal-1"
+                },
+                "name": "Goal 1 Example",
+                "description": "This is a goal 1 example for the *US Core Goal Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Condition"
+                    }
+                ],
+                "reference": {
+                    "reference": "Condition/hc1"
+                },
+                "name": "HC1 Example",
+                "description": "This is a hc1 example for the *US Core Condition Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/head-circumference"
+                },
+                "name": "Head Circumference Example",
+                "description": "This is a head circumference example for the *US Core Head Circumference Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-head-circumference"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/heart-rate"
+                },
+                "name": "Heart Rate Example",
+                "description": "This is a heart rate example for the *Vitalsigns Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/height"
+                },
+                "name": "Height Example",
+                "description": "This is a height example for the *Vitalsigns Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-height"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/hemoglobin"
+                },
+                "name": "Hemoglobin Example",
+                "description": "This is a hemoglobin example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Location"
+                    }
+                ],
+                "reference": {
+                    "reference": "Location/hl7east"
+                },
+                "name": "HL7East Example",
+                "description": "This is a HL7East example for the *US Core Location Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-location"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Immunization"
+                    }
+                ],
+                "reference": {
+                    "reference": "Immunization/imm-1"
+                },
+                "name": "Imm 1 Example",
+                "description": "This is a imm 1 example for the *US Core Immunization Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/length"
+                },
+                "name": "Length Example",
+                "description": "This is a length example for the *Vitalsigns Profile* which shows how body length (typically used for infants) is represented using 8306-3 -*Body height - lying* as an additional observation code.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-height"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/mchc"
+                },
+                "name": "MCHC Example",
+                "description": "This is a MCHC example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "DiagnosticReport"
+                    }
+                ],
+                "reference": {
+                    "reference": "DiagnosticReport/metabolic-panel"
+                },
+                "name": "Metabolic Panel Example",
+                "description": "This is a metabolic panel example for the *US Core DiagnosticReport Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/neutrophils"
+                },
+                "name": "Neutrophils Example",
+                "description": "This is a neutrophils example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/satO2-fiO2"
+                },
+                "name": "Observation SatO2 FiO2 Example",
+                "description": "This is a observation satO2 fiO2 example for the *US Core Pulse Oximetry Profile* representing a spO2 value with a for a patient on 6 l/min of O2 suppplemental oxygen.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/ofc-percentile"
+                },
+                "name": "OFC Percentile Example",
+                "description": "This is a OFC percentile example for the *Head Occipital Frontal Circumference Percentile Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/oxygen-saturation"
+                },
+                "name": "Oxygen Saturation Example",
+                "description": "This is a typical oxygen saturation example for the *US Core Pulse Oximetry Profile* on room air where no oxygen concentration is recorded.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Patient"
+                    }
+                ],
+                "reference": {
+                    "reference": "Patient/child-example"
+                },
+                "name": "Patient Child Example",
+                "description": "This is a patient child example for the *US Core Patient Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Patient"
+                    }
+                ],
+                "reference": {
+                    "reference": "Patient/example"
+                },
+                "name": "Patient Example",
+                "description": "This is a patient example for the *US Core Patient Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Patient"
+                    }
+                ],
+                "reference": {
+                    "reference": "Patient/infant-example"
+                },
+                "name": "Patient Infant Example",
+                "description": "This is a patient infant example for the *US Core Patient Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/pediatric-bmi-example"
+                },
+                "name": "Pediatric BMI Example",
+                "description": "This is a pediatric BMI example for the *Pediatric BMI For Age Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/pediatric-wt-example"
+                },
+                "name": "Pediatric Wt Example",
+                "description": "This is a pediatric wt example for the *Pediatric Weight For Height Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Practitioner"
+                    }
+                ],
+                "reference": {
+                    "reference": "Practitioner/practitioner-1"
+                },
+                "name": "Practitioner 1 Example",
+                "description": "This is a practitioner 1 example for the *US Core Practitioner Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Practitioner"
+                    }
+                ],
+                "reference": {
+                    "reference": "Practitioner/practitioner-2"
+                },
+                "name": "Practitioner 2 Example",
+                "description": "This is a practitioner 2 example for the *US Core Practitioner Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Procedure"
+                    }
+                ],
+                "reference": {
+                    "reference": "Procedure/rehab"
+                },
+                "name": "Rehab Example",
+                "description": "This is a rehab example for the *US Core Procedure Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/respiratory-rate"
+                },
+                "name": "Respiratory Rate Example",
+                "description": "This is a respiratory rate example for the *Vitalsigns Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-respiratory-rate"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Organization"
+                    }
+                ],
+                "reference": {
+                    "reference": "Organization/saint-luke-w-endpoint"
+                },
+                "name": "Saint Luke W Endpoint Example",
+                "description": "This is a saint luke w endpoint example for the *US Core Organization Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "MedicationRequest"
+                    }
+                ],
+                "reference": {
+                    "reference": "MedicationRequest/self-tylenol"
+                },
+                "name": "Self Tylenol Example",
+                "description": "This is a self tylenol example for the *MedicationRequest Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/serum-calcium"
+                },
+                "name": "Serum Calcium Example",
+                "description": "This is a serum calcium example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/serum-chloride"
+                },
+                "name": "Serum Chloride Example",
+                "description": "This is a serum chloride example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/serum-co2"
+                },
+                "name": "Serum CO2 Example",
+                "description": "This is a serum CO2 example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/serum-creatinine"
+                },
+                "name": "Serum Creatinine Example",
+                "description": "This is a serum creatinine example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/serum-potassium"
+                },
+                "name": "Serum Potassium Example",
+                "description": "This is a serum potassium example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/serum-sodium"
+                },
+                "name": "Serum Sodium Example",
+                "description": "This is a serum sodium example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/serum-total-bilirubin"
+                },
+                "name": "Serum Total Bilirubin Example",
+                "description": "This is a serum total bilirubin example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/some-day-smoker"
+                },
+                "name": "Some Day Smoker Example",
+                "description": "This is a some day smoker example for the *US Core Smokingstatus Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/temperature"
+                },
+                "name": "Temperature Example",
+                "description": "This is a temperature example for the *Vitalsigns Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-temperature"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Device"
+                    }
+                ],
+                "reference": {
+                    "reference": "Device/udi-1"
+                },
+                "name": "UDI 1 Example",
+                "description": "This is a UDI 1 example for the *US Core Implantable Device Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "DiagnosticReport"
+                    }
+                ],
+                "reference": {
+                    "reference": "DiagnosticReport/urinalysis"
+                },
+                "name": "Urinalysis Example",
+                "description": "This is a urinalysis example for the *US Core DiagnosticReport Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-bacteria"
+                },
+                "name": "Urine Bacteria Example",
+                "description": "This is a urine bacteria example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-bilirubin"
+                },
+                "name": "Urine Bilirubin Example",
+                "description": "This is a urine bilirubin example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-cells"
+                },
+                "name": "Urine Cells Example",
+                "description": "This is a urine cells example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-clarity"
+                },
+                "name": "Urine Clarity Example",
+                "description": "This is a urine clarity example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-color"
+                },
+                "name": "Urine Color Example",
+                "description": "This is a urine color example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-epi-cells"
+                },
+                "name": "Urine Epi Cells Example",
+                "description": "This is a urine epi cells example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-glucose"
+                },
+                "name": "Urine Glucose Example",
+                "description": "This is a urine glucose example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-hemoglobin"
+                },
+                "name": "Urine Hemoglobin Example",
+                "description": "This is a urine hemoglobin example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-ketone"
+                },
+                "name": "Urine Ketone Example",
+                "description": "This is a urine ketone example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-leukocyte-esterase"
+                },
+                "name": "Urine Leukocyte Esterase Example",
+                "description": "This is a urine leukocyte esterase example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-nitrite"
+                },
+                "name": "Urine Nitrite Example",
+                "description": "This is a urine nitrite example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-ph"
+                },
+                "name": "Urine pH Example",
+                "description": "This is a urine pH example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-protein"
+                },
+                "name": "Urine Protein Example",
+                "description": "This is a urine protein example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-rbcs"
+                },
+                "name": "Urine RBCsExample",
+                "description": "This is a urine RBCsexample for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-sediment"
+                },
+                "name": "Urine Sediment Example",
+                "description": "This is a urine sediment example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urine-wbcs"
+                },
+                "name": "Urine WBCsExample",
+                "description": "This is a urine WBCsexample for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/urobilinogen"
+                },
+                "name": "Urobilinogen Example",
+                "description": "This is a urobilinogen example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Medication"
+                    }
+                ],
+                "reference": {
+                    "reference": "Medication/uscore-med1"
+                },
+                "name": "Uscore Med1 Example",
+                "description": "This is a uscore med1 example for the *US Core Medication Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Medication"
+                    }
+                ],
+                "reference": {
+                    "reference": "Medication/uscore-med2"
+                },
+                "name": "Uscore Med2 Example",
+                "description": "This is a uscore med2 example for the *US Core Medication Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "MedicationRequest"
+                    }
+                ],
+                "reference": {
+                    "reference": "MedicationRequest/uscore-mo1"
+                },
+                "name": "Uscore MO1 Example",
+                "description": "This is a uscore mo1 example for the *US Core MedicationRequest Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "MedicationRequest"
+                    }
+                ],
+                "reference": {
+                    "reference": "MedicationRequest/uscore-mo2"
+                },
+                "name": "Uscore MO2 Example",
+                "description": "This is a uscore MO2 example for the *US Core MedicationRequest Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Bundle"
+                    }
+                ],
+                "reference": {
+                    "reference": "Bundle/uscore-mo3"
+                },
+                "name": "Uscore MO3 Example",
+                "description": "This is a uscore mo3 example for the *Bundle Profile*.",
+                "exampleBoolean": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/usg"
+                },
+                "name": "USG Example",
+                "description": "This is a USG example for the *US Core Observation Lab Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab"
+            },
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/tools/StructureDefinition/resource-information",
+                        "valueString": "Observation"
+                    }
+                ],
+                "reference": {
+                    "reference": "Observation/weight"
+                },
+                "name": "Weight Example",
+                "description": "This is a weight example for the *Vitalsigns Profile*.",
+                "exampleCanonical": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-weight"
+            }
+        ],
+        "page": {
+            "nameUrl": "toc.html",
+            "title": "Table of Contents",
+            "generation": "html",
+            "page": [
+                {
+                    "nameUrl": "index.html",
+                    "title": "Index",
+                    "generation": "markdown"
+                },
+                {
+                    "nameUrl": "guidance.html",
+                    "title": "Guidance",
+                    "generation": "markdown",
+                    "page": [
+                        {
+                            "nameUrl": "general-guidance.html",
+                            "title": "General Guidance",
+                            "generation": "markdown"
+                        },
+                        {
+                            "nameUrl": "conformance-expectations.html",
+                            "title": "Conformance Expectations",
+                            "generation": "markdown"
+                        },
+                        {
+                            "nameUrl": "clinical-notes-guidance.html",
+                            "title": "Clinical Notes Guidance",
+                            "generation": "markdown"
+                        },
+                        {
+                            "nameUrl": "medication-list-guidance.html",
+                            "title": "Medication List Guidance",
+                            "generation": "markdown"
+                        },
+                        {
+                            "nameUrl": "basic-provenance.html",
+                            "title": "Basic Provenance",
+                            "generation": "markdown"
+                        },
+                        {
+                            "nameUrl": "DSTU2-to-R4-conversion.html",
+                            "title": "DSTU2 to R4 Conversion",
+                            "generation": "markdown"
+                        },
+                        {
+                            "nameUrl": "future-of-US-core.html",
+                            "title": "Future of US Core",
+                            "generation": "markdown"
+                        }
+                    ]
+                },
+                {
+                    "nameUrl": "profiles-and-extensions.html",
+                    "title": "Profiles and Extensions",
+                    "generation": "markdown"
+                },
+                {
+                    "nameUrl": "capability-statements.html",
+                    "title": "Capability Statements",
+                    "generation": "markdown"
+                },
+                {
+                    "nameUrl": "search-parameters-and-operations.html",
+                    "title": "Search Parameters and Operations",
+                    "generation": "markdown"
+                },
+                {
+                    "nameUrl": "terminology.html",
+                    "title": "Terminology",
+                    "generation": "markdown"
+                },
+                {
+                    "nameUrl": "security.html",
+                    "title": "Security",
+                    "generation": "markdown"
+                },
+                {
+                    "nameUrl": "examples.html",
+                    "title": "Examples",
+                    "generation": "markdown"
+                },
+                {
+                    "nameUrl": "downloads.html",
+                    "title": "Downloads",
+                    "generation": "markdown"
+                }
+            ]
+        },
+        "parameter": [
+        ]
+    }
 }

--- a/conformance/fhir-ig-us-core/src/test/java/com/ibm/fhir/ig/us/core/tool/v311/ResourceProcessor.java
+++ b/conformance/fhir-ig-us-core/src/test/java/com/ibm/fhir/ig/us/core/tool/v311/ResourceProcessor.java
@@ -10,6 +10,8 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
+import java.util.Collections;
+import java.util.Map;
 
 import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
@@ -19,6 +21,7 @@ import jakarta.json.JsonReader;
 import jakarta.json.JsonReaderFactory;
 import jakarta.json.JsonWriter;
 import jakarta.json.JsonWriterFactory;
+import jakarta.json.stream.JsonGenerator;
 
 /**
  * This class fixes two issues with the packaged US Core artifacts:
@@ -29,8 +32,9 @@ import jakarta.json.JsonWriterFactory;
  */
 public class ResourceProcessor {
     public static void main(String[] args) throws Exception {
+        Map<String, Object> writerConfig = Collections.singletonMap(JsonGenerator.PRETTY_PRINTING, true);
         JsonReaderFactory jsonReaderFactory = Json.createReaderFactory(null);
-        JsonWriterFactory jsonWriterFactory = Json.createWriterFactory(null);
+        JsonWriterFactory jsonWriterFactory = Json.createWriterFactory(writerConfig);
         JsonBuilderFactory jsonBuilderFactory = Json.createBuilderFactory(null);
 
         File dir = new File("src/main/resources/hl7/fhir/us/core/311/package/");
@@ -51,16 +55,16 @@ public class ResourceProcessor {
 
                 JsonObject text = jsonObject.getJsonObject("text");
                 if (text != null) {
-                    JsonObjectBuilder textBuilder = jsonBuilderFactory.createObjectBuilder(text);
-                    String div = text.getString("div");
-                    div = div.replace("<p><pre>", "<pre>").replace("</pre></p>", "</pre>");
-                    textBuilder.add("div", div);
+                    // Replace the generated text with some [much smaller] generic placeholder
+                    JsonObjectBuilder textBuilder = jsonBuilderFactory.createObjectBuilder();
+                    textBuilder.add("status", "empty");
+                    textBuilder.add("div", "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>");
                     jsonObjectBuilder.add("text", textBuilder);
                 }
 
                 if (!jsonObject.containsKey("version")) {
                     System.out.println("file: " + file + " does not have a version");
-                    jsonObjectBuilder.add("version", "0.1.0");
+                    jsonObjectBuilder.add("version", "3.1.1");
                 }
 
                 jsonObject = jsonObjectBuilder.build();

--- a/conformance/fhir-ig-us-core/src/test/java/com/ibm/fhir/ig/us/core/tool/v400/ResourceProcessor.java
+++ b/conformance/fhir-ig-us-core/src/test/java/com/ibm/fhir/ig/us/core/tool/v400/ResourceProcessor.java
@@ -10,6 +10,8 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
+import java.util.Collections;
+import java.util.Map;
 
 import jakarta.json.Json;
 import jakarta.json.JsonBuilderFactory;
@@ -19,6 +21,7 @@ import jakarta.json.JsonReader;
 import jakarta.json.JsonReaderFactory;
 import jakarta.json.JsonWriter;
 import jakarta.json.JsonWriterFactory;
+import jakarta.json.stream.JsonGenerator;
 
 /**
  * This class fixes two issues with the packaged US Core artifacts:
@@ -29,8 +32,9 @@ import jakarta.json.JsonWriterFactory;
  */
 public class ResourceProcessor {
     public static void main(String[] args) throws Exception {
+        Map<String, Object> writerConfig = Collections.singletonMap(JsonGenerator.PRETTY_PRINTING, true);
         JsonReaderFactory jsonReaderFactory = Json.createReaderFactory(null);
-        JsonWriterFactory jsonWriterFactory = Json.createWriterFactory(null);
+        JsonWriterFactory jsonWriterFactory = Json.createWriterFactory(writerConfig);
         JsonBuilderFactory jsonBuilderFactory = Json.createBuilderFactory(null);
 
         File dir = new File("src/main/resources/hl7/fhir/us/core/400/package/");
@@ -51,16 +55,16 @@ public class ResourceProcessor {
 
                 JsonObject text = jsonObject.getJsonObject("text");
                 if (text != null) {
-                    JsonObjectBuilder textBuilder = jsonBuilderFactory.createObjectBuilder(text);
-                    String div = text.getString("div");
-                    div = div.replace("<p><pre>", "<pre>").replace("</pre></p>", "</pre>");
-                    textBuilder.add("div", div);
+                    // Replace the generated text with some [much smaller] generic placeholder
+                    JsonObjectBuilder textBuilder = jsonBuilderFactory.createObjectBuilder();
+                    textBuilder.add("status", "empty");
+                    textBuilder.add("div", "<div xmlns=\"http://www.w3.org/1999/xhtml\">Redacted for size</div>");
                     jsonObjectBuilder.add("text", textBuilder);
                 }
 
                 if (!jsonObject.containsKey("version")) {
                     System.out.println("file: " + file + " does not have a version");
-                    jsonObjectBuilder.add("version", "0.1.0");
+                    jsonObjectBuilder.add("version", "4.0.0");
                 }
 
                 jsonObject = jsonObjectBuilder.build();


### PR DESCRIPTION
For space efficiency.  https://github.com/IBM/FHIR/pull/2851 already
replaced the narrative text for a select handful of the resources...this
PR proposes to expand that to cover all resources in the IG.

The parsson JsonGenerator used from our ResourceProcessors uses spaces
instead of tabs for pretty-printing, so we also have that change on every file.

Signed-off-by: Lee Surprenant <lmsurpre@us.ibm.com>